### PR TITLE
Let the renderer frame a wmux-plugin: page

### DIFF
--- a/changelog.d/853.md
+++ b/changelog.d/853.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Enabling a UI plugin no longer puts its panel into an endless restore loop. The renderer's production Content-Security-Policy did not allow framing the `wmux-plugin:` scheme its sandboxed iframe loads from, so the panel was blocked and retried forever. Development builds set no CSP at all, so this only affected installed releases.

--- a/src/main/window/__tests__/csp.test.ts
+++ b/src/main/window/__tests__/csp.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { buildProductionCsp, ownsResponseCsp } from '../csp';
+import { PLUGIN_PROTOCOL_SCHEME } from '../../../shared/pluginHost';
+
+/**
+ * #848 — enabling a UI plugin put its panel into an endless restore loop in
+ * production builds only, because the renderer's `frame-src` did not name the
+ * `wmux-plugin:` scheme that PluginFrame.tsx points its iframe at. Dev builds
+ * skip the CSP entirely, so nothing caught it before release.
+ */
+
+function directive(csp: string, name: string): string {
+  const found = csp.split(';').map((d) => d.trim()).find((d) => d.startsWith(`${name} `));
+  if (!found) throw new Error(`no ${name} directive in: ${csp}`);
+  return found;
+}
+
+describe('buildProductionCsp', () => {
+  it('lets the renderer frame a plugin page', () => {
+    expect(directive(buildProductionCsp(), 'frame-src')).toContain(`${PLUGIN_PROTOCOL_SCHEME}:`);
+  });
+
+  it('does not let the renderer document itself load plugin code', () => {
+    // The plugin scheme belongs in frame-src and nowhere else: a plugin
+    // bundle is a framed document, never a source for the host document.
+    const csp = buildProductionCsp();
+    for (const name of ['script-src', 'style-src', 'connect-src', 'img-src', 'font-src']) {
+      expect(directive(csp, name)).not.toContain(PLUGIN_PROTOCOL_SCHEME);
+    }
+  });
+
+  it('keeps the directives the renderer needs to render at all', () => {
+    const csp = buildProductionCsp();
+    // Tailwind and xterm.js inject inline styles at runtime.
+    expect(directive(csp, 'style-src')).toContain("'unsafe-inline'");
+    // Strict where it counts: no eval, and no inline script.
+    expect(csp).not.toContain('unsafe-eval');
+    expect(directive(csp, 'script-src')).toBe("script-src 'self'");
+    // The browser surface frames real sites.
+    expect(directive(csp, 'frame-src')).toContain('https:');
+  });
+});
+
+describe('ownsResponseCsp', () => {
+  it('leaves a plugin response its own, stricter policy', () => {
+    expect(ownsResponseCsp(`${PLUGIN_PROTOCOL_SCHEME}://hello-panel/index.html`)).toBe(false);
+  });
+
+  it('stamps the renderer policy on everything else', () => {
+    expect(ownsResponseCsp('file:///C:/app/index.html')).toBe(true);
+    expect(ownsResponseCsp('https://example.com/')).toBe(true);
+  });
+});

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { platformChoice } from '../../shared/platform';
 import { IPC } from '../../shared/constants';
 import { attachFlashFrameAutoClear } from './flashFrame';
+import { buildProductionCsp, ownsResponseCsp } from './csp';
 
 // OS-aware window-icon extension. Mirrors tray.ts so the same generated asset
 // set (icon.ico / icon.icns / icon.png) is used in both places.
@@ -147,9 +148,9 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   // CSP header — production only.
   // In development, Vite serves scripts from localhost with inline module
   // loaders and eval-based HMR, which are incompatible with strict CSP.
-  // We only enforce CSP in production builds.
-  // 'unsafe-inline' in style-src is required because Tailwind CSS and xterm.js
-  // inject inline styles at runtime; removing it breaks UI rendering.
+  // We only enforce CSP in production builds. The policy itself lives in
+  // ./csp so it can be asserted in tests — a missing directive here is
+  // invisible until a production build runs (#848).
   //
   // #582: The dev-only "Insecure Content-Security-Policy" warning is suppressed
   // via ELECTRON_DISABLE_SECURITY_WARNINGS — but that is now set at the very
@@ -159,9 +160,13 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   // the production CSP below is strict (no unsafe-eval), so this is dev-only
   // noise reduction, not a security trade-off.
   if (!MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    const cspPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self'; frame-src 'self' https: http:";
+    const cspPolicy = buildProductionCsp();
 
     mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+      if (!ownsResponseCsp(details.url)) {
+        callback({ responseHeaders: details.responseHeaders });
+        return;
+      }
       callback({
         responseHeaders: {
           ...details.responseHeaders,

--- a/src/main/window/csp.ts
+++ b/src/main/window/csp.ts
@@ -1,0 +1,50 @@
+// Production Content-Security-Policy for the main renderer.
+//
+// Split out of createWindow.ts so the policy is assertable in tests: #848
+// shipped a policy whose `frame-src` had no `wmux-plugin:` entry, which
+// silently broke every UI plugin (see buildProductionCsp below).
+
+import { PLUGIN_PROTOCOL_SCHEME } from '../../shared/pluginHost';
+
+/**
+ * The renderer's own policy. Note what this does NOT cover: a plugin page is
+ * served by `protocol.handle` with its own, stricter CSP
+ * (`PLUGIN_PAGE_CSP` in main/plugins/pluginProtocol.ts). This policy only has
+ * to permit the *framing* of that page — the plugin's scripts and styles are
+ * governed by the plugin response's own header, not by this one.
+ *
+ * `frame-src` therefore names the plugin scheme, and nothing else here does.
+ * Adding `wmux-plugin:` to `script-src`/`style-src` would be wrong: it would
+ * let the renderer document itself pull code out of a plugin bundle.
+ */
+export function buildProductionCsp(): string {
+  return [
+    "default-src 'self'",
+    "script-src 'self'",
+    // 'unsafe-inline' is required because Tailwind CSS and xterm.js inject
+    // inline styles at runtime; removing it breaks UI rendering.
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "font-src 'self'",
+    // 'self' — the app's own frames. https:/http: — the browser surface.
+    // wmux-plugin: — sandboxed UI plugin panels/widgets (#848). Without it
+    // the iframe in renderer/plugins/PluginFrame.tsx is blocked outright and
+    // the panel retries forever.
+    `frame-src 'self' https: http: ${PLUGIN_PROTOCOL_SCHEME}:`,
+  ].join('; ');
+}
+
+/**
+ * Responses this policy must not be stamped onto.
+ *
+ * Plugin bundle responses already carry the tighter `PLUGIN_PAGE_CSP`, which
+ * has no `connect-src` at all. Overwriting it with the renderer policy would
+ * both break the plugin (its bundled scripts are not `'self'` to an opaque
+ * origin) and relax the sandbox. Whether `onHeadersReceived` fires for a
+ * `protocol.handle` scheme is a Chromium implementation detail we would
+ * rather not depend on either way.
+ */
+export function ownsResponseCsp(url: string): boolean {
+  return !url.startsWith(`${PLUGIN_PROTOCOL_SCHEME}://`);
+}


### PR DESCRIPTION
Enabling any UI plugin puts its panel into an endless restore loop in production
builds. `PluginFrame.tsx` points its sandboxed iframe at
`wmux-plugin://<name>/<entry>`, but the renderer's production CSP listed only
`frame-src 'self' https: http:` — so the frame is blocked outright and the panel
retries forever.

Dev builds skip the CSP entirely (Vite's HMR needs `unsafe-eval`), which is why
`scripts/b1-plugin-host-dogfood.mjs` passes against a dev instance and this still
shipped. Moving the policy into its own module makes the directives assertable
without a packaged build.

## Changes

- `src/main/window/csp.ts` — the production policy, with `wmux-plugin:` added to
  `frame-src`.
- `ownsResponseCsp()` — plugin responses keep their own, stricter
  `PLUGIN_PAGE_CSP`. Overwriting it with the renderer policy would both break the
  page (its bundled scripts are not `'self'` to an opaque origin) and relax the
  sandbox, since `PLUGIN_PAGE_CSP` has no `connect-src` at all.
- `src/main/window/__tests__/csp.test.ts` — pins the directives, including the
  negative: the plugin scheme belongs in `frame-src` and nowhere else. Adding it
  to `script-src`/`style-src` would let the renderer document pull code out of a
  plugin bundle.

## Verification

Packaged builds, A/B, with hello-panel installed and an iframe mounted at the
same URL and sandbox `PluginFrame.tsx` uses. Policies read off the wire rather
than from source.

Before — renderer header `frame-src 'self' https: http:`:

```
Framing 'wmux-plugin://hello-panel/' violates the following Content Security
Policy directive: "frame-src 'self' https: http:". The request has been blocked.
```

After — renderer header `frame-src 'self' https: http: wmux-plugin:`, no
violations, and the plugin document loads carrying its own policy
(`default-src 'none'; ...; frame-src 'none'`), which confirms the response guard
holds.

Not covered: the approval-dialog path from unconfirmed plugin to rendered panel
was not driven, since that is a human approval gate. The CSP layer is where both
the fault and the fix are decided.

Closes #848