### PR TITLE
fix(cli): scope browser navigation to caller workspace

### DIFF
--- a/changelog.d/845.md
+++ b/changelog.d/845.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Scoped CLI browser navigation to its calling workspace.** `wmux browser navigate` now uses verified pane identity inside wmux instead of potentially navigating the first globally registered browser; invocations outside wmux retain the existing active-target behavior. (#845)

--- a/docs/internal/browser-tabs-workspace-contract.md
+++ b/docs/internal/browser-tabs-workspace-contract.md
@@ -395,13 +395,20 @@ only the intended surface through the full sequence.
 
 ## 8. Adjacent findings and explicit non-goals
 
-### 8.1 Omitted-`surfaceId` navigation remains a separate audit
+### 8.1 Omitted-`surfaceId` navigation is caller-workspace scoped
 
-Static inspection found that `browser_navigate` and `browser_navigate_back` send `browser.navigate` / `browser.goBack` without a workspace ID when their optional `surfaceId` is omitted. Main then calls `WebviewCdpManager.getTarget(undefined)`, whose documented fallback is the first globally registered target.
+Bundled MCP `browser_navigate` and `browser_navigate_back` already resolve the
+connection's workspace and route `browser.navigate` / `browser.goBack` through
+`sendScopedBrowserRpc`, even when their optional `surfaceId` is omitted. The
+remaining gap was the standalone `wmux browser navigate` command: it sent only
+the URL, so main could fall back to the first globally registered target.
 
-That path is not fixed merely by making `browser_tabs select` workspace-scoped. Until a separate audit resolves the default-target contract, callers should pass the `surfaceId` returned by `browser_tabs` to subsequent browser operations.
-
-This should be confirmed with a focused two-workspace test and, if reproduced, tracked separately rather than silently expanding the #565 implementation.
+The CLI now resolves its verified parent-process context in the same way as
+`wmux open` and `wmux browser close`. When invoked from a wmux pane it sends the
+caller's `workspaceId`; outside wmux it omits that field and preserves the
+existing active-target compatibility behavior. Supplying the `surfaceId`
+returned by `browser_tabs` remains the strongest way to pin a subsequent
+browser operation to one exact surface.
 
 ### 8.2 `browser.cdp.info` cross-workspace target metadata (now scoped, defense-in-depth)
 

--- a/src/cli/commands/__tests__/browser.test.ts
+++ b/src/cli/commands/__tests__/browser.test.ts
@@ -1,0 +1,63 @@
+/**
+ * `wmux browser navigate` — issue #810.
+ *
+ * The main-process target lookup scopes only when the request carries a
+ * workspaceId. The CLI used to omit it unconditionally, so a command run from
+ * workspace A could navigate the first registered browser target in workspace
+ * B. These tests pin verified self-context routing while preserving the
+ * outside-wmux active-target fallback.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../client', () => ({
+  sendRequest: vi.fn(),
+}));
+vi.mock('../../identity', () => ({
+  resolveSelfContext: vi.fn(),
+  getParentPidDefault: vi.fn(),
+}));
+
+import { sendRequest } from '../../client';
+import { getParentPidDefault, resolveSelfContext } from '../../identity';
+import { handleBrowser } from '../browser';
+
+const rpc = sendRequest as unknown as ReturnType<typeof vi.fn>;
+const selfContext = resolveSelfContext as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selfContext.mockResolvedValue({ ptyId: 'pty-self', workspaceId: 'ws-self' });
+  rpc.mockResolvedValue({ id: 'rpc-ok', ok: true, result: { ok: true } });
+  vi.spyOn(console, 'log').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('wmux browser navigate caller scoping (#810)', () => {
+  it('routes navigation to the verified caller workspace', async () => {
+    await handleBrowser(['navigate', 'https://example.com'], false);
+
+    expect(selfContext).toHaveBeenCalledWith({
+      sendRequest,
+      env: process.env,
+      ppid: process.ppid,
+      getParentPid: getParentPidDefault,
+    });
+    expect(rpc).toHaveBeenCalledWith('browser.navigate', {
+      url: 'https://example.com',
+      workspaceId: 'ws-self',
+    });
+  });
+
+  it('preserves active-target fallback when no caller workspace resolves', async () => {
+    selfContext.mockResolvedValue({});
+
+    await handleBrowser(['navigate', 'https://example.com/outside'], false);
+
+    expect(rpc).toHaveBeenCalledWith('browser.navigate', {
+      url: 'https://example.com/outside',
+    });
+  });
+});

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -47,7 +47,7 @@ USAGE
   wmux browser <subcommand> [args]
 
 SUBCOMMANDS
-  navigate <url>                  Navigate the active browser surface to a URL
+  navigate <url>                  Navigate your workspace's browser surface
   close [--workspace <id>]        Close the browser panel (defaults to your own
                                   workspace when run inside a wmux pane)
   session start [--profile <name>]  Start a browser session
@@ -85,7 +85,21 @@ export async function handleBrowser(
         console.error('Error: browser navigate requires <url>');
         process.exit(1);
       }
-      response = await sendRequest('browser.navigate', { url });
+      // Resolve the caller exactly like `wmux open` / `wmux browser close`.
+      // Inside a wmux pane this prevents a background workspace from
+      // navigating whichever browser target happened to register first.
+      // Outside wmux, no workspace resolves and active-target compatibility is
+      // preserved by omitting the field.
+      const ctx = await resolveSelfContext({
+        sendRequest,
+        env: process.env,
+        ppid: process.ppid,
+        getParentPid: getParentPidDefault,
+      });
+      const params: Record<string, unknown> = { url };
+      if (ctx.workspaceId) params.workspaceId = ctx.workspaceId;
+
+      response = await sendRequest('browser.navigate', params);
       if (jsonMode) {
         printResult(response);
       } else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -123,7 +123,7 @@ DIAGNOSTICS
                                     counters) from the running app.
 
 BROWSER COMMANDS
-  browser navigate <url>            Navigate the browser surface to a URL
+  browser navigate <url>            Navigate your workspace's browser surface
   browser close                     Close the browser panel
   browser session start [--profile <name>]  Start a browser session
   browser session stop              Stop the active browser session


### PR DESCRIPTION
## Summary

Scope `wmux browser navigate` to the verified workspace of the calling wmux pane. Inside wmux, navigation now follows the same self-context contract as `browser open` and `browser close`; outside wmux, the existing active-target fallback remains unchanged.

This prevents an in-session CLI invocation from navigating the first globally registered browser when another workspace happens to register first.

## Changes

- Resolve verified CLI self-context before dispatching `browser.navigate`.
- Send `workspaceId` only when a non-empty verified workspace identity is available.
- Preserve the existing outside-wmux active-browser fallback.
- Add focused CLI coverage and correct the internal browser-tabs contract documentation.

## CHANGELOG entry

### Fixed

- **Scoped CLI browser navigation to its calling workspace.** `wmux browser navigate` now uses verified pane identity inside wmux instead of potentially navigating the first globally registered browser; invocations outside wmux retain the existing active-target behavior. (#845)

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [x] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — this uses the existing optional `workspaceId` parameter on `browser.navigate`; no RPC, parameter, or wire shape is added. The internal contract documentation is corrected to match the established verified self-context behavior.

## Test plan

- Focused navigate/self-context suite: 2 files, 10 tests passed.
- Full CLI suite: 15 files, 274 tests passed.
- `npx tsc --noEmit`, production-source ESLint, and `npm run build:cli` passed.
- `npm run test:parallel`: 719 files / 10,685 tests passed; 2 files / 24 tests skipped.
- Isolated packaged-app integration: [issue #810 dogfood harness](https://github.com/snowyukitty/wmux/blob/test/810-integration/scripts/issue-810-dogfood.mjs) passed 24/24. With workspace B deliberately registered first, a packaged CLI process launched from workspace A's pane ancestry navigated only A.
- Known unrelated local runtime baseline: 140 passed, 2 failed, 10 skipped. Both failures are in `shellIntegration.runtime.test.ts` on Windows (`node-pty` `AttachConsole failed` / PowerShell timeout); this branch does not touch daemon or shell integration paths.

## Related issues / PRs

Tracks #810. Independent second step of the accepted three-step series.

## Reviewer checklist

- [ ] CHANGELOG entry above is filled in or explicitly marked n/a.
- [ ] Stability tier impact is correctly classified.
- [ ] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [ ] Tests cover the new behavior and the regression case (if a bug fix).
- [ ] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.