### PR TITLE
fix(remote): restore attachments across reload and keep mirrored panes live

### DIFF
--- a/changelog.d/831.md
+++ b/changelog.d/831.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **Attached remote workspaces survive a reload and a restart.** Pressing Cmd+R,
+  or quitting and reopening wmux, silently emptied the Remote section of the
+  sidebar and every mirror with it — re-attaching meant walking back through the
+  picker each time. Attachments are now remembered, and are restored on launch
+  with a fresh pane list fetched from the host. A host that is asleep or
+  unreachable keeps its row, marked as stale, rather than being deleted;
+  detaching is still yours to decide.
+
+- **Mirrors follow panes opened and closed on the remote machine.** The pane
+  layout was frozen at the moment you attached: a pane closed on the other
+  machine left a dead tile in the grid forever, and a pane opened there was
+  invisible until you detached and attached again. The grid now follows the
+  remote workspace, with surviving panes staying in place instead of shuffling
+  when one comes or goes.

--- a/changelog.d/831.md
+++ b/changelog.d/831.md
@@ -4,9 +4,11 @@
   or quitting and reopening wmux, silently emptied the Remote section of the
   sidebar and every mirror with it — re-attaching meant walking back through the
   picker each time. Attachments are now remembered, and are restored on launch
-  with a fresh pane list fetched from the host. A host that is asleep or
-  unreachable keeps its row, marked as stale, rather than being deleted;
-  detaching is still yours to decide.
+  with a fresh pane list fetched from the host. Every row appears immediately,
+  even when a host takes its time answering. A host that is asleep or
+  unreachable keeps its row, marked as stale, rather than being deleted, and
+  its mirrors reconnect on their own once it comes back; detaching is still
+  yours to decide.
 
 - **Mirrors follow panes opened and closed on the remote machine.** The pane
   layout was frozen at the moment you attached: a pane closed on the other
@@ -14,3 +16,8 @@
   invisible until you detached and attached again. The grid now follows the
   remote workspace, with surviving panes staying in place instead of shuffling
   when one comes or goes.
+
+- **Removing a remote host clears its mirrors.** The host disappeared from the
+  picker but its mirrored workspaces stayed in the sidebar for the rest of the
+  session, quietly failing to refresh against a machine wmux no longer knew
+  about. They now go with it.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -72,6 +72,7 @@ import { registerProjectConfigHandlers } from './ipc/handlers/projectConfig.hand
 import { registerChannelLocalHandlers } from './ipc/handlers/channelLocal.handler';
 import { registerRemoteHandlers } from './ipc/handlers/remote.handler';
 import { RemoteHostsStore } from './remote/RemoteHostsStore';
+import { RemoteAttachmentsStore } from './remote/RemoteAttachmentsStore';
 import { registerFanOutHandler } from './ipc/handlers/fanout.handler';
 import { createFanOutService } from './worktask/createFanOutService';
 import { registerFanOutRpc } from './pipe/handlers/fanout.rpc';
@@ -672,7 +673,10 @@ registerChannelLocalHandlers(() => daemonClient);
 // channelLocal above). Registered once, outside the daemon-swap cycle: the
 // registered hosts/tokens live on disk in main, independent of the local
 // daemon connection. See remote.handler.ts for the push-routing contract.
-registerRemoteHandlers({ store: new RemoteHostsStore(path.join(getWmuxDir(), 'remote-hosts.json')) });
+registerRemoteHandlers({
+  store: new RemoteHostsStore(path.join(getWmuxDir(), 'remote-hosts.json')),
+  attachments: new RemoteAttachmentsStore(path.join(getWmuxDir(), 'remote-attachments.json')),
+});
 // J1 fan-out — 프롬프트 1개 → N 격리 태스크. 렌더러 다이얼로그가 fanout:start를
 // invoke하면 main의 FanOutService가 데몬 RPC + 렌더러 spawn을 조립한다(channelLocal과
 // 동일 renderer-trusted 신원).

--- a/src/main/ipc/handlers/__tests__/remote.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/remote.handler.test.ts
@@ -844,6 +844,45 @@ describe('remote.handler — attachment descriptors', () => {
     await expect(getHandler(IPC.REMOTE_ATTACHMENTS_LIST)({})).resolves.toEqual([]);
   });
 
+  // Finding 9 — `key` is what every later lookup addresses the record by.
+  it('refuses a descriptor whose key does not derive from its own ids', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments();
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_ADD)({}, { ...descriptor, key: 'h9:ws-9' })).resolves.toBe(false);
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_ADD)({}, { ...descriptor, key: 'ws-1' })).resolves.toBe(false);
+    expect(attachments.add).not.toHaveBeenCalled();
+  });
+
+  it('refuses a remove for a key nothing could have minted', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments([descriptor]);
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_REMOVE)({}, 'no-separator')).resolves.toBe(false);
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_REMOVE)({}, ':ws-1')).resolves.toBe(false);
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_REMOVE)({}, 'h1:')).resolves.toBe(false);
+    expect(attachments.remove).not.toHaveBeenCalled();
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_LIST)({})).resolves.toEqual([descriptor]);
+  });
+
+  // Finding 5 — the cascade runs AFTER the host is already gone from the
+  // store, so letting it throw would report a completed removal as a failure.
+  it('hostsRemove still reports success when the descriptor cascade fails', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments([descriptor]);
+    attachments.removeByHost.mockImplementation(() => { throw new Error('EACCES'); });
+    const client = fakeClient(host);
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never, clientFactory: () => client });
+    // Clients are lazy — attach once so there is something left to tear down.
+    await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender: fakeSender(202) }, 'h1', 's1');
+
+    await expect(getHandler(IPC.REMOTE_HOSTS_REMOVE)({}, 'h1')).resolves.toBe(true);
+    // The rest of the teardown still ran.
+    expect(client.detachAll).toHaveBeenCalledTimes(1);
+  });
+
   it('hostsRemove cascades into the descriptors of that host', async () => {
     const store = fakeStore([host]);
     const attachments = fakeAttachments([descriptor, { ...descriptor, key: 'h2:ws-1', hostId: 'h2' }]);

--- a/src/main/ipc/handlers/__tests__/remote.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/remote.handler.test.ts
@@ -39,7 +39,7 @@ vi.mock('electron', () => {
 
 import { registerRemoteHandlers } from '../remote.handler';
 import { IPC } from '../../../../shared/constants';
-import type { RemoteHost, RemoteHostPublic, RemoteWorkspacesResponse } from '../../../../shared/remoteHosts';
+import type { RemoteAttachmentDescriptor, RemoteHost, RemoteHostPublic, RemoteWorkspacesResponse } from '../../../../shared/remoteHosts';
 import type { RemoteHostClient, RemoteMetaEvent, RemoteDataEvent, RemoteExitEvent, RemoteErrorEvent } from '../../../remote/RemoteHostClient';
 
 function getHandler(channel: string): (...args: unknown[]) => unknown {
@@ -164,6 +164,24 @@ function fakeStore(hosts: RemoteHost[] = []) {
   };
 }
 
+/** A minimal fake RemoteAttachmentsStore — in-memory, same shape as the real
+ *  one (which is exercised directly in RemoteAttachmentsStore.test.ts). */
+function fakeAttachments(seed: RemoteAttachmentDescriptor[] = []) {
+  const byKey = new Map(seed.map((a) => [a.key, a]));
+  return {
+    list: vi.fn((): RemoteAttachmentDescriptor[] => [...byKey.values()]),
+    add: vi.fn((d: RemoteAttachmentDescriptor) => { byKey.set(d.key, d); }),
+    remove: vi.fn((key: string) => byKey.delete(key)),
+    removeByHost: vi.fn((hostId: string) => {
+      let n = 0;
+      for (const [key, a] of [...byKey.entries()]) {
+        if (a.hostId === hostId) { byKey.delete(key); n++; }
+      }
+      return n;
+    }),
+  };
+}
+
 function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 404): Response {
   return { ok, status, json: async () => body } as unknown as Response;
 }
@@ -178,7 +196,7 @@ describe('remote.handler — hostsAdd', () => {
   it('probes /api/config before persisting and refuses an old remote (404)', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => jsonResponse({}, false));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t') as { ok: boolean; error?: string };
 
@@ -189,7 +207,7 @@ describe('remote.handler — hostsAdd', () => {
   it('refuses an old remote that returns unparseable JSON', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => ({ ok: true, json: async () => { throw new Error('bad json'); } } as unknown as Response));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t') as { ok: boolean; error?: string };
 
@@ -201,7 +219,7 @@ describe('remote.handler — hostsAdd', () => {
   it('persists + returns allowInput from a successful probe', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => jsonResponse({ serverVersion: '1.0', protocolVersion: 1, minProtocolVersion: 1, allowInput: true }));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t') as { ok: true; host: RemoteHostPublic };
 
@@ -221,7 +239,7 @@ describe('remote.handler — hostsAdd', () => {
   it('rejects an invalid URL without ever probing', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn();
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'not a url') as { ok: boolean; error?: string };
 
@@ -235,7 +253,7 @@ describe('remote.handler — hostsAdd', () => {
   it('reports a rejected token distinctly from "too old" on a 401', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => jsonResponse({}, false, 401));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t') as { ok: boolean; error?: string };
 
@@ -246,7 +264,7 @@ describe('remote.handler — hostsAdd', () => {
   it('reports an unreachable host distinctly from "too old" when fetch throws', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t') as { ok: boolean; error?: string };
 
@@ -257,7 +275,7 @@ describe('remote.handler — hostsAdd', () => {
   it('still reports "too old" for a genuinely incompatible remote (404)', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => jsonResponse({}, false, 404));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t') as { ok: boolean; error?: string };
 
@@ -272,7 +290,7 @@ describe('remote.handler — hostsAdd', () => {
     const store = fakeStore();
     store.add.mockImplementationOnce(() => { throw new Error('EACCES: chmod failed'); });
     const fetchImpl = vi.fn(async () => jsonResponse({ allowInput: true }));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     await expect(
       getHandler(IPC.REMOTE_HOSTS_ADD)({}, 'https://box:9600?token=t'),
@@ -287,7 +305,7 @@ describe('remote.handler — hostsPair', () => {
       if (String(url).includes('/api/pair')) return jsonResponse({ deviceId: 'd1', deviceSecret: 's1', token: 'd1.s1' });
       return jsonResponse({ allowInput: true });
     });
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'ABCD1234') as { ok: true; host: RemoteHostPublic };
 
@@ -307,7 +325,7 @@ describe('remote.handler — hostsPair', () => {
       if (String(url).includes('/api/pair')) return jsonResponse({ token: 't' });
       return jsonResponse({ allowInput: false });
     });
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600/some/path/', 'CODE');
 
@@ -317,7 +335,7 @@ describe('remote.handler — hostsPair', () => {
   it('refuses a non-http(s) origin without ever fetching', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn();
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'ftp://box:9600', 'CODE') as { ok: boolean; reason?: string };
 
@@ -328,7 +346,7 @@ describe('remote.handler — hostsPair', () => {
   it('refuses an unparseable origin without ever fetching', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn();
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'not a url', 'CODE') as { ok: boolean; reason?: string };
 
@@ -340,7 +358,7 @@ describe('remote.handler — hostsPair', () => {
     const existing: RemoteHost = { id: 'h1', label: 'box', origin: 'https://box:9600', token: 't', addedAt: 0 };
     const store = fakeStore([existing]);
     const fetchImpl = vi.fn();
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'CODE') as { ok: boolean; reason?: string };
 
@@ -356,7 +374,7 @@ describe('remote.handler — hostsPair', () => {
   ])('maps a 403 body {error: %s} to reason %s', async (bodyError, expectedReason) => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => jsonResponse({ error: bodyError }, false, 403));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'CODE') as { ok: boolean; reason?: string };
 
@@ -367,7 +385,7 @@ describe('remote.handler — hostsPair', () => {
   it('maps an "invalid code" 403 body to invalid-code and carries attemptsLeft', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => jsonResponse({ error: 'invalid code', attemptsLeft: 3 }, false, 403));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'WRONG') as { ok: boolean; reason?: string; attemptsLeft?: number };
 
@@ -377,7 +395,7 @@ describe('remote.handler — hostsPair', () => {
   it('reports unreachable when the fetch itself throws', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => { throw new Error('ECONNREFUSED'); });
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'CODE') as { ok: boolean; reason?: string };
 
@@ -388,7 +406,7 @@ describe('remote.handler — hostsPair', () => {
   it('reports pairing-failed for a 500', async () => {
     const store = fakeStore();
     const fetchImpl = vi.fn(async () => jsonResponse({ error: 'pairing failed' }, false, 500));
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'CODE') as { ok: boolean; reason?: string };
 
@@ -401,7 +419,7 @@ describe('remote.handler — hostsPair', () => {
       if (String(url).includes('/api/pair')) return jsonResponse({ token: 'freshly-minted' });
       return jsonResponse({}, false, 404); // /api/config probe fails
     });
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'CODE') as { ok: boolean; reason?: string };
 
@@ -416,7 +434,7 @@ describe('remote.handler — hostsPair', () => {
       if (String(url).includes('/api/pair')) return jsonResponse({ token: 't' });
       return jsonResponse({ allowInput: true });
     });
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     await expect(
       getHandler(IPC.REMOTE_HOSTS_PAIR)({}, 'https://box:9600', 'CODE'),
@@ -432,7 +450,7 @@ describe('remote.handler — workspacesList', () => {
     const client = fakeClient(host);
     client.listWorkspaces.mockRejectedValueOnce(new Error('network down'));
     const fetchImpl = vi.fn(async () => jsonResponse({ allowInput: false }));
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_WORKSPACES_LIST)({}, 'h1') as { ok: boolean; error?: string };
 
@@ -444,7 +462,7 @@ describe('remote.handler — workspacesList', () => {
     const client = fakeClient(host);
     client.listWorkspaces.mockResolvedValueOnce({ workspaces: [{ id: 'w1', name: 'proj', panes: [] }] });
     const fetchImpl = vi.fn(async () => jsonResponse({ allowInput: false }));
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_WORKSPACES_LIST)({}, 'h1') as { ok: true; workspaces: unknown[] };
 
@@ -455,7 +473,7 @@ describe('remote.handler — workspacesList', () => {
   it('reports unknown host without touching a client', async () => {
     const store = fakeStore([]);
     const fetchImpl = vi.fn();
-    registerRemoteHandlers({ store: store as never, fetchImpl: fetchImpl as unknown as typeof fetch });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, fetchImpl: fetchImpl as unknown as typeof fetch });
 
     const res = await getHandler(IPC.REMOTE_WORKSPACES_LIST)({}, 'missing') as { ok: boolean; error?: string };
 
@@ -470,7 +488,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('wires client events to the attaching event.sender with the right channel names', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(101);
     const res = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { ok: true; attachId: string };
@@ -490,7 +508,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('never pushes to a destroyed sender', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(102);
     const res = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { ok: true; attachId: string };
@@ -504,7 +522,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('a duplicate attach for the same (sender, host, session) returns the existing attachId without a second SSE open', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(103);
     const first = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { ok: true; attachId: string };
@@ -517,7 +535,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('a different session on the same sender opens a distinct attach', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(104);
     const a = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { ok: true; attachId: string };
@@ -530,7 +548,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('an exit event detaches the dead attach and clears its idempotency key', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(111);
     const first = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -549,7 +567,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('paneDetach forwards to the client and forgets the attach', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(105);
     const { attachId } = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -566,7 +584,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('paneWrite forwards to the owning client fire-and-forget', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(110);
     const { attachId } = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -579,7 +597,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('paneWrite for an unknown attachId is a silent no-op', () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     expect(() => getListener(IPC.REMOTE_PANE_WRITE)({}, 'never-attached', 'hello')).not.toThrow();
     expect(client.write).not.toHaveBeenCalled();
@@ -588,7 +606,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it("sender 'destroyed' detaches every attachId it owns", async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(106);
     const a = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -604,7 +622,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it("sender 'render-process-gone' detaches every attachId it owns", async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(107);
     const a = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -617,7 +635,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it("a main-frame, non-same-document 'did-start-navigation' (e.g. Cmd+R) detaches every attachId the sender owns", async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(112);
     const a = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -639,7 +657,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it("ignores a same-document 'did-start-navigation' (isInPlace)", async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(113);
     await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1');
@@ -657,7 +675,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('two attach->navigation cycles on the same sender do not stack cleanup listeners', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(120) as ReturnType<typeof fakeSender> & { listenerCounts: () => Record<string, number> };
 
@@ -684,7 +702,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it("ignores a subframe 'did-start-navigation' (isMainFrame=false)", async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(114);
     await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1');
@@ -697,7 +715,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('forwards a client onError to the owning sender on REMOTE_PANE_ERROR', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(115);
     const { attachId } = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'session-1') as { attachId: string };
@@ -713,7 +731,7 @@ describe('remote.handler — pane attach/detach/write push routing', () => {
   it('a second sender is unaffected by the first sender being destroyed', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const senderA = fakeSender(108);
     const senderB = fakeSender(109);
@@ -734,7 +752,7 @@ describe('remote.handler — quit + host removal cleanup', () => {
     const store = fakeStore([host1, host2]);
     const clientsByHost = new Map<string, ReturnType<typeof fakeClient>>();
     registerRemoteHandlers({
-      store: store as never,
+      store: store as never, attachments: fakeAttachments() as never,
       clientFactory: (h) => {
         const c = fakeClient(h);
         clientsByHost.set(h.id, c);
@@ -758,7 +776,7 @@ describe('remote.handler — quit + host removal cleanup', () => {
     const host1: RemoteHost = { id: 'h1', label: 'box1', origin: 'https://box1:9600', token: 't1', addedAt: 0 };
     const store = fakeStore([host1]);
     const client = fakeClient(host1);
-    registerRemoteHandlers({ store: store as never, clientFactory: () => client });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
 
     const sender = fakeSender(201);
     await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 's1');
@@ -767,5 +785,89 @@ describe('remote.handler — quit + host removal cleanup', () => {
 
     expect(removed).toBe(true);
     expect(client.detachAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('remote.handler — attachment descriptors', () => {
+  const host: RemoteHost = { id: 'h1', label: 'box1', origin: 'https://box1:9600', token: 't1', addedAt: 0 };
+  const descriptor: RemoteAttachmentDescriptor = {
+    key: 'h1:ws-1',
+    hostId: 'h1',
+    hostLabel: 'box1',
+    workspaceId: 'ws-1',
+    name: 'Remote WS',
+  };
+
+  it('add → list roundtrips a descriptor', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments();
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_ADD)({}, descriptor)).resolves.toBe(true);
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_LIST)({})).resolves.toEqual([descriptor]);
+  });
+
+  it('strips a pane list off an add — panes are never persisted', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments();
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await getHandler(IPC.REMOTE_ATTACHMENTS_ADD)({}, { ...descriptor, panes: [{ sessionId: 's1' }] });
+    expect(attachments.add).toHaveBeenCalledWith(descriptor);
+  });
+
+  it('refuses a descriptor for an unregistered host', async () => {
+    const store = fakeStore();
+    const attachments = fakeAttachments();
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_ADD)({}, descriptor)).resolves.toBe(false);
+    expect(attachments.add).not.toHaveBeenCalled();
+  });
+
+  it('reports false rather than rejecting when the disk write fails', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments();
+    attachments.add.mockImplementation(() => { throw new Error('EACCES'); });
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_ADD)({}, descriptor)).resolves.toBe(false);
+  });
+
+  it('remove drops the descriptor and reports whether it existed', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments([descriptor]);
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_REMOVE)({}, 'h1:ws-1')).resolves.toBe(true);
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_REMOVE)({}, 'h1:ws-1')).resolves.toBe(false);
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_LIST)({})).resolves.toEqual([]);
+  });
+
+  it('hostsRemove cascades into the descriptors of that host', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments([descriptor, { ...descriptor, key: 'h2:ws-1', hostId: 'h2' }]);
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never });
+
+    await getHandler(IPC.REMOTE_HOSTS_REMOVE)({}, 'h1');
+    expect(attachments.removeByHost).toHaveBeenCalledWith('h1');
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_LIST)({})).resolves.toEqual([
+      { ...descriptor, key: 'h2:ws-1', hostId: 'h2' },
+    ]);
+  });
+
+  it('a renderer reload tears down live SSE attaches but keeps the descriptors', async () => {
+    const store = fakeStore([host]);
+    const attachments = fakeAttachments([descriptor]);
+    const client = fakeClient(host);
+    registerRemoteHandlers({ store: store as never, attachments: attachments as never, clientFactory: () => client });
+
+    const sender = fakeSender(300);
+    const res = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 's1') as { ok: true; attachId: string };
+    sender.fireNavigation(false, true);
+
+    expect(client.detach).toHaveBeenCalledWith(res.attachId);
+    // The descriptor survives — that is what the renderer restores from.
+    await expect(getHandler(IPC.REMOTE_ATTACHMENTS_LIST)({})).resolves.toEqual([descriptor]);
   });
 });

--- a/src/main/ipc/handlers/remote.handler.ts
+++ b/src/main/ipc/handlers/remote.handler.ts
@@ -22,7 +22,7 @@ import { wrapHandler } from '../wrapHandler';
 import { RemoteHostClient } from '../../remote/RemoteHostClient';
 import type { RemoteHostsStore } from '../../remote/RemoteHostsStore';
 import type { RemoteAttachmentsStore } from '../../remote/RemoteAttachmentsStore';
-import { parseWebUrl } from '../../../shared/remoteHosts';
+import { parseRemoteAttachmentKey, parseWebUrl, remoteAttachmentKey } from '../../../shared/remoteHosts';
 import type {
   PairFailureReason,
   RemoteAttachmentDescriptor,
@@ -417,8 +417,13 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
       if (!removed) return false;
 
       // A descriptor pointing at an unregistered host can never be restored
-      // (no token to reach it with), so it must not outlive the host.
-      attachments.removeByHost(hostId);
+      // (no token to reach it with), so it must not outlive the host. The
+      // write is best-effort ON PURPOSE: the host is already gone from the
+      // store by now, and letting a disk failure escape here would report a
+      // removal that actually happened as a failure.
+      try {
+        attachments.removeByHost(hostId);
+      } catch { /* see above — an orphan descriptor restores as a stale row */ }
       allowInputCache.delete(hostId);
       const client = clients.get(hostId);
       if (client) {
@@ -479,6 +484,11 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
         workspaceId: assertString(d.workspaceId, 'workspaceId'),
         name: typeof d.name === 'string' ? d.name : '',
       };
+      // The key is what every later lookup addresses this record by, so it
+      // must actually derive from the pair it claims to describe — a record
+      // filed under someone else's key would be unremovable by its owner and
+      // would restore as a row pointing at the wrong workspace.
+      if (entry.key !== remoteAttachmentKey(entry.hostId, entry.workspaceId)) return false;
       // Refuse to record an attachment for a host we do not have — it could
       // never be restored, and would leak a row into the sidebar forever.
       if (!store.get(entry.hostId)) return false;
@@ -497,7 +507,12 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
   ipcMain.handle(IPC.REMOTE_ATTACHMENTS_REMOVE, wrapHandler(IPC.REMOTE_ATTACHMENTS_REMOVE,
     async (_e: IpcMainInvokeEvent, key: unknown): Promise<boolean> => {
       try {
-        return attachments.remove(assertString(key, 'key'));
+        const k = assertString(key, 'key');
+        // Same derivation gate as add: only a well-formed
+        // `<hostId>:<workspaceId>` addresses a record, so a key that cannot
+        // have been minted by the attach path deletes nothing.
+        if (!parseRemoteAttachmentKey(k)) return false;
+        return attachments.remove(k);
       } catch {
         return false;
       }

--- a/src/main/ipc/handlers/remote.handler.ts
+++ b/src/main/ipc/handlers/remote.handler.ts
@@ -21,9 +21,11 @@ import { IPC } from '../../../shared/constants';
 import { wrapHandler } from '../wrapHandler';
 import { RemoteHostClient } from '../../remote/RemoteHostClient';
 import type { RemoteHostsStore } from '../../remote/RemoteHostsStore';
+import type { RemoteAttachmentsStore } from '../../remote/RemoteAttachmentsStore';
 import { parseWebUrl } from '../../../shared/remoteHosts';
 import type {
   PairFailureReason,
+  RemoteAttachmentDescriptor,
   RemoteHost,
   RemoteHostPublic,
   RemoteWorkspaceSummary,
@@ -53,6 +55,9 @@ type ProbeResult =
 
 export interface RegisterRemoteHandlersDeps {
   store: RemoteHostsStore;
+  /** Persisted attach descriptors — what makes an attachment survive a
+   *  renderer reload and an app restart. */
+  attachments: RemoteAttachmentsStore;
   /** Test seam: how a RemoteHostClient is built for a host record. Defaults
    *  to `new RemoteHostClient(host, fetchImpl)`. */
   clientFactory?: (host: RemoteHost) => RemoteHostClient;
@@ -201,7 +206,7 @@ async function exchangePairCode(
 }
 
 export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => void {
-  const { store } = deps;
+  const { store, attachments } = deps;
   const fetchImpl: typeof fetch = deps.fetchImpl ?? fetch;
   const makeClient = deps.clientFactory ?? ((host: RemoteHost) => new RemoteHostClient(host, fetchImpl));
 
@@ -411,6 +416,9 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
       const removed = store.remove(hostId);
       if (!removed) return false;
 
+      // A descriptor pointing at an unregistered host can never be restored
+      // (no token to reach it with), so it must not outlive the host.
+      attachments.removeByHost(hostId);
       allowInputCache.delete(hostId);
       const client = clients.get(hostId);
       if (client) {
@@ -445,6 +453,53 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
         return { ok: true, workspaces: res.workspaces };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }));
+
+  // Attach descriptors — the persistence half of "attachments survive a
+  // reload". Deliberately independent of the SSE attach lifecycle below: the
+  // reload teardown in installSenderCleanup still kills every live stream (a
+  // stale SSE connection must die), and these records are what lets the
+  // renderer rebuild the attachments from scratch afterwards.
+  ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_LIST);
+  ipcMain.handle(IPC.REMOTE_ATTACHMENTS_LIST, wrapHandler(IPC.REMOTE_ATTACHMENTS_LIST,
+    async (): Promise<RemoteAttachmentDescriptor[]> => attachments.list()));
+
+  ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_ADD);
+  ipcMain.handle(IPC.REMOTE_ATTACHMENTS_ADD, wrapHandler(IPC.REMOTE_ATTACHMENTS_ADD,
+    async (_e: IpcMainInvokeEvent, descriptor: unknown): Promise<boolean> => {
+      if (typeof descriptor !== 'object' || descriptor === null) {
+        throw new Error('descriptor is required');
+      }
+      const d = descriptor as Record<string, unknown>;
+      const entry: RemoteAttachmentDescriptor = {
+        key: assertString(d.key, 'key'),
+        hostId: assertString(d.hostId, 'hostId'),
+        hostLabel: typeof d.hostLabel === 'string' ? d.hostLabel : '',
+        workspaceId: assertString(d.workspaceId, 'workspaceId'),
+        name: typeof d.name === 'string' ? d.name : '',
+      };
+      // Refuse to record an attachment for a host we do not have — it could
+      // never be restored, and would leak a row into the sidebar forever.
+      if (!store.get(entry.hostId)) return false;
+      // A write failure must not reject: the attach itself already succeeded
+      // in the renderer, and losing persistence only costs this attachment
+      // its restore-after-reload.
+      try {
+        attachments.add(entry);
+      } catch {
+        return false;
+      }
+      return true;
+    }));
+
+  ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_REMOVE);
+  ipcMain.handle(IPC.REMOTE_ATTACHMENTS_REMOVE, wrapHandler(IPC.REMOTE_ATTACHMENTS_REMOVE,
+    async (_e: IpcMainInvokeEvent, key: unknown): Promise<boolean> => {
+      try {
+        return attachments.remove(assertString(key, 'key'));
+      } catch {
+        return false;
       }
     }));
 
@@ -506,6 +561,9 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
     ipcMain.removeHandler(IPC.REMOTE_HOSTS_PAIR);
     ipcMain.removeHandler(IPC.REMOTE_HOSTS_REMOVE);
     ipcMain.removeHandler(IPC.REMOTE_WORKSPACES_LIST);
+    ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_LIST);
+    ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_ADD);
+    ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_REMOVE);
     ipcMain.removeHandler(IPC.REMOTE_PANE_ATTACH);
     ipcMain.removeHandler(IPC.REMOTE_PANE_DETACH);
     ipcMain.removeAllListeners(IPC.REMOTE_PANE_WRITE);

--- a/src/main/remote/RemoteAttachmentsStore.ts
+++ b/src/main/remote/RemoteAttachmentsStore.ts
@@ -1,0 +1,104 @@
+// Persisted registry of ATTACHED remote workspaces (main process only).
+//
+// Sibling of RemoteHostsStore, deliberately a separate file: a descriptor here
+// holds no credential (the bearer token stays in remote-hosts.json), so this
+// one is written with the ordinary atomic-JSON path rather than
+// secureWriteTokenFile. Keeping them apart is what makes that difference
+// structural instead of a convention someone has to remember.
+//
+// Why persist at all: the renderer's remoteWorkspacesSlice is memory-only and
+// a reload (Cmd+R) or app restart recreates it empty, which silently dropped
+// every attachment. The DESCRIPTORS live here; the panes never do — they are
+// re-fetched from the host at restore time.
+
+import { atomicReadJSONSync, atomicWriteJSONSync } from '../../daemon/util/atomicWrite';
+import type { RemoteAttachmentDescriptor } from '../../shared/remoteHosts';
+
+/** Structural validation for a loaded file — malformed/foreign shapes are
+ *  treated the same as a missing file (empty list, never throw). */
+function isDescriptorArray(v: unknown): v is RemoteAttachmentDescriptor[] {
+  if (!Array.isArray(v)) return false;
+  return v.every((r) => {
+    if (typeof r !== 'object' || r === null) return false;
+    const rec = r as Record<string, unknown>;
+    return (
+      typeof rec.key === 'string' &&
+      typeof rec.hostId === 'string' &&
+      typeof rec.hostLabel === 'string' &&
+      typeof rec.workspaceId === 'string' &&
+      typeof rec.name === 'string'
+    );
+  });
+}
+
+/** Strips anything beyond the five persisted fields — a caller that hands us
+ *  a full AttachedRemoteWorkspace must not get its `panes` written to disk. */
+function toDescriptor(d: RemoteAttachmentDescriptor): RemoteAttachmentDescriptor {
+  return {
+    key: d.key,
+    hostId: d.hostId,
+    hostLabel: d.hostLabel,
+    workspaceId: d.workspaceId,
+    name: d.name,
+  };
+}
+
+export class RemoteAttachmentsStore {
+  private readonly filePath: string;
+  private attachments: RemoteAttachmentDescriptor[] = [];
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+    this.load();
+  }
+
+  list(): RemoteAttachmentDescriptor[] {
+    return this.attachments.map(toDescriptor);
+  }
+
+  /** Dedup by key — re-attaching the same workspace refreshes the stored
+   *  label/name in place rather than appending a duplicate row. */
+  add(descriptor: RemoteAttachmentDescriptor): void {
+    const entry = toDescriptor(descriptor);
+    const idx = this.attachments.findIndex((a) => a.key === entry.key);
+    const next = [...this.attachments];
+    if (idx === -1) next.push(entry);
+    else next[idx] = entry;
+    this.persist(next);
+    this.attachments = next;
+  }
+
+  remove(key: string): boolean {
+    const next = this.attachments.filter((a) => a.key !== key);
+    if (next.length === this.attachments.length) return false;
+    this.persist(next);
+    this.attachments = next;
+    return true;
+  }
+
+  /** Cascade for host removal — a descriptor pointing at a host that is no
+   *  longer registered can never be restored, so it must not outlive it. */
+  removeByHost(hostId: string): number {
+    const next = this.attachments.filter((a) => a.hostId !== hostId);
+    const removed = this.attachments.length - next.length;
+    if (removed === 0) return 0;
+    this.persist(next);
+    this.attachments = next;
+    return removed;
+  }
+
+  private persist(attachments: RemoteAttachmentDescriptor[]): void {
+    atomicWriteJSONSync(this.filePath, attachments);
+  }
+
+  private load(): void {
+    try {
+      const parsed = atomicReadJSONSync<unknown>(this.filePath);
+      this.attachments = isDescriptorArray(parsed) ? parsed.map(toDescriptor) : [];
+    } catch {
+      // Missing/corrupt file → empty list, never throw (load-on-construct
+      // contract, same as RemoteHostsStore).
+      this.attachments = [];
+    }
+  }
+}

--- a/src/main/remote/RemoteHostClient.ts
+++ b/src/main/remote/RemoteHostClient.ts
@@ -10,7 +10,12 @@
 // endpoint on the remote host.
 
 import * as crypto from 'crypto';
-import type { RemoteHost, RemoteWorkspacesResponse } from '../../shared/remoteHosts';
+import type {
+  RemoteHost,
+  RemotePaneSummary,
+  RemoteWorkspaceSummary,
+  RemoteWorkspacesResponse,
+} from '../../shared/remoteHosts';
 
 export interface RemoteMetaEvent {
   attachId: string;
@@ -98,6 +103,44 @@ function backoffForAttempt(attempt: number): number {
   return jitteredDelay(step);
 }
 
+/** `/api/workspaces` is a trust boundary: the body is produced by ANOTHER
+ *  machine, possibly running an older or misbehaving build, and nothing but a
+ *  TypeScript cast stood between it and callers that do `.find()` / `.map()`
+ *  on it. A single malformed body used to throw far downstream and take a
+ *  whole refresh round — every other host in it — with it.
+ *
+ *  So: normalise here, once, where every caller benefits. Anything that does
+ *  not match the declared shape is DROPPED rather than passed on; a workspace
+ *  with no usable id, or a pane with no sessionId, cannot be addressed anyway. */
+function normalizeWorkspaces(body: unknown): RemoteWorkspaceSummary[] {
+  if (typeof body !== 'object' || body === null) return [];
+  const list = (body as { workspaces?: unknown }).workspaces;
+  if (!Array.isArray(list)) return [];
+
+  const workspaces: RemoteWorkspaceSummary[] = [];
+  for (const rawWs of list) {
+    if (typeof rawWs !== 'object' || rawWs === null) continue;
+    const ws = rawWs as Record<string, unknown>;
+    if (typeof ws.id !== 'string' || !ws.id) continue;
+
+    const panes: RemotePaneSummary[] = [];
+    if (Array.isArray(ws.panes)) {
+      for (const rawPane of ws.panes) {
+        if (typeof rawPane !== 'object' || rawPane === null) continue;
+        const pane = rawPane as Record<string, unknown>;
+        if (typeof pane.sessionId !== 'string' || !pane.sessionId) continue;
+        panes.push({
+          sessionId: pane.sessionId,
+          ...(typeof pane.shell === 'string' ? { shell: pane.shell } : {}),
+          ...(typeof pane.cwd === 'string' ? { cwd: pane.cwd } : {}),
+        });
+      }
+    }
+    workspaces.push({ id: ws.id, name: typeof ws.name === 'string' ? ws.name : '', panes });
+  }
+  return workspaces;
+}
+
 export class RemoteHostClient implements RemotePaneEvents {
   private readonly host: RemoteHost;
   private readonly fetchImpl: typeof fetch;
@@ -143,7 +186,13 @@ export class RemoteHostClient implements RemotePaneEvents {
     if (!res.ok) {
       throw new Error(`listWorkspaces failed: HTTP ${res.status}`);
     }
-    return (await res.json()) as RemoteWorkspacesResponse;
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      throw new Error('listWorkspaces failed: response body was not JSON');
+    }
+    return { workspaces: normalizeWorkspaces(body) };
   }
 
   attach(sessionId: string): string {

--- a/src/main/remote/__tests__/RemoteAttachmentsStore.test.ts
+++ b/src/main/remote/__tests__/RemoteAttachmentsStore.test.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RemoteAttachmentsStore } from '../RemoteAttachmentsStore';
+import type { RemoteAttachmentDescriptor } from '../../../shared/remoteHosts';
+
+function descriptor(overrides: Partial<RemoteAttachmentDescriptor> = {}): RemoteAttachmentDescriptor {
+  return {
+    key: 'h1:ws-1',
+    hostId: 'h1',
+    hostLabel: 'office-mac',
+    workspaceId: 'ws-1',
+    name: 'Remote WS',
+    ...overrides,
+  };
+}
+
+describe('RemoteAttachmentsStore', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-remote-attachments-'));
+    filePath = path.join(dir, 'remote-attachments.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('add → list roundtrips across a fresh construct (survives restart)', () => {
+    const store = new RemoteAttachmentsStore(filePath);
+    store.add(descriptor());
+    store.add(descriptor({ key: 'h1:ws-2', workspaceId: 'ws-2', name: 'Second' }));
+
+    // A second construct reads what the first wrote — this is the reload /
+    // app-restart path the renderer's boot restore depends on.
+    const reloaded = new RemoteAttachmentsStore(filePath);
+    expect(reloaded.list()).toEqual([
+      descriptor(),
+      descriptor({ key: 'h1:ws-2', workspaceId: 'ws-2', name: 'Second' }),
+    ]);
+  });
+
+  it('never persists a pane list, even when handed one', () => {
+    const store = new RemoteAttachmentsStore(filePath);
+    store.add({
+      ...descriptor(),
+      // Callers may hand over a full AttachedRemoteWorkspace shape.
+      panes: [{ sessionId: 's1' }],
+    } as RemoteAttachmentDescriptor & { panes: unknown });
+
+    expect(store.list()[0]).toEqual(descriptor());
+    const onDisk = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown[];
+    expect(onDisk[0]).toEqual(descriptor());
+  });
+
+  it('add dedups by key and refreshes the stored snapshot in place', () => {
+    const store = new RemoteAttachmentsStore(filePath);
+    store.add(descriptor());
+    store.add(descriptor({ name: 'Renamed', hostLabel: 'renamed-host' }));
+
+    expect(store.list()).toHaveLength(1);
+    expect(store.list()[0].name).toBe('Renamed');
+    expect(store.list()[0].hostLabel).toBe('renamed-host');
+  });
+
+  it('remove drops one key and reports whether it existed', () => {
+    const store = new RemoteAttachmentsStore(filePath);
+    store.add(descriptor());
+    expect(store.remove('h1:missing')).toBe(false);
+    expect(store.remove('h1:ws-1')).toBe(true);
+    expect(store.list()).toHaveLength(0);
+    expect(new RemoteAttachmentsStore(filePath).list()).toHaveLength(0);
+  });
+
+  it('removeByHost drops every descriptor for that host and leaves others', () => {
+    const store = new RemoteAttachmentsStore(filePath);
+    store.add(descriptor());
+    store.add(descriptor({ key: 'h1:ws-2', workspaceId: 'ws-2' }));
+    store.add(descriptor({ key: 'h2:ws-9', hostId: 'h2', workspaceId: 'ws-9' }));
+
+    expect(store.removeByHost('h1')).toBe(2);
+    expect(store.list().map((a) => a.key)).toEqual(['h2:ws-9']);
+    expect(store.removeByHost('h-none')).toBe(0);
+  });
+
+  it('tolerates a corrupt file on construct', () => {
+    fs.writeFileSync(filePath, '{ not json at all');
+    const store = new RemoteAttachmentsStore(filePath);
+    expect(store.list()).toEqual([]);
+    // And is still writable afterwards.
+    store.add(descriptor());
+    expect(new RemoteAttachmentsStore(filePath).list()).toHaveLength(1);
+  });
+
+  it('tolerates a structurally foreign file on construct', () => {
+    fs.writeFileSync(filePath, JSON.stringify([{ key: 1, hostId: null }]));
+    expect(new RemoteAttachmentsStore(filePath).list()).toEqual([]);
+  });
+
+  it('treats a missing file as an empty list', () => {
+    expect(new RemoteAttachmentsStore(path.join(dir, 'nope.json')).list()).toEqual([]);
+  });
+});

--- a/src/main/remote/__tests__/RemoteHostClient.test.ts
+++ b/src/main/remote/__tests__/RemoteHostClient.test.ts
@@ -94,6 +94,52 @@ describe('RemoteHostClient', () => {
       expect(init?.redirect).toBe('error');
       expect(init?.signal).toBeInstanceOf(AbortSignal);
     });
+
+    // Finding 3 — the body comes off ANOTHER machine. It used to be handed on
+    // with nothing but a cast, so a shape the remote had no business sending
+    // threw far downstream and took a whole refresh round with it.
+    describe('normalises an untrustworthy body', () => {
+      function clientFor(body: unknown): RemoteHostClient {
+        const fetchImpl = vi.fn(async () => ({ ok: true, status: 200, json: async () => body }) as unknown as Response);
+        return new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+      }
+
+      it('turns a non-array `workspaces` into an empty list', async () => {
+        await expect(clientFor({ workspaces: null }).listWorkspaces()).resolves.toEqual({ workspaces: [] });
+        await expect(clientFor({ workspaces: 'nope' }).listWorkspaces()).resolves.toEqual({ workspaces: [] });
+        await expect(clientFor({}).listWorkspaces()).resolves.toEqual({ workspaces: [] });
+        await expect(clientFor(null).listWorkspaces()).resolves.toEqual({ workspaces: [] });
+      });
+
+      it('turns a null pane list into an empty one', async () => {
+        await expect(clientFor({ workspaces: [{ id: 'w1', name: 'proj', panes: null }] }).listWorkspaces())
+          .resolves.toEqual({ workspaces: [{ id: 'w1', name: 'proj', panes: [] }] });
+      });
+
+      it('drops entries that cannot be addressed and keeps the rest', async () => {
+        const body = {
+          workspaces: [
+            null,
+            { name: 'no id', panes: [] },
+            { id: '', panes: [] },
+            { id: 'w1', panes: [{ sessionId: 's1', shell: 'zsh' }, { shell: 'no session id' }, 42] },
+          ],
+        };
+        await expect(clientFor(body).listWorkspaces()).resolves.toEqual({
+          workspaces: [{ id: 'w1', name: '', panes: [{ sessionId: 's1', shell: 'zsh' }] }],
+        });
+      });
+
+      it('rejects a body that is not JSON at all', async () => {
+        const fetchImpl = vi.fn(async () => ({
+          ok: true,
+          status: 200,
+          json: async () => { throw new SyntaxError('Unexpected token <'); },
+        }) as unknown as Response);
+        const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+        await expect(client.listWorkspaces()).rejects.toThrow(/not JSON/);
+      });
+    });
   });
 
   describe('attach', () => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -29,7 +29,7 @@ import type {
   WebStartArgs,
   WebTerminalInfo,
 } from '../shared/web';
-import type { PairFailureReason, RemoteHostPublic, RemoteWorkspaceSummary } from '../shared/remoteHosts';
+import type { PairFailureReason, RemoteAttachmentDescriptor, RemoteHostPublic, RemoteWorkspaceSummary } from '../shared/remoteHosts';
 
 /** Mirrors {@link McpStatusPayload} in src/main/ipc/handlers/mcp.handler.ts. */
 export interface McpTargetStatusPayload {
@@ -1240,6 +1240,12 @@ document.addEventListener('DOMContentLoaded', () => {
     ipcRenderer.invoke(IPC.REMOTE_WORKSPACES_LIST, hostId) as Promise<
       { ok: true; workspaces: RemoteWorkspaceSummary[] } | { ok: false; error: string }
     >,
+  attachmentsList: () =>
+    ipcRenderer.invoke(IPC.REMOTE_ATTACHMENTS_LIST) as Promise<RemoteAttachmentDescriptor[]>,
+  attachmentsAdd: (descriptor: RemoteAttachmentDescriptor) =>
+    ipcRenderer.invoke(IPC.REMOTE_ATTACHMENTS_ADD, descriptor) as Promise<boolean>,
+  attachmentsRemove: (key: string) =>
+    ipcRenderer.invoke(IPC.REMOTE_ATTACHMENTS_REMOVE, key) as Promise<boolean>,
   paneAttach: (hostId: string, sessionId: string) =>
     ipcRenderer.invoke(IPC.REMOTE_PANE_ATTACH, hostId, sessionId) as Promise<
       { ok: true; attachId: string } | { ok: false; error: string }

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -46,6 +46,7 @@ import { useWorkspaceMirrorPush } from '../../hooks/useWorkspaceMirrorPush';
 import { useResizeGuard } from '../../hooks/useResizeGuard';
 import { useApprovalInboxBridge } from '../../hooks/useApprovalInboxBridge';
 import { useRemoteInboxBridge } from '../../hooks/useRemoteInboxBridge';
+import { useRemoteAttachmentsLifecycle } from '../../hooks/useRemoteAttachmentsLifecycle';
 import { useDeckStream } from '../../hooks/useDeckStream';
 import { useChannelsEventSubscription } from '../../hooks/useChannelsEventSubscription';
 import { useChannelsHydration } from '../../hooks/useChannelsHydration';
@@ -386,6 +387,10 @@ export default function AppLayout() {
   // LanLink PR-2 — own the remote-inbox subscription (always-on, mounted once)
   // so remote peer messages accumulate in the store before any surface opens.
   useRemoteInboxBridge();
+  // Remote workspace attach — restore persisted attachments on boot (the slice
+  // is memory-only, so a reload wipes it) and keep each mirror's pane set in
+  // sync with the remote (exit events + a 10s safety-net poll).
+  useRemoteAttachmentsLifecycle();
   // Command Deck Phase 2 — own the Commander brain stream subscription
   // (always-on, mounted once) so orchestrator turn events land in deckSlice even
   // when the dock or the Commander tab is not visible.

--- a/src/renderer/components/Remote/RemoteWorkspaceView.tsx
+++ b/src/renderer/components/Remote/RemoteWorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { useT } from '../../hooks/useT';
 import type { AttachedRemoteWorkspace } from '../../stores/slices/remoteWorkspacesSlice';
 import type { RemotePaneSummary } from '../../../shared/remoteHosts';
@@ -18,28 +18,63 @@ function gridStyle(count: number): CSSProperties {
 
 /** One pane cell: owns the paneAttach call (and its resulting attachId), the
  *  shell/cwd caption, and the mirror terminal itself. Attach is idempotent in
- *  main, so a StrictMode double-effect here is harmless. */
-function PaneCell({ hostId, pane, readOnly }: { hostId: string; pane: RemotePaneSummary; readOnly: boolean }) {
+ *  main, so a StrictMode double-effect here is harmless.
+ *
+ *  `attachEpoch` re-runs the attach without changing the cell's React key. A
+ *  host that slept past RemoteHostClient's reconnect budget comes back with
+ *  the SAME remote sessionIds, so nothing in the pane list changes and this
+ *  effect would never fire again — the mirror would sit blank forever with no
+ *  visible error. The epoch is bumped by the store whenever `stale` clears. */
+function PaneCell({ hostId, pane, readOnly, attachEpoch }: {
+  hostId: string;
+  pane: RemotePaneSummary;
+  readOnly: boolean;
+  attachEpoch: number | undefined;
+}) {
   const [attachId, setAttachId] = useState<string | null>(null);
   const [error, setError] = useState<string | undefined>(undefined);
+  /** The previous run's detach. Main keys attach idempotency on
+   *  (sender, host, session), so the old and the new attach are the SAME
+   *  record: if the re-attach reached main first it would be handed the dying
+   *  attachId, and the detach behind it would then kill the stream we had just
+   *  asked for. Waiting on this makes the order teardown-then-attach. */
+  const teardown = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
     let cancelled = false;
     const remote = window.electronAPI?.remote;
     if (!remote) return;
-    remote.paneAttach(hostId, pane.sessionId).then((res) => {
-      if (cancelled) return;
-      if (res.ok) setAttachId(res.attachId);
-      else setError(res.error);
-    }).catch((err: unknown) => {
-      // Unexpected IPC rejection (not the {ok:false} result path) — surface
-      // it the same way a rejected attach result does, rather than leaving
-      // this cell silently stuck with attachId: null forever.
-      if (cancelled) return;
-      setError(err instanceof Error ? err.message : String(err));
-    });
-    return () => { cancelled = true; };
-  }, [hostId, pane.sessionId]);
+    setAttachId(null);
+    setError(undefined);
+    let openedId: string | null = null;
+
+    const attaching = teardown.current
+      .then(() => remote.paneAttach(hostId, pane.sessionId))
+      .then((res) => {
+        if (res.ok) {
+          openedId = res.attachId;
+          if (!cancelled) setAttachId(res.attachId);
+        } else if (!cancelled) {
+          setError(res.error);
+        }
+      })
+      .catch((err: unknown) => {
+        // Unexpected IPC rejection (not the {ok:false} result path) — surface
+        // it the same way a rejected attach result does, rather than leaving
+        // this cell silently stuck with attachId: null forever.
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+
+    return () => {
+      cancelled = true;
+      // Panes now come and go with the poll, so a cell can unmount while its
+      // attach is still in flight. Chaining the detach onto the attach is what
+      // stops that from leaving a live SSE stream behind in main.
+      teardown.current = attaching
+        .then(() => (openedId ? remote.paneDetach(openedId) : undefined))
+        .catch(() => { /* teardown is best effort — main drops it on reload anyway */ });
+    };
+  }, [hostId, pane.sessionId, attachEpoch]);
 
   return (
     <div className="flex flex-col min-h-0 min-w-0" style={{ background: 'var(--bg-base)' }}>
@@ -64,6 +99,13 @@ function PaneCell({ hostId, pane, readOnly }: { hostId: string; pane: RemotePane
  * technique WorkspaceViewport uses for local workspaces. Unmounting on every
  * sidebar switch would re-attach every SSE stream and repaint the full
  * snapshot each time.
+ *
+ * Known cost of that rule now that attachments are restored on boot: launching
+ * the app alone opens up to MAX_MIRRORS authenticated streams per restored
+ * workspace, before the user has selected any of them. Attaching lazily on
+ * first selection would fix it, but it is a change to the mount contract this
+ * view shares with WorkspaceCenter, not a tweak here — deliberately left out
+ * of the lifecycle fix.
  */
 export default function RemoteWorkspaceView({ workspace }: { workspace: AttachedRemoteWorkspace }) {
   const t = useT();
@@ -103,7 +145,13 @@ export default function RemoteWorkspaceView({ workspace }: { workspace: Attached
         style={{ display: 'grid', ...gridStyle(visiblePanes.length), gap: '2px', background: 'var(--bg-surface)' }}
       >
         {visiblePanes.map((pane) => (
-          <PaneCell key={pane.sessionId} hostId={workspace.hostId} pane={pane} readOnly={allowInput === false} />
+          <PaneCell
+            key={pane.sessionId}
+            hostId={workspace.hostId}
+            pane={pane}
+            readOnly={allowInput === false}
+            attachEpoch={workspace.attachEpoch}
+          />
         ))}
       </div>
       {hiddenCount > 0 && (

--- a/src/renderer/components/Remote/__tests__/RemoteWorkspaceView.attach.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteWorkspaceView.attach.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// PaneCell's attach lifecycle. The mirror terminal itself is stubbed out —
+// what is under test here is WHEN main is asked to attach and detach, which is
+// what findings 2 and 8 are about, not anything xterm renders.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import RemoteWorkspaceView from '../RemoteWorkspaceView';
+import type { AttachedRemoteWorkspace } from '../../../stores/slices/remoteWorkspacesSlice';
+
+vi.mock('../RemoteMirrorTerminal', () => ({
+  default: ({ attachId }: { attachId: string | null }) =>
+    React.createElement('div', { 'data-attach-id': attachId ?? '' }),
+}));
+
+vi.mock('../../../hooks/useT', () => ({ useT: () => (k: string) => k }));
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let paneAttach: ReturnType<typeof vi.fn>;
+let paneDetach: ReturnType<typeof vi.fn>;
+/** Every attachId main has handed out, so a test can tell a re-attach from a
+ *  handed-back idempotent one. */
+let nextAttachId: number;
+
+function installElectronApi(opts: { attachImpl?: () => Promise<unknown> } = {}): void {
+  nextAttachId = 0;
+  paneAttach = vi.fn(opts.attachImpl ?? (async () => {
+    nextAttachId += 1;
+    return { ok: true as const, attachId: `att-${nextAttachId}` };
+  }));
+  paneDetach = vi.fn(async () => undefined);
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    remote: {
+      paneAttach,
+      paneDetach,
+      hostsList: vi.fn(async () => [{ id: 'h1', label: 'office-mac', origin: 'https://x', addedAt: 0, allowInput: true }]),
+    },
+  };
+}
+
+function workspace(overrides: Partial<AttachedRemoteWorkspace> = {}): AttachedRemoteWorkspace {
+  return {
+    key: 'h1:ws-1',
+    hostId: 'h1',
+    hostLabel: 'office-mac',
+    workspaceId: 'ws-1',
+    name: 'Remote WS',
+    panes: [{ sessionId: 's1' }],
+    ...overrides,
+  };
+}
+
+function render(w: AttachedRemoteWorkspace): void {
+  act(() => { root.render(React.createElement(RemoteWorkspaceView, { workspace: w })); });
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 6; i += 1) await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe('RemoteWorkspaceView — PaneCell attach lifecycle', () => {
+  it('attaches once per pane on mount', async () => {
+    installElectronApi();
+    render(workspace());
+    await settle();
+
+    expect(paneAttach).toHaveBeenCalledTimes(1);
+    expect(paneAttach).toHaveBeenCalledWith('h1', 's1');
+    expect(container.querySelector('[data-attach-id="att-1"]')).not.toBeNull();
+  });
+
+  // Finding 2 — the pane list is byte-identical when a slept host returns,
+  // so the epoch is the only thing that can trigger a re-attach.
+  it('re-attaches when attachEpoch changes even though the panes did not', async () => {
+    installElectronApi();
+    render(workspace({ attachEpoch: undefined }));
+    await settle();
+    expect(paneAttach).toHaveBeenCalledTimes(1);
+
+    render(workspace({ attachEpoch: 1 }));
+    await settle();
+
+    expect(paneAttach).toHaveBeenCalledTimes(2);
+    // The dead stream is torn down BEFORE the new one is asked for: main keys
+    // attach idempotency on (sender, host, session), so the reverse order
+    // would hand back the dying attachId and then kill it.
+    expect(paneDetach).toHaveBeenCalledWith('att-1');
+    expect(paneDetach.mock.invocationCallOrder[0])
+      .toBeLessThan(paneAttach.mock.invocationCallOrder[1]);
+    expect(container.querySelector('[data-attach-id="att-2"]')).not.toBeNull();
+  });
+
+  it('does not re-attach when the epoch is unchanged', async () => {
+    installElectronApi();
+    render(workspace({ attachEpoch: 3 }));
+    await settle();
+    render(workspace({ attachEpoch: 3, name: 'Renamed' }));
+    await settle();
+
+    expect(paneAttach).toHaveBeenCalledTimes(1);
+    expect(paneDetach).not.toHaveBeenCalled();
+  });
+
+  // Finding 8 — panes now come and go with the poll, so a cell can disappear
+  // while its attach is still in flight.
+  it('detaches a pane that vanishes from the workspace', async () => {
+    installElectronApi();
+    render(workspace({ panes: [{ sessionId: 's1' }, { sessionId: 's2' }] }));
+    await settle();
+    expect(paneAttach).toHaveBeenCalledTimes(2);
+
+    render(workspace({ panes: [{ sessionId: 's1' }] }));
+    await settle();
+
+    expect(paneDetach).toHaveBeenCalledTimes(1);
+    expect(paneDetach).toHaveBeenCalledWith('att-2');
+  });
+
+  it('detaches an attachId that only lands AFTER the pane is gone', async () => {
+    let releaseAttach: (v: { ok: true; attachId: string }) => void = () => { /* set below */ };
+    installElectronApi({
+      attachImpl: () => new Promise((resolve) => { releaseAttach = resolve as typeof releaseAttach; }),
+    });
+    render(workspace());
+    await settle();
+    expect(paneAttach).toHaveBeenCalledTimes(1);
+
+    // The pane closes on the remote before main has answered the attach.
+    render(workspace({ panes: [] }));
+    await settle();
+    expect(paneDetach).not.toHaveBeenCalled();
+
+    releaseAttach({ ok: true, attachId: 'att-late' });
+    await settle();
+
+    // Without chaining, that stream would stay open in main forever.
+    expect(paneDetach).toHaveBeenCalledWith('att-late');
+  });
+
+  it('surfaces an attach failure instead of leaving the cell blank', async () => {
+    installElectronApi({ attachImpl: async () => ({ ok: false as const, error: 'unknown host' }) });
+    render(workspace());
+    await settle();
+
+    expect(paneDetach).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-attach-id=""]')).not.toBeNull();
+  });
+});

--- a/src/renderer/components/Sidebar/AttachRemoteModal.tsx
+++ b/src/renderer/components/Sidebar/AttachRemoteModal.tsx
@@ -6,6 +6,7 @@ import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
+import { remoteAttachmentKey } from '../../../shared/remoteHosts';
 import type { PairFailureReason, RemoteHostPublic, RemoteWorkspaceSummary } from '../../../shared/remoteHosts';
 
 type AddHostMode = 'pair' | 'url';
@@ -208,6 +209,11 @@ export default function AttachRemoteModal({ onClose }: AttachRemoteModalProps) {
     if (!remote) return;
     try {
       await remote.hostsRemove(hostId);
+      // Main cascades the persisted descriptors, but the renderer's mirrors
+      // are memory-only: without this they stay in the sidebar for the rest of
+      // the session and fail every poll as an unknown host.
+      const orphans = useStore.getState().remoteWorkspaces.filter((w) => w.hostId === hostId);
+      for (const w of orphans) useStore.getState().detachRemoteWorkspace(w.key);
     } finally {
       if (selectedHostId === hostId) {
         setSelectedHostId(null);
@@ -222,7 +228,7 @@ export default function AttachRemoteModal({ onClose }: AttachRemoteModalProps) {
     const host = hosts.find((h) => h.id === selectedHostId);
     if (!host) return;
     attachRemoteWorkspace({
-      key: `${host.id}:${ws.id}`,
+      key: remoteAttachmentKey(host.id, ws.id),
       hostId: host.id,
       hostLabel: host.label,
       workspaceId: ws.id,

--- a/src/renderer/components/Sidebar/RemoteWorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/RemoteWorkspaceItem.tsx
@@ -58,13 +58,20 @@ export default function RemoteWorkspaceItem({ workspace, isActive, onSelect, onD
         <div className="flex min-w-0 items-center gap-2">
           <div
             className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-            style={{ backgroundColor: isActive ? 'var(--accent)' : 'var(--text-muted)' }}
+            style={{ backgroundColor: isActive && !workspace.stale ? 'var(--accent)' : 'var(--text-muted)' }}
           />
           <div className="flex-1 min-w-0">
             <div className="text-caption font-mono truncate">
               {workspace.name || workspace.workspaceId.slice(0, 8)}
             </div>
-            <div className="text-[10px] font-mono truncate" style={{ color: 'var(--accent)' }}>
+            {/* A stale entry is unreachable, not gone: it keeps its row (only
+                the user detaches) but drops the live accent colour and says
+                why on hover. */}
+            <div
+              className="text-[10px] font-mono truncate"
+              style={{ color: workspace.stale ? 'var(--text-muted)' : 'var(--accent)' }}
+              title={workspace.stale ? t('remote.disconnected') : undefined}
+            >
               {workspace.hostLabel}
             </div>
           </div>

--- a/src/renderer/components/Sidebar/__tests__/AttachRemoteModal.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/AttachRemoteModal.test.tsx
@@ -204,6 +204,32 @@ describe('AttachRemoteModal', () => {
     unmount();
   });
 
+  // Finding 5 — main cascades the persisted descriptors, but the renderer's
+  // mirrors are memory-only: they used to stay in the sidebar for the rest of
+  // the session, failing every poll as an unknown host.
+  it('drops the removed host\'s mirrors from the sidebar', async () => {
+    useStore.setState({
+      remoteWorkspaces: [
+        { key: 'host-1:ws-abcdef12', hostId: 'host-1', hostLabel: 'office-mac', workspaceId: 'ws-abcdef12', name: 'my-project', panes: [] },
+        { key: 'host-2:ws-other', hostId: 'host-2', hostLabel: 'other-box', workspaceId: 'ws-other', name: 'other', panes: [] },
+      ],
+      activeRemoteKey: 'host-1:ws-abcdef12',
+    });
+
+    const { container, unmount } = render(<AttachRemoteModal onClose={() => { /* noop */ }} />);
+    await flush();
+
+    hostsList.mockResolvedValue([]);
+    const removeButton = container.querySelector('button[aria-label="Remove host"]') as HTMLButtonElement;
+    act(() => { removeButton.click(); });
+    await flush();
+
+    expect(useStore.getState().remoteWorkspaces.map((w) => w.key)).toEqual(['host-2:ws-other']);
+    expect(useStore.getState().activeRemoteKey).toBeNull();
+
+    unmount();
+  });
+
   // m9 — a stale-response race: select host A then host B before A's
   // workspacesList resolves. A resolving last must not clobber B's list
   // while B is still the selected host.

--- a/src/renderer/hooks/__tests__/useRemoteAttachmentsLifecycle.dynamic.test.tsx
+++ b/src/renderer/hooks/__tests__/useRemoteAttachmentsLifecycle.dynamic.test.tsx
@@ -32,21 +32,35 @@ interface RemoteApiStub {
 
 let api: RemoteApiStub;
 
+/** A promise the test resolves by hand — models a host that has not answered
+ *  yet (an asleep laptop burns the full request timeout before it fails). */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ListResult = any;
+
 function installElectronApi(opts: {
   descriptors?: RemoteAttachmentDescriptor[];
   workspaces?: RemoteWorkspaceSummary[];
   listFails?: boolean;
+  /** Full control over the per-host answer, for the multi-host cases. */
+  listImpl?: (hostId: string) => Promise<ListResult>;
+  attachmentsListImpl?: () => Promise<RemoteAttachmentDescriptor[]>;
 } = {}): void {
   exitCb = undefined;
   exitUnsub = vi.fn();
   api = {
-    attachmentsList: vi.fn(async () => opts.descriptors ?? []),
+    attachmentsList: vi.fn(opts.attachmentsListImpl ?? (async () => opts.descriptors ?? [])),
     attachmentsAdd: vi.fn(async () => true),
     attachmentsRemove: vi.fn(async () => true),
-    workspacesList: vi.fn(async () =>
+    workspacesList: vi.fn(opts.listImpl ?? (async () =>
       opts.listFails
         ? { ok: false as const, error: 'could not reach that host' }
-        : { ok: true as const, workspaces: opts.workspaces ?? [] }),
+        : { ok: true as const, workspaces: opts.workspaces ?? [] })),
     onPaneExit: vi.fn((cb: () => void) => {
       exitCb = cb;
       return exitUnsub;
@@ -94,6 +108,16 @@ function seedAttached(panes: Array<{ sessionId: string }>): void {
     });
   });
 }
+
+/** Descriptor for a SECOND host — the parallelism and one-bad-host cases need
+ *  two machines to have anything to say. */
+const descriptor2: RemoteAttachmentDescriptor = {
+  key: 'h2:ws-2',
+  hostId: 'h2',
+  hostLabel: 'shed-linux',
+  workspaceId: 'ws-2',
+  name: 'Other WS',
+};
 
 beforeEach(() => {
   act(() => {
@@ -164,6 +188,146 @@ describe('useRemoteAttachmentsLifecycle — boot restore', () => {
   });
 });
 
+// Findings 1 and 4 — boot restore is not instantaneous: it waits on hosts that
+// may take a full request timeout to fail, and the user is free to act on the
+// same keys in the meantime.
+describe('useRemoteAttachmentsLifecycle — boot restore races the user', () => {
+  it('shows every row IMMEDIATELY, before any host has answered', async () => {
+    const pendingHost = deferred<ListResult>();
+    installElectronApi({ descriptors: [descriptor], listImpl: () => pendingHost.promise });
+    mount();
+    await settle();
+
+    // The host is still hanging — the sidebar must not be empty for that long.
+    const entries = useStore.getState().remoteWorkspaces;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('Remote WS');
+    expect(entries[0].stale).toBe(true);
+    expect(entries[0].panes).toEqual([]);
+
+    pendingHost.resolve({ ok: true, workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 's1' }] }] });
+    await settle();
+    expect(useStore.getState().remoteWorkspaces[0].panes.map((p) => p.sessionId)).toEqual(['s1']);
+    expect(useStore.getState().remoteWorkspaces[0].stale).toBe(false);
+    unmount();
+  });
+
+  it('queries hosts in PARALLEL, not one timeout after another', async () => {
+    const pending = deferred<ListResult>();
+    installElectronApi({
+      descriptors: [descriptor, descriptor2],
+      listImpl: () => pending.promise,
+    });
+    mount();
+    await settle();
+
+    // Sequentially, the second host would not be contacted until the first
+    // one had answered — which it still has not.
+    expect(api.workspacesList.mock.calls.map((c) => c[0]).sort()).toEqual(['h1', 'h2']);
+    pending.resolve({ ok: true, workspaces: [] });
+    await settle();
+    unmount();
+  });
+
+  it('a manual attach during restore is NOT clobbered by the late restore', async () => {
+    const pendingDescriptors = deferred<RemoteAttachmentDescriptor[]>();
+    installElectronApi({
+      attachmentsListImpl: () => pendingDescriptors.promise,
+      workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 'live' }] }],
+    });
+    mount();
+    await settle();
+
+    // The user attaches the very workspace the restore is about to replay.
+    act(() => {
+      useStore.getState().attachRemoteWorkspace({ ...descriptor, panes: [{ sessionId: 'live' }] });
+    });
+
+    pendingDescriptors.resolve([descriptor]);
+    await settle();
+
+    const entries = useStore.getState().remoteWorkspaces;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].panes.map((p) => p.sessionId)).toEqual(['live']);
+    // The live entry keeps the selection the attach gave it.
+    expect(useStore.getState().activeRemoteKey).toBe('h1:ws-1');
+    unmount();
+  });
+
+  it('a detach during restore is NOT resurrected as a ghost row', async () => {
+    const pendingHost = deferred<ListResult>();
+    installElectronApi({ descriptors: [descriptor], listImpl: () => pendingHost.promise });
+    mount();
+    await settle();
+    expect(useStore.getState().remoteWorkspaces).toHaveLength(1);
+
+    // The user detaches the restored row while the host is still hanging;
+    // main drops the descriptor from disk with it.
+    act(() => { useStore.getState().detachRemoteWorkspace('h1:ws-1'); });
+    expect(useStore.getState().remoteWorkspaces).toHaveLength(0);
+
+    pendingHost.resolve({ ok: true, workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 's1' }] }] });
+    await settle();
+
+    expect(useStore.getState().remoteWorkspaces).toEqual([]);
+    unmount();
+  });
+});
+
+// Finding 3 — /api/workspaces is another machine's answer. A body that does
+// not match the declared shape must cost that host its round, nothing more.
+describe('useRemoteAttachmentsLifecycle — malformed remote responses', () => {
+  it('a non-array `workspaces` does not abort the round for other hosts', async () => {
+    installElectronApi({
+      descriptors: [descriptor, descriptor2],
+      listImpl: async (hostId: string) => (hostId === 'h1'
+        ? { ok: true, workspaces: 'not an array' }
+        : { ok: true, workspaces: [{ id: 'ws-2', name: 'Other WS', panes: [{ sessionId: 'ok' }] }] }),
+    });
+    mount();
+    await settle();
+
+    const byKey = new Map(useStore.getState().remoteWorkspaces.map((w) => [w.key, w]));
+    expect(byKey.get('h1:ws-1')?.stale).toBe(true);
+    expect(byKey.get('h2:ws-2')?.stale).toBe(false);
+    expect(byKey.get('h2:ws-2')?.panes.map((p) => p.sessionId)).toEqual(['ok']);
+    unmount();
+  });
+
+  it('a workspace with a null pane list goes stale instead of throwing', async () => {
+    installElectronApi({
+      descriptors: [descriptor, descriptor2],
+      listImpl: async (hostId: string) => (hostId === 'h1'
+        ? { ok: true, workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: null }] }
+        : { ok: true, workspaces: [{ id: 'ws-2', name: 'Other WS', panes: [{ sessionId: 'ok' }] }] }),
+    });
+    mount();
+    await settle();
+
+    const byKey = new Map(useStore.getState().remoteWorkspaces.map((w) => [w.key, w]));
+    expect(byKey.get('h1:ws-1')?.stale).toBe(true);
+    expect(byKey.get('h2:ws-2')?.panes.map((p) => p.sessionId)).toEqual(['ok']);
+    unmount();
+  });
+
+  it('an IPC rejection for one host leaves the other host restored', async () => {
+    installElectronApi({
+      descriptors: [descriptor, descriptor2],
+      listImpl: async (hostId: string) => {
+        if (hostId === 'h1') throw new Error('channel closed');
+        return { ok: true, workspaces: [{ id: 'ws-2', name: 'Other WS', panes: [{ sessionId: 'ok' }] }] };
+      },
+    });
+    mount();
+    await settle();
+
+    const byKey = new Map(useStore.getState().remoteWorkspaces.map((w) => [w.key, w]));
+    expect(byKey.get('h1:ws-1')?.stale).toBe(true);
+    expect(byKey.get('h2:ws-2')?.panes.map((p) => p.sessionId)).toEqual(['ok']);
+    unmount();
+  });
+});
+
 describe('useRemoteAttachmentsLifecycle — exit-driven refresh', () => {
   it('an exit event refetches and drops the pane that closed', async () => {
     vi.useFakeTimers();
@@ -202,12 +366,16 @@ describe('useRemoteAttachmentsLifecycle — exit-driven refresh', () => {
 });
 
 describe('useRemoteAttachmentsLifecycle — safety-net poll', () => {
-  it('does not poll while nothing is attached', async () => {
+  // Asserting only "workspacesList was never called" would pass even with the
+  // guard deleted — an empty remoteWorkspaces yields no hostIds, so a running
+  // interval would still make no request. Count the TIMER instead.
+  it('arms no interval at all while nothing is attached', async () => {
     vi.useFakeTimers();
     installElectronApi();
     mount();
     await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
 
+    expect(vi.getTimerCount()).toBe(0);
     expect(api.workspacesList).not.toHaveBeenCalled();
     unmount();
   });
@@ -227,19 +395,24 @@ describe('useRemoteAttachmentsLifecycle — safety-net poll', () => {
     unmount();
   });
 
-  it('stops polling once the last attachment is detached', async () => {
+  it('clears the interval on detach and arms exactly one again on re-attach', async () => {
     vi.useFakeTimers();
     installElectronApi({ workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 'a' }] }] });
     mount();
     seedAttached([{ sessionId: 'a' }]);
+    expect(vi.getTimerCount()).toBe(1);
 
     await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
     expect(api.workspacesList).toHaveBeenCalledTimes(1);
 
     act(() => { useStore.getState().detachRemoteWorkspace('h1:ws-1'); });
+    expect(vi.getTimerCount()).toBe(0);
     await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
-
     expect(api.workspacesList).toHaveBeenCalledTimes(1);
+
+    // Re-attaching must leave ONE interval, not stack a second one.
+    seedAttached([{ sessionId: 'a' }]);
+    expect(vi.getTimerCount()).toBe(1);
     unmount();
   });
 
@@ -253,6 +426,49 @@ describe('useRemoteAttachmentsLifecycle — safety-net poll', () => {
 
     expect(useStore.getState().remoteWorkspaces).toHaveLength(1);
     expect(useStore.getState().remoteWorkspaces[0].stale).toBe(true);
+    unmount();
+  });
+
+  // Finding 6 — the SSE layer backs off and eventually gives up; the poll used
+  // to retry a permanently dead host at full rate forever.
+  it('backs a repeatedly failing host off instead of retrying every 10s', async () => {
+    vi.useFakeTimers();
+    installElectronApi({ listFails: true });
+    mount();
+    seedAttached([{ sessionId: 'a' }]);
+
+    // 6 poll ticks. Without backoff that is 6 requests; with it, the delay
+    // doubles from one poll interval after each consecutive failure.
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+    const backedOff = api.workspacesList.mock.calls.length;
+    expect(backedOff).toBeGreaterThan(0);
+    expect(backedOff).toBeLessThan(6);
+    unmount();
+  });
+
+  it('a host that answers again is polled at full rate immediately', async () => {
+    vi.useFakeTimers();
+    let healthy = false;
+    installElectronApi({
+      listImpl: async () => (healthy
+        ? { ok: true, workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 'a' }] }] }
+        : { ok: false, error: 'could not reach that host' }),
+    });
+    mount();
+    seedAttached([{ sessionId: 'a' }]);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+    expect(useStore.getState().remoteWorkspaces[0].stale).toBe(true);
+
+    healthy = true;
+    // Far enough past the first backoff step for the retry to land.
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+    expect(useStore.getState().remoteWorkspaces[0].stale).toBe(false);
+
+    // Backoff cleared: the next two ticks are both requests again.
+    const afterRecovery = api.workspacesList.mock.calls.length;
+    await act(async () => { await vi.advanceTimersByTimeAsync(20_000); });
+    expect(api.workspacesList.mock.calls.length).toBe(afterRecovery + 2);
     unmount();
   });
 });

--- a/src/renderer/hooks/__tests__/useRemoteAttachmentsLifecycle.dynamic.test.tsx
+++ b/src/renderer/hooks/__tests__/useRemoteAttachmentsLifecycle.dynamic.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+//
+// Dynamic verification for useRemoteAttachmentsLifecycle. The restore replay,
+// the exit-driven refetch and the safety-net poll all live INSIDE React
+// effects, so — like useNotificationListener.activity.dynamic.test.tsx — the
+// REAL hook is mounted against the REAL store with a mocked
+// `window.electronAPI.remote`, and the assertions are made on the live store.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useRemoteAttachmentsLifecycle } from '../useRemoteAttachmentsLifecycle';
+import { useStore } from '../../stores';
+import type { RemoteAttachmentDescriptor, RemoteWorkspaceSummary } from '../../../shared/remoteHosts';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+/** The captured REMOTE_PANE_EXIT callback the hook registered at mount. */
+let exitCb: (() => void) | undefined;
+/** Unsubscribe spy for that callback — proves teardown. */
+let exitUnsub: ReturnType<typeof vi.fn>;
+
+interface RemoteApiStub {
+  attachmentsList: ReturnType<typeof vi.fn>;
+  attachmentsAdd: ReturnType<typeof vi.fn>;
+  attachmentsRemove: ReturnType<typeof vi.fn>;
+  workspacesList: ReturnType<typeof vi.fn>;
+  onPaneExit: ReturnType<typeof vi.fn>;
+}
+
+let api: RemoteApiStub;
+
+function installElectronApi(opts: {
+  descriptors?: RemoteAttachmentDescriptor[];
+  workspaces?: RemoteWorkspaceSummary[];
+  listFails?: boolean;
+} = {}): void {
+  exitCb = undefined;
+  exitUnsub = vi.fn();
+  api = {
+    attachmentsList: vi.fn(async () => opts.descriptors ?? []),
+    attachmentsAdd: vi.fn(async () => true),
+    attachmentsRemove: vi.fn(async () => true),
+    workspacesList: vi.fn(async () =>
+      opts.listFails
+        ? { ok: false as const, error: 'could not reach that host' }
+        : { ok: true as const, workspaces: opts.workspaces ?? [] }),
+    onPaneExit: vi.fn((cb: () => void) => {
+      exitCb = cb;
+      return exitUnsub;
+    }),
+  };
+  (window as unknown as { electronAPI: unknown }).electronAPI = { remote: api };
+}
+
+function mount(): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  function Harness(): null {
+    useRemoteAttachmentsLifecycle();
+    return null;
+  }
+  act(() => {
+    root.render(React.createElement(Harness));
+  });
+}
+
+function unmount(): void {
+  act(() => { root.unmount(); });
+  container.remove();
+}
+
+/** Lets the hook's queued promise chain settle inside act(). */
+async function settle(): Promise<void> {
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+const descriptor: RemoteAttachmentDescriptor = {
+  key: 'h1:ws-1',
+  hostId: 'h1',
+  hostLabel: 'office-mac',
+  workspaceId: 'ws-1',
+  name: 'Remote WS',
+};
+
+function seedAttached(panes: Array<{ sessionId: string }>): void {
+  act(() => {
+    useStore.setState((s) => {
+      s.remoteWorkspaces = [{ ...descriptor, panes }];
+      s.activeRemoteKey = null;
+    });
+  });
+}
+
+beforeEach(() => {
+  act(() => {
+    useStore.setState((s) => {
+      s.remoteWorkspaces = [];
+      s.activeRemoteKey = null;
+    });
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('useRemoteAttachmentsLifecycle — boot restore', () => {
+  it('restores a persisted descriptor with FRESHLY fetched panes', async () => {
+    installElectronApi({
+      descriptors: [descriptor],
+      workspaces: [{ id: 'ws-1', name: 'Renamed remotely', panes: [{ sessionId: 's1' }, { sessionId: 's2' }] }],
+    });
+    mount();
+    await settle();
+
+    const entries = useStore.getState().remoteWorkspaces;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].panes.map((p) => p.sessionId)).toEqual(['s1', 's2']);
+    expect(entries[0].name).toBe('Renamed remotely');
+    expect(entries[0].stale).toBe(false);
+    // A restore must not steal the user's current view.
+    expect(useStore.getState().activeRemoteKey).toBeNull();
+    unmount();
+  });
+
+  it('keeps the entry in a stale state when the host is unreachable', async () => {
+    installElectronApi({ descriptors: [descriptor], listFails: true });
+    mount();
+    await settle();
+
+    const entries = useStore.getState().remoteWorkspaces;
+    expect(entries).toHaveLength(1);
+    expect(entries[0].stale).toBe(true);
+    expect(entries[0].panes).toEqual([]);
+    unmount();
+  });
+
+  it('keeps the entry in a stale state when the workspace is gone from the host', async () => {
+    installElectronApi({
+      descriptors: [descriptor],
+      workspaces: [{ id: 'other-ws', name: 'Other', panes: [{ sessionId: 'x' }] }],
+    });
+    mount();
+    await settle();
+
+    expect(useStore.getState().remoteWorkspaces).toHaveLength(1);
+    expect(useStore.getState().remoteWorkspaces[0].stale).toBe(true);
+    unmount();
+  });
+
+  it('makes no host request when nothing was persisted', async () => {
+    installElectronApi({ descriptors: [] });
+    mount();
+    await settle();
+
+    expect(api.workspacesList).not.toHaveBeenCalled();
+    expect(useStore.getState().remoteWorkspaces).toEqual([]);
+    unmount();
+  });
+});
+
+describe('useRemoteAttachmentsLifecycle — exit-driven refresh', () => {
+  it('an exit event refetches and drops the pane that closed', async () => {
+    vi.useFakeTimers();
+    installElectronApi({ workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 'a' }] }] });
+    mount();
+    seedAttached([{ sessionId: 'a' }, { sessionId: 'b' }]);
+    expect(exitCb).toBeTruthy();
+
+    act(() => { exitCb!(); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+
+    expect(useStore.getState().remoteWorkspaces[0].panes.map((p) => p.sessionId)).toEqual(['a']);
+    unmount();
+  });
+
+  it('an exit BURST collapses into a single refetch', async () => {
+    vi.useFakeTimers();
+    installElectronApi({ workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [] }] });
+    mount();
+    seedAttached([{ sessionId: 'a' }, { sessionId: 'b' }, { sessionId: 'c' }]);
+
+    act(() => { exitCb!(); exitCb!(); exitCb!(); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+
+    expect(api.workspacesList).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('unsubscribes the exit listener on unmount', () => {
+    installElectronApi();
+    mount();
+    expect(exitUnsub).not.toHaveBeenCalled();
+    unmount();
+    expect(exitUnsub).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useRemoteAttachmentsLifecycle — safety-net poll', () => {
+  it('does not poll while nothing is attached', async () => {
+    vi.useFakeTimers();
+    installElectronApi();
+    mount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+
+    expect(api.workspacesList).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('polls once attached and picks up a pane OPENED on the remote', async () => {
+    vi.useFakeTimers();
+    installElectronApi({
+      workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 'a' }, { sessionId: 'new' }] }],
+    });
+    mount();
+    seedAttached([{ sessionId: 'a' }]);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+
+    expect(api.workspacesList).toHaveBeenCalledTimes(1);
+    expect(useStore.getState().remoteWorkspaces[0].panes.map((p) => p.sessionId)).toEqual(['a', 'new']);
+    unmount();
+  });
+
+  it('stops polling once the last attachment is detached', async () => {
+    vi.useFakeTimers();
+    installElectronApi({ workspaces: [{ id: 'ws-1', name: 'Remote WS', panes: [{ sessionId: 'a' }] }] });
+    mount();
+    seedAttached([{ sessionId: 'a' }]);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+    expect(api.workspacesList).toHaveBeenCalledTimes(1);
+
+    act(() => { useStore.getState().detachRemoteWorkspace('h1:ws-1'); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+
+    expect(api.workspacesList).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('a failed poll marks the entry stale without dropping it', async () => {
+    vi.useFakeTimers();
+    installElectronApi({ listFails: true });
+    mount();
+    seedAttached([{ sessionId: 'a' }]);
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+
+    expect(useStore.getState().remoteWorkspaces).toHaveLength(1);
+    expect(useStore.getState().remoteWorkspaces[0].stale).toBe(true);
+    unmount();
+  });
+});

--- a/src/renderer/hooks/useRemoteAttachmentsLifecycle.ts
+++ b/src/renderer/hooks/useRemoteAttachmentsLifecycle.ts
@@ -1,6 +1,10 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useStore } from '../stores';
-import type { RemoteAttachmentDescriptor } from '../../shared/remoteHosts';
+import type {
+  RemoteAttachmentDescriptor,
+  RemotePaneSummary,
+  RemoteWorkspaceSummary,
+} from '../../shared/remoteHosts';
 
 // ─── Remote attachment lifecycle ─────────────────────────────────────────────
 //
@@ -12,6 +16,9 @@ import type { RemoteAttachmentDescriptor } from '../../shared/remoteHosts';
 //     trusting anything on disk. A host that cannot be reached, or a workspace
 //     that no longer exists there, is restored in a `stale` state instead of
 //     being dropped — a sleeping laptop must not delete the user's attachment.
+//     Every row appears IMMEDIATELY (stale), before any host is contacted, and
+//     the fetch only fills panes in: an unreachable host costs a full request
+//     timeout, and the sidebar must not sit empty for that long.
 //
 //  ② PANE MEMBERSHIP. The remote wire carries no topology events, so pane
 //     open/close on the remote never reaches us directly. A pane CLOSE does
@@ -21,6 +28,10 @@ import type { RemoteAttachmentDescriptor } from '../../shared/remoteHosts';
 //     refetch-and-diff, and both are debounced/serialised so an exit burst
 //     costs one round of requests. No daemon-side change is involved, so this
 //     keeps working against older remote builds (version skew is real here).
+//
+// Every host in a round is queried in PARALLEL and every response is treated
+// as untrusted: one dead or misbehaving machine must not delay, or abort, the
+// round for the healthy ones.
 //
 // Actions are read via useStore.getState() so the effect deps stay minimal —
 // mirrors useRemoteInboxBridge.
@@ -32,6 +43,72 @@ const REFRESH_DEBOUNCE_MS = 400;
 /** Safety net for pane OPENS, which produce no event on this wire. */
 const POLL_INTERVAL_MS = 10_000;
 
+/** A permanently unreachable host would otherwise be retried at full poll rate
+ *  forever. Consecutive failures back the host off exponentially from one poll
+ *  interval up to this ceiling; the first success clears it. */
+const BACKOFF_MAX_MS = 5 * 60_000;
+
+/** What a host answered in one round. Never a rejection: the body comes off
+ *  another machine, and letting it throw would skip every host queued behind
+ *  it — during boot restore, that means descriptors that never restore at all. */
+type HostResult =
+  | { ok: true; workspaces: RemoteWorkspaceSummary[] }
+  | { ok: false };
+
+interface BackoffEntry {
+  failures: number;
+  nextAttemptAt: number;
+}
+
+type RemoteApi = NonNullable<NonNullable<typeof window.electronAPI>['remote']>;
+
+async function fetchHost(remote: RemoteApi, hostId: string): Promise<HostResult> {
+  let res: Awaited<ReturnType<RemoteApi['workspacesList']>>;
+  try {
+    res = await remote.workspacesList(hostId);
+  } catch {
+    return { ok: false };
+  }
+  if (!res?.ok) return { ok: false };
+  // Defensive even though RemoteHostClient normalises: this is a trust
+  // boundary, and `.find()` on a non-array is a thrown TypeError.
+  return { ok: true, workspaces: Array.isArray(res.workspaces) ? res.workspaces : [] };
+}
+
+/** Applies one host's answer to every attached workspace on it. Reads the
+ *  store fresh: an attach/detach may have landed while the request was in
+ *  flight, and both actions no-op on a key that is no longer there. */
+function applyHostResult(hostId: string, result: HostResult): void {
+  const attached = useStore.getState().remoteWorkspaces.filter((w) => w.hostId === hostId);
+  for (const w of attached) {
+    const found = result.ok
+      ? result.workspaces.find((ws) => ws?.id === w.workspaceId)
+      : undefined;
+    // No workspace, or a malformed one — keep the row, flag it, and let the
+    // user decide. Dropping it would be silent data loss.
+    if (!found || !Array.isArray(found.panes)) {
+      useStore.getState().setRemoteWorkspaceStale(w.key, true);
+      continue;
+    }
+    const panes: RemotePaneSummary[] = found.panes;
+    useStore.getState().setRemoteWorkspacePanes(
+      w.key,
+      panes,
+      typeof found.name === 'string' ? found.name : undefined,
+    );
+  }
+}
+
+function noteHostResult(backoff: Map<string, BackoffEntry>, hostId: string, ok: boolean): void {
+  if (ok) {
+    backoff.delete(hostId);
+    return;
+  }
+  const failures = (backoff.get(hostId)?.failures ?? 0) + 1;
+  const delay = Math.min(POLL_INTERVAL_MS * 2 ** (failures - 1), BACKOFF_MAX_MS);
+  backoff.set(hostId, { failures, nextAttemptAt: Date.now() + delay });
+}
+
 export function useRemoteAttachmentsLifecycle(): void {
   // A refresh round is serialised: while one is in flight, further triggers
   // set `pending` and are coalesced into a single follow-up round.
@@ -39,9 +116,15 @@ export function useRemoteAttachmentsLifecycle(): void {
   const pending = useRef(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const unmounted = useRef(false);
+  /** hostId → when the poll may talk to it again. Entries for hosts nothing is
+   *  attached to any more are dropped each round, so detach + re-attach starts
+   *  from a clean slate. */
+  const backoff = useRef(new Map<string, BackoffEntry>());
 
-  const refreshRef = useRef<() => Promise<void>>(async () => { /* replaced below */ });
-  refreshRef.current = async (): Promise<void> => {
+  // Stable for the renderer's lifetime — it closes over refs only, so the
+  // effects below can depend on it without ever re-subscribing. NEVER rejects:
+  // each host is contained below, so no caller needs a rejection handler.
+  const refresh = useCallback(async (): Promise<void> => {
     if (inFlight.current) {
       pending.current = true;
       return;
@@ -50,44 +133,37 @@ export function useRemoteAttachmentsLifecycle(): void {
     if (!remote) return;
     inFlight.current = true;
     try {
-      const store = useStore.getState();
       // One workspacesList per HOST, not per attached workspace — several
       // mirrors of the same machine share a single round trip.
-      const hostIds = [...new Set(store.remoteWorkspaces.map((w) => w.hostId))];
-      for (const hostId of hostIds) {
-        let res: Awaited<ReturnType<typeof remote.workspacesList>>;
-        try {
-          res = await remote.workspacesList(hostId);
-        } catch (err) {
-          res = { ok: false, error: err instanceof Error ? err.message : String(err) };
-        }
-        if (unmounted.current) return;
-        // Re-read: an attach/detach may have landed while that request was
-        // in flight.
-        const attached = useStore.getState().remoteWorkspaces.filter((w) => w.hostId === hostId);
-        for (const w of attached) {
-          if (!res.ok) {
-            useStore.getState().setRemoteWorkspaceStale(w.key, true);
-            continue;
-          }
-          const found = res.workspaces.find((ws) => ws.id === w.workspaceId);
-          if (!found) {
-            // The workspace is gone from the host (every pane closed) — keep
-            // the row, flag it, and let the user decide.
-            useStore.getState().setRemoteWorkspaceStale(w.key, true);
-            continue;
-          }
-          useStore.getState().setRemoteWorkspacePanes(w.key, found.panes);
-        }
+      const hostIds = [...new Set(useStore.getState().remoteWorkspaces.map((w) => w.hostId))];
+      for (const hostId of [...backoff.current.keys()]) {
+        if (!hostIds.includes(hostId)) backoff.current.delete(hostId);
       }
+      const now = Date.now();
+      const due = hostIds.filter((h) => (backoff.current.get(h)?.nextAttemptAt ?? 0) <= now);
+
+      // PARALLEL: a host that is asleep burns the full request timeout, and
+      // serialising would make every healthy host wait behind it.
+      await Promise.all(due.map(async (hostId) => {
+        try {
+          const result = await fetchHost(remote, hostId);
+          if (unmounted.current) return;
+          noteHostResult(backoff.current, hostId, result.ok);
+          applyHostResult(hostId, result);
+        } catch {
+          // One misbehaving host must never abort the round: the hosts queued
+          // behind it would be skipped, and on boot their descriptors would
+          // never be filled in at all.
+        }
+      }));
     } finally {
       inFlight.current = false;
       if (pending.current && !unmounted.current) {
         pending.current = false;
-        void refreshRef.current();
+        void refresh();
       }
     }
-  };
+  }, []);
 
   // ① Boot restore — once per renderer lifetime.
   useEffect(() => {
@@ -103,44 +179,33 @@ export function useRemoteAttachmentsLifecycle(): void {
       } catch {
         return; // older preload bundle / main not ready — nothing to restore
       }
-      if (cancelled || descriptors.length === 0) return;
+      if (cancelled || !Array.isArray(descriptors) || descriptors.length === 0) return;
 
-      const byHost = new Map<string, RemoteAttachmentDescriptor[]>();
+      // Rows first, panes second. Restore is additive, so a workspace the user
+      // attached (or detached) while attachmentsList was in flight wins.
       for (const d of descriptors) {
-        const list = byHost.get(d.hostId);
-        if (list) list.push(d);
-        else byHost.set(d.hostId, [d]);
+        useStore.getState().restoreRemoteWorkspace({
+          key: d.key,
+          hostId: d.hostId,
+          hostLabel: d.hostLabel,
+          workspaceId: d.workspaceId,
+          name: d.name,
+          // Panes ALWAYS come from the live fetch below, never from disk.
+          panes: [],
+          stale: true,
+        });
       }
-
-      for (const [hostId, group] of byHost) {
-        let res: Awaited<ReturnType<typeof remote.workspacesList>> | null = null;
-        try {
-          res = await remote.workspacesList(hostId);
-        } catch {
-          res = null; // unreachable host → every descriptor on it restores stale
-        }
-        if (cancelled) return;
-        for (const d of group) {
-          const found = res?.ok ? res.workspaces.find((ws) => ws.id === d.workspaceId) : undefined;
-          useStore.getState().restoreRemoteWorkspace({
-            key: d.key,
-            hostId: d.hostId,
-            hostLabel: d.hostLabel,
-            workspaceId: d.workspaceId,
-            name: found?.name ?? d.name,
-            // Panes ALWAYS come from the live fetch, never from disk.
-            panes: found?.panes ?? [],
-            stale: !found,
-          });
-        }
-      }
+      if (cancelled) return;
+      // Exactly the same refetch-and-diff the poll uses — a host that answers
+      // clears `stale` and fills the panes in, one that does not stays stale.
+      await refresh();
     })();
 
     return () => {
       cancelled = true;
       unmounted.current = true;
     };
-  }, []);
+  }, [refresh]);
 
   // ②-a Exit events → debounced refetch. Subscribed once; an exit carries only
   //     an attachId, so the refresh covers every attached host rather than
@@ -152,7 +217,7 @@ export function useRemoteAttachmentsLifecycle(): void {
       if (debounceTimer.current) clearTimeout(debounceTimer.current);
       debounceTimer.current = setTimeout(() => {
         debounceTimer.current = null;
-        void refreshRef.current();
+        void refresh();
       }, REFRESH_DEBOUNCE_MS);
     });
     return () => {
@@ -162,14 +227,14 @@ export function useRemoteAttachmentsLifecycle(): void {
         debounceTimer.current = null;
       }
     };
-  }, []);
+  }, [refresh]);
 
   // ②-b Safety-net poll — armed only while something is attached, so an app
   //     with no mirrors makes no periodic requests at all.
   const hasAttachments = useStore((s) => s.remoteWorkspaces.length > 0);
   useEffect(() => {
     if (!hasAttachments) return;
-    const id = setInterval(() => { void refreshRef.current(); }, POLL_INTERVAL_MS);
+    const id = setInterval(() => { void refresh(); }, POLL_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [hasAttachments]);
+  }, [hasAttachments, refresh]);
 }

--- a/src/renderer/hooks/useRemoteAttachmentsLifecycle.ts
+++ b/src/renderer/hooks/useRemoteAttachmentsLifecycle.ts
@@ -1,0 +1,175 @@
+import { useEffect, useRef } from 'react';
+import { useStore } from '../stores';
+import type { RemoteAttachmentDescriptor } from '../../shared/remoteHosts';
+
+// ─── Remote attachment lifecycle ─────────────────────────────────────────────
+//
+// The SINGLE owner of two things AppLayout has no other place for:
+//
+//  ① RESTORE. remoteWorkspacesSlice is memory-only, so a reload (Cmd+R) or an
+//     app restart recreates it empty. Main persists the descriptors; this hook
+//     replays them on boot, re-fetching each host's CURRENT panes rather than
+//     trusting anything on disk. A host that cannot be reached, or a workspace
+//     that no longer exists there, is restored in a `stale` state instead of
+//     being dropped — a sleeping laptop must not delete the user's attachment.
+//
+//  ② PANE MEMBERSHIP. The remote wire carries no topology events, so pane
+//     open/close on the remote never reaches us directly. A pane CLOSE does
+//     surface indirectly (its PTY dies → SSE exit → REMOTE_PANE_EXIT), which
+//     is used here as a refresh trigger; a pane OPEN produces nothing at all,
+//     which is what the 10s poll is for. Both go through the same
+//     refetch-and-diff, and both are debounced/serialised so an exit burst
+//     costs one round of requests. No daemon-side change is involved, so this
+//     keeps working against older remote builds (version skew is real here).
+//
+// Actions are read via useStore.getState() so the effect deps stay minimal —
+// mirrors useRemoteInboxBridge.
+
+/** An exit burst (a whole remote workspace being closed) must collapse into
+ *  one refetch. */
+const REFRESH_DEBOUNCE_MS = 400;
+
+/** Safety net for pane OPENS, which produce no event on this wire. */
+const POLL_INTERVAL_MS = 10_000;
+
+export function useRemoteAttachmentsLifecycle(): void {
+  // A refresh round is serialised: while one is in flight, further triggers
+  // set `pending` and are coalesced into a single follow-up round.
+  const inFlight = useRef(false);
+  const pending = useRef(false);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const unmounted = useRef(false);
+
+  const refreshRef = useRef<() => Promise<void>>(async () => { /* replaced below */ });
+  refreshRef.current = async (): Promise<void> => {
+    if (inFlight.current) {
+      pending.current = true;
+      return;
+    }
+    const remote = window.electronAPI?.remote;
+    if (!remote) return;
+    inFlight.current = true;
+    try {
+      const store = useStore.getState();
+      // One workspacesList per HOST, not per attached workspace — several
+      // mirrors of the same machine share a single round trip.
+      const hostIds = [...new Set(store.remoteWorkspaces.map((w) => w.hostId))];
+      for (const hostId of hostIds) {
+        let res: Awaited<ReturnType<typeof remote.workspacesList>>;
+        try {
+          res = await remote.workspacesList(hostId);
+        } catch (err) {
+          res = { ok: false, error: err instanceof Error ? err.message : String(err) };
+        }
+        if (unmounted.current) return;
+        // Re-read: an attach/detach may have landed while that request was
+        // in flight.
+        const attached = useStore.getState().remoteWorkspaces.filter((w) => w.hostId === hostId);
+        for (const w of attached) {
+          if (!res.ok) {
+            useStore.getState().setRemoteWorkspaceStale(w.key, true);
+            continue;
+          }
+          const found = res.workspaces.find((ws) => ws.id === w.workspaceId);
+          if (!found) {
+            // The workspace is gone from the host (every pane closed) — keep
+            // the row, flag it, and let the user decide.
+            useStore.getState().setRemoteWorkspaceStale(w.key, true);
+            continue;
+          }
+          useStore.getState().setRemoteWorkspacePanes(w.key, found.panes);
+        }
+      }
+    } finally {
+      inFlight.current = false;
+      if (pending.current && !unmounted.current) {
+        pending.current = false;
+        void refreshRef.current();
+      }
+    }
+  };
+
+  // ① Boot restore — once per renderer lifetime.
+  useEffect(() => {
+    unmounted.current = false;
+    const remote = window.electronAPI?.remote;
+    if (!remote) return;
+    let cancelled = false;
+
+    void (async () => {
+      let descriptors: RemoteAttachmentDescriptor[];
+      try {
+        descriptors = await remote.attachmentsList();
+      } catch {
+        return; // older preload bundle / main not ready — nothing to restore
+      }
+      if (cancelled || descriptors.length === 0) return;
+
+      const byHost = new Map<string, RemoteAttachmentDescriptor[]>();
+      for (const d of descriptors) {
+        const list = byHost.get(d.hostId);
+        if (list) list.push(d);
+        else byHost.set(d.hostId, [d]);
+      }
+
+      for (const [hostId, group] of byHost) {
+        let res: Awaited<ReturnType<typeof remote.workspacesList>> | null = null;
+        try {
+          res = await remote.workspacesList(hostId);
+        } catch {
+          res = null; // unreachable host → every descriptor on it restores stale
+        }
+        if (cancelled) return;
+        for (const d of group) {
+          const found = res?.ok ? res.workspaces.find((ws) => ws.id === d.workspaceId) : undefined;
+          useStore.getState().restoreRemoteWorkspace({
+            key: d.key,
+            hostId: d.hostId,
+            hostLabel: d.hostLabel,
+            workspaceId: d.workspaceId,
+            name: found?.name ?? d.name,
+            // Panes ALWAYS come from the live fetch, never from disk.
+            panes: found?.panes ?? [],
+            stale: !found,
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unmounted.current = true;
+    };
+  }, []);
+
+  // ②-a Exit events → debounced refetch. Subscribed once; an exit carries only
+  //     an attachId, so the refresh covers every attached host rather than
+  //     trying to map it back to one workspace.
+  useEffect(() => {
+    const remote = window.electronAPI?.remote;
+    if (!remote) return;
+    const off = remote.onPaneExit(() => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => {
+        debounceTimer.current = null;
+        void refreshRef.current();
+      }, REFRESH_DEBOUNCE_MS);
+    });
+    return () => {
+      off();
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+        debounceTimer.current = null;
+      }
+    };
+  }, []);
+
+  // ②-b Safety-net poll — armed only while something is attached, so an app
+  //     with no mirrors makes no periodic requests at all.
+  const hasAttachments = useStore((s) => s.remoteWorkspaces.length > 0);
+  useEffect(() => {
+    if (!hasAttachments) return;
+    const id = setInterval(() => { void refreshRef.current(); }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [hasAttachments]);
+}

--- a/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
-import { createRemoteWorkspacesSlice, type RemoteWorkspacesSlice, type AttachedRemoteWorkspace } from '../remoteWorkspacesSlice';
+import { createRemoteWorkspacesSlice, mergePaneSets, type RemoteWorkspacesSlice, type AttachedRemoteWorkspace } from '../remoteWorkspacesSlice';
 import { createWorkspace, type SessionData } from '../../../../shared/types';
 
 // Minimal store: workspaceSlice + remoteWorkspacesSlice only. Mirrors the
@@ -148,5 +148,90 @@ describe('remoteWorkspacesSlice', () => {
       store.getState().loadSession(data);
       expect(store.getState().activeRemoteKey).toBeNull();
     });
+  });
+});
+
+describe('mergePaneSets', () => {
+  const p = (sessionId: string, shell?: string) => ({ sessionId, shell });
+
+  it('drops panes that are gone from the remote', () => {
+    expect(mergePaneSets([p('a'), p('b'), p('c')], [p('a'), p('c')]))
+      .toEqual([p('a'), p('c')]);
+  });
+
+  it('appends newly opened panes at the end', () => {
+    expect(mergePaneSets([p('a'), p('b')], [p('a'), p('b'), p('c')]))
+      .toEqual([p('a'), p('b'), p('c')]);
+  });
+
+  it('keeps existing order when the remote reorders (grid must not shuffle)', () => {
+    expect(mergePaneSets([p('a'), p('b'), p('c')], [p('c'), p('b'), p('a')]))
+      .toEqual([p('a'), p('b'), p('c')]);
+  });
+
+  it('places a new pane after the survivors even when the remote lists it first', () => {
+    expect(mergePaneSets([p('a'), p('b')], [p('new'), p('b')]))
+      .toEqual([p('b'), p('new')]);
+  });
+
+  it('takes fresh field values for panes that survive', () => {
+    expect(mergePaneSets([p('a', 'bash')], [p('a', 'zsh')])).toEqual([p('a', 'zsh')]);
+  });
+});
+
+describe('remoteWorkspacesSlice — live pane membership', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+    store.getState().attachRemoteWorkspace(makeRemote({ panes: [{ sessionId: 'a' }, { sessionId: 'b' }] }));
+  });
+
+  it('setRemoteWorkspacePanes applies a removal and an addition in one update', () => {
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'b' }, { sessionId: 'c' }]);
+    expect(store.getState().remoteWorkspaces[0].panes.map((p) => p.sessionId)).toEqual(['b', 'c']);
+  });
+
+  it('setRemoteWorkspacePanes does not churn the array when nothing changed', () => {
+    const before = store.getState().remoteWorkspaces[0].panes;
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'a' }, { sessionId: 'b' }]);
+    expect(store.getState().remoteWorkspaces[0].panes).toBe(before);
+  });
+
+  it('setRemoteWorkspacePanes ignores an unknown key', () => {
+    store.getState().setRemoteWorkspacePanes('host-1:gone', [{ sessionId: 'z' }]);
+    expect(store.getState().remoteWorkspaces).toHaveLength(1);
+    expect(store.getState().remoteWorkspaces[0].panes).toHaveLength(2);
+  });
+
+  it('a successful pane update clears the stale flag', () => {
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', true);
+    expect(store.getState().remoteWorkspaces[0].stale).toBe(true);
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'a' }, { sessionId: 'b' }]);
+    expect(store.getState().remoteWorkspaces[0].stale).toBe(false);
+  });
+
+  it('setRemoteWorkspaceStale never drops the entry', () => {
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', true);
+    expect(store.getState().remoteWorkspaces).toHaveLength(1);
+    expect(store.getState().activeRemoteKey).toBe('host-1:ws-1');
+  });
+});
+
+describe('remoteWorkspacesSlice — restore', () => {
+  it('restore adds the entry WITHOUT stealing the selection', () => {
+    const store = createTestStore();
+    store.getState().restoreRemoteWorkspace(makeRemote({ stale: true }));
+    expect(store.getState().remoteWorkspaces).toHaveLength(1);
+    expect(store.getState().remoteWorkspaces[0].stale).toBe(true);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+
+  it('restore dedups by key, like attach', () => {
+    const store = createTestStore();
+    store.getState().restoreRemoteWorkspace(makeRemote());
+    store.getState().restoreRemoteWorkspace(makeRemote({ name: 'Renamed' }));
+    expect(store.getState().remoteWorkspaces).toHaveLength(1);
+    expect(store.getState().remoteWorkspaces[0].name).toBe('Renamed');
   });
 });

--- a/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
@@ -177,6 +177,13 @@ describe('mergePaneSets', () => {
   it('takes fresh field values for panes that survive', () => {
     expect(mergePaneSets([p('a', 'bash')], [p('a', 'zsh')])).toEqual([p('a', 'zsh')]);
   });
+
+  // Finding 7 — sessionId is a React key; a remote that repeats one must not
+  // produce two cells under the same key.
+  it('deduplicates a sessionId the remote reported twice', () => {
+    expect(mergePaneSets([], [p('a'), p('b'), p('a')])).toEqual([p('a'), p('b')]);
+    expect(mergePaneSets([p('a'), p('a')], [p('a')])).toEqual([p('a')]);
+  });
 });
 
 describe('remoteWorkspacesSlice — live pane membership', () => {
@@ -216,6 +223,67 @@ describe('remoteWorkspacesSlice — live pane membership', () => {
     expect(store.getState().remoteWorkspaces).toHaveLength(1);
     expect(store.getState().activeRemoteKey).toBe('host-1:ws-1');
   });
+
+  it('setRemoteWorkspacePanes follows a rename on the remote', () => {
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'a' }, { sessionId: 'b' }], 'Renamed there');
+    expect(store.getState().remoteWorkspaces[0].name).toBe('Renamed there');
+  });
+});
+
+// Finding 2 — a host that comes back with UNCHANGED sessionIds produces a
+// byte-identical pane list, so nothing below re-attaches unless the recovery
+// itself is observable. attachEpoch is that signal.
+describe('remoteWorkspacesSlice — attachEpoch (recovery from stale)', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+    store.getState().attachRemoteWorkspace(makeRemote({ panes: [{ sessionId: 'a' }] }));
+  });
+
+  it('does not bump on the first successful fetch of a never-stale entry', () => {
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'a' }]);
+    expect(store.getState().remoteWorkspaces[0].attachEpoch).toBeUndefined();
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', false);
+    expect(store.getState().remoteWorkspaces[0].attachEpoch).toBeUndefined();
+  });
+
+  it('bumps when an unchanged pane set comes back from stale', () => {
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', true);
+    const panesBefore = store.getState().remoteWorkspaces[0].panes;
+
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'a' }]);
+
+    // The pane array is deliberately unchanged — the epoch is the ONLY signal.
+    expect(store.getState().remoteWorkspaces[0].panes).toBe(panesBefore);
+    expect(store.getState().remoteWorkspaces[0].stale).toBe(false);
+    expect(store.getState().remoteWorkspaces[0].attachEpoch).toBe(1);
+  });
+
+  it('bumps again on a second sleep/wake cycle', () => {
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', true);
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', false);
+    expect(store.getState().remoteWorkspaces[0].attachEpoch).toBe(1);
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', true);
+    store.getState().setRemoteWorkspacePanes('host-1:ws-1', [{ sessionId: 'a' }]);
+    expect(store.getState().remoteWorkspaces[0].attachEpoch).toBe(2);
+  });
+
+  it('re-attaching keeps the epoch rather than resetting live mirrors', () => {
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', true);
+    store.getState().setRemoteWorkspaceStale('host-1:ws-1', false);
+    store.getState().attachRemoteWorkspace(makeRemote({ panes: [{ sessionId: 'a' }] }));
+    expect(store.getState().remoteWorkspaces[0].attachEpoch).toBe(1);
+  });
+
+  it('setRemoteWorkspacePanes ignores a non-array pane list from the remote', () => {
+    store.getState().setRemoteWorkspacePanes(
+      'host-1:ws-1',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      null as any,
+    );
+    expect(store.getState().remoteWorkspaces[0].panes.map((p) => p.sessionId)).toEqual(['a']);
+  });
 });
 
 describe('remoteWorkspacesSlice — restore', () => {
@@ -227,11 +295,26 @@ describe('remoteWorkspacesSlice — restore', () => {
     expect(store.getState().activeRemoteKey).toBeNull();
   });
 
-  it('restore dedups by key, like attach', () => {
+  it('restore is a no-op when the key is already present', () => {
     const store = createTestStore();
     store.getState().restoreRemoteWorkspace(makeRemote());
     store.getState().restoreRemoteWorkspace(makeRemote({ name: 'Renamed' }));
     expect(store.getState().remoteWorkspaces).toHaveLength(1);
-    expect(store.getState().remoteWorkspaces[0].name).toBe('Renamed');
+    expect(store.getState().remoteWorkspaces[0].name).toBe('Remote WS');
+  });
+
+  // Finding 1 — boot restore awaits a possibly unreachable host for seconds,
+  // so it can land LONG after the user acted on the same key.
+  it('a late restore never clobbers a live attach', () => {
+    const store = createTestStore();
+    store.getState().attachRemoteWorkspace(makeRemote({ panes: [{ sessionId: 'a' }, { sessionId: 'b' }] }));
+
+    // The restore that was in flight since boot finally lands.
+    store.getState().restoreRemoteWorkspace(makeRemote({ panes: [], stale: true }));
+
+    const entry = store.getState().remoteWorkspaces[0];
+    expect(entry.panes.map((p) => p.sessionId)).toEqual(['a', 'b']);
+    expect(entry.stale).toBeUndefined();
+    expect(store.getState().activeRemoteKey).toBe('host-1:ws-1');
   });
 });

--- a/src/renderer/stores/slices/remoteWorkspacesSlice.ts
+++ b/src/renderer/stores/slices/remoteWorkspacesSlice.ts
@@ -5,12 +5,15 @@
  * persistence can never reach a remote entry by construction — a remote
  * workspace is a live mirror of another host's daemon, not a local pane tree.
  *
- * NOT persisted: attach is per-app-run (re-attach is one click from the host
- * list), so this slice never touches SessionData / loadSession.
+ * This array itself stays out of SessionData / loadSession. What survives a
+ * reload and an app restart is the DESCRIPTOR (no panes), persisted in the
+ * main process by RemoteAttachmentsStore and replayed on boot by
+ * useRemoteAttachmentsLifecycle — the panes are always re-fetched, never
+ * restored from disk.
  */
 import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
-import type { RemotePaneSummary } from '../../../shared/remoteHosts';
+import type { RemoteAttachmentDescriptor, RemotePaneSummary } from '../../../shared/remoteHosts';
 
 export interface AttachedRemoteWorkspace {
   key: string;                    // `${hostId}:${workspaceId}` — selection + dedup key
@@ -18,7 +21,58 @@ export interface AttachedRemoteWorkspace {
   hostLabel: string;
   workspaceId: string;
   name: string;                   // remote name snapshot ('' → UI falls back to workspaceId prefix)
-  panes: RemotePaneSummary[];     // refreshed on re-attach / manual refresh
+  panes: RemotePaneSummary[];     // refreshed on re-attach / exit event / poll
+  /** The host could not be reached, or the workspace is gone from it. The
+   *  entry deliberately STAYS in the sidebar — dropping a user's attachment
+   *  because a laptop slept would be silent data loss — it just renders
+   *  disconnected until a refresh succeeds or the user detaches. */
+  stale?: boolean;
+}
+
+/** Fire-and-forget descriptor persistence. Guarded for the node test
+ *  environment (no `window`) and for a preload without the remote bridge. */
+function persistApi() {
+  if (typeof window === 'undefined') return undefined;
+  return window.electronAPI?.remote;
+}
+
+function toDescriptor(w: AttachedRemoteWorkspace): RemoteAttachmentDescriptor {
+  return {
+    key: w.key,
+    hostId: w.hostId,
+    hostLabel: w.hostLabel,
+    workspaceId: w.workspaceId,
+    name: w.name,
+  };
+}
+
+/** Merges a freshly fetched pane set into the current one with STABLE
+ *  ordering: panes that are still there keep their slot (so the mirror grid
+ *  never reshuffles when an unrelated pane closes), panes that are gone drop
+ *  out, and newly opened panes append at the end. Field updates (shell/cwd)
+ *  from the fetch always win. */
+export function mergePaneSets(
+  current: RemotePaneSummary[],
+  next: RemotePaneSummary[],
+): RemotePaneSummary[] {
+  const nextById = new Map(next.map((p) => [p.sessionId, p]));
+  const kept: RemotePaneSummary[] = [];
+  for (const pane of current) {
+    const fresh = nextById.get(pane.sessionId);
+    if (fresh) kept.push(fresh);
+  }
+  const currentIds = new Set(current.map((p) => p.sessionId));
+  const added = next.filter((p) => !currentIds.has(p.sessionId));
+  return [...kept, ...added];
+}
+
+/** Whether a merge result is indistinguishable from what is already in the
+ *  store — the 10s poll runs forever, so an unchanged fetch must not push a
+ *  new array identity and re-render every mirror. */
+function samePanes(a: RemotePaneSummary[], b: RemotePaneSummary[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((pane, i) =>
+    pane.sessionId === b[i].sessionId && pane.shell === b[i].shell && pane.cwd === b[i].cwd);
 }
 
 export interface RemoteWorkspacesSlice {
@@ -28,10 +82,22 @@ export interface RemoteWorkspacesSlice {
    * activeWorkspaceId — WorkspaceCenter checks this field first. */
   activeRemoteKey: string | null;
   /** Dedup by key (re-attach refreshes the existing entry's snapshot in
-   * place), then select it. */
+   * place), then select it. Also persists the descriptor so the attachment
+   * survives a reload. */
   attachRemoteWorkspace: (w: AttachedRemoteWorkspace) => void;
-  /** Remove the entry; clears activeRemoteKey only if it was the active one. */
+  /** Boot-time replay of a persisted descriptor: adds the entry WITHOUT
+   * selecting it (a restore must not steal the user's view) and without
+   * re-persisting what it just read. */
+  restoreRemoteWorkspace: (w: AttachedRemoteWorkspace) => void;
+  /** Remove the entry AND its persisted descriptor; clears activeRemoteKey
+   * only if it was the active one. */
   detachRemoteWorkspace: (key: string) => void;
+  /** Applies a freshly fetched pane set (exit event / poll) with stable
+   * ordering, and clears `stale` — a successful fetch means reachable. No-ops
+   * when nothing changed. */
+  setRemoteWorkspacePanes: (key: string, panes: RemotePaneSummary[]) => void;
+  /** Marks the entry unreachable (or reachable again) without dropping it. */
+  setRemoteWorkspaceStale: (key: string, stale: boolean) => void;
   /** Selecting a LOCAL workspace calls this with null. */
   setActiveRemoteKey: (key: string | null) => void;
 }
@@ -40,21 +106,52 @@ export const createRemoteWorkspacesSlice: StateCreator<StoreState, [['zustand/im
   remoteWorkspaces: [],
   activeRemoteKey: null,
 
-  attachRemoteWorkspace: (w) => set((state: StoreState) => {
+  attachRemoteWorkspace: (w) => {
+    set((state: StoreState) => {
+      const idx = state.remoteWorkspaces.findIndex((r: AttachedRemoteWorkspace) => r.key === w.key);
+      if (idx === -1) {
+        state.remoteWorkspaces.push(w);
+      } else {
+        state.remoteWorkspaces[idx] = w;
+      }
+      state.activeRemoteKey = w.key;
+    });
+    // Fire-and-forget: a failed write only costs this attachment its
+    // restore-after-reload, and the attach itself has already happened. The
+    // method check covers an older preload bundle without these routes.
+    const api = persistApi();
+    if (api?.attachmentsAdd) void api.attachmentsAdd(toDescriptor(w)).catch(() => { /* see above */ });
+  },
+
+  restoreRemoteWorkspace: (w) => set((state: StoreState) => {
     const idx = state.remoteWorkspaces.findIndex((r: AttachedRemoteWorkspace) => r.key === w.key);
-    if (idx === -1) {
-      state.remoteWorkspaces.push(w);
-    } else {
-      state.remoteWorkspaces[idx] = w;
-    }
-    state.activeRemoteKey = w.key;
+    if (idx === -1) state.remoteWorkspaces.push(w);
+    else state.remoteWorkspaces[idx] = w;
   }),
 
-  detachRemoteWorkspace: (key) => set((state: StoreState) => {
-    const idx = state.remoteWorkspaces.findIndex((r: AttachedRemoteWorkspace) => r.key === key);
-    if (idx === -1) return;
-    state.remoteWorkspaces.splice(idx, 1);
-    if (state.activeRemoteKey === key) state.activeRemoteKey = null;
+  detachRemoteWorkspace: (key) => {
+    set((state: StoreState) => {
+      const idx = state.remoteWorkspaces.findIndex((r: AttachedRemoteWorkspace) => r.key === key);
+      if (idx === -1) return;
+      state.remoteWorkspaces.splice(idx, 1);
+      if (state.activeRemoteKey === key) state.activeRemoteKey = null;
+    });
+    const api = persistApi();
+    if (api?.attachmentsRemove) void api.attachmentsRemove(key).catch(() => { /* fire-and-forget, as above */ });
+  },
+
+  setRemoteWorkspacePanes: (key, panes) => set((state: StoreState) => {
+    const entry = state.remoteWorkspaces.find((r: AttachedRemoteWorkspace) => r.key === key);
+    if (!entry) return;
+    const merged = mergePaneSets(entry.panes, panes);
+    if (!samePanes(entry.panes, merged)) entry.panes = merged;
+    if (entry.stale) entry.stale = false;
+  }),
+
+  setRemoteWorkspaceStale: (key, stale) => set((state: StoreState) => {
+    const entry = state.remoteWorkspaces.find((r: AttachedRemoteWorkspace) => r.key === key);
+    if (!entry || entry.stale === stale) return;
+    entry.stale = stale;
   }),
 
   setActiveRemoteKey: (key) => set((state: StoreState) => {

--- a/src/renderer/stores/slices/remoteWorkspacesSlice.ts
+++ b/src/renderer/stores/slices/remoteWorkspacesSlice.ts
@@ -27,6 +27,13 @@ export interface AttachedRemoteWorkspace {
    *  because a laptop slept would be silent data loss — it just renders
    *  disconnected until a refresh succeeds or the user detaches. */
   stale?: boolean;
+  /** Bumped every time this entry recovers from `stale`. A host that slept
+   *  long enough for RemoteHostClient to give up reconnecting comes back with
+   *  the SAME remote sessionIds, so the pane list is byte-identical and
+   *  nothing below would otherwise re-attach — every mirror would stay blank
+   *  forever with no visible error. PaneCell keys its attach effect off this
+   *  counter, so a recovery re-opens the streams. */
+  attachEpoch?: number;
 }
 
 /** Fire-and-forget descriptor persistence. Guarded for the node test
@@ -50,20 +57,30 @@ function toDescriptor(w: AttachedRemoteWorkspace): RemoteAttachmentDescriptor {
  *  ordering: panes that are still there keep their slot (so the mirror grid
  *  never reshuffles when an unrelated pane closes), panes that are gone drop
  *  out, and newly opened panes append at the end. Field updates (shell/cwd)
- *  from the fetch always win. */
+ *  from the fetch always win.
+ *
+ *  sessionId is also the React key of a pane cell, so the result is
+ *  deduplicated: the pane list comes off another machine and a remote that
+ *  reports the same sessionId twice must not render two cells under one key. */
 export function mergePaneSets(
   current: RemotePaneSummary[],
   next: RemotePaneSummary[],
 ): RemotePaneSummary[] {
   const nextById = new Map(next.map((p) => [p.sessionId, p]));
-  const kept: RemotePaneSummary[] = [];
+  const merged: RemotePaneSummary[] = [];
+  const seen = new Set<string>();
   for (const pane of current) {
     const fresh = nextById.get(pane.sessionId);
-    if (fresh) kept.push(fresh);
+    if (!fresh || seen.has(pane.sessionId)) continue;
+    seen.add(pane.sessionId);
+    merged.push(fresh);
   }
-  const currentIds = new Set(current.map((p) => p.sessionId));
-  const added = next.filter((p) => !currentIds.has(p.sessionId));
-  return [...kept, ...added];
+  for (const pane of next) {
+    if (seen.has(pane.sessionId)) continue;
+    seen.add(pane.sessionId);
+    merged.push(pane);
+  }
+  return merged;
 }
 
 /** Whether a merge result is indistinguishable from what is already in the
@@ -87,15 +104,16 @@ export interface RemoteWorkspacesSlice {
   attachRemoteWorkspace: (w: AttachedRemoteWorkspace) => void;
   /** Boot-time replay of a persisted descriptor: adds the entry WITHOUT
    * selecting it (a restore must not steal the user's view) and without
-   * re-persisting what it just read. */
+   * re-persisting what it just read. ADDITIVE ONLY — see the implementation. */
   restoreRemoteWorkspace: (w: AttachedRemoteWorkspace) => void;
   /** Remove the entry AND its persisted descriptor; clears activeRemoteKey
    * only if it was the active one. */
   detachRemoteWorkspace: (key: string) => void;
   /** Applies a freshly fetched pane set (exit event / poll) with stable
    * ordering, and clears `stale` — a successful fetch means reachable. No-ops
-   * when nothing changed. */
-  setRemoteWorkspacePanes: (key: string, panes: RemotePaneSummary[]) => void;
+   * when nothing changed. `name` follows the remote when the fetch carries
+   * one, so a workspace renamed on the other machine renames here too. */
+  setRemoteWorkspacePanes: (key: string, panes: RemotePaneSummary[], name?: string) => void;
   /** Marks the entry unreachable (or reachable again) without dropping it. */
   setRemoteWorkspaceStale: (key: string, stale: boolean) => void;
   /** Selecting a LOCAL workspace calls this with null. */
@@ -112,7 +130,10 @@ export const createRemoteWorkspacesSlice: StateCreator<StoreState, [['zustand/im
       if (idx === -1) {
         state.remoteWorkspaces.push(w);
       } else {
-        state.remoteWorkspaces[idx] = w;
+        // Carry the epoch across a re-attach: its only job is to be different
+        // from the value the mounted PaneCells last saw, and resetting it
+        // would tear down streams that are perfectly healthy.
+        state.remoteWorkspaces[idx] = { ...w, attachEpoch: state.remoteWorkspaces[idx].attachEpoch };
       }
       state.activeRemoteKey = w.key;
     });
@@ -123,10 +144,15 @@ export const createRemoteWorkspacesSlice: StateCreator<StoreState, [['zustand/im
     if (api?.attachmentsAdd) void api.attachmentsAdd(toDescriptor(w)).catch(() => { /* see above */ });
   },
 
+  // ADDITIVE ONLY. A boot restore fetches each host's panes before it lands,
+  // which can take a full request timeout per unreachable host, and the user
+  // is free to act on the same key meanwhile. Overwriting would blank a mirror
+  // they just attached (panes: [], stale: true), and re-adding a key they
+  // detached would resurrect a ghost row with no descriptor behind it. Present
+  // key wins, always.
   restoreRemoteWorkspace: (w) => set((state: StoreState) => {
-    const idx = state.remoteWorkspaces.findIndex((r: AttachedRemoteWorkspace) => r.key === w.key);
-    if (idx === -1) state.remoteWorkspaces.push(w);
-    else state.remoteWorkspaces[idx] = w;
+    if (state.remoteWorkspaces.some((r: AttachedRemoteWorkspace) => r.key === w.key)) return;
+    state.remoteWorkspaces.push(w);
   }),
 
   detachRemoteWorkspace: (key) => {
@@ -140,18 +166,31 @@ export const createRemoteWorkspacesSlice: StateCreator<StoreState, [['zustand/im
     if (api?.attachmentsRemove) void api.attachmentsRemove(key).catch(() => { /* fire-and-forget, as above */ });
   },
 
-  setRemoteWorkspacePanes: (key, panes) => set((state: StoreState) => {
+  setRemoteWorkspacePanes: (key, panes, name) => set((state: StoreState) => {
     const entry = state.remoteWorkspaces.find((r: AttachedRemoteWorkspace) => r.key === key);
     if (!entry) return;
+    // The pane list originates on another machine: refuse a non-array rather
+    // than letting it throw here and abort the caller's whole refresh round.
+    if (!Array.isArray(panes)) return;
     const merged = mergePaneSets(entry.panes, panes);
     if (!samePanes(entry.panes, merged)) entry.panes = merged;
-    if (entry.stale) entry.stale = false;
+    if (name !== undefined && name !== entry.name) entry.name = name;
+    if (entry.stale) {
+      entry.stale = false;
+      entry.attachEpoch = (entry.attachEpoch ?? 0) + 1;
+    }
   }),
 
   setRemoteWorkspaceStale: (key, stale) => set((state: StoreState) => {
     const entry = state.remoteWorkspaces.find((r: AttachedRemoteWorkspace) => r.key === key);
-    if (!entry || entry.stale === stale) return;
+    if (!entry) return;
+    // Normalise before comparing: a never-flagged entry has `undefined`, not
+    // `false`, and treating that as a real transition would bump the epoch —
+    // and tear down live streams — on the very first successful fetch.
+    const wasStale = entry.stale === true;
+    if (wasStale === stale) return;
     entry.stale = stale;
+    if (!stale) entry.attachEpoch = (entry.attachEpoch ?? 0) + 1;
   }),
 
   setActiveRemoteKey: (key) => set((state: StoreState) => {

--- a/src/shared/__tests__/remoteHosts.test.ts
+++ b/src/shared/__tests__/remoteHosts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseWebUrl } from '../remoteHosts';
+import { parseRemoteAttachmentKey, parseWebUrl, remoteAttachmentKey } from '../remoteHosts';
 
 describe('parseWebUrl', () => {
   it('parses origin and token from a wmux web URL', () => {
@@ -18,5 +18,26 @@ describe('parseWebUrl', () => {
   it('rejects non-http schemes and garbage', () => {
     expect(parseWebUrl('ftp://x?token=t')).toBeNull();
     expect(parseWebUrl('not a url')).toBeNull();
+  });
+});
+
+// The attach descriptor key is minted renderer-side and enforced main-side —
+// both go through these, so the two cannot drift.
+describe('remote attachment key', () => {
+  it('round-trips a host/workspace pair', () => {
+    const key = remoteAttachmentKey('h1', 'ws-1');
+    expect(key).toBe('h1:ws-1');
+    expect(parseRemoteAttachmentKey(key)).toEqual({ hostId: 'h1', workspaceId: 'ws-1' });
+  });
+
+  it('splits on the FIRST colon, so a workspace id may contain one', () => {
+    expect(parseRemoteAttachmentKey('h1:ws:1')).toEqual({ hostId: 'h1', workspaceId: 'ws:1' });
+  });
+
+  it('rejects a key with no separator or an empty half', () => {
+    expect(parseRemoteAttachmentKey('h1')).toBeNull();
+    expect(parseRemoteAttachmentKey(':ws-1')).toBeNull();
+    expect(parseRemoteAttachmentKey('h1:')).toBeNull();
+    expect(parseRemoteAttachmentKey('')).toBeNull();
   });
 });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -522,6 +522,12 @@ export const IPC = {
   REMOTE_HOSTS_PAIR: 'remote:hosts:pair',
   REMOTE_HOSTS_REMOVE: 'remote:hosts:remove',
   REMOTE_WORKSPACES_LIST: 'remote:workspaces:list',
+  // Persisted attach descriptors (see RemoteAttachmentsStore). The renderer's
+  // remote-workspace slice is memory-only, so these are what survive a reload
+  // and an app restart; panes are never stored, only re-fetched.
+  REMOTE_ATTACHMENTS_LIST: 'remote:attachments:list',
+  REMOTE_ATTACHMENTS_ADD: 'remote:attachments:add',
+  REMOTE_ATTACHMENTS_REMOVE: 'remote:attachments:remove',
   REMOTE_PANE_ATTACH: 'remote:pane:attach',
   REMOTE_PANE_DETACH: 'remote:pane:detach',
   REMOTE_PANE_WRITE: 'remote:pane:write',

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -18,7 +18,7 @@ import type {
   WebStartArgs,
   WebTerminalInfo,
 } from './web';
-import type { PairFailureReason, RemoteHostPublic, RemoteWorkspaceSummary } from './remoteHosts';
+import type { PairFailureReason, RemoteAttachmentDescriptor, RemoteHostPublic, RemoteWorkspaceSummary } from './remoteHosts';
 import type {
   FirstRunCheckResult,
   RegisterMcpResult,
@@ -198,6 +198,16 @@ declare global {
         workspacesList: (hostId: string) => Promise<
           { ok: true; workspaces: RemoteWorkspaceSummary[] } | { ok: false; error: string }
         >;
+        /** Persisted attach descriptors — read on renderer boot to restore
+         *  the attachments a reload/restart wiped out of the memory-only
+         *  slice. Panes are never part of a descriptor: they are re-fetched
+         *  from the host with workspacesList at restore time. */
+        attachmentsList: () => Promise<RemoteAttachmentDescriptor[]>;
+        /** Resolves false when the descriptor could not be recorded (unknown
+         *  host, or a disk write failure) — never rejects, because the attach
+         *  it describes has already happened. */
+        attachmentsAdd: (descriptor: RemoteAttachmentDescriptor) => Promise<boolean>;
+        attachmentsRemove: (key: string) => Promise<boolean>;
         /** Idempotent per (host, session) for this renderer — a repeat call
          *  (e.g. React StrictMode's double-effect) returns the SAME attachId
          *  rather than opening a second SSE stream on the remote. */

--- a/src/shared/remoteHosts.ts
+++ b/src/shared/remoteHosts.ts
@@ -33,6 +33,20 @@ export interface RemoteWorkspacesResponse {
   workspaces: RemoteWorkspaceSummary[];
 }
 
+/** A persisted "this remote workspace was attached" record.
+ *
+ * Deliberately carries NO pane list: panes are a live property of the remote
+ * daemon, so a restored attachment always re-fetches them (a stale pane list
+ * on disk would mirror sessions that died while the app was closed). Carries
+ * no credential either — the token lives only in RemoteHost. */
+export interface RemoteAttachmentDescriptor {
+  key: string;           // `${hostId}:${workspaceId}` — same key the renderer slice uses
+  hostId: string;
+  hostLabel: string;     // label snapshot, so a sidebar row can render before the host list loads
+  workspaceId: string;
+  name: string;          // remote workspace name snapshot ('' possible)
+}
+
 /** Machine-readable reason for a REMOTE_HOSTS_PAIR failure — i18n happens
  *  renderer-side (AttachRemoteModal maps each reason to a translated
  *  string), so main never returns a human-facing message here. */

--- a/src/shared/remoteHosts.ts
+++ b/src/shared/remoteHosts.ts
@@ -47,6 +47,25 @@ export interface RemoteAttachmentDescriptor {
   name: string;          // remote workspace name snapshot ('' possible)
 }
 
+/** The ONE place the descriptor key is spelled out. Both the renderer (which
+ *  mints it on attach) and main (which refuses a descriptor whose key does not
+ *  derive from its own hostId/workspaceId) go through here, so the two can
+ *  never drift into main accepting a key nothing could have produced. */
+export function remoteAttachmentKey(hostId: string, workspaceId: string): string {
+  return `${hostId}:${workspaceId}`;
+}
+
+/** Inverse of remoteAttachmentKey. Returns null for anything that is not a
+ *  `<hostId>:<workspaceId>` pair with both halves non-empty. hostId is a local
+ *  uuid, so the FIRST colon is the separator. */
+export function parseRemoteAttachmentKey(
+  key: string,
+): { hostId: string; workspaceId: string } | null {
+  const sep = key.indexOf(':');
+  if (sep <= 0 || sep === key.length - 1) return null;
+  return { hostId: key.slice(0, sep), workspaceId: key.slice(sep + 1) };
+}
+
 /** Machine-readable reason for a REMOTE_HOSTS_PAIR failure — i18n happens
  *  renderer-side (AttachRemoteModal maps each reason to a translated
  *  string), so main never returns a human-facing message here. */


### PR DESCRIPTION
Two lifecycle defects in attached remote workspaces, both client-side only. No daemon change, so this keeps working against older remote builds — version skew is real for this feature.

## 1. Cmd+R and app restart silently dropped every attachment

`remoteWorkspacesSlice` is memory-only by design, so a reload recreated it empty and the Remote section vanished from the sidebar. The SSE teardown in `installSenderCleanup` is correct and untouched — stale streams must die on reload. What was missing is that the attach DESCRIPTORS died with them.

Descriptors now live in the main process, in `~/.wmux/remote-attachments.json`, a sibling of `RemoteHostsStore`. Deliberately a separate file: a descriptor holds no credential (the bearer token stays in `remote-hosts.json`), so it uses the ordinary atomic-JSON path rather than `secureWriteTokenFile`, and keeping them apart makes that difference structural instead of a convention to remember. Only `{key, hostId, hostLabel, workspaceId, name}` is stored, and `toDescriptor()` strips structurally, so a caller handing over a full `AttachedRemoteWorkspace` cannot get its pane list onto disk. Removing a host cascades.

`useRemoteAttachmentsLifecycle` replays the descriptors on boot, fetching each host's CURRENT workspaces — one call per host, not per workspace — so panes always come from the live host and never from disk. A host that cannot be reached, or a workspace that no longer exists there, is restored in a `stale` state rather than dropped: a sleeping laptop must not delete the user's attachment. Restore adds without selecting, so it never steals the view on startup.

## 2. Panes opened or closed on the remote never showed up

The pane list was a snapshot taken at attach time. A pane closed on the remote left a dead tile forever; a pane opened there was invisible until a manual re-attach.

The wire carries no topology events, but a close does surface indirectly — the PTY dies, which produces an SSE `exit` — so that is used as a refresh trigger, debounced 400 ms. An open produces nothing at all, which is what the 10 s poll is for; it is armed only while something is attached, so an app with no mirrors makes no periodic requests. Both paths run the same refetch-and-diff and are serialised, so an exit burst plus a poll tick collapse into one round. `mergePaneSets` keeps survivors in their slot and appends new panes, so the grid never reshuffles, and an identical fetch keeps the old array identity so the poll does not re-render mirrors forever.

## Tests

186 passing across the touched suites.

- `RemoteAttachmentsStore.test.ts` (new) — roundtrip across a fresh construct (the restart path), never persists a pane list even when handed one, key dedup, remove, host cascade, corrupt file, foreign shape, missing file.
- `remote.handler.test.ts` — add/list roundtrip, pane-list stripping, refusal for an unregistered host, write-failure returns false rather than rejecting, host-removal cascade, and a renderer reload tears down live SSE attaches but keeps the descriptors.
- `remoteWorkspacesSlice.test.ts` — `mergePaneSets` removal, addition, reorder stability, new-pane placement, field freshness; no-churn identity; stale cleared on success and never dropping a row; restore does not select and dedups.
- `useRemoteAttachmentsLifecycle.dynamic.test.tsx` (new) — restore with fresh panes, stale on unreachable host, stale on vanished workspace, no request when nothing is persisted; exit drops the closed pane, an exit burst is one fetch, unsubscribe on unmount; no poll while unattached, the poll picks up a remotely-opened pane, the poll stops after detach, a failed poll marks stale without dropping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote workspace attachments now persist across reloads and application restarts.
  * Mirrored workspaces and panes synchronize automatically with remote hosts.
  * Disconnected or unavailable workspaces remain visible and reconnect when recovered.
  * Removing a remote host also removes its associated workspace mirrors.

* **Bug Fixes**
  * Improved handling of malformed or unavailable remote workspace data.
  * Prevented duplicate panes and improved attachment and detachment reliability.
  * Added clearer disconnected-state indicators for stale workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->