### PR TITLE
chore(release): 3.40.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.40.2] — 2026-08-10
+
+### Security
+
+- **Hardened privileged RPC client recognition.** The bundled-MCP and CLI allowlists now require source-qualified wire provenance, so an approved in-process UI plugin whose manifest name collides with a recognised host identity stays on its own declared permissions instead of inheriting the first-party method set. (GHSA-x2xm-9w7w-hh6p)
+
 ## [3.40.1] — 2026-08-08
 
 ### Added

--- a/changelog.d/ghsa-x2xm-9w7w-hh6p.md
+++ b/changelog.d/ghsa-x2xm-9w7w-hh6p.md
@@ -1,3 +1,0 @@
-### Security
-
-- **Hardened privileged RPC client recognition.** The bundled-MCP and CLI allowlists now require source-qualified wire provenance, so an approved in-process UI plugin whose manifest name collides with a recognised host identity stays on its own declared permissions instead of inheriting the first-party method set. (GHSA-x2xm-9w7w-hh6p)

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.40.1 sources.** This file is produced by
+> **Generated from wmux v3.40.2 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.40.1",
+  "version": "3.40.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.40.1",
+      "version": "3.40.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.40.1",
+  "version": "3.40.2",
   "description": "Workspace multiplexer for AI agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Cuts 3.40.2 so the GHSA-x2xm-9w7w-hh6p fix that landed on `main` in 2bd6c94e reaches users.

Folds the pending changelog fragment, bumps the version in `package.json` and both `package-lock.json` sites, and regenerates `docs/api/reference.md` so its baked-in version matches — the CI drift guard checks that.

### Contents

One security fix. An installed, user-approved UI plugin could pick a manifest name that collided with a name-recognised privileged wire client (`claude-code`, `codex-mcp-client`, `opencode`, `wmux-cli`) and inherit that client's curated RPC allowlist instead of staying on its own declared permissions. The enforcer now requires source-qualified external-wire provenance before either name-recognised lane applies.

Affected 3.1.0 through 3.40.1. Reported by @snowyukitty.

### Verification

Beyond CI, the fix was checked against a live named pipe with the real router and enforcer under `enforce` mode: a wire client reporting `claude-code` still reaches the first-party allowlist, an in-process plugin host dispatch using the same name is rejected, and the same probe run against unpatched `main` reproduces the bypass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hardened privileged RPC client recognition to require verified source information, preventing unauthorized access from similarly named plugins.

- **Documentation**
  - Added release notes for version 3.40.2.
  - Updated the API reference to reflect version 3.40.2.

- **Chores**
  - Updated the package version to 3.40.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->