### PR TITLE
fix(release): retry the darwin asset check instead of failing on a slow listing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,8 +376,26 @@ jobs:
           FILE=$(basename "$ZIP")
           # The manifest must reference an asset that actually made it onto the
           # release — never publish a pointer to a missing download.
-          if ! gh release view "$RELEASE_TAG" --json assets -q '.assets[].name' | grep -qxF "$FILE"; then
-            echo "ERROR: $FILE is not on release $RELEASE_TAG — refusing to publish a manifest for it"
+          #
+          # Poll rather than ask once: the release asset listing is eventually
+          # consistent, so the upload step above can succeed and this read still
+          # not see the file. That is not hypothetical — it happened on v3.40.2,
+          # where the zip was on the release the whole time, this check missed
+          # it, and the darwin manifest never shipped. macOS auto-updates were
+          # cut for that release until the manifest was uploaded by hand.
+          # Retrying keeps the guard honest about a genuinely missing upload
+          # while no longer failing on a listing that is merely slow.
+          FOUND=
+          for attempt in $(seq 1 10); do
+            if gh release view "$RELEASE_TAG" --json assets -q '.assets[].name' | grep -qxF "$FILE"; then
+              FOUND=1
+              break
+            fi
+            echo "$FILE not listed on $RELEASE_TAG yet (attempt $attempt/10) — retrying in 6s"
+            sleep 6
+          done
+          if [ -z "$FOUND" ]; then
+            echo "ERROR: $FILE is not on release $RELEASE_TAG after 10 attempts — refusing to publish a manifest for it"
             exit 1
           fi
           SHA=$(shasum -a 256 "$ZIP" | awk '{print $1}')


### PR DESCRIPTION
### What happened

`v3.40.2` shipped without `update-manifest-darwin-arm64.json`. The macOS job died here:

```
ERROR: wmux-darwin-arm64-3.40.2.zip is not on release v3.40.2 — refusing to publish a manifest for it
```

The zip was on the release. The upload step had succeeded; the asset listing just had not caught up when the guard read it. The guard asked once, so a slow read looked identical to a missing upload.

The step's own comment spells out why that is expensive: *"a missing manifest silently cuts off darwin auto-updates until the next release"*. That is what happened — macOS arm64 clients could not see 3.40.2 through the update feed, on a security release.

`v3.40.2`'s manifest has since been uploaded by hand, built from the sha256 of the zip that is actually published, and verified by re-downloading it. That release is consistent now; this PR stops the next one from repeating it.

### The change

Poll instead of asking once — ten reads, six seconds apart. A genuinely missing upload still fails loudly after a minute, so the guard keeps doing its job; a listing that is merely slow no longer takes out the darwin update feed.

Deliberately not re-running the failed job to clear it: rebuilding macOS produces a differently-hashed zip, and if the same race hit again the published zip and the hand-written manifest would disagree — a broken auto-update is worse than a red badge.

### Verification

The guard was extracted and exercised against a stubbed `gh`:

- listing lags three reads (the v3.40.2 scenario) → recovers on read 4
- asset genuinely never uploaded → fails closed after 10 reads

`bash -n` on the step body, and the workflow YAML parses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS update reliability by waiting for release assets to become available before publishing the update manifest.
  * The process now retries several times and reports a failure if the required ZIP asset remains unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->