### PR TITLE
fix(plugins): allow plugin frames in production CSP

### DIFF
--- a/changelog.d/852.md
+++ b/changelog.d/852.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Restored approved plugin panels in packaged builds.** The production main-window CSP now permits registered `wmux-plugin:` iframe sources without broadening script or network access, preventing the panel restore loop that followed plugin approval. (#852)

--- a/src/main/window/__tests__/productionCsp.test.ts
+++ b/src/main/window/__tests__/productionCsp.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { PLUGIN_PROTOCOL_SCHEME } from '../../../shared/pluginHost';
+import { MAIN_WINDOW_PRODUCTION_CSP } from '../createWindow';
+
+function parseDirectives(policy: string): Map<string, string[]> {
+  return new Map(
+    policy.split(';').map((directive) => {
+      const [name, ...sources] = directive.trim().split(/\s+/);
+      return [name, sources];
+    }),
+  );
+}
+
+describe('main-window production CSP', () => {
+  it('allows the registered plugin scheme only as a frame source', () => {
+    const directives = parseDirectives(MAIN_WINDOW_PRODUCTION_CSP);
+    const pluginSource = `${PLUGIN_PROTOCOL_SCHEME}:`;
+
+    expect(directives.get('frame-src')).toContain(pluginSource);
+
+    for (const directive of ['default-src', 'script-src', 'connect-src']) {
+      expect(directives.get(directive), `${directive} must remain self-only`).toEqual(["'self'"]);
+    }
+
+    for (const [directive, sources] of directives) {
+      if (directive !== 'frame-src') {
+        expect(sources, `${directive} must not allow plugin resources`).not.toContain(pluginSource);
+      }
+    }
+  });
+});

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -2,12 +2,23 @@ import { app, BrowserWindow, shell } from 'electron';
 import path from 'node:path';
 import { platformChoice } from '../../shared/platform';
 import { IPC } from '../../shared/constants';
+import { PLUGIN_PROTOCOL_SCHEME } from '../../shared/pluginHost';
 import { attachFlashFrameAutoClear } from './flashFrame';
 
 // OS-aware window-icon extension. Mirrors tray.ts so the same generated asset
 // set (icon.ico / icon.icns / icon.png) is used in both places.
 const iconExt = platformChoice<string>({ win: 'ico', mac: 'icns', linux: 'png', default: 'png' });
 const iconFile = `icon.${iconExt}`;
+
+export const MAIN_WINDOW_PRODUCTION_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "connect-src 'self'",
+  "font-src 'self'",
+  `frame-src 'self' https: http: ${PLUGIN_PROTOCOL_SCHEME}:`,
+].join('; ');
 
 /**
  * Load the main renderer (Vite dev server in development, packaged HTML file
@@ -159,13 +170,11 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   // the production CSP below is strict (no unsafe-eval), so this is dev-only
   // noise reduction, not a security trade-off.
   if (!MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    const cspPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'self' https: http:";
-
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
       callback({
         responseHeaders: {
           ...details.responseHeaders,
-          'Content-Security-Policy': [cspPolicy],
+          'Content-Security-Policy': [MAIN_WINDOW_PRODUCTION_CSP],
         },
       });
     });


### PR DESCRIPTION
## Summary

- allow the registered `wmux-plugin:` scheme in the packaged main window's `frame-src` policy
- reuse `PLUGIN_PROTOCOL_SCHEME` so iframe URLs, protocol registration, and CSP stay in sync
- add a directive-level regression test that keeps plugin resources out of every non-frame directive and locks `default-src`, `script-src`, and `connect-src` to `'self'`

## Root cause

The main-window CSP is installed only for production/package builds. Approved plugin contributions mount as sandboxed `wmux-plugin://<name>/<entry>` iframes, but the production `frame-src` directive allowed only `'self'`, HTTP, and HTTPS. Chromium therefore rejected the approved plugin frame; the existing load-recovery path retried, producing the reported restore loop. Development did not reproduce the problem because Vite runs without this CSP.

## Security scope

This change adds `wmux-plugin:` only to `frame-src`. It does not broaden `default-src`, `script-src`, `connect-src`, or any other directive.

The scheme remains behind the existing containment gates: it has no `bypassCSP` privilege; the protocol handler is GET-only, accepts only loaded plugin names, and resolves files through realpath containment. The renderer mounts plugin UI only after trust approval, inside `sandbox="allow-scripts"` without `allow-same-origin`. Plugin responses also carry their own restrictive CSP with no network connections, nested frames, or objects.

## Verification

- `npx vitest run src/main/window/__tests__/productionCsp.test.ts src/main/window/__tests__/normalizeDevServerUrl.test.ts src/main/plugins/__tests__/PluginHostLoader.test.ts src/shared/__tests__/pluginHost.test.ts src/renderer/plugins/__tests__/pluginFrameRegistry.test.ts src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts` — 6 files, 36 tests passed
- `npx tsc --noEmit` — passed
- `npx eslint src/main/window/createWindow.ts src/main/window/__tests__/productionCsp.test.ts` — passed
- `npm run test:parallel` — 720 files / 10,726 tests passed; 2 files / 24 tests skipped
- `npm run package` — passed, including the production Vite/Electron package path
- `npm run test:runtime` — 10 files / 149 tests passed and 1 test skipped; 2 unrelated PowerShell shell-integration tests failed because the local Node 24 `node-pty` helper reported `AttachConsole failed`
- packaged hello-panel automation was attempted twice, but the local Electron/CDP harness timed out before approval completed; no manual-flow result is claimed

Fixes #848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored approved plugin panels in packaged builds.
  * Plugin panels can now load securely in the main application window.

* **Tests**
  * Added coverage to verify plugin panels are permitted only in approved frame locations while other security restrictions remain enforced.

* **Documentation**
  * Added a changelog entry describing the plugin panel restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->