### PR TITLE
fix(deck): stop-gate decision release, cap-out hysteresis, and active-work injection diet

### DIFF
--- a/changelog.d/832.md
+++ b/changelog.d/832.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **The orchestrator no longer re-prints the same message while waiting on you.** A
+  pending decision (deck_ask_decision) now releases the Stop gate — previously the
+  gate kept refusing the turn while the decision block forbade acting, leaving the
+  brain nothing to do but restate its question, up to four times per wake cycle. (#832)
+- **A wake loop over unchanged fleet state no longer re-buys the same refusals every
+  cycle.** When the Stop gate caps out, it remembers exactly what it was holding on
+  and stays quiet until that state actually changes, you act (a message, the Wake
+  button, answering a decision), or a 15-minute reminder interval passes. Only a
+  state the gate actually refused can be suppressed. (#832)
+- **Re-sent instructions no longer pile up in the active-work record.** Follow-up
+  dedupe now checks the objective and every retained follow-up with
+  whitespace-insensitive comparison, instead of only the most recent entry. (#832)
+
+### Changed
+
+- **The terminal brain's [active-work] block goes on a diet.** An unchanged block
+  collapses to a one-line reminder (id + the finish-via-deck_complete_work contract)
+  instead of re-typing the full objective, follow-ups, and task list onto the
+  terminal every turn. Any change to the record — or a conversation reset in the
+  TUI — re-sends the block in full. (#832)

--- a/src/main/deck/__tests__/deckWorkStore.test.ts
+++ b/src/main/deck/__tests__/deckWorkStore.test.ts
@@ -21,6 +21,7 @@ import {
   loadActiveDeckWorks,
   hasPendingDeckWorkA2aTasks,
   renderActiveDeckWorkBlock,
+  renderActiveDeckWorkReminderLine,
   renderStrandedDeckWorkBlock,
   getDeckWorkPath,
   setDeckWorkBootId,
@@ -78,6 +79,30 @@ describe('deckWorkStore — ownership lifecycle', () => {
     beginOrContinueDeckWork('ws-1', 'retry', dir);
     const third = beginOrContinueDeckWork('ws-1', 'retry', dir)!.work;
     expect(third.followUps).toEqual(['retry']);
+  });
+
+  it('collapses a NON-adjacent repeat — a poll-loop human re-sends the same instruction', () => {
+    // Transcript 2026-08-07: the same supervision instruction re-sent every
+    // cycle got past the last-item-only check whenever another message landed
+    // in between, then re-rendered into every later turn's [active-work] block.
+    beginOrContinueDeckWork('ws-1', 'objective', dir);
+    beginOrContinueDeckWork('ws-1', 'check the pane', dir);
+    beginOrContinueDeckWork('ws-1', 'also run tests', dir);
+    const fourth = beginOrContinueDeckWork('ws-1', 'check the pane', dir)!.work;
+    expect(fourth.followUps).toEqual(['check the pane', 'also run tests']);
+  });
+
+  it('collapses a whitespace-variant repeat (TUI re-wrap / paste artifacts)', () => {
+    beginOrContinueDeckWork('ws-1', 'objective', dir);
+    beginOrContinueDeckWork('ws-1', 'check the pane and report', dir);
+    const third = beginOrContinueDeckWork('ws-1', 'check the  pane\nand report', dir)!.work;
+    expect(third.followUps).toEqual(['check the pane and report']);
+  });
+
+  it('a whitespace-variant of the objective is not a follow-up either', () => {
+    beginOrContinueDeckWork('ws-1', 'build it', dir);
+    const again = beginOrContinueDeckWork('ws-1', 'build  it', dir)!.work;
+    expect(again.followUps).toEqual([]);
   });
 
   it('caps the follow-up list, keeping the most recent', () => {
@@ -483,6 +508,20 @@ describe('deckWorkStore — boot-scoped permission (parked records)', () => {
   it('unparkDeckWork is a no-op when there is no record', () => {
     expect(() => unparkDeckWork('ws-none', dir)).not.toThrow();
     expect(loadActiveDeckWork('ws-none', dir)).toBeNull();
+  });
+});
+
+describe('renderActiveDeckWorkReminderLine', () => {
+  it('names the id and restates the two imperatives that must survive summarization', () => {
+    beginOrContinueDeckWork('ws-1', 'ship the roster', dir, 1_000);
+    const work = loadActiveDeckWork('ws-1', dir)!;
+    const line = renderActiveDeckWorkReminderLine(work);
+    expect(line).toContain('[active-work]');
+    expect(line).toContain(work.id);
+    expect(line).toMatch(/still ACTIVE/i);
+    expect(line).toContain('deck_complete_work');
+    // A reminder, not the contract: the objective and follow-ups stay out.
+    expect(line).not.toContain('ship the roster');
   });
 });
 

--- a/src/main/deck/__tests__/stopGate.test.ts
+++ b/src/main/deck/__tests__/stopGate.test.ts
@@ -124,6 +124,129 @@ describe('evaluateStopGate', () => {
   });
 });
 
+// Rule 4: deck_ask_decision is the brain saying "only a human can move this
+// forward", and the decision block orders it NOT to proceed. Refusing the Stop
+// on top of that left the model exactly one move — re-printing its question —
+// which is the transcript pathology (2026-08-07) this rule removes.
+describe('a pending decision releases the gate (rule 4)', () => {
+  it('allows even with outstanding panes AND active work', () => {
+    const verdict = evaluateStopGate({
+      snapshot: snapshot([pane({ agentStatus: 'running' })]),
+      activeWork: { id: 'work-1' },
+      pendingDecision: true,
+      consecutiveBlocks: 0,
+    });
+    expect(verdict.block).toBe(false);
+  });
+
+  it('does not mark the pending-decision allow as a cap-out', () => {
+    const verdict = evaluateStopGate({
+      snapshot: snapshot([pane({ agentStatus: 'running' })]),
+      activeWork: { id: 'work-1' },
+      pendingDecision: true,
+      consecutiveBlocks: 99,
+    });
+    expect(verdict).toEqual({ block: false });
+  });
+
+  it('an explicit false keeps the gate armed', () => {
+    const verdict = evaluateStopGate({
+      snapshot: snapshot([pane({ agentStatus: 'running' })]),
+      pendingDecision: false,
+      consecutiveBlocks: 0,
+    });
+    expect(verdict.block).toBe(true);
+  });
+});
+
+// Rule 5: the consecutive-block counter is per turn, so a wake loop over
+// unchanged fleet state re-bought the same three refusals every cycle. The
+// cap-out allow carries a fingerprint; passing it back keeps the gate quiet
+// until the state actually changes.
+describe('cap-out hysteresis (rule 5)', () => {
+  const busy = () => snapshot([pane({ ptyId: 'pty-a', agentStatus: 'running' })]);
+
+  it('every refusal names the state it is holding on', () => {
+    const verdict = evaluateStopGate({
+      snapshot: busy(),
+      activeWork: { id: 'work-1', updatedAt: 500 },
+      consecutiveBlocks: 0,
+    });
+    if (!verdict.block) throw new Error('expected a block');
+    expect(verdict.fingerprint).toBe('work-1@500|pty-a:running');
+  });
+
+  it('the allow that ends a refusal run at the cap carries the fingerprint', () => {
+    const verdict = evaluateStopGate({
+      snapshot: busy(),
+      activeWork: { id: 'work-1', updatedAt: 500 },
+      consecutiveBlocks: 3,
+    });
+    expect(verdict.block).toBe(false);
+    if (verdict.block) throw new Error('expected an allow');
+    expect(verdict.cappedOutFingerprint).toBe('work-1@500|pty-a:running');
+  });
+
+  it('an allow with nothing held carries no fingerprint', () => {
+    const verdict = evaluateStopGate({
+      snapshot: snapshot([pane({ agentStatus: 'idle' })]),
+      consecutiveBlocks: 3,
+    });
+    expect(verdict).toEqual({ block: false });
+  });
+
+  it('stays quiet while the suppressed fingerprint matches the current state', () => {
+    const capped = evaluateStopGate({
+      snapshot: busy(),
+      activeWork: { id: 'work-1', updatedAt: 500 },
+      consecutiveBlocks: 3,
+    });
+    if (capped.block) throw new Error('expected a cap-out allow');
+    const next = evaluateStopGate({
+      snapshot: busy(),
+      activeWork: { id: 'work-1', updatedAt: 500 },
+      consecutiveBlocks: 0,
+      suppressedFingerprint: capped.cappedOutFingerprint,
+    });
+    expect(next).toEqual({ block: false });
+  });
+
+  it('re-arms when the outstanding pane set changes', () => {
+    const suppressed = 'work-1@500|pty-a:running';
+    const flipped = evaluateStopGate({
+      snapshot: snapshot([pane({ ptyId: 'pty-a', agentStatus: 'awaiting_input' })]),
+      activeWork: { id: 'work-1', updatedAt: 500 },
+      consecutiveBlocks: 0,
+      suppressedFingerprint: suppressed,
+    });
+    expect(flipped.block).toBe(true);
+  });
+
+  it('re-arms when the active-work revision advances (a follow-up or A2A touch)', () => {
+    const suppressed = 'work-1@500|pty-a:running';
+    const touched = evaluateStopGate({
+      snapshot: busy(),
+      activeWork: { id: 'work-1', updatedAt: 501 },
+      consecutiveBlocks: 0,
+      suppressedFingerprint: suppressed,
+    });
+    expect(touched.block).toBe(true);
+  });
+
+  it('pane ordering cannot fake a state change', () => {
+    const a = pane({ ptyId: 'a', agentStatus: 'running' });
+    const b = pane({ ptyId: 'b', agentStatus: 'awaiting_input' });
+    const capped = evaluateStopGate({ snapshot: snapshot([a, b]), consecutiveBlocks: 3 });
+    if (capped.block) throw new Error('expected a cap-out allow');
+    const reordered = evaluateStopGate({
+      snapshot: snapshot([b, a]),
+      consecutiveBlocks: 0,
+      suppressedFingerprint: capped.cappedOutFingerprint,
+    });
+    expect(reordered).toEqual({ block: false });
+  });
+});
+
 // Regression: #733 — the brain read "resolve these panes" as "end these panes"
 // and ran `exit`, then Ctrl+D, in a live user shell. This string is the only
 // thing it reads about a block, so the prohibition has to be in it. Asserted on
@@ -193,4 +316,37 @@ describe('stop gate refusal names what not to do (#733)', () => {
     const reason = verdict.block ? verdict.reason : '';
     expect(reason.match(/Do NOT close or kill a pane/g)).toHaveLength(1);
   });
+});
+
+// The observed stall (transcript, 2026-08-07): a refused model's cheapest move
+// is re-printing its previous message, so every refusal must forbid exactly
+// that — and name the legitimate way to wait (deck_ask_decision releases the
+// gate, rule 4). Asserted on both block shapes, once each.
+describe('stop gate refusal forbids repeating and names the wait state', () => {
+  const cases: Array<[string, Parameters<typeof evaluateStopGate>[0]]> = [
+    [
+      'pane block',
+      {
+        snapshot: {
+          ts: Date.now(),
+          panes: [{ ptyId: 'pty-a', agentStatus: 'running' }],
+        } as unknown as FleetSnapshot,
+        consecutiveBlocks: 0,
+      },
+    ],
+    [
+      'active-work-only block',
+      { snapshot: null, activeWork: { id: 'work-1' }, consecutiveBlocks: 0 },
+    ],
+  ];
+
+  for (const [label, input] of cases) {
+    it(`names both on a ${label}`, () => {
+      const verdict = evaluateStopGate(input);
+      expect(verdict.block).toBe(true);
+      const reason = verdict.block ? verdict.reason : '';
+      expect(reason.match(/Do NOT re-send or restate your previous message/g)).toHaveLength(1);
+      expect(reason).toMatch(/a pending decision releases this gate/);
+    });
+  }
 });

--- a/src/main/deck/__tests__/stopGateState.test.ts
+++ b/src/main/deck/__tests__/stopGateState.test.ts
@@ -16,6 +16,11 @@ import {
   clearGateVerdict,
   resetGateVerdicts,
   GATE_VERDICT_TTL_MS,
+  noteGateCapOut,
+  suppressedGateFingerprint,
+  clearGateCapOut,
+  resetGateCapOuts,
+  GATE_CAP_SUPPRESSION_TTL_MS,
 } from '../stopGateState';
 import { evaluateStopGate, DEFAULT_MAX_SNAPSHOT_AGE_MS } from '../stopGate';
 import type { FleetSnapshot } from '../../../shared/workspaceMirror';
@@ -119,5 +124,42 @@ describe('stopGateState (#733)', () => {
       now: NOW,
     });
     expect(verdict.block && verdict.outstandingPtyIds).toEqual([]);
+  });
+});
+
+// Rule 5 companion state: what the gate was holding on when it capped out.
+// The record's whole job is to keep the NEXT turn's gate from re-buying the
+// same refusal run on unchanged state — and to expire so a wedged fleet still
+// gets a rate-limited reminder.
+describe('cap-out suppression (stop gate rule 5)', () => {
+  beforeEach(() => resetGateCapOuts());
+
+  it('remembers the fingerprint the gate capped out on', () => {
+    noteGateCapOut(WS, 'work-1@500|pty-a:running');
+    expect(suppressedGateFingerprint(WS)).toBe('work-1@500|pty-a:running');
+  });
+
+  it('does not leak across workspaces', () => {
+    noteGateCapOut(WS, 'fp');
+    expect(suppressedGateFingerprint('ws-2')).toBe(null);
+  });
+
+  it('expires so a truly wedged fleet still gets a rate-limited reminder', () => {
+    const t0 = 1_000_000;
+    noteGateCapOut(WS, 'fp', t0);
+    expect(suppressedGateFingerprint(WS, t0 + GATE_CAP_SUPPRESSION_TTL_MS - 1)).toBe('fp');
+    expect(suppressedGateFingerprint(WS, t0 + GATE_CAP_SUPPRESSION_TTL_MS + 1)).toBe(null);
+  });
+
+  it('clears on demand — a human turn or a retired commander re-arms the gate', () => {
+    noteGateCapOut(WS, 'fp');
+    clearGateCapOut(WS);
+    expect(suppressedGateFingerprint(WS)).toBe(null);
+  });
+
+  it('last write wins when the gate caps out on a new state', () => {
+    noteGateCapOut(WS, 'old');
+    noteGateCapOut(WS, 'new');
+    expect(suppressedGateFingerprint(WS)).toBe('new');
   });
 });

--- a/src/main/deck/deckWorkStore.ts
+++ b/src/main/deck/deckWorkStore.ts
@@ -97,6 +97,13 @@ function cleanText(value: unknown, max: number): string {
   return typeof value === 'string' ? value.trim().slice(0, max) : '';
 }
 
+/** Whitespace-insensitive comparison key for follow-up dedupe. A human
+ *  re-sending the same instruction through the TUI picks up re-wrapped lines
+ *  and paste artifacts, so byte equality misses most real duplicates. */
+function dedupeKey(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
 function sanitizeTask(value: unknown): DeckWorkA2aTask | null {
   if (!isRecord(value)) return null;
   const taskId = cleanText(value.taskId, 256);
@@ -301,7 +308,15 @@ export function beginOrContinueDeckWork(
   if (current && !isDeckWorkParked(current)) {
     const followUp = cleanText(cleaned, MAX_FOLLOW_UP_CHARS);
     const followUps = [...current.followUps];
-    if (followUp && followUp !== current.objective && followUps.at(-1) !== followUp) {
+    // Dedupe against the objective AND every retained follow-up, not only the
+    // last one. A human supervising a poll loop re-sends the same instruction
+    // every cycle; each copy that got past the old last-item check was then
+    // re-rendered into EVERY later turn's [active-work] block, compounding the
+    // duplication quadratically (transcript, 2026-08-07). A re-send is a
+    // re-confirmation, not a new instruction — updatedAt still advances below,
+    // so the record shows the touch either way.
+    const seen = new Set([current.objective, ...followUps].map(dedupeKey));
+    if (followUp && !seen.has(dedupeKey(followUp))) {
       followUps.push(followUp);
     }
     next = {
@@ -493,4 +508,22 @@ export function renderActiveDeckWorkBlock(work: ActiveDeckWork): string {
     'use deck_ask_decision and leave this work active.',
   );
   return lines.join('\n');
+}
+
+/** One-line stand-in for an [active-work] block this conversation has already
+ *  seen, byte-identical. The visible TUI brain re-types its whole prompt on
+ *  screen, and the full block — objective, every follow-up, every A2A row,
+ *  the ownership imperatives — re-sent on every wake was the largest recurring
+ *  injection in a supervision loop. The id keeps the reminder correlatable
+ *  with the full block earlier in the conversation; the two imperatives that
+ *  must survive summarization (still ACTIVE, only deck_complete_work finishes
+ *  it) are restated because they are the contract, not context.
+ *
+ *  Never used for a PARKED record: parking changes what the block MEANS (a
+ *  prohibition, not ownership), so a parked record always renders in full. */
+export function renderActiveDeckWorkReminderLine(work: ActiveDeckWork): string {
+  return (
+    `[active-work] id: ${work.id} — unchanged since your last turn (full contract earlier in this conversation). ` +
+    'Still ACTIVE: you still own it, and only a successful deck_complete_work({summary, verification}) finishes it.'
+  );
 }

--- a/src/main/deck/stopGate.ts
+++ b/src/main/deck/stopGate.ts
@@ -12,7 +12,7 @@
 // a mirror, a pty, or a claude. Everything stateful (the consecutive-block
 // counter, the snapshot lookup) lives in the adapter that calls this.
 //
-// Three fail-open rules, all deliberate:
+// Five fail-open rules, all deliberate:
 //   1. A null snapshot never blocks. The gate INFERS outstanding work from pane
 //      status; a derived signal cannot prove absence, so a missing or stale
 //      mirror must not wedge the brain.
@@ -28,6 +28,20 @@
 //      trap, so the deadlock-avoidance it buys is worth the turns it lets
 //      through: a wrongly-allowed Stop costs one wake event, a wrongly-held
 //      turn costs the whole fleet its orchestrator.
+//   4. A PENDING deck decision releases the gate outright. deck_ask_decision
+//      is the brain saying "only a human can move this forward", and the
+//      decision block orders it NOT to proceed — holding the turn open then
+//      forces the one thing a stalled model can still do: re-print the same
+//      question. The coalescer already suppresses every wake under a pending
+//      decision; this is the mirror image for ending the turn. The resolve
+//      path kicks an explicit resume turn, so nothing is lost by stopping.
+//   5. A cap-out is remembered (hysteresis). The consecutive-block counter is
+//      per turn, so a wake loop over UNCHANGED fleet state re-bought the same
+//      three refusals — and three re-printed turns — every cycle. The verdict
+//      carries a fingerprint of exactly what was held on; the caller records
+//      it at cap-out and passes it back, and the gate stays quiet until the
+//      state actually changes (or the record expires / a human turn clears
+//      it — both the caller's job, see stopGateState).
 
 import type { FleetSnapshot, FleetSnapshotPane } from '../../shared/workspaceMirror';
 
@@ -48,8 +62,30 @@ const NO_KILL_SENTENCE =
   'Those sessions belong to the human. If a pane will not resolve, leave it running and ' +
   'raise it with deck_ask_decision instead of ending it.';
 
+/** Every refusal must also forbid the cheap non-action. The observed failure
+ *  (transcript, 2026-08-07) was the same "shall I proceed?" message re-printed
+ *  on every refused Stop — a blocked model's path of least resistance is to
+ *  restate itself, which spends tokens and moves nothing. The sentence also
+ *  names the one legitimate way to WAIT: a pending decision releases this gate
+ *  (rule 4), so prose questions the gate cannot see become tool calls it can. */
+const NO_REPEAT_SENTENCE =
+  'Do NOT re-send or restate your previous message — a repeated turn is not progress; ' +
+  'take a NEW concrete step. If only a human answer can move this forward, raise it with ' +
+  'deck_ask_decision({question, options}): a pending decision releases this gate and ' +
+  'pauses auto-wakes until the human answers.';
+
 export type StopGateVerdict =
-  | { block: false }
+  | {
+      block: false;
+      /**
+       * Present ONLY on the allow that ends a refusal run at the cap (rule 5):
+       * the fingerprint of exactly what the gate was holding on when it gave
+       * up. The caller records it (`noteGateCapOut`) and passes it back as
+       * `suppressedFingerprint`, so identical state cannot re-buy another run
+       * of refusals on the next turn. Absent on every other allow.
+       */
+      cappedOutFingerprint?: string;
+    }
   /**
    * `outstandingPtyIds` is the set of panes this refusal is actually about, and
    * it is EMPTY for a block that names none — an active-work hold with a
@@ -58,7 +94,16 @@ export type StopGateVerdict =
    * a caller re-reading a stale snapshot would protect panes the model was
    * never told about, which is the drift this field exists to make impossible.
    */
-  | { block: true; reason: string; outstandingPtyIds: string[] };
+  | {
+      block: true;
+      reason: string;
+      outstandingPtyIds: string[];
+      /** What this refusal is holding on (rule 5). The caller remembers the
+       *  last one so a cap-out only suppresses a state that was actually
+       *  refused — never a state that appeared for the first time on the
+       *  capping Stop (e.g. a worker dispatched mid-refusal-run). */
+      fingerprint: string;
+    };
 
 /** Pane statuses that mean "this pane still needs the orchestrator". The same
  *  attention set CommanderEventCoalescer treats as non-quiescent. */
@@ -72,6 +117,26 @@ function describePane(pane: FleetSnapshotPane): string {
   return `${name} (${pane.agentStatus})`;
 }
 
+/** One line naming exactly what the gate is holding on: the active-work
+ *  revision plus the outstanding pane set. Equal fingerprints mean "the gate
+ *  would refuse for the reason it already refused" — that is the whole
+ *  hysteresis predicate (rule 5). `updatedAt` is in the work half because any
+ *  touch to the record (a human follow-up, an A2A transition) is exactly the
+ *  state change that should re-arm the gate; pane statuses are in the other
+ *  half so a worker flipping running → awaiting_input re-arms it too. Sorted
+ *  so pane ordering in the snapshot cannot fake a change. */
+function gateFingerprint(
+  activeWork: { id: string; updatedAt?: number } | null,
+  outstanding: readonly FleetSnapshotPane[],
+): string {
+  const work = activeWork ? `${activeWork.id}@${activeWork.updatedAt ?? 0}` : '';
+  const panes = outstanding
+    .map((p) => `${p.ptyId}:${p.agentStatus}`)
+    .sort()
+    .join(',');
+  return `${work}|${panes}`;
+}
+
 /**
  * Decide whether this Stop may end the turn.
  *
@@ -83,8 +148,19 @@ export function evaluateStopGate(input: {
   /** `getWorkspaceMirror().getFleetSnapshot(workspaceId)`, or null when absent. */
   snapshot: FleetSnapshot | null;
   /** A durable human request that still belongs to this commander. Unlike pane
-   *  state, this is authoritative even when the renderer snapshot is absent. */
-  activeWork?: { id: string } | null;
+   *  state, this is authoritative even when the renderer snapshot is absent.
+   *  `updatedAt` (when supplied) rides into the hysteresis fingerprint so any
+   *  touch to the record re-arms a capped-out gate. */
+  activeWork?: { id: string; updatedAt?: number } | null;
+  /** TRUE when this workspace has a PENDING deck decision — the brain raised
+   *  deck_ask_decision and the human has not answered (rule 4). Read fresh at
+   *  every Stop by the caller, so resolve/clear re-arms the gate with no extra
+   *  state. */
+  pendingDecision?: boolean;
+  /** The fingerprint recorded at this workspace's last cap-out, or null (rule
+   *  5). Matching the current state means the gate already gave up on exactly
+   *  this hold — stay quiet instead of re-buying the same refusal run. */
+  suppressedFingerprint?: string | null;
   /** How many times in a row this turn's Stop has already been refused. */
   consecutiveBlocks: number;
   maxConsecutiveBlocks?: number;
@@ -93,8 +169,42 @@ export function evaluateStopGate(input: {
   maxSnapshotAgeMs?: number;
 }): StopGateVerdict {
   const { snapshot, activeWork } = input;
+  // Rule 4 first: a pending decision is the one legitimate "waiting on a
+  // human" state, and it is checked before anything else because every other
+  // input describes work the brain could still drive — this one says it must
+  // not. The decision block already orders the brain to stop acting; refusing
+  // the Stop on top of that leaves it nothing to do but repeat itself.
+  if (input.pendingDecision) return { block: false };
+
+  // Rules 1+2 folded into one read: a null or stale snapshot contributes no
+  // outstanding panes (a derived signal cannot prove absence), while a fresh
+  // one contributes its running/awaiting_input set. Computed up front because
+  // the fingerprint needs the same set the block branches use.
+  const now = input.now ?? Date.now();
+  const maxAge = input.maxSnapshotAgeMs ?? DEFAULT_MAX_SNAPSHOT_AGE_MS;
+  const outstanding =
+    snapshot && now - snapshot.ts <= maxAge
+      ? snapshot.panes.filter((p) => isOutstanding(p.agentStatus))
+      : [];
+
+  // Nothing held — no active work, no outstanding panes. The common allow.
+  if (!activeWork && outstanding.length === 0) return { block: false };
+
+  // Rule 5: the gate already capped out on exactly this state. Stay quiet
+  // until the state changes; the caller's TTL and the next human turn bound
+  // how long "quiet" can last.
+  const fingerprint = gateFingerprint(activeWork ?? null, outstanding);
+  if (input.suppressedFingerprint != null && input.suppressedFingerprint === fingerprint) {
+    return { block: false };
+  }
+
+  // Rule 3: the refusal-run cap. The fingerprint travels with this allow so
+  // the caller can record what was held on — an allow for exhaustion, not for
+  // completion.
   const max = input.maxConsecutiveBlocks ?? DEFAULT_MAX_CONSECUTIVE_BLOCKS;
-  if (input.consecutiveBlocks >= max) return { block: false };
+  if (input.consecutiveBlocks >= max) {
+    return { block: false, cappedOutFingerprint: fingerprint };
+  }
 
   // A durable active-work record is stronger than the renderer-derived pane
   // snapshot. Even with no/freshness-lost snapshot, give the brain a bounded
@@ -112,29 +222,18 @@ export function evaluateStopGate(input: {
   // escalated to `exit`/Ctrl+D on a live user shell. `input.rpc` cannot cover it
   // either, since it protects the panes the verdict names and this verdict names
   // none. So the sentence has to be carried by the reason string itself.
-  const activeWorkOnlyReason = finalizeReason
-    ? `${finalizeReason} ${NO_KILL_SENTENCE}`
-    : null;
-  if (!snapshot) {
-    return activeWorkOnlyReason
-      ? { block: true, reason: activeWorkOnlyReason, outstandingPtyIds: [] }
-      : { block: false };
-  }
-  // Staleness means pane state cannot be used to infer outstanding workers. An
-  // active-work record can still hold the turn because it is durable runtime
-  // state rather than a stale renderer inference.
-  const maxAge = input.maxSnapshotAgeMs ?? DEFAULT_MAX_SNAPSHOT_AGE_MS;
-  const age = (input.now ?? Date.now()) - snapshot.ts;
-  if (age > maxAge) {
-    return activeWorkOnlyReason
-      ? { block: true, reason: activeWorkOnlyReason, outstandingPtyIds: [] }
-      : { block: false };
-  }
-
-  const outstanding = snapshot.panes.filter((p) => isOutstanding(p.agentStatus));
   if (outstanding.length === 0) {
-    return activeWorkOnlyReason
-      ? { block: true, reason: activeWorkOnlyReason, outstandingPtyIds: [] }
+    // activeWork is non-null here (the nothing-held allow above returned
+    // otherwise), covering all three former exits: no snapshot, stale
+    // snapshot, and a fresh snapshot whose panes are all quiescent. The
+    // ternary keeps that invariant type-checked rather than trusted.
+    return finalizeReason
+      ? {
+          block: true,
+          reason: `${finalizeReason} ${NO_KILL_SENTENCE} ${NO_REPEAT_SENTENCE}`,
+          outstandingPtyIds: [],
+          fingerprint,
+        }
       : { block: false };
   }
 
@@ -153,10 +252,12 @@ export function evaluateStopGate(input: {
   return {
     block: true,
     outstandingPtyIds: outstanding.map((p) => p.ptyId),
+    fingerprint,
     reason:
       `Do not end this turn yet: ${outstanding.length} worker ${noun} still need you — ${list}. ` +
       'Check each one (read its screen, answer what it is waiting on, or delegate the next step). ' +
       `${NO_KILL_SENTENCE} ` +
-      (finalizeReason ?? 'If there is genuinely nothing left for you to do, say so and stop again.'),
+      (finalizeReason ?? 'If there is genuinely nothing left for you to do, say so and stop again.') +
+      ` ${NO_REPEAT_SENTENCE}`,
   };
 }

--- a/src/main/deck/stopGateState.ts
+++ b/src/main/deck/stopGateState.ts
@@ -75,3 +75,68 @@ export function clearGateVerdict(workspaceId: string): void {
 export function resetGateVerdicts(): void {
   holds.clear();
 }
+
+// ─── Cap-out hysteresis (stop gate rule 5) ───────────────────────────────────
+//
+// The consecutive-block counter lives on the brain adapter and dies with the
+// turn, so a wake loop over UNCHANGED fleet state re-bought the same three
+// refusals — three re-printed turns — every cycle. This records what the gate
+// was holding on when it capped out (the verdict's `cappedOutFingerprint`), so
+// the next turn's gate can stay quiet until the state actually changes.
+//
+// Cleared three ways, each deliberate:
+//   - fingerprint mismatch: the gate compares fresh state itself, so any real
+//     change (a follow-up, an A2A transition, a pane flipping status) re-arms
+//     it with no call here;
+//   - a human turn (beginTrackedWork): the human spoke, the brain owes the
+//     fleet a fresh look even if nothing else moved;
+//   - the TTL below: a truly wedged fleet still gets a rate-limited reminder
+//     instead of silence forever.
+
+/** How long a cap-out suppression holds. Three refusals per this window on a
+ *  wedged, unchanging fleet — versus three per wake cycle without it. */
+export const GATE_CAP_SUPPRESSION_TTL_MS = 15 * 60_000;
+
+interface CapOut {
+  fingerprint: string;
+  at: number;
+}
+
+const capOuts = new Map<string, CapOut>();
+
+/** Record that `workspaceId`'s gate capped out while holding on `fingerprint`
+ *  (the allow verdict's `cappedOutFingerprint`). Last write wins. */
+export function noteGateCapOut(
+  workspaceId: string,
+  fingerprint: string,
+  now: number = Date.now(),
+): void {
+  capOuts.set(workspaceId, { fingerprint, at: now });
+}
+
+/** The fingerprint whose re-block is currently suppressed, or null. Fail-open
+ *  like the holds: unknown workspace or an expired record reads as null, and
+ *  the gate simply re-arms — a wrongly-expired suppression costs at most one
+ *  more capped refusal run. */
+export function suppressedGateFingerprint(
+  workspaceId: string,
+  now: number = Date.now(),
+): string | null {
+  const rec = capOuts.get(workspaceId);
+  if (!rec) return null;
+  if (now - rec.at > GATE_CAP_SUPPRESSION_TTL_MS) {
+    capOuts.delete(workspaceId);
+    return null;
+  }
+  return rec.fingerprint;
+}
+
+/** Re-arm the gate: a human turn landed, or the commander was retired. */
+export function clearGateCapOut(workspaceId: string): void {
+  capOuts.delete(workspaceId);
+}
+
+/** Test seam. */
+export function resetGateCapOuts(): void {
+  capOuts.clear();
+}

--- a/src/main/ipc/handlers/__tests__/deck.handler.activeWorkDiet.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.activeWorkDiet.test.ts
@@ -1,0 +1,244 @@
+// The [active-work] injection diet (terminal brain only): the full block —
+// objective, every follow-up, every A2A row, the ownership imperatives — used
+// to be re-typed onto the visible TUI on EVERY turn. Unchanged content now
+// collapses to a one-line reminder (renderActiveDeckWorkReminderLine); any
+// change to the rendered block re-sends it in full. Same changed-only contract
+// as the ambient autonomy/policy blocks, settled only by a clean turn.
+//
+// Stores are mocked in-memory (the handler's CONTRACT is under test); the real
+// render functions come through importOriginal so the strings asserted here are
+// the strings the brain actually reads.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const captured = new Map<string, (...args: unknown[]) => unknown>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, fn: (...args: unknown[]) => unknown) => {
+      captured.set(channel, fn);
+    }),
+    removeHandler: vi.fn((channel: string) => captured.delete(channel)),
+  },
+  app: { once: vi.fn(), removeListener: vi.fn() },
+}));
+
+vi.mock('../../../deck/commanderSessionStore', () => ({
+  loadCommanderSession: vi.fn(() => null),
+  saveCommanderSession: vi.fn(async () => undefined),
+}));
+
+// In-memory active-work store with the REAL render functions. The fake
+// beginOrContinueDeckWork mirrors the real dedupe contract: a repeated message
+// only bumps updatedAt (which the block does not render), a new message lands
+// as a follow-up (which it does).
+interface FakeWork {
+  id: string;
+  workspaceId: string;
+  objective: string;
+  followUps: string[];
+  startedAt: number;
+  updatedAt: number;
+  a2aTasks: Record<string, never>;
+  bootId: string;
+}
+const works = new Map<string, FakeWork>();
+vi.mock('../../../deck/deckWorkStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../deck/deckWorkStore')>();
+  return {
+    ...actual,
+    loadActiveDeckWork: vi.fn((ws: string) => works.get(ws) ?? null),
+    loadActiveDeckWorks: vi.fn(() => Object.fromEntries(works.entries())),
+    loadLiveDeckWork: vi.fn((ws: string) => works.get(ws) ?? null),
+    loadLiveDeckWorks: vi.fn(() => Object.fromEntries(works.entries())),
+    // isDeckWorkParked and setDeckWorkBootId stay REAL (via the spread): the
+    // real renderActiveDeckWorkBlock consults the real parked predicate
+    // internally, so the fake records must be live the real way — stamped with
+    // the boot id the beforeEach installs.
+    unparkDeckWork: vi.fn(() => undefined),
+    beginOrContinueDeckWork: vi.fn((ws: string, text: string) => {
+      const cur = works.get(ws);
+      if (cur) {
+        if (text !== cur.objective && !cur.followUps.includes(text)) {
+          cur.followUps = [...cur.followUps, text];
+        }
+        cur.updatedAt += 1;
+        return { work: cur };
+      }
+      const work: FakeWork = {
+        id: 'work-diet-1',
+        workspaceId: ws,
+        objective: text,
+        followUps: [],
+        startedAt: 1,
+        updatedAt: 1,
+        a2aTasks: {},
+        bootId: 'boot-diet-test',
+      };
+      works.set(ws, work);
+      return { work };
+    }),
+    recordDeckWorkA2aTask: vi.fn(() => null),
+    completeActiveDeckWork: vi.fn(() => null),
+    clearActiveDeckWork: vi.fn(() => null),
+    hasPendingDeckWorkA2aTasks: vi.fn(() => false),
+  };
+});
+
+vi.mock('../../../deck/deckLoopStateStore', () => ({
+  LOOP_STATE_LIMITS: { MIN_ITERATIONS: 1, MAX_ITERATIONS: 100, DEFAULT_ITERATIONS: 25 },
+  loadWorkspaceLoopState: vi.fn(() => null),
+  renderLoopStateBlock: vi.fn(() => ''),
+  startLoop: vi.fn(async () => null),
+  clearLoop: vi.fn(async () => undefined),
+  setLoopStatus: vi.fn(async () => null),
+  setTaskPasses: vi.fn(async () => null),
+}));
+
+vi.mock('../../../deck/deckAutonomyStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../deck/deckAutonomyStore')>();
+  return {
+    ...actual,
+    loadWorkspaceAutonomy: vi.fn(() => ({ mode: 'assist', ...actual.modeToCaps('assist') })),
+    loadWorkspaceMode: vi.fn(() => 'assist' as const),
+    setWorkspaceAutonomy: vi.fn(async () => ({})),
+    setWorkspaceMode: vi.fn(async () => ({})),
+  };
+});
+
+vi.mock('../../../deck/deckScheduleStore', () => ({
+  loadDeckSchedules: vi.fn(() => []),
+  saveDeckSchedules: vi.fn(async () => undefined),
+  createSchedule: vi.fn(() => null),
+  dueSchedules: vi.fn(() => []),
+  advanceAfterRun: vi.fn((s: unknown) => s),
+  DECK_SCHEDULE_LIMITS: { MAX_SCHEDULES: 50, MAX_PROMPT_CHARS: 4000 },
+}));
+
+vi.mock('../../../deck/deckDecisionStore', () => ({
+  loadWorkspaceDecision: vi.fn(() => null),
+  loadDeckDecisions: vi.fn(() => ({})),
+  hasPendingDecision: vi.fn(() => false),
+  resolveDecision: vi.fn(async () => null),
+  clearResolvedDecision: vi.fn(async () => undefined),
+  clearDecision: vi.fn(async () => undefined),
+  renderDecisionBlock: vi.fn(() => ''),
+  renderStaleDecisionBlock: vi.fn(() => ''),
+  isDecisionStale: vi.fn(() => false),
+  raiseDecision: vi.fn(async () => null),
+}));
+
+vi.mock('../../../deck/deckPolicy', () => ({
+  loadDeckPolicyBlock: vi.fn(() => null),
+  ensureDeckPolicySeed: vi.fn(() => undefined),
+  getDeckPolicyPath: vi.fn(() => '/fake/deck-policy.md'),
+}));
+
+import { registerDeckHandler } from '../deck.handler';
+import { setDeckWorkBootId } from '../../../deck/deckWorkStore';
+import { IPC } from '../../../../shared/constants';
+import type { BrainAdapter, BrainEvent, BrainStartOptions } from '../../../deck/BrainAdapter';
+
+/** Fake adapter recording the exact text each turn was sent with. */
+class FakeAdapter implements BrainAdapter {
+  sessionId: string | null = null;
+  sentTexts: string[] = [];
+  constructor(public readonly workspaceId: string) {}
+  start(opts: BrainStartOptions): void {
+    void opts;
+  }
+  async *send(text: string): AsyncIterable<BrainEvent> {
+    this.sentTexts.push(text);
+    yield { type: 'turn-end', sessionId: 'sess-1' } as BrainEvent;
+  }
+  interrupt(): void {
+    /* no-op fake */
+  }
+  dispose(): void {
+    /* no-op fake */
+  }
+}
+
+let adapters: FakeAdapter[];
+let cleanup: (() => void) | null = null;
+
+const fakeWindow = {
+  isDestroyed: () => false,
+  webContents: { send: () => undefined },
+} as unknown as import('electron').BrowserWindow;
+
+const invoke = (channel: string, payload: Record<string, unknown>) =>
+  captured.get(channel)!({}, payload) as Promise<Record<string, unknown>>;
+
+const send = (text: string) => invoke(IPC.DECK_SEND, { workspaceId: 'ws-1', text });
+
+/** All texts every fake adapter has been sent, in order. */
+const sentTexts = (): string[] => adapters.flatMap((a) => a.sentTexts);
+
+beforeEach(() => {
+  captured.clear();
+  works.clear();
+  adapters = [];
+  cleanup?.();
+  // The vendor defaults to claude-pty and no getDaemonClient means "daemon
+  // available", so the injected adapter is recorded as the terminal brain —
+  // the vendor the diet applies to. Reconcile is deferred out of the test.
+  cleanup = registerDeckHandler(() => fakeWindow, {
+    reconcileDelayMs: 600_000,
+    createAdapter: (opts) => {
+      const a = new FakeAdapter(opts.workspaceId);
+      adapters.push(a);
+      return a;
+    },
+  });
+  // AFTER register (which stamps the EventBus boot id): make the fake records'
+  // stamp the current boot, so the real parked predicate reads them as LIVE.
+  setDeckWorkBootId('boot-diet-test');
+});
+
+describe('[active-work] changed-only injection (terminal brain)', () => {
+  it('sends the full block on the first turn', async () => {
+    const res = await send('ship the roster');
+    expect(res.ok).toBe(true);
+    expect(sentTexts()).toHaveLength(1);
+    expect(sentTexts()[0]).toContain('[active-work] id: work-diet-1');
+    expect(sentTexts()[0]).toContain('objective: ship the roster');
+    expect(sentTexts()[0]).toContain('You OWN this request');
+  });
+
+  it('collapses an UNCHANGED block to the one-line reminder on the next turn', async () => {
+    await send('ship the roster');
+    // The repeat only bumps updatedAt (the real store dedupes the text), so
+    // the rendered block is byte-identical to what the conversation has seen.
+    await send('ship the roster');
+    const second = sentTexts()[1];
+    expect(second).toContain('[active-work] id: work-diet-1');
+    expect(second).toContain('unchanged since your last turn');
+    // The contract's imperatives survive in the reminder…
+    expect(second).toMatch(/still ACTIVE/i);
+    expect(second).toContain('deck_complete_work');
+    // …but the full block does not re-send.
+    expect(second).not.toContain('You OWN this request');
+    expect(second).not.toContain('objective: ship the roster');
+  });
+
+  it('re-sends the full block as soon as the record changes (a new follow-up)', async () => {
+    await send('ship the roster');
+    await send('ship the roster');
+    await send('also add tests');
+    const third = sentTexts()[2];
+    expect(third).toContain('You OWN this request');
+    expect(third).toContain('objective: ship the roster');
+    expect(third).toContain('- also add tests');
+    expect(third).not.toContain('unchanged since your last turn');
+  });
+
+  it('a changed block re-arms the reminder for the turn after it', async () => {
+    await send('ship the roster');
+    await send('also add tests');
+    await send('also add tests');
+    const third = sentTexts()[2];
+    expect(third).toContain('unchanged since your last turn');
+    expect(third).not.toContain('You OWN this request');
+  });
+});

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -32,7 +32,13 @@ import {
   type DaemonClientLike,
 } from '../../deck/ClaudePtyBrainAdapter';
 import { evaluateStopGate } from '../../deck/stopGate';
-import { noteGateVerdict, clearGateVerdict } from '../../deck/stopGateState';
+import {
+  noteGateVerdict,
+  clearGateVerdict,
+  noteGateCapOut,
+  suppressedGateFingerprint,
+  clearGateCapOut,
+} from '../../deck/stopGateState';
 import type { BrainVendor } from '../../../shared/types';
 import { getMemoryRootDir } from '../../deck/commanderMemory';
 import { loadDeckPolicyBlock, ensureDeckPolicySeed } from '../../deck/deckPolicy';
@@ -93,6 +99,7 @@ import {
   loadLiveDeckWorks,
   recordDeckWorkA2aTask,
   renderActiveDeckWorkBlock,
+  renderActiveDeckWorkReminderLine,
   renderStrandedDeckWorkBlock,
   setDeckWorkBootId,
   unparkDeckWork,
@@ -276,6 +283,12 @@ export function registerDeckHandler(
     }
   };
 
+  // The fingerprint of each workspace's LAST refused Stop (rule 5). A cap-out
+  // is recorded for suppression only when it names this same state — the gate
+  // must never silence a hold no refusal was ever issued for. In-memory and
+  // per-registration, cleared with the commander (retireManager).
+  const lastBlockedFingerprints = new Map<string, string>();
+
   const createAdapter =
     opts.createAdapter ??
     ((adapterOpts: {
@@ -315,6 +328,15 @@ export function registerDeckHandler(
                 snapshot,
                 activeWork: loadActiveDeckWork(workspaceId),
                 consecutiveBlocks,
+                // A pending decision means the brain is legitimately waiting
+                // on a human (gate rule 4) — the same signal that already
+                // suppresses every auto-wake releases the Stop gate. Read
+                // fresh per Stop, so resolve/clear re-arms with no state.
+                pendingDecision: hasPendingDecision(workspaceId),
+                // Cap-out hysteresis (rule 5): once the gate has given up on
+                // this exact state, re-blocking on it next turn only re-buys
+                // the same refusal run.
+                suppressedFingerprint: suppressedGateFingerprint(workspaceId),
               });
               // Record which panes are holding the gate so input.rpc can refuse
               // session-terminating input aimed at them (#733). The list comes
@@ -326,6 +348,18 @@ export function registerDeckHandler(
                 workspaceId,
                 verdict.block ? verdict.outstandingPtyIds : null,
               );
+              if (verdict.block) {
+                lastBlockedFingerprints.set(workspaceId, verdict.fingerprint);
+              } else if (
+                verdict.cappedOutFingerprint &&
+                // Suppress only a state the gate actually REFUSED at least
+                // once. The capping Stop sees the fleet as it is NOW — a
+                // worker dispatched mid-refusal-run would otherwise be
+                // silenced by a cap-out no refusal ever named.
+                lastBlockedFingerprints.get(workspaceId) === verdict.cappedOutFingerprint
+              ) {
+                noteGateCapOut(workspaceId, verdict.cappedOutFingerprint);
+              }
               return verdict;
             },
             onForeignTurnEnd: adapterOpts.onForeignTurnEnd,
@@ -385,6 +419,10 @@ export function registerDeckHandler(
   const retireManager = (workspaceId: string): void => {
     managers.delete(workspaceId);
     clearGateVerdict(workspaceId);
+    // The cap-out suppression dies with the commander too — a new commander in
+    // the same workspace starts with a fully-armed gate.
+    clearGateCapOut(workspaceId);
+    lastBlockedFingerprints.delete(workspaceId);
   };
 
   // Fleet-wide ceiling on CONCURRENT autonomous turns. Each workspace's manager
@@ -561,6 +599,10 @@ export function registerDeckHandler(
   const beginTrackedWork = (workspaceId: string, text: string): void => {
     const humanText = text.trim();
     try {
+      // A human turn re-arms a capped-out Stop gate (rule 5): whatever state
+      // the gate went quiet on, the human has now spoken, and the brain owes
+      // the fleet a fresh look even if nothing else changed.
+      clearGateCapOut(workspaceId);
       // The placeholder stands in for a prompt main never saw — the terminal
       // brain's UserPromptSubmit can carry an empty body. It is a fine objective
       // for a workspace that owns nothing yet, and it is NOT allowed to be
@@ -689,7 +731,18 @@ export function registerDeckHandler(
           coalescer?.notifyHumanSend(workspaceId);
         },
         onForeignTurnEnd: () => managerRef?.notifyForeignTurnEnd(),
-        onForeignSessionId: (sessionId) => managerRef?.notifyForeignSessionId(sessionId),
+        onForeignSessionId: (sessionId) => {
+          // A CHANGED session id means the TUI conversation was reset (e.g.
+          // /clear typed into the terminal) — the new conversation has never
+          // seen the ambient rules or the full [active-work] block, so the
+          // changed-only memory must forget or the reminder line would point
+          // at a contract that no longer exists anywhere on screen. The first
+          // announcement of a session is not a reset and keeps the memory.
+          const prev = lastForeignSessionIds.get(workspaceId);
+          lastForeignSessionIds.set(workspaceId, sessionId);
+          if (prev !== undefined && prev !== sessionId) forgetAmbient(workspaceId);
+          managerRef?.notifyForeignSessionId(sessionId);
+        },
         ...(model ? { model } : {}),
         ...(fullPower ? { fullPower: true } : {}),
       }),
@@ -754,21 +807,42 @@ export function registerDeckHandler(
   // anything, so marking at build time permanently skipped those blocks for the
   // retry. Promoted to `shown` only by a CLEAN turn (settleAmbient).
   const pendingAmbientBlocks = new Map<string, string>();
-  /** Resolve the ambient blocks this workspace's just-finished turn carried.
-   *  `code:'errored'` covers both a thrown adapter and one that merely YIELDED
-   *  an error event (the TUI-dialog case) — either way the brain did not see
-   *  the blocks, so the next turn must re-send them. */
+  // Same changed-only memory for the [active-work] block, for the same reason:
+  // the full block (objective + every follow-up + every A2A row + the ownership
+  // imperatives) re-typed on screen every wake was the largest recurring
+  // injection in a supervision loop. An UNCHANGED block collapses to a one-line
+  // reminder (renderActiveDeckWorkReminderLine) rather than to nothing — unlike
+  // autonomy/policy, the ownership contract must stay in every turn's face.
+  const shownActiveWorkBlocks = new Map<string, string>();
+  const pendingActiveWorkBlocks = new Map<string, string>();
+  // The last session id each workspace's TUI brain announced. A CHANGE means
+  // the on-screen conversation was reset, which invalidates everything the
+  // changed-only memory believes the brain has already seen.
+  const lastForeignSessionIds = new Map<string, string>();
+  /** Resolve the changed-only blocks this workspace's just-finished turn
+   *  carried. `code:'errored'` covers both a thrown adapter and one that merely
+   *  YIELDED an error event (the TUI-dialog case) — either way the brain did
+   *  not see the blocks, so the next turn must re-send them. */
   const settleAmbient = (workspaceId: string, verdict: CommanderSendResult): void => {
+    const delivered = verdict.ok && verdict.code !== 'errored';
     const pending = pendingAmbientBlocks.get(workspaceId);
-    if (pending === undefined) return;
-    pendingAmbientBlocks.delete(workspaceId);
-    if (verdict.ok && verdict.code !== 'errored') shownAmbientBlocks.set(workspaceId, pending);
+    if (pending !== undefined) {
+      pendingAmbientBlocks.delete(workspaceId);
+      if (delivered) shownAmbientBlocks.set(workspaceId, pending);
+    }
+    const pendingWork = pendingActiveWorkBlocks.get(workspaceId);
+    if (pendingWork !== undefined) {
+      pendingActiveWorkBlocks.delete(workspaceId);
+      if (delivered) shownActiveWorkBlocks.set(workspaceId, pendingWork);
+    }
   };
-  /** Drop both halves of the ambient memory — a retired conversation must be
-   *  told the rules again. */
+  /** Drop the changed-only memory — a retired conversation must be told the
+   *  rules (and the full active-work contract) again. */
   const forgetAmbient = (workspaceId: string): void => {
     shownAmbientBlocks.delete(workspaceId);
     pendingAmbientBlocks.delete(workspaceId);
+    shownActiveWorkBlocks.delete(workspaceId);
+    pendingActiveWorkBlocks.delete(workspaceId);
   };
   const withLoopContext = (workspaceId: string, text: string): string => {
     // Mode is read fresh here (not cached) so a Settings flip between turns
@@ -816,7 +890,25 @@ export function registerDeckHandler(
     // urgent trusted context. Both decision + loop survive a reboot as atomic
     // JSON, so a resumed brain re-reads exactly where it paused.
     if (decision) blocks.push(renderDecisionBlock(decision));
-    if (activeWork) blocks.push(renderActiveDeckWorkBlock(activeWork));
+    if (activeWork) {
+      // Changed-only injection for the visible TUI brain, same vendor gate as
+      // the ambient blocks above. An unchanged block collapses to a one-line
+      // reminder instead of vanishing — the ownership contract must survive in
+      // some form on every turn. PARKED records are exempt: parking changes
+      // what the block means (a prohibition, not ownership), and the reminder
+      // line speaks ownership language, so a parked record always goes in full.
+      const workBlock = renderActiveDeckWorkBlock(activeWork);
+      if (vendorForWorkspace(workspaceId) === 'claude-pty' && !isDeckWorkParked(activeWork)) {
+        if (shownActiveWorkBlocks.get(workspaceId) === workBlock) {
+          blocks.push(renderActiveDeckWorkReminderLine(activeWork));
+        } else {
+          pendingActiveWorkBlocks.set(workspaceId, workBlock);
+          blocks.push(workBlock);
+        }
+      } else {
+        blocks.push(workBlock);
+      }
+    }
     if (loop) blocks.push(renderLoopStateBlock(loop));
     if (blocks.length === 0) return text;
     return `${blocks.join('\n\n')}\n\n${text}`;
@@ -1295,6 +1387,9 @@ export function registerDeckHandler(
         : {};
       const workspaceId = readWorkspaceId(req);
       if (!workspaceId) return { ok: false, code: 'invalid_workspace' };
+      // A pressed Wake button is a human acting: the turn it kicks must meet
+      // an ARMED stop gate, whatever state a cap-out went quiet on (rule 5).
+      clearGateCapOut(workspaceId);
       // Non-queued on purpose: a button press wants an immediate verdict — a
       // busy reject (this workspace mid-turn, or the fleet gate full) returns
       // right away and the human just presses again later. runTurnForWorkspace
@@ -2159,6 +2254,11 @@ export function registerDeckHandler(
       // itself rides the prompt, so a "drop it" answer is the brain's to act on;
       // un-parking grants permission to act, not a decision about what to do.
       unparkDeckWork(workspaceId);
+      // A human answering IS a human turn for the stop gate's purposes (rule
+      // 5): the resume turn that carries this answer must meet an ARMED gate,
+      // or a model that no-ops the answer and stops slips through a cap-out
+      // suppression recorded before the decision was even raised.
+      clearGateCapOut(workspaceId);
       // Un-blocked now (hasPendingDecision is false). Kick a resume turn; a busy
       // reject is fine — the resolution rides withLoopContext on the next turn
       // (event / schedule / human) and is consumed then. Fire-and-forget: the


### PR DESCRIPTION
## Problem

A 90-minute supervision loop (transcript, 2026-08-07) exposed three compounding token sinks in the Command Deck orchestrator:

1. **Gate vs. waiting-on-human**: the Stop gate refused to end a turn while active work was open, but the brain was waiting on a human answer — its only remaining move was re-printing the same question, which it did 4x per cycle (3 refusals + cap).
2. **Per-turn cap, per-minute loop**: the consecutive-block counter resets every turn, so a wake loop over *unchanged* fleet state re-bought the same three refusals every cycle.
3. **Full re-injection**: the complete [active-work] block (objective + every follow-up + A2A rows + imperatives) was re-typed onto the visible TUI on every turn, and the follow-up dedupe was last-item-only, so re-sent instructions accumulated quadratically.

## Changes

- **stopGate rule 4** — a PENDING deck decision releases the gate. Mirror image of the coalescer's existing wake suppression under a pending decision; the resolve path already kicks an explicit resume turn.
- **stopGate rule 5** — cap-out hysteresis. The capping allow carries a fingerprint of what was held on (`work.id@updatedAt | sorted pane:status`); the handler records it **only when that exact state was actually refused**, and the gate stays quiet on identical state until it changes, a human acts (DECK_SEND / TUI prompt / Wake / decision resolve), or a 15-min TTL expires.
- **Refusal strings** — every refusal now forbids re-sending the previous message and names deck_ask_decision as the legitimate way to wait (it releases the gate).
- **followUps dedupe** — whitespace-normalized compare against the objective and *every* retained follow-up, append-time only (stored records are never rewritten; the completeWork CAS is untouched).
- **[active-work] injection diet** (terminal brain only) — a byte-identical block collapses to a one-line reminder that keeps the id and the two imperatives (still ACTIVE, deck_complete_work). Settled like the ambient blocks (only a clean turn marks it shown); PARKED records always render in full; a TUI conversation reset (foreign session id change) forgets the memory so the full block re-sends.

## Verification

- `tsc --noEmit` clean; `npx vitest run src/main/deck src/main/ipc/handlers`: **954 passed**; full `test:parallel`: 10,387 passed (1 pre-existing environment-dependent failure in `bridgePermissionGate.test.ts`, fails identically at HEAD).
- New/extended tests: stopGate (rule 4/5, fingerprint, refusal strings), stopGateState (cap-out TTL/clear), deckWorkStore (non-adjacent + whitespace-variant dedupe, reminder line), and `deck.handler.activeWorkDiet.test.ts` (full → reminder → full-on-change → reminder re-arm).
- An adversarial multi-agent review of the diff confirmed 3 defects, all fixed in this PR: decision-resolve/Wake not re-arming a capped-out gate; the diet memory surviving a TUI conversation reset; a cap-out suppressing a state no refusal ever named.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending decisions now correctly release the stop gate.
  * Repeated refusal messages are suppressed until work or state changes.
  * Follow-up instructions are deduplicated, including whitespace variations and repeats of the original objective.
  * Stop-gate suppression expires safely and resets after relevant actions or state changes.

* **Improvements**
  * Active work is shown compactly after its initial display, expanding again when details change or conversations reset.
  * Parked work continues to display complete details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->