### PR TITLE
fix(cwd): resolve the host platform from the preload bridge

### DIFF
--- a/changelog.d/834.md
+++ b/changelog.d/834.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **A pane's working directory follows `cd` again on Windows.** The per-surface
+  cwd was frozen at whatever directory the pane started in, so `surface.list`
+  and `pane.list` reported a stale path no matter how many times you changed
+  directory — and `task.fanout.start`, which derives the repository from that
+  value, refused to start with "the calling terminal's directory is not inside a
+  git repository" even when the pane was sitting inside one. The shape guard on
+  the cwd write resolved the host platform from `process.platform`, which does
+  not exist in the renderer under context isolation; it therefore assumed a
+  POSIX host and discarded every `C:\…` as impossible. It now reads the platform
+  from the preload bridge. The workspace-level directory was never affected,
+  which is why only agents and MCP callers saw the stale value. (#834)

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -182,12 +182,62 @@ describe('surfaceSlice.updateSurfaceCwd', () => {
     const paneId = state.workspaces[0].rootPane.id;
     slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\\a');
 
-    slice.updateSurfaceCwd('', 'D:\\nope');
-    slice.updateSurfaceCwd('ghost', 'D:\\nope');
+    // POSIX shapes on purpose: a Windows path would also be dropped by the
+    // cwdShape guard on a POSIX runner, so this would pass without the ptyId
+    // check doing any work at all.
+    slice.updateSurfaceCwd('', '/nope');
+    slice.updateSurfaceCwd('ghost', '/nope');
 
     const pane = state.workspaces[0].rootPane;
     if (pane.type !== 'leaf') throw new Error('expected leaf pane');
     expect(pane.surfaces[0].cwd).toBe('C:\\a');
+  });
+
+  // Issue #833 — on a Windows host the per-surface cwd never followed a `cd`.
+  // updateSurfaceCwd guards with isPlausibleCwd() and passed no platform; the
+  // renderer has no `process` (contextIsolation), so the default resolved to
+  // 'linux' and rejected every `C:\…`. The workspace-level cwd has a second,
+  // unguarded feeder (the metadata route), which is why only the surface value
+  // looked frozen — and why `surface.list`/`pane.list` reported the spawn
+  // directory forever, breaking task.fanout.start's repo precondition.
+  //
+  // The suite runs on POSIX in CI, so the host platform is stubbed through the
+  // preload bridge — the same channel the renderer really reads.
+  it('follows a cd on a Windows host (#833)', () => {
+    const host = globalThis as { electronAPI?: { platform?: string } };
+    host.electronAPI = { platform: 'win32' };
+    try {
+      const { state, slice } = createHarness();
+      const paneId = state.workspaces[0].rootPane.id;
+      slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\\Users\\rizz');
+
+      slice.updateSurfaceCwd('pty-1', 'D:\\AI_Projects\\wmux-fork');
+
+      const pane = state.workspaces[0].rootPane;
+      if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+      expect(pane.surfaces[0].cwd).toBe('D:\\AI_Projects\\wmux-fork');
+    } finally {
+      delete host.electronAPI;
+    }
+  });
+
+  it('still rejects an implausible shape for the host (prompt-scrape guard)', () => {
+    const host = globalThis as { electronAPI?: { platform?: string } };
+    host.electronAPI = { platform: 'darwin' };
+    try {
+      const { state, slice } = createHarness();
+      const paneId = state.workspaces[0].rootPane.id;
+      slice.addSurface(paneId, 'zsh-1', 'zsh', '/Users/me');
+
+      // The 2026-07-20 incident: "PS C:\…>" scraped off screen text on a mac.
+      slice.updateSurfaceCwd('zsh-1', 'C:\\Users\\me');
+
+      const pane = state.workspaces[0].rootPane;
+      if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+      expect(pane.surfaces[0].cwd).toBe('/Users/me');
+    } finally {
+      delete host.electronAPI;
+    }
   });
 });
 

--- a/src/shared/__tests__/cwdShape.test.ts
+++ b/src/shared/__tests__/cwdShape.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { isPlausibleCwd } from '../cwdShape';
+
+type BridgeHost = { electronAPI?: { platform?: string } };
+
+/** Stand in for the preload bridge — the renderer's only host-platform source. */
+function setBridgedPlatform(platform: string | undefined): void {
+  const host = globalThis as BridgeHost;
+  if (platform === undefined) delete host.electronAPI;
+  else host.electronAPI = { platform };
+}
 
 // Regression (2026-07-21): a pane's cwd was stored as the literal string "path"
 // — a prompt-scrape false positive that the old win32 rule ("any non-empty
@@ -47,5 +56,45 @@ describe('isPlausibleCwd — absolute-shape guard', () => {
 
   it('rejects a ~-prefixed non-anchor token (e.g. "~foo" is a username ref, not a cwd we track)', () => {
     expect(isPlausibleCwd('~foo/bar', 'linux')).toBe(false);
+  });
+});
+
+// Issue #833: the renderer has no `process` (contextIsolation), so the omitted-
+// platform default resolved to 'linux' there and rejected every Windows path.
+// That is the write path for the per-surface cwd, so on a Windows host the cwd
+// froze at the spawn directory. These lock the default's resolution order —
+// they are the tests that would have caught it, since every existing case above
+// passes the platform explicitly and so never exercises the default at all.
+describe('isPlausibleCwd — default platform resolution', () => {
+  afterEach(() => setBridgedPlatform(undefined));
+
+  it('uses the preload bridge platform when there is no process (renderer)', () => {
+    setBridgedPlatform('win32');
+    // No explicit platform — exactly how surfaceSlice.updateSurfaceCwd calls it.
+    expect(isPlausibleCwd('C:\\Users\\me\\repo')).toBe(true);
+    expect(isPlausibleCwd('D:\\')).toBe(true);
+    expect(isPlausibleCwd('\\\\server\\share')).toBe(true);
+  });
+
+  it('still rejects an impossible shape when the bridge reports a POSIX host', () => {
+    setBridgedPlatform('darwin');
+    expect(isPlausibleCwd('C:\\Users\\me')).toBe(false);
+    expect(isPlausibleCwd('/Users/me')).toBe(true);
+  });
+
+  it('prefers the bridge over process.platform when both exist', () => {
+    setBridgedPlatform('win32');
+    // The suite runs on POSIX in CI, where process.platform would reject this.
+    expect(isPlausibleCwd('C:\\Users\\me')).toBe(true);
+  });
+
+  it('falls back to process.platform when no bridge is present (main/daemon)', () => {
+    setBridgedPlatform(undefined);
+    // POSIX-absolute passes on every platform, so this holds on any runner.
+    expect(isPlausibleCwd('/home/me')).toBe(true);
+    // A Windows shape tracks the real host: accepted on win32, rejected on POSIX.
+    expect(isPlausibleCwd('C:\\Users\\me')).toBe(process.platform === 'win32');
+    // A relative token is rejected regardless of which source answered.
+    expect(isPlausibleCwd('path')).toBe(false);
   });
 });

--- a/src/shared/cwdShape.ts
+++ b/src/shared/cwdShape.ts
@@ -12,10 +12,32 @@
 // repo resolution). Reject anything that is not drive-absolute, UNC, POSIX-
 // absolute, or ~-anchored — on every platform.
 
+/**
+ * Resolve the host platform from whichever channel this process actually has.
+ *
+ * The renderer runs under `contextIsolation: true` / `nodeIntegration: false`,
+ * so it has no `process` global at all — the preload bridge is its only source
+ * of the host platform. The old default fell straight through to 'linux' there,
+ * which made every Windows path implausible in the renderer (issue #833): the
+ * per-surface cwd write silently dropped `C:\…` on every `cd`, so `surface.list`
+ * / `pane.list` stayed pinned to the spawn directory while the workspace row —
+ * fed by a second, unguarded path — followed along correctly.
+ *
+ * Order is deliberate: the bridge first (it is the only correct answer in the
+ * renderer, and in main it agrees with `process.platform` anyway), then the real
+ * `process`, then the historical 'linux' fallback for a bare non-Electron host.
+ */
+function hostPlatform(): NodeJS.Platform | string {
+  const bridged = (globalThis as { electronAPI?: { platform?: string } }).electronAPI?.platform;
+  if (typeof bridged === 'string' && bridged) return bridged;
+  if (typeof process !== 'undefined' && process.platform) return process.platform;
+  return 'linux';
+}
+
 /** Whether the cwd shape can exist on the current platform. platform defaults to the runtime environment. */
 export function isPlausibleCwd(
   cwd: string,
-  platform: NodeJS.Platform | string = typeof process !== 'undefined' ? process.platform : 'linux',
+  platform: NodeJS.Platform | string = hostPlatform(),
 ): boolean {
   if (!cwd) return false;
   const isWinShape = /^[A-Za-z]:[\\/]/.test(cwd) || cwd.startsWith('\\\\');


### PR DESCRIPTION
## What

`isPlausibleCwd()` resolves the host platform from the preload bridge before
falling back to `process.platform`. That single default was the whole bug.

Fixes #833.

## Why the surface cwd froze but the workspace cwd did not

`updateSurfaceCwd` guards its write with the shape check and passes **no**
platform:

```ts
// src/renderer/stores/slices/surfaceSlice.ts
if (!isPlausibleCwd(cwd)) return;
```

The default read `process.platform`. The renderer runs under
`contextIsolation: true` / `nodeIntegration: false`, so it has no `process`
global at all — the guard fell through to its `'linux'` fallback, where
`isWinShape` is fatal:

```ts
if (platform === 'win32') return true;
return !isWinShape;   // every C:\… is "implausible"
```

So on a Windows host **every** `cd` was dropped on the floor at the write.

The workspace-level cwd survived because it has a second feeder with no shape
guard at all — `metadata.onUpdate` → `applyToWorkspace`, alongside the
unguarded write in the same coalescer callback in `useNotificationListener`.
One field, two writers, one of them guarded: that asymmetry is what made this
look like "OSC 7 isn't being followed" when the signal was arriving correctly
the entire time.

The triage note that `gitBranch` follows the `cd` is the confirming detail, and
it also proves the event really does reach the renderer: the daemon's
`GitContextWatcher` is driven off `session:cwd`, the same event that is
broadcast as `cwd.changed` → `IPC.CWD_CHANGED`. Every hop between them is
unconditional. Nothing upstream of the renderer was broken.

## Consequences this fixes

- `surface.list` and `pane.list` both serve `surface.cwd || workspaceCwd`, so
  both reported the spawn directory forever.
- `task.fanout.start` derives its repo from that value
  (`resolveSenderSurfaceCwd` in `fanout.rpc.ts`), so fan-out refused to start
  from any pane whose app had not opened directly on the repository — the
  `FAILED_PRECONDITION` in the report.

## Why fix the default rather than the call site

Two other renderer call sites — `GitTab.tsx:60` and `ReviewTab.tsx:82` — had
already hit this and worked around it locally by passing
`window.electronAPI.platform`, with a comment naming the exact trap. Those are
both *read* paths; the *write* path was left on the broken default, which is
why the stored value was wrong while the views that re-checked it looked fine.
Patching the third call site would have left the same trap armed for the
fourth. Fixing the default fixes every present and future caller, and call
sites that pass a platform explicitly are unaffected.

Per-call-site verdicts for `isPlausibleCwd`:

| Call site | Verdict |
|---|---|
| `main/pty/cwdDetect.ts:88` | passes platform explicitly; main has a real `process`. No change. |
| `renderer/components/Deck/GitTab.tsx:60` | already passes the bridge platform. No change (and now correct even if it stops). |
| `renderer/components/Deck/ReviewTab.tsx:82` | same. No change. |
| `renderer/stores/slices/surfaceSlice.ts:315` | **the bug** — omitted platform on the write path. |

## Adjacent instance, deliberately not bundled

`createPathLinkProvider` (`renderer/terminal/pathLinkProvider.ts:166`) has the
same `process.platform`-or-`'linux'` default and its only caller
(`useTerminal.ts:907`) omits the argument, so UNC paths are not linkified on
Windows. Its docstring already documents that degradation as understood, and it
is cosmetic rather than a correctness bug, so it is out of scope here. Happy to
send it separately if you want it.

## Verification

- `src/shared/__tests__/cwdShape.test.ts` — new `default platform resolution`
  block. Every pre-existing case passes a platform explicitly, so the default
  was never exercised; that is why the suite could not have caught this.
- `src/renderer/stores/slices/__tests__/surfaceSlice.test.ts` — reproduces the
  reported symptom at the store level, plus a case proving the 2026-07-20
  prompt-scrape guard still rejects a `C:\…` on a POSIX host.
- Both stub the host platform through the preload bridge, the same channel the
  renderer really reads, so they are meaningful on a POSIX CI runner.
- I also fixed a test that passed for the wrong reason: the "unknown ptyId"
  no-op case asserted with `D:\nope`, which a POSIX runner rejects on shape
  before the ptyId check does any work. It uses a POSIX path now.
- Confirmed load-bearing: with `process.platform` stubbed to `linux` to emulate
  a POSIX runner, the new test fails without the change
  (`expected false to be true`) and passes with it.
- `npx tsc --noEmit` clean; `eslint` clean on the touched files.

Verified by static trace plus the regression tests above. I did not do a live
run of a packaged build against a real daemon, so the integration hop is argued
from the code rather than observed.

## Not addressed

The report also notes there is no wire-level workaround because `pane.split`
takes no `cwd` and `workspace.new` forwards only `name`. That is a separate
enhancement and is left alone here; it stops being a workaround-blocker once
the tracked cwd is correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows support for pane working directories, including updates after changing directories.
  * Directory listings now report the current path correctly.
  * Repository detection for task fan-out now recognizes pane directories.
  * Improved validation of Windows and macOS path formats across platforms.
  * Added a reliable fallback for detecting the host platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->