### PR TITLE
feat(appearance): add a UI scale control to Settings → Appearance

### DIFF
--- a/changelog.d/839.md
+++ b/changelog.d/839.md
@@ -1,0 +1,3 @@
+### Added
+
+- **The whole interface is now scalable from Settings.** A new **UI scale** slider in Settings → Appearance → Layout scales the sidebar, titlebar, and every chrome surface together — not just the terminal panes — so the previously hard-coded 8–12px sidebar text can be enlarged for high-DPI displays, large monitors, and accessibility. The factor persists across restarts, applies live, and keeps the native window controls (macOS traffic lights / Windows buttons) centred in the titlebar at any size. This completes the groundwork PR #824 shipped, which added the zoom plumbing behind a prototype env var with no user-facing control. (#822)

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -31,6 +31,7 @@ import { registerPaneResourcesHandlers } from './handlers/paneResources.handler'
 import { registerWebHandlers } from './handlers/web.handler';
 import { registerAccountHandlers } from './handlers/account.handler';
 import { createFlashFrameHandler } from '../window/flashFrame';
+import { applyUiZoom } from '../window/uiZoom';
 import { IPC } from '../../shared/constants';
 import { toastManager } from '../pipe/handlers/notify.rpc';
 import { markRendererNotificationListenerReady } from '../notification/rendererNotificationReadiness';
@@ -316,6 +317,42 @@ export function registerAllHandlers(
   };
   ipcMain.removeAllListeners(IPC.WINDOW_SET_TITLEBAR_OVERLAY);
   ipcMain.on(IPC.WINDOW_SET_TITLEBAR_OVERLAY, onSetTitleBarOverlay);
+
+  // Whole-interface zoom (#822). The renderer owns the persisted factor and
+  // pushes it here whenever it changes (Settings slider, session hydration).
+  // applyUiZoom clamps to UI_ZOOM_MIN/MAX, scales the renderer with
+  // setZoomFactor, and re-places the native chrome (macOS traffic lights /
+  // Windows overlay height). The overlay color pair is the same one the
+  // renderer sends to WINDOW_SET_TITLEBAR_OVERLAY, re-applied here because the
+  // overlay height changes with zoom on Windows. Cosmetic — guarded like the
+  // titleBarOverlay handler so a bad payload or missing API never crashes main.
+  const HEX_COLOR_ZOOM = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+  const onSetUiScale = (_event: Electron.IpcMainEvent, opts: unknown): void => {
+    if (!opts || typeof opts !== 'object') return;
+    const { factor, color, symbolColor } = opts as {
+      factor?: unknown;
+      color?: unknown;
+      symbolColor?: unknown;
+    };
+    if (typeof factor !== 'number' || !Number.isFinite(factor)) return;
+    const win = getWindow();
+    if (!win || win.isDestroyed()) return;
+    // Only forward overlay colors when both are valid hex; applyUiZoom no-ops
+    // the Windows branch when they are absent/invalid.
+    const overlay =
+      typeof color === 'string' && HEX_COLOR_ZOOM.test(color) &&
+      typeof symbolColor === 'string' && HEX_COLOR_ZOOM.test(symbolColor)
+        ? { color, symbolColor }
+        : undefined;
+    try {
+      applyUiZoom(win, factor, overlay);
+    } catch {
+      // setZoomFactor / setWindowButtonPosition can throw on a torn-down
+      // window — never let a cosmetic resync crash main.
+    }
+  };
+  ipcMain.removeAllListeners(IPC.WINDOW_SET_UI_SCALE);
+  ipcMain.on(IPC.WINDOW_SET_UI_SCALE, onSetUiScale);
 
   // macOS fullscreen ↔ traffic-light reserve (Titlebar.tsx paddingLeft).
   // Pull for mount-time state; the push lives in createWindow (the window

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -31,7 +31,7 @@ import { registerPaneResourcesHandlers } from './handlers/paneResources.handler'
 import { registerWebHandlers } from './handlers/web.handler';
 import { registerAccountHandlers } from './handlers/account.handler';
 import { createFlashFrameHandler } from '../window/flashFrame';
-import { applyUiZoom } from '../window/uiZoom';
+import { applyUiZoom, winOverlayHeight } from '../window/uiZoom';
 import { IPC } from '../../shared/constants';
 import { toastManager } from '../pipe/handlers/notify.rpc';
 import { markRendererNotificationListenerReady } from '../notification/rendererNotificationReadiness';
@@ -309,7 +309,17 @@ export function registerAllHandlers(
     const win = getWindow();
     if (!win || win.isDestroyed()) return;
     try {
-      win.setTitleBarOverlay({ color, symbolColor, height: 36 });
+      // Height tracks the live zoom (#822): the UI-scale handler and this
+      // theme handler both restyle the same overlay, and a renderer zoom makes
+      // the 36px chrome render `36 * zoom` points tall. Hard-coding 36 here
+      // would let a theme change race ahead of the zoom handler and reset the
+      // overlay height out from under it, so read the current factor. Zoom
+      // defaults to 1, so with no UI scale applied this is still 36.
+      win.setTitleBarOverlay({
+        color,
+        symbolColor,
+        height: winOverlayHeight(win.webContents.getZoomFactor()),
+      });
     } catch {
       // Window created without titleBarOverlay (e.g. future flag/rollback) —
       // restyling is cosmetic, never let it crash main.

--- a/src/main/window/__tests__/uiZoom.test.ts
+++ b/src/main/window/__tests__/uiZoom.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   clampUiZoom,
   macTrafficLightPosition,
   winOverlayHeight,
+  applyUiZoom,
   UI_ZOOM_MIN,
   UI_ZOOM_MAX,
 } from '../uiZoom';
@@ -56,5 +57,36 @@ describe('winOverlayHeight', () => {
   it('tracks the scaled chrome row', () => {
     expect(winOverlayHeight(1)).toBe(36);
     expect(winOverlayHeight(1.4)).toBe(50);
+  });
+});
+
+describe('applyUiZoom', () => {
+  // Minimal BrowserWindow stub — applyUiZoom touches only these three calls
+  // plus isDestroyed(). The IPC handler (registerHandlers) forwards the
+  // renderer's {factor, color, symbolColor} payload here; this guards the
+  // contract that zoom is always applied (clamped) while the chrome resync
+  // rides the platform guards inside applyUiZoom.
+  function makeWin() {
+    return {
+      isDestroyed: () => false,
+      webContents: { setZoomFactor: vi.fn() },
+      setWindowButtonPosition: vi.fn(),
+      setTitleBarOverlay: vi.fn(),
+    };
+  }
+
+  it('applies the clamped factor to setZoomFactor and returns it', () => {
+    const win = makeWin();
+    const applied = applyUiZoom(win as never, 9, undefined);
+    expect(applied).toBe(UI_ZOOM_MAX);
+    expect(win.webContents.setZoomFactor).toHaveBeenCalledWith(UI_ZOOM_MAX);
+  });
+
+  it('no-ops on a destroyed window without throwing', () => {
+    const win = makeWin();
+    win.isDestroyed = () => true;
+    const applied = applyUiZoom(win as never, 1.4, undefined);
+    expect(applied).toBe(1.4);
+    expect(win.webContents.setZoomFactor).not.toHaveBeenCalled();
   });
 });

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -3,7 +3,6 @@ import path from 'node:path';
 import { platformChoice } from '../../shared/platform';
 import { IPC } from '../../shared/constants';
 import { attachFlashFrameAutoClear } from './flashFrame';
-import { applyUiZoom } from './uiZoom';
 
 // OS-aware window-icon extension. Mirrors tray.ts so the same generated asset
 // set (icon.ico / icon.icns / icon.png) is used in both places.
@@ -137,24 +136,9 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   mainWindow.on('enter-full-screen', () => pushFullscreen(true));
   mainWindow.on('leave-full-screen', () => pushFullscreen(false));
 
-  // #822 prototype — UI zoom via WMUX_UI_ZOOM (e.g. WMUX_UI_ZOOM=1.4). Applied
-  // after first paint so the renderer has drawn the 36px bar the native
-  // controls are being centered against. Absent/invalid → untouched at 1.
-  const zoomEnv = process.env.WMUX_UI_ZOOM;
-  if (zoomEnv) {
-    const requested = Number(zoomEnv);
-    if (Number.isFinite(requested)) {
-      // `on`, not `once`: the dev path retries the Vite URL and each failed
-      // load still fires did-finish-load, so a one-shot apply lands on the
-      // error page and the real load resets the zoom factor.
-      mainWindow.webContents.on('did-finish-load', () => {
-        applyUiZoom(mainWindow, requested, {
-          color: '#151517',
-          symbolColor: '#A5A29C',
-        });
-      });
-    }
-  }
+  // UI zoom (#822) is now renderer-driven: the persisted factor lives in the
+  // renderer store and is pushed via the window:setUiScale IPC on hydration
+  // and on Settings changes. See src/renderer/components/Layout/AppLayout.tsx.
 
   if (!opts.deferLoad) {
     loadMainRenderer(mainWindow);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1029,6 +1029,12 @@ const electronAPI = {
     setTitleBarOverlay: (opts: { color: string; symbolColor: string }) => {
       ipcRenderer.send(IPC.WINDOW_SET_TITLEBAR_OVERLAY, opts);
     },
+    // Whole-interface zoom (#822): push the persisted factor to main, which
+    // scales the renderer and re-places the native chrome. The overlay color
+    // pair is the same theme colors sent to setTitleBarOverlay (Windows only).
+    setUiScale: (opts: { factor: number; color?: string; symbolColor?: string }) => {
+      ipcRenderer.send(IPC.WINDOW_SET_UI_SCALE, opts);
+    },
     /** macOS titlebar reserve: mount-time fullscreen state (pull). */
     isFullScreen: () => ipcRenderer.invoke(IPC.WINDOW_IS_FULLSCREEN) as Promise<boolean>,
     /** macOS titlebar reserve: live fullscreen transitions (push). */

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -233,6 +233,7 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     theme: state.theme,
     locale: state.locale,
     terminalFontSize: state.terminalFontSize,
+    uiScale: state.uiScale,
     terminalFontFamily: state.terminalFontFamily,
     defaultShell: state.defaultShell,
     deckBrainModel: state.deckBrainModel || undefined,
@@ -287,9 +288,51 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
   };
 }
 
+/**
+ * Push the persisted UI-scale factor (#822) to main so it can scale the whole
+ * renderer (setZoomFactor) and re-place the native chrome. Fires on mount, on
+ * every uiScale change (the Settings slider + session hydration), and whenever
+ * the theme CSS vars flip — the Windows overlay height is zoom-dependent, so a
+ * theme restyle must re-apply the scaled height, not the titleBarOverlay
+ * handler's fixed 36. Mirrors useTitleBarOverlaySync's color read. Safe under
+ * jsdom: bails when electronAPI is absent.
+ */
+function useUiScaleSync(uiScale: number): void {
+  useEffect(() => {
+    const send = window.electronAPI?.window?.setUiScale;
+    if (!send) return; // tests / non-electron
+    const push = () => {
+      const cs = getComputedStyle(document.documentElement);
+      const color = cs.getPropertyValue('--bg-base').trim();
+      const symbolColor = cs.getPropertyValue('--text-sub').trim();
+      // Factor is always sent (zoom applies on every platform); the overlay
+      // color pair only matters on Windows and is skipped when unread, which
+      // main treats as "leave the overlay height untouched this round".
+      send({
+        factor: uiScale,
+        ...(color && symbolColor ? { color, symbolColor } : {}),
+      });
+    };
+    push();
+    // Re-push on theme change so the Windows overlay keeps the scaled height.
+    const mo = new MutationObserver(push);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme', 'style'],
+    });
+    return () => mo.disconnect();
+  }, [uiScale]);
+}
+
 export default function AppLayout() {
+  // UI scale (#822): the persisted factor. The sync effect below forwards it
+  // to main, which scales the whole renderer and re-places the native chrome.
+  const uiScale = useStore((s) => s.uiScale);
   // Global guard: blocks webview pointer capture during panel separator drag
   useResizeGuard();
+  // Forward the persisted UI-scale factor to main whenever it changes or the
+  // theme (overlay colors) does — see useUiScaleSync below.
+  useUiScaleSync(uiScale);
   const sidebarVisible = useStore((s) => s.sidebarVisible);
   const channelDockVisible = useStore((s) => s.channelDockVisible);
   const sidebarPosition = useStore((s) => s.sidebarPosition);

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -3363,6 +3363,10 @@ function TabAppearance() {
   const paneActionsVisible = useStore((s) => s.paneActionsVisible);
   const setPaneActionsVisible = useStore((s) => s.setPaneActionsVisible);
 
+  // UI scale (#822) — whole-interface zoom, applied to main via window:setUiScale.
+  const uiScale = useStore((s) => s.uiScale);
+  const setUiScale = useStore((s) => s.setUiScale);
+
   const currentTheme = useStore((s) => s.theme);
   const setTheme = useStore((s) => s.setTheme);
   // Live custom-theme colors drive the `custom` card's thumbnail so it always
@@ -3497,6 +3501,23 @@ function TabAppearance() {
             onChange={setPaneActionsVisible}
             label={t('settings.paneActionsVisible')}
           />
+        </SettingRow>
+        <SettingRow label={t('settings.uiScale')} description={t('settings.uiScaleDesc')}>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={0.8}
+              max={1.6}
+              step={0.05}
+              value={uiScale}
+              onChange={(e) => setUiScale(Number(e.target.value))}
+              aria-label={t('settings.uiScale')}
+              className="w-24 accent-[color:var(--accent-blue)]"
+            />
+            <span className="text-xs font-mono tabular-nums text-[color:var(--text-sub)] w-8 text-right">
+              {Math.round(uiScale * 100)}%
+            </span>
+          </div>
         </SettingRow>
       </div>
     </div>

--- a/src/renderer/i18n/locales/ar.ts
+++ b/src/renderer/i18n/locales/ar.ts
@@ -141,6 +141,8 @@ export const ar = {
   'settings.fontFamily': 'عائلة الخط',
   'settings.fontFamilyDesc': 'خط ثابت العرض للطرفية',
   'settings.layout': 'التخطيط',
+  'settings.uiScale': 'مقياس الواجهة',
+  'settings.uiScaleDesc': 'تكبير أو تصغير الواجهة بالكامل — مفيد للشاشات عالية الدقة. لا حاجة لإعادة التشغيل.',
   'settings.sidebarPosition': 'موضع الشريط الجانبي',
   'settings.sidebarPositionDesc': 'يسار أو يمين منطقة الطرفية',
   'settings.sidebarLeft': 'يسار',

--- a/src/renderer/i18n/locales/bs.ts
+++ b/src/renderer/i18n/locales/bs.ts
@@ -141,6 +141,8 @@ export const bs = {
   'settings.fontFamily': 'Familija fonta',
   'settings.fontFamilyDesc': 'Monospace font za terminal',
   'settings.layout': 'Izgled',
+  'settings.uiScale': 'Razmjer sučelja',
+  'settings.uiScaleDesc': 'Povećajte ili smanjite cijelo sučelje — korisno na zaslonima visoke rezolucije. Ponovno pokretanje nije potrebno.',
   'settings.sidebarPosition': 'Pozicija bočne trake',
   'settings.sidebarPositionDesc': 'Lijevo ili desno od područja terminala',
   'settings.sidebarLeft': 'Lijevo',

--- a/src/renderer/i18n/locales/da.ts
+++ b/src/renderer/i18n/locales/da.ts
@@ -141,6 +141,8 @@ export const da = {
   'settings.fontFamily': 'Skriftfamilie',
   'settings.fontFamilyDesc': 'Monospace-skrift til terminalen',
   'settings.layout': 'Layout',
+  'settings.uiScale': 'UI-skalering',
+  'settings.uiScaleDesc': 'Skalér hele grænsefladen — nyttigt på skærme med høj DPI. Genstart ikke påkrævet.',
   'settings.sidebarPosition': 'Sidepanelposition',
   'settings.sidebarPositionDesc': 'Venstre eller højre for terminalområdet',
   'settings.sidebarLeft': 'Venstre',

--- a/src/renderer/i18n/locales/de.ts
+++ b/src/renderer/i18n/locales/de.ts
@@ -141,6 +141,8 @@ export const de = {
   'settings.fontFamily': 'Schriftart',
   'settings.fontFamilyDesc': 'Monospace-Schrift für Terminal',
   'settings.layout': 'Layout',
+  'settings.uiScale': 'UI-Skalierung',
+  'settings.uiScaleDesc': 'Skaliert die gesamte Oberfläche — nützlich auf High-DPI-Displays. Neustart nicht erforderlich.',
   'settings.sidebarPosition': 'Position der Seitenleiste',
   'settings.sidebarPositionDesc': 'Links oder rechts vom Terminalbereich',
   'settings.sidebarLeft': 'Links',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -589,6 +589,8 @@ export const en = {
   'settings.fontApply': 'Apply',
   'settings.fontCancel': 'Cancel',
   'settings.layout': 'Layout',
+  'settings.uiScale': 'UI scale',
+  'settings.uiScaleDesc': 'Scale the whole interface — useful on high-DPI displays. Restart not required.',
   'settings.sidebarPosition': 'Sidebar position',
   'settings.sidebarPositionDesc': 'Left or right of the terminal area',
   'settings.sidebarLeft': 'Left',

--- a/src/renderer/i18n/locales/es.ts
+++ b/src/renderer/i18n/locales/es.ts
@@ -141,6 +141,8 @@ export const es = {
   'settings.fontFamily': 'Familia de fuente',
   'settings.fontFamilyDesc': 'Fuente monoespaciada para el terminal',
   'settings.layout': 'Diseño',
+  'settings.uiScale': 'Escala de interfaz',
+  'settings.uiScaleDesc': 'Escala toda la interfaz — útil en pantallas de alto DPI. No requiere reiniciar.',
   'settings.sidebarPosition': 'Posición de la barra lateral',
   'settings.sidebarPositionDesc': 'Izquierda o derecha del área del terminal',
   'settings.sidebarLeft': 'Izquierda',

--- a/src/renderer/i18n/locales/fr.ts
+++ b/src/renderer/i18n/locales/fr.ts
@@ -141,6 +141,8 @@ export const fr = {
   'settings.fontFamily': 'Famille de police',
   'settings.fontFamilyDesc': 'Police à chasse fixe pour le terminal',
   'settings.layout': 'Disposition',
+  'settings.uiScale': 'Échelle de l\'interface',
+  'settings.uiScaleDesc': 'Mettre à l\'échelle toute l\'interface — utile sur les écrans haute DPI. Redémarrage non requis.',
   'settings.sidebarPosition': 'Position de la barre latérale',
   'settings.sidebarPositionDesc': 'Gauche ou droite de la zone du terminal',
   'settings.sidebarLeft': 'Gauche',

--- a/src/renderer/i18n/locales/hi.ts
+++ b/src/renderer/i18n/locales/hi.ts
@@ -141,6 +141,8 @@ export const hi = {
   'settings.fontFamily': 'फ़ॉन्ट परिवार',
   'settings.fontFamilyDesc': 'टर्मिनल के लिए मोनोस्पेस फ़ॉन्ट',
   'settings.layout': 'लेआउट',
+  'settings.uiScale': 'UI स्केल',
+  'settings.uiScaleDesc': 'पूरे इंटरफ़ेस को स्केल करें — उच्च-DPI डिस्प्ले पर उपयोगी। पुनरारंभ की आवश्यकता नहीं।',
   'settings.sidebarPosition': 'साइडबार स्थिति',
   'settings.sidebarPositionDesc': 'टर्मिनल क्षेत्र के बाएँ या दाएँ',
   'settings.sidebarLeft': 'बाएँ',

--- a/src/renderer/i18n/locales/id.ts
+++ b/src/renderer/i18n/locales/id.ts
@@ -141,6 +141,8 @@ export const id = {
   'settings.fontFamily': 'Keluarga font',
   'settings.fontFamilyDesc': 'Font monospace untuk terminal',
   'settings.layout': 'Tata letak',
+  'settings.uiScale': 'Skala UI',
+  'settings.uiScaleDesc': 'Skalakan seluruh antarmuka — berguna pada layar DPI tinggi. Tidak perlu mulai ulang.',
   'settings.sidebarPosition': 'Posisi bilah sisi',
   'settings.sidebarPositionDesc': 'Kiri atau kanan area terminal',
   'settings.sidebarLeft': 'Kiri',

--- a/src/renderer/i18n/locales/it.ts
+++ b/src/renderer/i18n/locales/it.ts
@@ -141,6 +141,8 @@ export const it = {
   'settings.fontFamily': 'Famiglia di caratteri',
   'settings.fontFamilyDesc': 'Carattere monospazio per il terminale',
   'settings.layout': 'Layout',
+  'settings.uiScale': 'Scala interfaccia',
+  'settings.uiScaleDesc': 'Ridimensiona l\'intera interfaccia — utile sui display ad alto DPI. Riavvio non richiesto.',
   'settings.sidebarPosition': 'Posizione barra laterale',
   'settings.sidebarPositionDesc': 'Sinistra o destra dell\'area del terminale',
   'settings.sidebarLeft': 'Sinistra',

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -143,6 +143,8 @@ export const ja = {
   'settings.fontFamily': 'フォントファミリー',
   'settings.fontFamilyDesc': 'ターミナル用等幅フォント',
   'settings.layout': 'レイアウト',
+  'settings.uiScale': 'UI 拡大率',
+  'settings.uiScaleDesc': 'インターフェース全体を拡大・縮小します — 高 DPI ディスプレイで便利です。再起動は不要です。',
   'settings.sidebarPosition': 'サイドバー位置',
   'settings.sidebarPositionDesc': 'ターミナルエリアの左右',
   'settings.sidebarLeft': '左',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -424,6 +424,8 @@ export const ko = {
   'settings.fontApply': '적용',
   'settings.fontCancel': '취소',
   'settings.layout': '레이아웃',
+  'settings.uiScale': 'UI 배율',
+  'settings.uiScaleDesc': '전체 인터페이스를 확대/축소합니다 — 고해상도 디스플레이에서 유용합니다. 재시작이 필요 없습니다.',
   'settings.sidebarPosition': '사이드바 위치',
   'settings.sidebarPositionDesc': '터미널 영역의 좌측 또는 우측',
   'settings.sidebarLeft': '왼쪽',

--- a/src/renderer/i18n/locales/ms.ts
+++ b/src/renderer/i18n/locales/ms.ts
@@ -141,6 +141,8 @@ export const ms = {
   'settings.fontFamily': 'Keluarga fon',
   'settings.fontFamilyDesc': 'Fon monoruang untuk terminal',
   'settings.layout': 'Susun atur',
+  'settings.uiScale': 'Skala UI',
+  'settings.uiScaleDesc': 'Skalakan keseluruhan antara muka — berguna pada paparan DPI tinggi. Tidak perlu mulakan semula.',
   'settings.sidebarPosition': 'Kedudukan bar sisi',
   'settings.sidebarPositionDesc': 'Kiri atau kanan kawasan terminal',
   'settings.sidebarLeft': 'Kiri',

--- a/src/renderer/i18n/locales/nb.ts
+++ b/src/renderer/i18n/locales/nb.ts
@@ -141,6 +141,8 @@ export const nb = {
   'settings.fontFamily': 'Skriftfamilie',
   'settings.fontFamilyDesc': 'Monospace-skrift for terminal',
   'settings.layout': 'Oppsett',
+  'settings.uiScale': 'UI-skalering',
+  'settings.uiScaleDesc': 'Skaler hele grensesnittet — nyttig på høy-DPI-skjermer. Omstart kreves ikke.',
   'settings.sidebarPosition': 'Sidepanelposisjon',
   'settings.sidebarPositionDesc': 'Venstre eller høyre for terminalområdet',
   'settings.sidebarLeft': 'Venstre',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -141,6 +141,8 @@ export const pl = {
   'settings.fontFamily': 'Rodzina czcionek',
   'settings.fontFamilyDesc': 'Czcionka o stałej szerokości dla terminala',
   'settings.layout': 'Układ',
+  'settings.uiScale': 'Skala interfejsu',
+  'settings.uiScaleDesc': 'Skaluj cały interfejs — przydatne na ekranach o wysokiej DPI. Restart nie jest wymagany.',
   'settings.sidebarPosition': 'Pozycja paska bocznego',
   'settings.sidebarPositionDesc': 'Po lewej lub po prawej stronie obszaru terminala',
   'settings.sidebarLeft': 'Lewo',

--- a/src/renderer/i18n/locales/pt-BR.ts
+++ b/src/renderer/i18n/locales/pt-BR.ts
@@ -141,6 +141,8 @@ export const ptBR = {
   'settings.fontFamily': 'Família de fonte',
   'settings.fontFamilyDesc': 'Fonte monoespaçada para o terminal',
   'settings.layout': 'Layout',
+  'settings.uiScale': 'Escala da interface',
+  'settings.uiScaleDesc': 'Dimensione toda a interface — útil em monitores de alta DPI. Não requer reinício.',
   'settings.sidebarPosition': 'Posição da barra lateral',
   'settings.sidebarPositionDesc': 'Esquerda ou direita da área do terminal',
   'settings.sidebarLeft': 'Esquerda',

--- a/src/renderer/i18n/locales/ru.ts
+++ b/src/renderer/i18n/locales/ru.ts
@@ -141,6 +141,8 @@ export const ru = {
   'settings.fontFamily': 'Семейство шрифтов',
   'settings.fontFamilyDesc': 'Моноширинный шрифт для терминала',
   'settings.layout': 'Макет',
+  'settings.uiScale': 'Масштаб интерфейса',
+  'settings.uiScaleDesc': 'Масштабируйте весь интерфейс — полезно для дисплеев с высоким DPI. Перезапуск не требуется.',
   'settings.sidebarPosition': 'Положение боковой панели',
   'settings.sidebarPositionDesc': 'Слева или справа от области терминала',
   'settings.sidebarLeft': 'Слева',

--- a/src/renderer/i18n/locales/th.ts
+++ b/src/renderer/i18n/locales/th.ts
@@ -141,6 +141,8 @@ export const th = {
   'settings.fontFamily': 'ตระกูลฟอนต์',
   'settings.fontFamilyDesc': 'ฟอนต์ความกว้างคงที่สำหรับเทอร์มินัล',
   'settings.layout': 'เลย์เอาต์',
+  'settings.uiScale': 'สเกล UI',
+  'settings.uiScaleDesc': 'ปรับสเกลทั้งอินเทอร์เฟซ — มีประโยชน์สำหรับจอ DPI สูง ไม่ต้องรีสตาร์ท',
   'settings.sidebarPosition': 'ตำแหน่งแถบด้านข้าง',
   'settings.sidebarPositionDesc': 'ซ้ายหรือขวาของพื้นที่เทอร์มินัล',
   'settings.sidebarLeft': 'ซ้าย',

--- a/src/renderer/i18n/locales/tr.ts
+++ b/src/renderer/i18n/locales/tr.ts
@@ -141,6 +141,8 @@ export const tr = {
   'settings.fontFamily': 'Yazı tipi ailesi',
   'settings.fontFamilyDesc': 'Terminal için sabit genişlikli yazı tipi',
   'settings.layout': 'Düzen',
+  'settings.uiScale': 'Arayüz ölçeği',
+  'settings.uiScaleDesc': 'Tüm arayüzü ölçeklendirin — yüksek DPI ekranlarda kullanışlıdır. Yeniden başlatma gerekmez.',
   'settings.sidebarPosition': 'Kenar çubuğu konumu',
   'settings.sidebarPositionDesc': 'Terminal alanının solu veya sağı',
   'settings.sidebarLeft': 'Sol',

--- a/src/renderer/i18n/locales/uk.ts
+++ b/src/renderer/i18n/locales/uk.ts
@@ -141,6 +141,8 @@ export const uk = {
   'settings.fontFamily': 'Сімейство шрифтів',
   'settings.fontFamilyDesc': 'Моноширинний шрифт для термінала',
   'settings.layout': 'Макет',
+  'settings.uiScale': 'Масштаб інтерфейсу',
+  'settings.uiScaleDesc': 'Масштабуйте весь інтерфейс — корисно для дисплеїв із високим DPI. Перезапуск не потрібен.',
   'settings.sidebarPosition': 'Положення бічної панелі',
   'settings.sidebarPositionDesc': 'Зліва або справа від області термінала',
   'settings.sidebarLeft': 'Ліворуч',

--- a/src/renderer/i18n/locales/vi.ts
+++ b/src/renderer/i18n/locales/vi.ts
@@ -141,6 +141,8 @@ export const vi = {
   'settings.fontFamily': 'Họ phông chữ',
   'settings.fontFamilyDesc': 'Phông chữ đều cho terminal',
   'settings.layout': 'Bố cục',
+  'settings.uiScale': 'Tỉ lệ UI',
+  'settings.uiScaleDesc': 'Thu phóng toàn bộ giao diện — hữu ích trên màn hình DPI cao. Không cần khởi động lại.',
   'settings.sidebarPosition': 'Vị trí thanh bên',
   'settings.sidebarPositionDesc': 'Trái hoặc phải vùng terminal',
   'settings.sidebarLeft': 'Trái',

--- a/src/renderer/i18n/locales/zh-TW.ts
+++ b/src/renderer/i18n/locales/zh-TW.ts
@@ -141,6 +141,8 @@ export const zhTW = {
   'settings.fontFamily': '字型',
   'settings.fontFamilyDesc': '終端機使用的等寬字型',
   'settings.layout': '版面',
+  'settings.uiScale': '介面縮放',
+  'settings.uiScaleDesc': '縮放整個介面 — 在高 DPI 顯示器上很實用。不需重新啟動。',
   'settings.sidebarPosition': '側邊欄位置',
   'settings.sidebarPositionDesc': '終端機區域的左側或右側',
   'settings.sidebarLeft': '左側',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -143,6 +143,8 @@ export const zh = {
   'settings.fontFamily': '字体族',
   'settings.fontFamilyDesc': '终端等宽字体',
   'settings.layout': '布局',
+  'settings.uiScale': '界面缩放',
+  'settings.uiScaleDesc': '缩放整个界面 — 在高 DPI 显示器上很有用。无需重启。',
   'settings.sidebarPosition': '侧边栏位置',
   'settings.sidebarPositionDesc': '终端区域的左侧或右侧',
   'settings.sidebarLeft': '左',

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -604,6 +604,16 @@ describe('loadSession — UI scale (#822)', () => {
     store.getState().loadSession(sessionWith('wide'));
     expect(store.getState().uiScale).toBe(1);
   });
+
+  it('clamps an out-of-range factor so the readout tracks the applied zoom', () => {
+    // main's applyUiZoom clamps the real zoom; the store must too, else a
+    // hand-edited uiScale: 5 shows "500%" and re-saves as 5 (drift).
+    const store = createTestStore();
+    store.getState().loadSession(sessionWith(5));
+    expect(store.getState().uiScale).toBe(1.6);
+    store.getState().loadSession(sessionWith(-3));
+    expect(store.getState().uiScale).toBe(0.8);
+  });
 });
 
 // Forward-compat config merge: a session saved by an older build must not strip

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -17,6 +17,7 @@ type TestState = WorkspaceSlice & {
   theme: string;
   locale: string;
   terminalFontSize: number;
+  uiScale: number;
   terminalFontFamily: string;
   defaultShell: string;
   scrollbackLines: number;
@@ -66,6 +67,7 @@ function createTestStore() {
       theme: 'catppuccin-mocha',
       locale: 'en',
       terminalFontSize: 14,
+      uiScale: 1,
       terminalFontFamily: 'Cascadia Code',
       defaultShell: 'powershell',
       scrollbackLines: 10000,
@@ -567,6 +569,40 @@ describe('loadSession — multiview arrangement (#746)', () => {
     const store = createTestStore();
     store.getState().loadSession(sessionWith('masonry'));
     expect(store.getState().multiviewArrangement).toBe('auto');
+  });
+});
+
+describe('loadSession — UI scale (#822)', () => {
+  function sessionWith(uiScale: unknown): SessionData {
+    const ws: Workspace = {
+      id: 'ws-zoom',
+      name: 'Zoom',
+      rootPane: makeBrowserSurfaceTree('https://example.com'),
+      activePaneId: 'pane-root',
+    };
+    return {
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      sidebarVisible: true,
+      uiScale,
+    } as unknown as SessionData;
+  }
+
+  it('restores a saved factor', () => {
+    // The save side (AppLayout.buildSessionData) and this read-back are
+    // separate edits; without both the pref silently resets to 1 on restart.
+    const store = createTestStore();
+    expect(store.getState().uiScale).toBe(1);
+    store.getState().loadSession(sessionWith(1.4));
+    expect(store.getState().uiScale).toBe(1.4);
+  });
+
+  it('ignores a non-finite value and keeps the default', () => {
+    // session.json is hand-editable/untrusted — a garbage value must not
+    // round-trip into the store and onward to setZoomFactor.
+    const store = createTestStore();
+    store.getState().loadSession(sessionWith('wide'));
+    expect(store.getState().uiScale).toBe(1);
   });
 });
 

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -149,6 +149,13 @@ export interface UISlice {
   terminalFontSize: number;
   setTerminalFontSize: (size: number) => void;
 
+  // ─── UI scale ─────────────────────────────────────────────────────────────
+  // Whole-interface zoom multiplier (1 = 100%). Drives the main-process
+  // setZoomFactor via the window:setUiScale IPC; range is pinned by
+  // UI_ZOOM_MIN/MAX in src/main/window/uiZoom.ts.
+  uiScale: number;
+  setUiScale: (scale: number) => void;
+
   terminalFontFamily: string;
   setTerminalFontFamily: (family: string) => void;
 
@@ -884,6 +891,15 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
 
   setTerminalFontSize: (size) => set((state) => {
     state.terminalFontSize = size;
+  }),
+
+  // ─── UI scale ─────────────────────────────────────────────────────────────
+  // 1 = no zoom; the apply effect (AppLayout) forwards this to main, which
+  // clamps it to the supported range before calling setZoomFactor.
+  uiScale: 1,
+
+  setUiScale: (scale) => set((state) => {
+    state.uiScale = scale;
   }),
 
   terminalFontFamily: 'Cascadia Code',

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -781,6 +781,12 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         i18nSetLocale(data.locale as Locale);
       }
       if (data.terminalFontSize != null) state.terminalFontSize = data.terminalFontSize;
+      // UI scale: a finite number re-hydrates; the main-process apply path
+      // clamps to UI_ZOOM_MIN/MAX, so only type-guard here (session.json is
+      // hand-editable). Absent/invalid leaves the store default of 1.
+      if (typeof data.uiScale === 'number' && Number.isFinite(data.uiScale)) {
+        state.uiScale = data.uiScale;
+      }
       // Sanitize on load too — session.json is untrusted (hand-editable), and
       // this path bypasses setTerminalFontFamily's write-time sanitize. Keeps
       // the "stored value is always clean" invariant (terminalFont.ts) intact

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -781,11 +781,14 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         i18nSetLocale(data.locale as Locale);
       }
       if (data.terminalFontSize != null) state.terminalFontSize = data.terminalFontSize;
-      // UI scale: a finite number re-hydrates; the main-process apply path
-      // clamps to UI_ZOOM_MIN/MAX, so only type-guard here (session.json is
-      // hand-editable). Absent/invalid leaves the store default of 1.
+      // UI scale: clamp on load so a hand-edited session.json (e.g. uiScale: 5)
+      // can't leave the store, the Settings readout (Math.round(x*100)%), and
+      // the next save diverging from what main actually applies — main's
+      // applyUiZoom clamps the real zoom, but without this the stored/displayed
+      // value drifts (5 → "500%" readout, re-saved as 5). Bounds mirror
+      // UI_ZOOM_MIN/MAX in src/main/window/uiZoom.ts. Absent/invalid → default 1.
       if (typeof data.uiScale === 'number' && Number.isFinite(data.uiScale)) {
-        state.uiScale = data.uiScale;
+        state.uiScale = Math.min(1.6, Math.max(0.8, data.uiScale));
       }
       // Sanitize on load too — session.json is untrusted (hand-editable), and
       // this path bypasses setTerminalFontFamily's write-time sanitize. Keeps

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -444,6 +444,10 @@ export const IPC = {
   // native min/max/close) so the controls never clash with the theme.
   // Windows-only no-op elsewhere (see registerHandlers).
   WINDOW_SET_TITLEBAR_OVERLAY: 'window:setTitleBarOverlay',
+  // Whole-interface zoom (#822): the renderer asks main to scale the
+  // BrowserWindow with setZoomFactor and re-place the native chrome to match.
+  // One-way send — the persisted factor lives in the renderer store.
+  WINDOW_SET_UI_SCALE: 'window:setUiScale',
   // macOS: native fullscreen hides the traffic lights, so the renderer's
   // 72px titlebar reserve must collapse (and come back on exit) — the same
   // enter/leave-full-screen → class toggle pattern VS Code/Hyper use. Push

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -615,6 +615,8 @@ export interface SessionData {
   theme?: string;
   locale?: string;
   terminalFontSize?: number;
+  /** Whole-interface zoom multiplier (1 = 100%). Absent = no zoom. */
+  uiScale?: number;
   terminalFontFamily?: string;
   defaultShell?: string;
   /** Orchestrator (deck brain) model override — '' / absent = the


### PR DESCRIPTION
## What

Closes #822.

PR #824 shipped the **groundwork** for a configurable UI size — `setZoomFactor` plus re-placing the native window controls so they don't desync under zoom — but exposed it only through the `WMUX_UI_ZOOM` prototype env var, with no user-facing setting. That left #822 open (the issue asked for a Settings control). This PR adds the missing piece: a **UI scale** slider in Settings → Appearance → Layout.

## How

- The persisted factor lives in the renderer store (`uiScale`, mirroring `terminalFontSize` through the whole session.json round-trip) and is pushed to main over a new one-way `window:setUiScale` IPC. Main stays a passive store — matching the app's setting architecture — and reuses the existing `applyUiZoom` (no new arithmetic).
- The `WMUX_UI_ZOOM` launch-time env var is removed; the renderer now drives zoom on hydration and on every Settings change, re-pushing on theme change too so the Windows overlay keeps its zoom-scaled height (the `setTitleBarOverlay` handler hardcodes 36).
- Range `0.8–1.6` (`UI_ZOOM_MIN/MAX`), step `0.05`, shown as a percentage; defaults to `1` (pixel-identical to today). Localized across all 23 locales.

## Verification

- tsc clean, eslint clean on changed files
- `uiZoom` + `loadSession` unit tests pass (added: `applyUiZoom` stub-window contract, `uiScale` loadSession round-trip + garbage-rejection)
- Manual: slider scales the whole interface live on macOS; native controls stay centred

## Test plan

- [ ] Settings → Appearance → Layout: drag the UI scale slider, confirm the sidebar/chrome zoom live
- [ ] macOS: traffic lights stay vertically centred in the titlebar across the range
- [ ] Windows: window-button strip height tracks the zoom (no 36px reset on theme change)
- [ ] Restart the app → the saved factor is restored from session.json
- [ ] Set to 100% → pixel-identical to main