### PR TITLE
Own the application menu instead of inheriting Electron's

### DIFF
--- a/changelog.d/854.md
+++ b/changelog.d/854.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- wmux now defines its own application menu instead of inheriting Electron's default one, which had been quietly owning shortcuts wmux binds. On macOS `Cmd+Shift+R` triggered Force Reload rather than renaming a workspace, and the reload dropped every attached remote workspace; `Cmd+W` closed the window instead of the active surface, and the zoom keys resized the UI instead of the terminal font. On Windows and Linux `Ctrl+R` no longer reloads when focus sits outside a terminal.
+- Settings → Shortcuts lists the built-in key bindings from one shared table, so a custom keybinding that collides with `Ctrl+Shift+A`, `Ctrl+Shift+G`, `Ctrl+M`, `Ctrl+Tab` or the zoom keys is now flagged as a conflict instead of being accepted and silently never firing.

--- a/scripts/probe-menu-role-accelerators.js
+++ b/scripts/probe-menu-role-accelerators.js
@@ -1,0 +1,57 @@
+/**
+ * Read each Electron menu role's default accelerator out of the Electron build
+ * that is actually installed, and print it as JSON.
+ *
+ * `src/main/menu/appMenu.ts` keeps a copy of this table (#818): a template walk
+ * cannot see a role's accelerator — the item's own `accelerator` field is
+ * undefined — so the collision test that keeps the application menu off wmux's
+ * keymap has to know what each role installs. A hand-copied table goes stale
+ * silently on an Electron upgrade, hence this probe plus the
+ * PROBED_ELECTRON_MAJOR tripwire in appMenu.template.test.ts.
+ *
+ * Usage (from the repo root):
+ *
+ *   npx electron scripts/probe-menu-role-accelerators.js
+ *
+ * Then reconcile the output with ROLE_DEFAULT_ACCELERATORS and bump
+ * PROBED_ELECTRON_MAJOR. Note that Electron reports platform-agnostic strings
+ * (`CommandOrControl+W`), and that a few roles genuinely differ per platform —
+ * run the probe on each OS you care about, or trust the per-platform keys
+ * already recorded.
+ */
+const { app, Menu } = require('electron');
+
+const ROLES = [
+  'about', 'hide', 'hideOthers', 'unhide', 'quit', 'close', 'minimize', 'zoom', 'front',
+  'undo', 'redo', 'cut', 'copy', 'paste', 'pasteAndMatchStyle', 'delete', 'selectAll',
+  'reload', 'forceReload', 'toggleDevTools', 'resetZoom', 'zoomIn', 'zoomOut',
+  'togglefullscreen',
+];
+
+const COMPOSITES = ['appMenu', 'fileMenu', 'editMenu', 'viewMenu', 'windowMenu'];
+
+app.whenReady().then(() => {
+  const out = { platform: process.platform, electron: process.versions.electron, roles: {}, composites: {} };
+
+  for (const role of ROLES) {
+    try {
+      const menu = Menu.buildFromTemplate([{ role }]);
+      out.roles[role] = menu.items[0] ? menu.items[0].accelerator || null : 'ROLE_REJECTED';
+    } catch (err) {
+      out.roles[role] = `ERROR: ${err.message}`;
+    }
+  }
+
+  for (const composite of COMPOSITES) {
+    try {
+      const menu = Menu.buildFromTemplate([{ role: composite }]);
+      const sub = menu.items[0] && menu.items[0].submenu ? menu.items[0].submenu.items : [];
+      out.composites[composite] = sub.map((i) => `${i.role || i.label || '(separator)'}=${i.accelerator || '-'}`);
+    } catch (err) {
+      out.composites[composite] = `ERROR: ${err.message}`;
+    }
+  }
+
+  console.log(JSON.stringify(out, null, 2));
+  app.exit(0);
+});

--- a/src/main/__tests__/appMenu.template.test.ts
+++ b/src/main/__tests__/appMenu.template.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * #818 — wmux owns its accelerator table.
+ *
+ * These lock the two things that can silently regress:
+ *
+ *   1. The template declares no accelerator that WMUX_KEYMAP reserves. The
+ *      assertion runs through `keymapCollisions`, which resolves a `role` to
+ *      the accelerator Electron attaches to it. Walking only the declared
+ *      `accelerator` fields would pass vacuously — every role item has
+ *      `accelerator: undefined`, and unattributed role accelerators are exactly
+ *      what caused this bug.
+ *   2. `installApplicationMenu()` actually calls `Menu.setApplicationMenu`. A
+ *      perfectly-shaped template that is never installed leaves Electron's
+ *      default menu in charge, i.e. the bug, with tests green.
+ */
+
+// vi.hoisted, not bare consts: the module under test is imported statically
+// below, and vi.mock's factory is hoisted above plain const declarations.
+const { setApplicationMenuMock, buildFromTemplateMock } = vi.hoisted(() => ({
+  setApplicationMenuMock: vi.fn(),
+  buildFromTemplateMock: vi.fn((t: unknown) => ({ __built: t })),
+}));
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+  BrowserWindow: { getFocusedWindow: vi.fn(() => null) },
+  Menu: {
+    setApplicationMenu: setApplicationMenuMock,
+    buildFromTemplate: buildFromTemplateMock,
+  },
+}));
+
+import {
+  PROBED_ELECTRON_MAJOR,
+  buildAppMenuTemplate,
+  effectiveAccelerators,
+  installApplicationMenu,
+  keymapCollisions,
+} from '../menu/appMenu';
+import { acceleratorsMatch } from '../../shared/keymap';
+
+const PLATFORMS: NodeJS.Platform[] = ['darwin', 'win32', 'linux'];
+
+/** Flatten a template to every item, submenus included. */
+function allItems(
+  template: readonly Electron.MenuItemConstructorOptions[],
+): Electron.MenuItemConstructorOptions[] {
+  return template.flatMap((item) => {
+    const sub = Array.isArray(item.submenu)
+      ? allItems(item.submenu as Electron.MenuItemConstructorOptions[])
+      : [];
+    return [item, ...sub];
+  });
+}
+
+function roles(template: readonly Electron.MenuItemConstructorOptions[]): string[] {
+  return allItems(template)
+    .map((i) => i.role)
+    .filter((r): r is NonNullable<typeof r> => Boolean(r));
+}
+
+function hasAccelerator(
+  template: readonly Electron.MenuItemConstructorOptions[],
+  platform: NodeJS.Platform,
+  accelerator: string,
+): boolean {
+  return effectiveAccelerators(template, platform).some((a) =>
+    acceleratorsMatch(a, accelerator, platform),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildAppMenuTemplate — no accelerator wmux binds', () => {
+  for (const platform of PLATFORMS) {
+    for (const isDev of [false, true]) {
+      it(`${platform}${isDev ? ' (dev)' : ''} declares zero keymap collisions`, () => {
+        const template = buildAppMenuTemplate({ platform, isDev });
+        expect(keymapCollisions(template, platform)).toEqual([]);
+      });
+    }
+  }
+
+  // The three combos named in the issue, asserted by name so a regression
+  // reads as the symptom rather than as an opaque collision count.
+  it('macOS: Cmd+Shift+R is not force-reload — it stays wmux rename-workspace', () => {
+    const template = buildAppMenuTemplate({ platform: 'darwin', isDev: false });
+    expect(hasAccelerator(template, 'darwin', 'Command+Shift+R')).toBe(false);
+    expect(roles(template)).not.toContain('forceReload');
+  });
+
+  it('macOS: Cmd+W closes the surface, so the menu must not claim it', () => {
+    const template = buildAppMenuTemplate({ platform: 'darwin', isDev: false });
+    expect(hasAccelerator(template, 'darwin', 'Command+W')).toBe(false);
+    expect(roles(template)).not.toContain('close');
+  });
+
+  it('macOS: window-close survives on Alt+Cmd+W', () => {
+    const template = buildAppMenuTemplate({ platform: 'darwin', isDev: false });
+    expect(hasAccelerator(template, 'darwin', 'Alt+Command+W')).toBe(true);
+  });
+
+  it('no platform declares the zoom roles — Cmd/Ctrl+0/=/- are terminal font zoom', () => {
+    for (const platform of PLATFORMS) {
+      const template = buildAppMenuTemplate({ platform, isDev: true });
+      expect(roles(template)).not.toContain('resetZoom');
+      expect(roles(template)).not.toContain('zoomIn');
+      expect(roles(template)).not.toContain('zoomOut');
+    }
+  });
+
+  it('Windows/Linux: Minimize does not claim Ctrl+M (the scrollback bookmark)', () => {
+    for (const platform of ['win32', 'linux'] as NodeJS.Platform[]) {
+      const template = buildAppMenuTemplate({ platform, isDev: false });
+      expect(hasAccelerator(template, platform, 'Control+M')).toBe(false);
+    }
+    // On macOS the bookmark stays on literal Ctrl+M, so the role's Cmd+M is free.
+    const mac = buildAppMenuTemplate({ platform: 'darwin', isDev: false });
+    expect(roles(mac)).toContain('minimize');
+  });
+});
+
+describe('buildAppMenuTemplate — reload is dev-only and off the conflicting keys', () => {
+  for (const platform of PLATFORMS) {
+    it(`${platform}: a packaged build ships no reload path at all`, () => {
+      const template = buildAppMenuTemplate({ platform, isDev: false });
+      expect(roles(template)).not.toContain('reload');
+      expect(roles(template)).not.toContain('forceReload');
+      expect(hasAccelerator(template, platform, platform === 'darwin' ? 'Command+R' : 'Control+R')).toBe(false);
+      expect(allItems(template).map((i) => i.label)).not.toContain('&Developer');
+    });
+
+    it(`${platform}: a dev build reloads on Alt, never on plain Cmd/Ctrl+R`, () => {
+      const template = buildAppMenuTemplate({ platform, isDev: true });
+      expect(allItems(template).map((i) => i.label)).toContain('&Developer');
+      const plainReload = platform === 'darwin' ? 'Command+R' : 'Control+R';
+      expect(hasAccelerator(template, platform, plainReload)).toBe(false);
+      const altReload = platform === 'darwin' ? 'Alt+Command+R' : 'Control+Alt+R';
+      expect(hasAccelerator(template, platform, altReload)).toBe(true);
+    });
+  }
+});
+
+describe('buildAppMenuTemplate — platform structure', () => {
+  it('macOS gets the app menu (About / Services / Hide / Quit)', () => {
+    const template = buildAppMenuTemplate({ platform: 'darwin', isDev: false });
+    expect(roles(template)).toContain('appMenu');
+  });
+
+  it('Windows/Linux get Quit under File instead of an app menu', () => {
+    for (const platform of ['win32', 'linux'] as NodeJS.Platform[]) {
+      const template = buildAppMenuTemplate({ platform, isDev: false });
+      expect(roles(template)).not.toContain('appMenu');
+      expect(roles(template)).toContain('quit');
+    }
+  });
+
+  it('keeps the Edit roles intact — the useTerminal.ts:962 paste guard assumes them', () => {
+    for (const platform of PLATFORMS) {
+      const template = buildAppMenuTemplate({ platform, isDev: false });
+      expect(roles(template)).toContain('editMenu');
+      const paste = platform === 'darwin' ? 'Command+V' : 'Control+V';
+      expect(hasAccelerator(template, platform, paste)).toBe(true);
+    }
+  });
+
+  it('keeps fullscreen reachable', () => {
+    for (const platform of PLATFORMS) {
+      const template = buildAppMenuTemplate({ platform, isDev: false });
+      expect(roles(template)).toContain('togglefullscreen');
+    }
+  });
+});
+
+describe('effectiveAccelerators', () => {
+  it('resolves a role to the accelerator Electron attaches to it', () => {
+    // The regression guard's own guard: if this ever returns [] for a role
+    // item, every collision assertion above silently stops checking anything.
+    // Compared normalized because Electron reports platform-agnostic strings
+    // (`Shift+CmdOrCtrl+R`), which is what the probe recorded.
+    const one = (t: Electron.MenuItemConstructorOptions[], p: NodeJS.Platform) => {
+      const accels = effectiveAccelerators(t, p);
+      expect(accels).toHaveLength(1);
+      return accels[0];
+    };
+    expect(acceleratorsMatch(one([{ role: 'forceReload' }], 'darwin'), 'Command+Shift+R', 'darwin')).toBe(true);
+    expect(acceleratorsMatch(one([{ role: 'close' }], 'darwin'), 'Command+W', 'darwin')).toBe(true);
+    // Probed, not assumed: quit has no accelerator on Windows (Alt+F4 is the
+    // OS gesture) but does on Linux.
+    expect(effectiveAccelerators([{ role: 'quit' }], 'win32')).toEqual([]);
+    expect(acceleratorsMatch(one([{ role: 'quit' }], 'linux'), 'Control+Q', 'linux')).toBe(true);
+  });
+
+  it('expands the editMenu composite to its members', () => {
+    const accels = effectiveAccelerators([{ role: 'editMenu' }], 'darwin');
+    expect(accels.some((a) => acceleratorsMatch(a, 'Command+V', 'darwin'))).toBe(true);
+    expect(accels.some((a) => acceleratorsMatch(a, 'Command+A', 'darwin'))).toBe(true);
+  });
+
+  it('flags a template that re-adds the default View menu — the #818 regression', () => {
+    // The exact mistake: someone adds back reload/forceReload/zoom "for
+    // convenience". If this ever returns [], the suite above is decorative.
+    const bad: Electron.MenuItemConstructorOptions[] = [
+      { label: '&View', submenu: [{ role: 'forceReload' }, { role: 'resetZoom' }, { role: 'zoomIn' }] },
+      { label: '&File', submenu: [{ role: 'close' }] },
+    ];
+    for (const platform of PLATFORMS) {
+      const hits = keymapCollisions(bad, platform);
+      const hit = (a: string) => hits.some((h) => acceleratorsMatch(h, a, platform));
+      expect(hit('CommandOrControl+Shift+R')).toBe(true);
+      expect(hit('CommandOrControl+0')).toBe(true);
+      // zoomIn is spelled `Plus`; the reservation is `Ctrl+=`. If key-name
+      // folding ever breaks, this is the assertion that notices.
+      expect(hit('CommandOrControl+Plus')).toBe(true);
+      expect(hit('CommandOrControl+W')).toBe(true);
+    }
+  });
+
+  it('recurses into submenus', () => {
+    const accels = effectiveAccelerators(
+      [{ label: 'X', submenu: [{ label: 'Y', accelerator: 'Alt+Command+R' }] }],
+      'darwin',
+    );
+    expect(accels).toEqual(['Alt+Command+R']);
+  });
+});
+
+describe('ROLE_DEFAULT_ACCELERATORS staleness tripwire', () => {
+  it('fails when Electron is upgraded past the version the role table was probed against', async () => {
+    // The table is read out of a running Electron, not copied from its source
+    // (that is how `quit` having no Windows accelerator was caught). An upgrade
+    // can change a role default and every collision assertion above would keep
+    // passing against a stale map, so make the upgrade loud instead.
+    const pkg = (await import('../../../package.json')).default as {
+      devDependencies?: Record<string, string>;
+      dependencies?: Record<string, string>;
+    };
+    const spec = pkg.devDependencies?.electron ?? pkg.dependencies?.electron ?? '';
+    const major = Number.parseInt(spec.replace(/^[^\d]*/, ''), 10);
+    expect(
+      major,
+      `Electron ${major} != probed ${PROBED_ELECTRON_MAJOR}. Re-run ` +
+        '`npx electron scripts/probe-menu-role-accelerators.js`, reconcile ' +
+        'ROLE_DEFAULT_ACCELERATORS, then bump PROBED_ELECTRON_MAJOR.',
+    ).toBe(PROBED_ELECTRON_MAJOR);
+  });
+});
+
+describe('installApplicationMenu', () => {
+  it('installs the built menu — a template nobody installs is the bug itself', () => {
+    installApplicationMenu();
+    expect(buildFromTemplateMock).toHaveBeenCalledTimes(1);
+    expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+    expect(setApplicationMenuMock).toHaveBeenCalledWith(buildFromTemplateMock.mock.results[0].value);
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -975,6 +975,21 @@ app.on('ready', async () => {
   logLine('info', 'main', 'app.on(ready) fired');
   console.log('[Main] App ready, creating window...');
 
+  // #818: own the accelerator table before any window can exist. Skipping this
+  // left Electron's default menu in charge, and on macOS its NSMenu key
+  // equivalents fire before the renderer — Cmd+Shift+R force-reloaded (wiping
+  // every attached remote workspace) instead of renaming, and Cmd+W closed the
+  // window instead of the surface.
+  //
+  // Must stay BEFORE this callback's first `await` (Codex review on #854).
+  // `app.on('activate')` is registered at module scope, so once `ready` has
+  // fired macOS can dispatch an activate while this callback is parked on a
+  // pending promise; that handler sees zero windows and calls createWindow()
+  // itself. A window built during that gap would be governed by the default
+  // menu — the exact startup path this change exists to close. App-global and
+  // idempotent, so this one call covers those windows too.
+  installApplicationMenu();
+
   // P3 — macOS CLI shim: DMG/ZIP 설치엔 Squirrel 훅이 없으므로 첫 실행 시 1회만
   // `/usr/local/bin/wmux`(폴백 `~/.local/bin/wmux`) 심링크 설치를 시도한다.
   // 마커 파일로 1회 게이트하되, 마커가 있어도 "우리 소유 심링크가 현재 번들을
@@ -1092,14 +1107,6 @@ app.on('ready', async () => {
   }
   registerPluginProtocolHandler(() => pluginHostLoader);
   markBoot('plugins-loaded');
-
-  // #818: own the accelerator table before any window exists. Skipping this
-  // left Electron's default menu in charge, and on macOS its NSMenu key
-  // equivalents fire before the renderer — Cmd+Shift+R force-reloaded (wiping
-  // every attached remote workspace) instead of renaming, and Cmd+W closed the
-  // window instead of the surface. App-global, so this one call covers the
-  // windows created later by the macOS `activate` path too.
-  installApplicationMenu();
 
   mainWindow = createWindow({ deferLoad: true });
   markBoot('window-created');

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -108,6 +108,7 @@ import { DaemonRespawnController } from './daemon/DaemonRespawnController';
 import { loadConfig, getWmuxDir } from '../daemon/config';
 import { CHANNELS_EPOCH } from '../shared/channels';
 import { createTray, destroyTray, updateTraySessionCount } from './tray';
+import { installApplicationMenu } from './menu/appMenu';
 import { FirstRunOrchestrator } from './firstRun/FirstRunOrchestrator';
 import { registerFirstRunHandlers } from './firstRun';
 import { isSquirrelInstallerEvent } from './squirrel';
@@ -1091,6 +1092,14 @@ app.on('ready', async () => {
   }
   registerPluginProtocolHandler(() => pluginHostLoader);
   markBoot('plugins-loaded');
+
+  // #818: own the accelerator table before any window exists. Skipping this
+  // left Electron's default menu in charge, and on macOS its NSMenu key
+  // equivalents fire before the renderer — Cmd+Shift+R force-reloaded (wiping
+  // every attached remote workspace) instead of renaming, and Cmd+W closed the
+  // window instead of the surface. App-global, so this one call covers the
+  // windows created later by the macOS `activate` path too.
+  installApplicationMenu();
 
   mainWindow = createWindow({ deferLoad: true });
   markBoot('window-created');

--- a/src/main/menu/appMenu.ts
+++ b/src/main/menu/appMenu.ts
@@ -1,0 +1,283 @@
+import { app, BrowserWindow, Menu } from 'electron';
+import { collidesWithKeymap } from '../../shared/keymap';
+
+/**
+ * wmux's application menu.
+ *
+ * Until #818, `Menu.setApplicationMenu()` was never called, so Electron
+ * installed its default menu and that menu's roles owned the accelerator table.
+ * On macOS those are NSMenu key equivalents: they are dispatched before the web
+ * contents see the key, so a renderer `preventDefault()` cannot take them back.
+ * wmux is a multiplexer with its own keymap, and it was building that keymap on
+ * top of someone else's accelerators. Three consequences, one cause:
+ *
+ *   - `Cmd+Shift+R` was View ▸ Force Reload, not wmux's rename-workspace. The
+ *     reload wipes the renderer store, and `remoteWorkspaces[]` is per-app-run
+ *     state, so every attached remote workspace vanished.
+ *   - `Cmd+W` was File ▸ Close, so "close the active surface" closed the whole
+ *     window instead.
+ *   - `Cmd+0` / `Cmd+=` / `Cmd+-` were the View zoom roles, so terminal font
+ *     zoom hit webFrame zoom instead (and now fights the UI-scale control).
+ *
+ * The rule this module follows: **wmux declares every accelerator it keeps, and
+ * declares none that `WMUX_KEYMAP` reserves.** A menu entry we want for
+ * discoverability but not for its key gets a custom `click` item rather than a
+ * `role`, because a role silently re-installs its default key equivalent.
+ *
+ * Dispatch differs by platform, which is why this matters more on macOS:
+ *
+ *   macOS      key ──▶ NSMenu key equivalent ──▶ (renderer never sees it)
+ *   Win/Linux  key ──▶ renderer ──▶ preventDefault? ──▶ menu accelerator
+ *
+ * So on Windows/Linux every combo wmux binds already wins; the exposure there is
+ * the combos wmux does NOT bind — `Ctrl+R` (Reload) fires whenever focus sits
+ * outside a terminal, which is the same remote-workspace data loss.
+ */
+
+/**
+ * Electron version these role accelerators were probed against. Bumping
+ * Electron without re-probing is how this table silently goes wrong, so
+ * `appMenu.template.test.ts` fails when package.json's major drifts from this.
+ * Re-probe with `npx electron scripts/probe-menu-role-accelerators.js`.
+ */
+export const PROBED_ELECTRON_MAJOR = 41;
+
+/**
+ * Accelerators Electron attaches to a role when the template does not spell one
+ * out. Kept here because a template walk sees `accelerator: undefined` on every
+ * role item — a test that only reads declared accelerators passes vacuously,
+ * which is precisely the blind spot that let the default menu own these keys in
+ * the first place. Roles absent from this map have no default accelerator.
+ *
+ * `all` is the platform-agnostic string Electron itself reports (it hands back
+ * `CommandOrControl+W`, not a resolved `Cmd+W`); per-platform keys are only for
+ * the roles that genuinely differ. Not hand-copied from Electron's source —
+ * read out of the running Electron 41 build by the probe script above, which is
+ * how `quit` was caught: it has NO accelerator on Windows (Alt+F4 is the OS
+ * gesture), only on Linux.
+ */
+type RoleAccelerator = { all?: string; darwin?: string; win32?: string; linux?: string };
+
+export const ROLE_DEFAULT_ACCELERATORS: Readonly<Record<string, RoleAccelerator>> = {
+  about: {},
+  unhide: {},
+  delete: {},
+  zoom: {},
+  front: {},
+  // macOS-only roles.
+  hide: { darwin: 'Command+H' },
+  hideOthers: { darwin: 'Command+Alt+H' },
+  quit: { darwin: 'Command+Q', linux: 'Control+Q' },
+  close: { all: 'CommandOrControl+W' },
+  minimize: { all: 'CommandOrControl+M' },
+  undo: { all: 'CommandOrControl+Z' },
+  redo: { darwin: 'Shift+Command+Z', win32: 'Control+Y', linux: 'Control+Y' },
+  cut: { all: 'CommandOrControl+X' },
+  copy: { all: 'CommandOrControl+C' },
+  paste: { all: 'CommandOrControl+V' },
+  pasteAndMatchStyle: { all: 'Shift+CommandOrControl+V' },
+  selectAll: { all: 'CommandOrControl+A' },
+  reload: { all: 'CmdOrCtrl+R' },
+  forceReload: { all: 'Shift+CmdOrCtrl+R' },
+  toggleDevTools: { darwin: 'Alt+Command+I', win32: 'Control+Shift+I', linux: 'Control+Shift+I' },
+  resetZoom: { all: 'CommandOrControl+0' },
+  zoomIn: { all: 'CommandOrControl+Plus' },
+  zoomOut: { all: 'CommandOrControl+-' },
+  togglefullscreen: { darwin: 'Control+Command+F', win32: 'F11', linux: 'F11' },
+};
+
+/** The accelerator a role installs on `platform`, or undefined for none. */
+function roleAccelerator(role: string, platform: NodeJS.Platform): string | undefined {
+  const entry = ROLE_DEFAULT_ACCELERATORS[role];
+  if (!entry) return undefined;
+  if (platform === 'darwin') return entry.darwin ?? entry.all;
+  if (platform === 'win32') return entry.win32 ?? entry.all;
+  return entry.linux ?? entry.all;
+}
+
+/**
+ * Every accelerator a template actually installs: the ones it declares, plus
+ * the ones its roles bring along. Recurses into submenus.
+ *
+ * Exported for `appMenu.template.test.ts`, which is the regression pin: a menu
+ * item that steals a `WMUX_KEYMAP` combo fails CI instead of shipping as a dead
+ * shortcut nobody notices for three releases.
+ */
+export function effectiveAccelerators(
+  template: readonly Electron.MenuItemConstructorOptions[],
+  platform: NodeJS.Platform,
+): string[] {
+  const out: string[] = [];
+  const walk = (items: readonly Electron.MenuItemConstructorOptions[]): void => {
+    for (const item of items) {
+      if (item.accelerator) {
+        out.push(item.accelerator);
+      } else if (item.role) {
+        const fromRole = roleAccelerator(item.role, platform);
+        if (fromRole) out.push(fromRole);
+        // A composite role (appMenu / editMenu / windowMenu …) expands to a
+        // submenu Electron builds itself, so its children are invisible here.
+        // buildAppMenuTemplate never uses the composite View/File roles for
+        // exactly that reason; editMenu is the one deliberate exception and its
+        // members are enumerated below so the walk still sees them.
+        if (item.role === 'editMenu') {
+          for (const member of EDIT_MENU_MEMBERS) {
+            const acc = roleAccelerator(member, platform);
+            if (acc) out.push(acc);
+          }
+        }
+      }
+      const sub = item.submenu;
+      if (Array.isArray(sub)) walk(sub as Electron.MenuItemConstructorOptions[]);
+    }
+  };
+  walk(template);
+  return out;
+}
+
+/**
+ * Roles Electron's `editMenu` composite expands to. The probe shows non-mac
+ * builds omit `pasteAndMatchStyle` (and mac adds a Speech submenu, which has no
+ * accelerators); listing it on every platform only over-claims a reservation
+ * candidate, which is the safe direction for a collision check.
+ */
+const EDIT_MENU_MEMBERS = [
+  'undo',
+  'redo',
+  'cut',
+  'copy',
+  'paste',
+  'pasteAndMatchStyle',
+  'delete',
+  'selectAll',
+] as const;
+
+/**
+ * Build the application menu template.
+ *
+ * Pure so the shape can be asserted without an Electron runtime — same split as
+ * `tray.ts` / `tray.macTemplate.test.ts`.
+ *
+ * `isDev` gates the Developer submenu. Reload stays reachable while developing,
+ * but on `Alt`-prefixed keys (never `Cmd+R` / `Cmd+Shift+R`) and never in a
+ * packaged build, where a stray reload costs the user their attached remotes.
+ */
+export function buildAppMenuTemplate(opts: {
+  platform: NodeJS.Platform;
+  isDev: boolean;
+}): Electron.MenuItemConstructorOptions[] {
+  const isMac = opts.platform === 'darwin';
+  const template: Electron.MenuItemConstructorOptions[] = [];
+
+  if (isMac) {
+    // appMenu carries About / Services / Hide (Cmd+H) / Quit (Cmd+Q). None of
+    // those collide: wmux's flash-pane is Cmd+Shift+H and its close-pane is
+    // Cmd+Shift+Q.
+    template.push({ role: 'appMenu' });
+  }
+
+  template.push({
+    label: '&File',
+    submenu: isMac
+      ? [
+          // NOT `role: 'close'` — that role's key equivalent is Cmd+W, which is
+          // wmux's close-active-surface. iTerm2 / Terminal.app / VS Code all
+          // read Cmd+W as "close the tab", so wmux keeps it and window-close
+          // moves one modifier over. Shift+Cmd+W was unavailable: it is
+          // already wmux's close-workspace.
+          {
+            label: 'Close Window',
+            accelerator: 'Alt+Command+W',
+            click: () => BrowserWindow.getFocusedWindow()?.close(),
+          },
+        ]
+      : // Windows/Linux keep Ctrl+Q for quit (wmux binds nothing there, and
+        // xterm swallows it under terminal focus). Window-close has no menu
+        // entry here: Ctrl+W is wmux's close-surface and the native frame
+        // already provides the button.
+        [{ role: 'quit' }],
+  });
+
+  // Unchanged from Electron's default. The macOS Cmd+V race documented at
+  // useTerminal.ts:962 is guarded against the assumption that this role exists;
+  // re-evaluating that guard is deliberately a separate change (#818), so the
+  // premise is kept intact here.
+  template.push({ label: '&Edit', role: 'editMenu' });
+
+  template.push({
+    label: '&View',
+    submenu: [
+      // Reload and Force Reload are gone: Cmd+Shift+R was wmux's rename and
+      // Cmd+R destroys attached remote workspaces. The three zoom roles are
+      // gone too — Cmd+0/=/- are terminal font zoom.
+      { role: 'togglefullscreen' },
+    ],
+  });
+
+  template.push({
+    label: '&Window',
+    submenu: isMac
+      ? [{ role: 'minimize' }, { role: 'zoom' }, { type: 'separator' }, { role: 'front' }]
+      : [
+          // `role: 'minimize'` would declare Ctrl+M, which is wmux's scrollback
+          // bookmark on every OS. On macOS the role is safe because the
+          // bookmark stays on literal Ctrl+M there while the role takes Cmd+M.
+          {
+            label: 'Minimize',
+            click: () => BrowserWindow.getFocusedWindow()?.minimize(),
+          },
+          { role: 'zoom' },
+        ],
+  });
+
+  if (opts.isDev) {
+    template.push({
+      label: '&Developer',
+      submenu: [
+        {
+          label: 'Reload',
+          accelerator: isMac ? 'Alt+Command+R' : 'Control+Alt+R',
+          click: () => BrowserWindow.getFocusedWindow()?.webContents.reload(),
+        },
+        {
+          label: 'Force Reload',
+          accelerator: isMac ? 'Shift+Alt+Command+R' : 'Control+Shift+Alt+R',
+          click: () => BrowserWindow.getFocusedWindow()?.webContents.reloadIgnoringCache(),
+        },
+        { role: 'toggleDevTools' },
+      ],
+    });
+  }
+
+  return template;
+}
+
+/**
+ * Install the application menu. App-global and idempotent, so one call at
+ * startup covers every window, including the one macOS's `activate` handler
+ * re-creates after the last window closed.
+ *
+ * Call this BEFORE the first `createWindow()` so no window is ever briefly
+ * governed by Electron's default accelerator table.
+ */
+export function installApplicationMenu(): void {
+  const template = buildAppMenuTemplate({
+    platform: process.platform,
+    // Mirrors tray.ts: resolve via app.isPackaged, not NODE_ENV, which is not
+    // reliably set and could ship the Developer submenu in a release build.
+    isDev: !app.isPackaged,
+  });
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+/**
+ * Every accelerator in `template` that collides with wmux's renderer keymap.
+ * Empty for a correct template; the test asserts on it, and it is exported so a
+ * future menu change can be checked without re-deriving the role table.
+ */
+export function keymapCollisions(
+  template: readonly Electron.MenuItemConstructorOptions[],
+  platform: NodeJS.Platform,
+): string[] {
+  return effectiveAccelerators(template, platform).filter((a) => collidesWithKeymap(a, platform));
+}

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -95,8 +95,12 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
     //   - macOS: 'hidden' keeps the traffic lights, nudged to center in 36px.
     //   - Linux: keep the native frame (titleBarStyle is ignored there; a
     //     frameless window would lose drag/resize with no replacement).
-    // The menu itself is NOT removed — autoHideMenuBar keeps every
-    // accelerator working and Alt still reveals the menu on demand.
+    // The menu bar is hidden, not removed — Alt still reveals it on demand and
+    // the accelerators keep working. Which accelerators those are is no longer
+    // Electron's call: main/menu/appMenu.ts installs wmux's own menu before the
+    // first window (#818). Before that, the default menu's roles owned
+    // Cmd+Shift+R, Cmd+W, and the zoom keys, and silently beat the renderer to
+    // them on macOS.
     autoHideMenuBar: true,
     ...platformChoice<Partial<Electron.BrowserWindowConstructorOptions>>({
       win: {

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -24,6 +24,7 @@ import {
 import type { CustomThemeColors, NotificationCategory, XtermThemeColors } from '../../../shared/types';
 import { NOTIFICATION_CATEGORIES } from '../../../shared/types';
 import { ORCH_ROLES, launcherSupportsModelFlag } from '../../../shared/orchestratorRole';
+import { ADVERTISED_SHORTCUTS, WMUX_BUILTIN_COMBOS, macDisplayCombo, type KeymapEntry } from '../../../shared/keymap';
 import { MODEL_OPTIONS } from '../Deck/OrchestratorModelChip';
 import { MULTIVIEW_ARRANGEMENTS } from '../../utils/multiviewGrid';
 import type { NicInfo, LanLinkNic, LanLinkStatus, LanLinkPeerSummary } from '../../../shared/lanlink';
@@ -3918,12 +3919,11 @@ function keyCodeToDisplay(code: string): string {
  * tmux-convention combos (Ctrl+B prefix, Ctrl+M / Ctrl+Shift+M bookmark family)
  * stay on literal Ctrl across every OS, so we never substitute ⌘ for those.
  */
-function shortcutLabel(combo: string): string {
+function shortcutLabel(entry: KeymapEntry): string {
   const isMac = window.electronAPI.platform === 'darwin';
-  if (!isMac) return combo;
-  // Preserve tmux/bookmark conventions (must match useKeyboard.ts literalCtrl branches).
-  if (combo === 'Ctrl+B' || combo === 'Ctrl+M' || combo === 'Ctrl+Shift+M') return combo;
-  return combo.replace(/Ctrl/g, '⌘');
+  // literalCtrl entries (tmux prefix, bookmark family) stay literal on macOS —
+  // the flag lives in WMUX_KEYMAP so this and useKeyboard.ts can't drift.
+  return isMac ? macDisplayCombo(entry) : entry.combo;
 }
 
 const PREFIX_ACTION_IDS = [
@@ -3959,13 +3959,11 @@ function TabShortcuts() {
   const [capturingBindingKey, setCapturingBindingKey] = useState<string | null>(null);
   const [addingBinding, setAddingBinding] = useState(false);
 
-  const BUILTIN_KEYS = new Set([
-    'Ctrl+B', 'Ctrl+N', 'Ctrl+D', 'Ctrl+T', 'Ctrl+W', 'Ctrl+F',
-    'Ctrl+K', 'Ctrl+I', 'Ctrl+,',
-    'Ctrl+Shift+W', 'Ctrl+Shift+D', 'Ctrl+Shift+L', 'Ctrl+Shift+X',
-    'Ctrl+Shift+H', 'Ctrl+Shift+R', 'Ctrl+Shift+U', 'Ctrl+Shift+O',
-    'Ctrl+Shift+]', 'Ctrl+Shift+[', 'Ctrl+Shift+M', 'Ctrl+Shift+Q',
-  ]);
+  // Was a hand-copied subset that had drifted — Ctrl+Shift+A / Ctrl+Shift+G /
+  // Ctrl+M / Ctrl+Tab and the zoom keys are all bound but were missing, so a
+  // custom keybinding on one of them got no conflict warning and then silently
+  // never fired. Derived from WMUX_KEYMAP now (#818).
+  const BUILTIN_KEYS = WMUX_BUILTIN_COMBOS;
 
   const prefixKeyDisplay = `Ctrl+${keyCodeToDisplay(prefixConfig.key)}`;
   const bindingEntries = Object.entries(prefixConfig.bindings);
@@ -3974,19 +3972,11 @@ function TabShortcuts() {
   // tmux/bookmark family. prefixKeyDisplay always renders as literal Ctrl
   // because the prefix combo stays on Ctrl across every OS.
   const shortcuts = [
-    { keys: prefixKeyDisplay,                description: t('settings.prefixMode') },
-    { keys: shortcutLabel('Ctrl+D'),         description: t('settings.sc.splitHorizontal') },
-    { keys: shortcutLabel('Ctrl+Shift+D'),   description: t('settings.sc.splitVertical') },
-    { keys: shortcutLabel('Ctrl+T'),         description: t('settings.sc.newWorkspace') },
-    { keys: shortcutLabel('Ctrl+W'),         description: t('settings.sc.closeSurface') },
-    { keys: shortcutLabel('Ctrl+Shift+Q'),   description: t('settings.sc.closePane') },
-    { keys: shortcutLabel('Ctrl+F'),         description: t('settings.sc.searchTerminal') },
-    { keys: shortcutLabel('Ctrl+K'),         description: t('settings.sc.commandPalette') },
-    { keys: shortcutLabel('Ctrl+I'),         description: t('settings.sc.toggleNotifications') },
-    { keys: shortcutLabel('Ctrl+Shift+X'),   description: t('settings.sc.viCopyMode') },
-    { keys: shortcutLabel('Ctrl+Shift+R'),   description: t('settings.sc.renameWorkspace') },
-    { keys: shortcutLabel('Ctrl+Shift+H'),   description: t('settings.sc.highlightPane') },
-    { keys: shortcutLabel('Ctrl+`'),         description: t('settings.sc.floatingPane') },
+    { keys: prefixKeyDisplay, description: t('settings.prefixMode') },
+    ...ADVERTISED_SHORTCUTS.map((entry) => ({
+      keys: shortcutLabel(entry),
+      description: t(entry.descriptionKey as Parameters<typeof t>[0]),
+    })),
   ];
 
   return (

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -24,7 +24,7 @@ import {
 import type { CustomThemeColors, NotificationCategory, XtermThemeColors } from '../../../shared/types';
 import { NOTIFICATION_CATEGORIES } from '../../../shared/types';
 import { ORCH_ROLES, launcherSupportsModelFlag } from '../../../shared/orchestratorRole';
-import { ADVERTISED_SHORTCUTS, WMUX_BUILTIN_COMBOS, macDisplayCombo, type KeymapEntry } from '../../../shared/keymap';
+import { ADVERTISED_SHORTCUTS, builtinCombosFor, macDisplayCombo, type KeymapEntry } from '../../../shared/keymap';
 import { MODEL_OPTIONS } from '../Deck/OrchestratorModelChip';
 import { MULTIVIEW_ARRANGEMENTS } from '../../utils/multiviewGrid';
 import type { NicInfo, LanLinkNic, LanLinkStatus, LanLinkPeerSummary } from '../../../shared/lanlink';
@@ -3962,8 +3962,12 @@ function TabShortcuts() {
   // Was a hand-copied subset that had drifted — Ctrl+Shift+A / Ctrl+Shift+G /
   // Ctrl+M / Ctrl+Tab and the zoom keys are all bound but were missing, so a
   // custom keybinding on one of them got no conflict warning and then silently
-  // never fired. Derived from WMUX_KEYMAP now (#818).
-  const BUILTIN_KEYS = WMUX_BUILTIN_COMBOS;
+  // never fired. Derived from WMUX_KEYMAP now (#818), and resolved for the
+  // running platform — on macOS a built-in that fires on ⌘ cannot collide with
+  // a custom binding, which is matched on literal Ctrl.
+  const BUILTIN_KEYS = builtinCombosFor(
+    window.electronAPI?.platform === 'darwin' ? 'darwin' : 'win32',
+  );
 
   const prefixKeyDisplay = `Ctrl+${keyCodeToDisplay(prefixConfig.key)}`;
   const bindingEntries = Object.entries(prefixConfig.bindings);

--- a/src/shared/__tests__/keymap.test.ts
+++ b/src/shared/__tests__/keymap.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  WMUX_KEYMAP,
+  builtinCombosFor,
+  collidesWithKeymap,
+  ADVERTISED_SHORTCUTS,
+} from '../keymap';
+
+/**
+ * The table only earns its keep if its rows are in the SAME spelling the
+ * Settings conflict check compares against — an exact Set lookup on whatever
+ * `formatKeyCombo()` persisted. Every case here is a way the two can drift
+ * apart while every existing test still passes (Codex review on #854).
+ */
+
+/** The renderer's `formatKeyCombo` (useKeyboard.ts), duplicated to pin the shape. */
+function formatKeyCombo(ctrl: boolean, shift: boolean, alt: boolean, key: string): string {
+  const parts: string[] = [];
+  if (ctrl) parts.push('Ctrl');
+  if (shift) parts.push('Shift');
+  if (alt) parts.push('Alt');
+  parts.push(key.length === 1 ? key.toUpperCase() : key);
+  return parts.join('+');
+}
+
+describe('storage form', () => {
+  it('spells directional keys the way KeyboardEvent.key does', () => {
+    // e.key is 'ArrowUp', never 'Up'. A row written as 'Ctrl+Shift+Up' can
+    // never match what the capture overlay persisted.
+    const combos = builtinCombosFor('win32');
+    expect(combos.has(formatKeyCombo(true, true, false, 'ArrowUp'))).toBe(true);
+    expect(combos.has(formatKeyCombo(true, false, true, 'ArrowRight'))).toBe(true);
+    expect(combos.has(formatKeyCombo(false, false, true, 'ArrowDown'))).toBe(true);
+  });
+
+  it('covers the zoom aliases the handler accepts without requiring !shift', () => {
+    // zoomIn takes '=', '+', Equal and NumpadAdd; zoomOut takes '-', '_',
+    // Minus and NumpadSubtract. None of them check shift, so the shifted
+    // spellings reach zoom too and a custom binding on them never fires.
+    const combos = builtinCombosFor('win32');
+    for (const key of ['=', '+']) {
+      expect(combos.has(formatKeyCombo(true, false, false, key))).toBe(true);
+      expect(combos.has(formatKeyCombo(true, true, false, key))).toBe(true);
+    }
+    for (const key of ['-', '_']) {
+      expect(combos.has(formatKeyCombo(true, false, false, key))).toBe(true);
+      expect(combos.has(formatKeyCombo(true, true, false, key))).toBe(true);
+    }
+  });
+
+  it('leaves reset zoom unshifted, matching its !shift guard', () => {
+    expect(builtinCombosFor('win32').has('Ctrl+0')).toBe(true);
+    expect(builtinCombosFor('win32').has('Ctrl+Shift+0')).toBe(false);
+  });
+
+  it('writes every row in formatKeyCombo modifier order', () => {
+    for (const { combo } of WMUX_KEYMAP) {
+      // The key half can itself be '+', so the separator is the LAST '+'
+      // that is not the key — 'Ctrl++' is Ctrl plus the '+' key.
+      const key = combo.endsWith('+') ? '+' : combo.slice(combo.lastIndexOf('+') + 1);
+      const modStr = combo.slice(0, combo.length - key.length).replace(/\+$/, '');
+      const mods = modStr ? modStr.split('+') : [];
+      expect(mods).toEqual(['Ctrl', 'Shift', 'Alt'].filter((m) => mods.includes(m)));
+    }
+  });
+});
+
+describe('builtinCombosFor', () => {
+  it('drops the cmdOrCtrl family on macOS', () => {
+    // A custom binding is matched on literal Ctrl everywhere, but these
+    // built-ins fire on ⌘ under macOS — so they cannot collide there.
+    const mac = builtinCombosFor('darwin');
+    expect(mac.has('Ctrl+D')).toBe(false);
+    expect(mac.has('Ctrl+Shift+A')).toBe(false);
+    expect(builtinCombosFor('win32').has('Ctrl+D')).toBe(true);
+  });
+
+  it('keeps the literal-Ctrl family and the Ctrl-less rows on macOS', () => {
+    const mac = builtinCombosFor('darwin');
+    expect(mac.has('Ctrl+M')).toBe(true);        // bookmark — literal Ctrl on mac
+    expect(mac.has('Ctrl+B')).toBe(true);        // tmux prefix
+    expect(mac.has('Alt+ArrowUp')).toBe(true);   // no Ctrl at all
+  });
+});
+
+describe('accelerator side is unaffected by the storage spelling', () => {
+  it('still catches a menu accelerator naming a directional chord', () => {
+    // Electron spells these 'Up'; the table now says 'ArrowUp'.
+    // normalizeAcceleratorKey folds them together, so the menu guard holds.
+    expect(collidesWithKeymap('Control+Shift+Up', 'win32')).toBe(true);
+    expect(collidesWithKeymap('Alt+Up', 'win32')).toBe(true);
+  });
+
+  it('still catches the zoom roles', () => {
+    expect(collidesWithKeymap('CommandOrControl+0', 'win32')).toBe(true);
+    expect(collidesWithKeymap('CommandOrControl+Plus', 'win32')).toBe(true);
+    expect(collidesWithKeymap('CommandOrControl+-', 'win32')).toBe(true);
+  });
+});
+
+describe('ADVERTISED_SHORTCUTS', () => {
+  it('lists only rows carrying an i18n key, in table order', () => {
+    const expected = WMUX_KEYMAP.filter((e) => e.descriptionKey !== null).map((e) => e.combo);
+    expect(ADVERTISED_SHORTCUTS.map((e) => e.combo)).toEqual(expected);
+  });
+});

--- a/src/shared/keymap.ts
+++ b/src/shared/keymap.ts
@@ -83,9 +83,22 @@ export const WMUX_KEYMAP: readonly KeymapEntry[] = [
   // Terminal font zoom. These are the combos Electron's default View menu
   // owned as resetZoom / zoomIn / zoomOut, so on macOS they hit webFrame zoom
   // instead of the terminal font — the reason the menu must not declare them.
+  //
+  // The zoom-in/out handlers accept the shifted and numpad spellings of the
+  // same physical key and do NOT require `!shift`, so every alias below is
+  // swallowed before a custom binding could see it. Listing only the plain
+  // forms let a user bind e.g. Ctrl+Shift++ with no conflict warning and then
+  // watch it never fire (Codex review on #854). Reset (Ctrl+0) does require
+  // `!shift`, so it has no shifted alias.
   { combo: 'Ctrl+0', descriptionKey: null },
   { combo: 'Ctrl+=', descriptionKey: null },
+  { combo: 'Ctrl++', descriptionKey: null },
+  { combo: 'Ctrl+Shift+=', descriptionKey: null },
+  { combo: 'Ctrl+Shift++', descriptionKey: null },
   { combo: 'Ctrl+-', descriptionKey: null },
+  { combo: 'Ctrl+_', descriptionKey: null },
+  { combo: 'Ctrl+Shift+-', descriptionKey: null },
+  { combo: 'Ctrl+Shift+_', descriptionKey: null },
   // Workspace jump: Ctrl+1 … Ctrl+9.
   { combo: 'Ctrl+1', descriptionKey: null },
   { combo: 'Ctrl+2', descriptionKey: null },
@@ -98,16 +111,23 @@ export const WMUX_KEYMAP: readonly KeymapEntry[] = [
   { combo: 'Ctrl+9', descriptionKey: null },
   // Directional movement. Ctrl+Shift+Arrow moves focus; Ctrl+Alt+Arrow is the
   // alternate (⌘+Alt+Arrow on mac) focus combo; Alt+Arrow cycles workspaces.
-  { combo: 'Ctrl+Shift+Up', literalCtrl: true, descriptionKey: null },
-  { combo: 'Ctrl+Shift+Down', literalCtrl: true, descriptionKey: null },
-  { combo: 'Ctrl+Shift+Left', literalCtrl: true, descriptionKey: null },
-  { combo: 'Ctrl+Shift+Right', literalCtrl: true, descriptionKey: null },
-  { combo: 'Ctrl+Alt+Up', descriptionKey: null },
-  { combo: 'Ctrl+Alt+Down', descriptionKey: null },
-  { combo: 'Ctrl+Alt+Left', descriptionKey: null },
-  { combo: 'Ctrl+Alt+Right', descriptionKey: null },
-  { combo: 'Alt+Up', descriptionKey: null },
-  { combo: 'Alt+Down', descriptionKey: null },
+  //
+  // Spelled `ArrowUp`, not `Up`: `combo` is the STORAGE form, and storage is
+  // whatever `formatKeyCombo()` produces from `KeyboardEvent.key` — which is
+  // `ArrowUp`. Writing `Up` here made the Settings conflict check (an exact
+  // Set lookup) miss every directional binding (Codex review on #854). The
+  // accelerator side is unaffected: `normalizeAcceleratorKey` already folds
+  // `arrowup` onto Electron's `Up`.
+  { combo: 'Ctrl+Shift+ArrowUp', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+ArrowDown', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+ArrowLeft', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+ArrowRight', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Alt+ArrowUp', descriptionKey: null },
+  { combo: 'Ctrl+Alt+ArrowDown', descriptionKey: null },
+  { combo: 'Ctrl+Alt+ArrowLeft', descriptionKey: null },
+  { combo: 'Ctrl+Alt+ArrowRight', descriptionKey: null },
+  { combo: 'Alt+ArrowUp', descriptionKey: null },
+  { combo: 'Alt+ArrowDown', descriptionKey: null },
 ];
 
 /**
@@ -118,8 +138,25 @@ export const ADVERTISED_SHORTCUTS: readonly Required<KeymapEntry>[] =
   WMUX_KEYMAP.filter((e): e is KeymapEntry & { descriptionKey: string } => e.descriptionKey !== null)
     .map((e) => ({ literalCtrl: false, ...e }));
 
-/** Every combo wmux binds, as a Set of the literal storage form. */
-export const WMUX_BUILTIN_COMBOS: ReadonlySet<string> = new Set(WMUX_KEYMAP.map((e) => e.combo));
+/**
+ * The combos a CUSTOM keybinding can actually lose to on `platform`.
+ *
+ * Not simply every row: custom bindings are matched with literal `e.ctrlKey`
+ * on every OS (see the `formatKeyCombo(literalCtrl, …)` call in useKeyboard),
+ * while a non-`literalCtrl` row is dispatched on `e.metaKey` under macOS. So on
+ * macOS a custom `Ctrl+Shift+A` never meets the built-in, which fires on
+ * `⌘+Shift+A` — warning about it is a false conflict (Codex review on #854).
+ * Rows that are `literalCtrl`, or that carry no Ctrl at all (`Alt+ArrowUp`),
+ * stay reachable there and do collide.
+ *
+ * On Windows and Linux `cmdOrCtrl === literalCtrl`, so every row collides.
+ */
+export function builtinCombosFor(platform: NodeJS.Platform): ReadonlySet<string> {
+  const rows = platform === 'darwin'
+    ? WMUX_KEYMAP.filter((e) => e.literalCtrl || !e.combo.startsWith('Ctrl'))
+    : WMUX_KEYMAP;
+  return new Set(rows.map((e) => e.combo));
+}
 
 /**
  * Render a stored combo for display on macOS: `Ctrl` becomes `⌘` unless the

--- a/src/shared/keymap.ts
+++ b/src/shared/keymap.ts
@@ -1,0 +1,228 @@
+/**
+ * Canonical table of the key combos wmux's renderer keymap owns.
+ *
+ * This exists because the same list used to be hand-copied into three places
+ * (`useKeyboard.ts`'s if-chain, `SettingsPanel.tsx`'s BUILTIN_KEYS + shortcut
+ * rows, `KeyboardCheatSheet.buildShortcuts()`), and nothing kept them in sync.
+ * Issue #818 is what that costs: the application menu was never defined, so
+ * Electron's default menu quietly owned `Cmd+Shift+R`, `Cmd+W`, and the three
+ * zoom keys, and no single place in the codebase could be consulted to notice.
+ *
+ * `src/main/menu/appMenu.ts` is built against this table and
+ * `appMenu.template.test.ts` fails CI if a menu item ever declares one of these
+ * combos again. `useKeyboard.ts` still expresses its bindings as an if-chain —
+ * converting that is deliberately a separate change — so when a binding is
+ * added there, add its row here too.
+ *
+ *                       WMUX_KEYMAP (this file)
+ *                          │        │        │
+ *          ┌───────────────┘        │        └───────────────┐
+ *          ▼                        ▼                        ▼
+ *   SettingsPanel            appMenu.template.test    (useKeyboard.ts:
+ *   BUILTIN_KEYS +           reserved-accelerator      manual, see above)
+ *   shortcut rows            assertions
+ *
+ * `combo` is stored in the literal `Ctrl+…` form on every OS — the same form
+ * `formatKeyCombo()` produces for custom keybindings, and the form the settings
+ * UI persists. Rendering to `⌘` for macOS is a display concern; see
+ * `macDisplayCombo()`.
+ */
+
+export interface KeymapEntry {
+  /** Cross-OS storage form, e.g. `Ctrl+Shift+D`. */
+  combo: string;
+  /**
+   * When true the binding uses literal Ctrl on macOS as well (the tmux prefix
+   * and bookmark family — see the `literalCtrl` branches in useKeyboard.ts).
+   * When false/absent, macOS substitutes ⌘ (the `cmdOrCtrl` branches).
+   */
+  literalCtrl?: boolean;
+  /**
+   * i18n key for the Settings → Shortcuts list. `null` means the binding is
+   * real but not advertised there (it still reserves its accelerator).
+   */
+  descriptionKey: string | null;
+}
+
+/**
+ * Every combo `useKeyboard.ts` binds, in the order Settings renders the
+ * advertised subset. Rows with `descriptionKey: null` are bound but unlisted.
+ */
+export const WMUX_KEYMAP: readonly KeymapEntry[] = [
+  // ── Advertised in Settings → Shortcuts (order is the render order) ────────
+  { combo: 'Ctrl+D', descriptionKey: 'settings.sc.splitHorizontal' },
+  { combo: 'Ctrl+Shift+D', descriptionKey: 'settings.sc.splitVertical' },
+  { combo: 'Ctrl+T', descriptionKey: 'settings.sc.newWorkspace' },
+  { combo: 'Ctrl+W', descriptionKey: 'settings.sc.closeSurface' },
+  { combo: 'Ctrl+Shift+Q', descriptionKey: 'settings.sc.closePane' },
+  { combo: 'Ctrl+F', descriptionKey: 'settings.sc.searchTerminal' },
+  { combo: 'Ctrl+K', descriptionKey: 'settings.sc.commandPalette' },
+  { combo: 'Ctrl+I', descriptionKey: 'settings.sc.toggleNotifications' },
+  { combo: 'Ctrl+Shift+X', descriptionKey: 'settings.sc.viCopyMode' },
+  { combo: 'Ctrl+Shift+R', descriptionKey: 'settings.sc.renameWorkspace' },
+  { combo: 'Ctrl+Shift+H', descriptionKey: 'settings.sc.highlightPane' },
+  { combo: 'Ctrl+`', descriptionKey: 'settings.sc.floatingPane' },
+
+  // ── Bound but not advertised in the Settings list ─────────────────────────
+  { combo: 'Ctrl+N', descriptionKey: null },
+  { combo: 'Ctrl+M', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+B', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+B', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+M', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+,', descriptionKey: null },
+  { combo: 'Ctrl+Shift+W', descriptionKey: null },
+  { combo: 'Ctrl+Shift+A', descriptionKey: null },
+  { combo: 'Ctrl+Shift+U', descriptionKey: null },
+  { combo: 'Ctrl+Shift+L', descriptionKey: null },
+  { combo: 'Ctrl+Shift+O', descriptionKey: null },
+  { combo: 'Ctrl+Shift+G', descriptionKey: null },
+  { combo: 'Ctrl+Shift+]', descriptionKey: null },
+  { combo: 'Ctrl+Shift+[', descriptionKey: null },
+  { combo: 'Ctrl+Tab', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+Tab', literalCtrl: true, descriptionKey: null },
+  // Terminal font zoom. These are the combos Electron's default View menu
+  // owned as resetZoom / zoomIn / zoomOut, so on macOS they hit webFrame zoom
+  // instead of the terminal font — the reason the menu must not declare them.
+  { combo: 'Ctrl+0', descriptionKey: null },
+  { combo: 'Ctrl+=', descriptionKey: null },
+  { combo: 'Ctrl+-', descriptionKey: null },
+  // Workspace jump: Ctrl+1 … Ctrl+9.
+  { combo: 'Ctrl+1', descriptionKey: null },
+  { combo: 'Ctrl+2', descriptionKey: null },
+  { combo: 'Ctrl+3', descriptionKey: null },
+  { combo: 'Ctrl+4', descriptionKey: null },
+  { combo: 'Ctrl+5', descriptionKey: null },
+  { combo: 'Ctrl+6', descriptionKey: null },
+  { combo: 'Ctrl+7', descriptionKey: null },
+  { combo: 'Ctrl+8', descriptionKey: null },
+  { combo: 'Ctrl+9', descriptionKey: null },
+  // Directional movement. Ctrl+Shift+Arrow moves focus; Ctrl+Alt+Arrow is the
+  // alternate (⌘+Alt+Arrow on mac) focus combo; Alt+Arrow cycles workspaces.
+  { combo: 'Ctrl+Shift+Up', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+Down', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+Left', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Shift+Right', literalCtrl: true, descriptionKey: null },
+  { combo: 'Ctrl+Alt+Up', descriptionKey: null },
+  { combo: 'Ctrl+Alt+Down', descriptionKey: null },
+  { combo: 'Ctrl+Alt+Left', descriptionKey: null },
+  { combo: 'Ctrl+Alt+Right', descriptionKey: null },
+  { combo: 'Alt+Up', descriptionKey: null },
+  { combo: 'Alt+Down', descriptionKey: null },
+];
+
+/**
+ * The combos Settings advertises, in render order. Pairs each with its i18n
+ * key so the panel no longer keeps its own copy of the list.
+ */
+export const ADVERTISED_SHORTCUTS: readonly Required<KeymapEntry>[] =
+  WMUX_KEYMAP.filter((e): e is KeymapEntry & { descriptionKey: string } => e.descriptionKey !== null)
+    .map((e) => ({ literalCtrl: false, ...e }));
+
+/** Every combo wmux binds, as a Set of the literal storage form. */
+export const WMUX_BUILTIN_COMBOS: ReadonlySet<string> = new Set(WMUX_KEYMAP.map((e) => e.combo));
+
+/**
+ * Render a stored combo for display on macOS: `Ctrl` becomes `⌘` unless the
+ * binding is literal-Ctrl on every OS. Mirrors `shortcutLabel()`'s old inline
+ * logic in SettingsPanel and the `cmdOrCtrl` split in useKeyboard.ts.
+ */
+export function macDisplayCombo(entry: KeymapEntry): string {
+  return entry.literalCtrl ? entry.combo : entry.combo.replace(/Ctrl/g, '⌘');
+}
+
+/**
+ * The same combos in Electron accelerator syntax, resolved for one platform.
+ *
+ * Resolving matters: the cmdOrCtrl family is `⌘` on macOS and `Ctrl` elsewhere,
+ * while the literal-Ctrl family is `Ctrl` everywhere. On macOS that difference
+ * is the whole reason the Window menu can keep `role: 'minimize'` — its ⌘M does
+ * not touch wmux's Ctrl+M bookmark. A platform-agnostic comparison reports that
+ * as a collision, which is wrong.
+ */
+export function reservedAccelerators(platform: NodeJS.Platform): readonly string[] {
+  const cmdOrCtrl = platform === 'darwin' ? 'Command' : 'Control';
+  return WMUX_KEYMAP.map((e) =>
+    e.combo.replace(/^Ctrl/, e.literalCtrl ? 'Control' : cmdOrCtrl),
+  );
+}
+
+/**
+ * Resolve `CommandOrControl` / `CmdOrCtrl` to the concrete modifier `platform`
+ * uses. Electron reports role accelerators in the agnostic form, so both sides
+ * of a comparison have to be resolved before they can be compared exactly.
+ */
+export function resolveForPlatform(accelerator: string, platform: NodeJS.Platform): string {
+  const concrete = platform === 'darwin' ? 'Command' : 'Control';
+  return normalizeAccelerator(accelerator)
+    .split('+')
+    .map((part) => (part === 'CommandOrControl' ? concrete : part))
+    .join('+');
+}
+
+/**
+ * Normalize an Electron accelerator to the comparison form used above, so a
+ * menu declaring `Cmd+W`, `Command+W`, `CmdOrCtrl+W`, or `Ctrl+W` all collapse
+ * to one string. Modifier ORDER is normalized too — Electron accepts
+ * `Shift+CmdOrCtrl+R` and `CmdOrCtrl+Shift+R` as the same chord.
+ */
+export function normalizeAccelerator(accelerator: string): string {
+  const parts = accelerator.split('+').map((p) => p.trim()).filter(Boolean);
+  const key = parts[parts.length - 1];
+  const mods = new Set(
+    parts.slice(0, -1).map((m) => {
+      const lower = m.toLowerCase();
+      if (lower === 'cmd' || lower === 'command' || lower === 'super' || lower === 'meta') return 'Command';
+      if (lower === 'cmdorctrl' || lower === 'commandorcontrol') return 'CommandOrControl';
+      if (lower === 'ctrl' || lower === 'control') return 'Control';
+      if (lower === 'alt' || lower === 'option') return 'Alt';
+      if (lower === 'shift') return 'Shift';
+      return m;
+    }),
+  );
+  // Fixed modifier order so chord equality is order-insensitive.
+  const ordered = ['CommandOrControl', 'Command', 'Control', 'Alt', 'Shift'].filter((m) => mods.has(m));
+  const rest = [...mods].filter((m) => !ordered.includes(m));
+  return [...ordered, ...rest, normalizeAcceleratorKey(key)].join('+');
+}
+
+/**
+ * Fold the key half of an accelerator onto one spelling. Electron accepts
+ * several names for the same physical key (`Plus`/`=`, `Up`/`Arrow Up`,
+ * `Backquote`/`` ` ``), and the default menu's zoom roles use `Plus` where
+ * wmux's table says `=`.
+ */
+function normalizeAcceleratorKey(key: string): string {
+  const map: Record<string, string> = {
+    plus: '=',
+    numadd: '=',
+    numsub: '-',
+    minus: '-',
+    backquote: '`',
+    'arrowup': 'Up',
+    'arrowdown': 'Down',
+    'arrowleft': 'Left',
+    'arrowright': 'Right',
+  };
+  const lower = key.toLowerCase();
+  if (map[lower]) return map[lower];
+  // Single characters compare case-insensitively (`W` vs `w`); named keys keep
+  // their capitalized spelling (`Tab`, `Up`).
+  return key.length === 1 ? key.toUpperCase() : key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
+}
+
+/**
+ * True when two accelerators name the same chord on `platform`. Both sides are
+ * normalized (spelling, modifier order, `Plus` vs `=`) and resolved, so
+ * `CmdOrCtrl+W`, `Cmd+W`, and `Command+W` all compare equal on macOS while
+ * `Cmd+M` and `Ctrl+M` stay distinct there.
+ */
+export function acceleratorsMatch(a: string, b: string, platform: NodeJS.Platform): boolean {
+  return resolveForPlatform(a, platform) === resolveForPlatform(b, platform);
+}
+
+/** True when `accelerator` collides with a combo wmux's keymap owns on `platform`. */
+export function collidesWithKeymap(accelerator: string, platform: NodeJS.Platform): boolean {
+  return reservedAccelerators(platform).some((reserved) =>
+    acceleratorsMatch(reserved, accelerator, platform),
+  );
+}


### PR DESCRIPTION
`Menu.setApplicationMenu()` was never called, so Electron's default menu owned
the accelerator table. wmux is a multiplexer with its own keymap, and it was
building that keymap on top of someone else's accelerators.

On macOS the default menu's roles are NSMenu key equivalents: they dispatch
before the web contents see the key, so a renderer `preventDefault()` cannot take
them back. `Cmd+Shift+R` was Force Reload rather than rename-workspace, and the
reload wipes `remoteWorkspaces[]` — per-app-run state, so every attached remote
workspace vanished. On Windows/Linux the renderer wins the combos it binds, so
the exposure there is the ones it does not: `Ctrl+R` reloads whenever focus sits
outside a terminal, with the same data loss.

## Changes

- `src/main/menu/appMenu.ts` — wmux's own menu, installed before the first window
  so no window is ever briefly governed by the default table. The rule: declare
  every accelerator we keep, and none that `WMUX_KEYMAP` reserves. Entries we
  want for discoverability but not for their key (Close Window, Minimize) use a
  custom `click` rather than a `role`, because a role silently re-installs its
  default key equivalent.
- `src/shared/keymap.ts` — the combo list was hand-copied into three places and
  nothing kept them in sync. `SettingsPanel`'s copy had already drifted:
  `Ctrl+Shift+A`, `Ctrl+Shift+G`, `Ctrl+M`, `Ctrl+Tab` and the zoom keys were all
  bound but missing, so a custom keybinding on one of them got no conflict
  warning and then silently never fired. `useKeyboard.ts` still expresses its
  bindings as an if-chain; converting that is deliberately left out of this
  change.
- `src/main/__tests__/appMenu.template.test.ts` — fails CI if a menu item ever
  declares a reserved combo again. It resolves roles through a table of the
  accelerators Electron attaches implicitly, because a walk that only reads
  declared accelerators sees `undefined` on every role and passes vacuously —
  precisely the blind spot that let the default menu own these keys.
- `scripts/probe-menu-role-accelerators.js` — that table is read out of a running
  Electron rather than hand-copied, and the test fails when Electron's major
  drifts from the version it was probed against.

## Verification

Packaged builds, A/B, dumping `Menu.getApplicationMenu()` from the main process.

Before — Electron's default menu, holding every combo the issue named:

```
View   ▸ Reload             accel=CmdOrCtrl+R
       ▸ Force Reload       accel=Shift+CmdOrCtrl+R
       ▸ Actual Size/In/Out accel=CommandOrControl+0 / +Plus / +-
Window ▸ Minimize           accel=CommandOrControl+M
       ▸ Close              accel=CommandOrControl+W
```

After, all six are gone: View carries only Toggle Full Screen, File only Exit,
and Minimize declares no accelerator. `packaged: true` shows no Developer
submenu, so the dev-only Reload does not reach release builds. The probed role
table matched the live dump, including `quit` having no accelerator on Windows.

Not covered: macOS was not exercised — the `Cmd+Shift+R` data-loss path is
macOS-specific and this was verified on Windows. The dump does confirm its cause
directly, since the default menu demonstrably owns that accelerator.

The `Cmd+V` paste-corruption race guarded at `useTerminal.ts:962` is untouched:
Edit keeps `role: 'editMenu'`, so that guard's premise still holds. Re-evaluating
it is a separate change.

Closes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed application-menu shortcuts being intercepted by Electron defaults across platforms.
  - Prevented conflicts between built-in menu actions and WMUX workspace, surface, reload, and terminal zoom shortcuts.
  - Improved detection of custom shortcut conflicts in Settings.

- **Improvements**
  - Standardized shortcut labels and macOS formatting.
  - Expanded the displayed shortcut list and aligned it with the active platform’s built-in bindings.
  - Ensured shortcut handling is active during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->