### PR TITLE
Read the registry PATH as UTF-16 so non-ASCII entries survive

### DIFF
--- a/changelog.d/855.md
+++ b/changelog.d/855.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Directories with non-ASCII names in `PATH` now resolve in wmux terminals. A path such as `D:\软件\Python312` was being read from the registry through a code-page-encoded pipe, which replaced characters the code page could not represent and left the rest as `U+FFFD`, so the directory matched nothing on disk and commands from it resolved to a later `PATH` entry instead — for Python, the Microsoft Store stub. Accented Latin characters were affected the same way.

--- a/src/shared/__tests__/windowsPathEnv.test.ts
+++ b/src/shared/__tests__/windowsPathEnv.test.ts
@@ -1,13 +1,145 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   expandPercentRefs,
   composeRegistryPath,
   mergeFreshPathWithBase,
   withFreshWindowsPath,
   resetFreshPathCacheForTests,
+  parseRegExportValue,
+  readRegistryEnvPath,
 } from '../windowsPathEnv';
 
 beforeEach(() => resetFreshPathCacheForTests());
+
+/** Build a `.reg` export body around one root section. */
+function regFile(section: string, extra = ''): string {
+  return [
+    'Windows Registry Editor Version 5.00',
+    '',
+    '[HKEY_CURRENT_USER\\Environment]',
+    section,
+    extra,
+    '',
+  ].join('\r\n');
+}
+
+/** UTF-16LE bytes of `s` (NUL-terminated) as a `.reg` hex(2) token list. */
+function hexBytes(s: string): string {
+  const buf = Buffer.from(`${s}\0`, 'ucs2');
+  return [...buf].map((b) => b.toString(16).padStart(2, '0')).join(',');
+}
+
+/**
+ * #849 — the registry read used to pipe reg.exe text and decode it as UTF-8,
+ * but reg.exe encodes a pipe in the console code page: `D:\软件\Python312` came
+ * back as `D:\?<FFFD><FFFD>\Python312`, a path that exists nowhere, so command
+ * resolution fell through to a later PATH entry. Reading a UTF-16LE `.reg`
+ * export instead keeps every byte. These cases pin the parser's contract:
+ * decode exactly what it can prove, return null for everything else.
+ */
+describe('parseRegExportValue', () => {
+  it('round-trips non-ASCII through hex(2), which is what a user PATH is', () => {
+    const value = 'D:\\软件\\Python312;D:\\héllo;%SystemRoot%\\System32';
+    expect(parseRegExportValue(regFile(`"Path"=hex(2):${hexBytes(value)}`), 'Path')).toBe(value);
+  });
+
+  it('joins backslash-continued hex lines', () => {
+    const value = 'C:\\a;C:\\b';
+    const tokens = hexBytes(value).split(',');
+    const split = `"Path"=hex(2):${tokens.slice(0, 4).join(',')},\\\r\n  ${tokens.slice(4).join(',')}`;
+    expect(parseRegExportValue(regFile(split), 'Path')).toBe(value);
+  });
+
+  it('decodes REG_SZ escaping, which is not JSON escaping', () => {
+    // A literal backslash-n in a path must stay two characters.
+    expect(parseRegExportValue(regFile('"Path"="C:\\\\new;C:\\\\b"'), 'Path')).toBe('C:\\new;C:\\b');
+    expect(parseRegExportValue(regFile('"Path"="C:\\\\a \\"q\\" b"'), 'Path')).toBe('C:\\a "q" b');
+    expect(parseRegExportValue(regFile('"Path"="\\\\\\\\server\\\\share"'), 'Path')).toBe('\\\\server\\share');
+  });
+
+  it('matches the value name case-insensitively', () => {
+    expect(parseRegExportValue(regFile('"PATH"="C:\\\\a"'), 'Path')).toBe('C:\\a');
+  });
+
+  it('ignores a subkey section — only the root key owns our value', () => {
+    const withSub = regFile(
+      '"TEMP"="C:\\\\t"',
+      '\r\n[HKEY_CURRENT_USER\\Environment\\Sub]\r\n"Path"="C:\\\\decoy"',
+    );
+    expect(parseRegExportValue(withSub, 'Path')).toBeNull();
+  });
+
+  it('returns null rather than a partial PATH on anything malformed', () => {
+    const bad = [
+      `"Path"=hex(2):${hexBytes('C:\\a')},41`,        // odd byte count
+      '"Path"=hex(2):44,00,zz,00',                     // non-hex token
+      '"Path"=hex(2):44,00,\\',                        // continuation off the end
+      `"Path"=hex(7):${hexBytes('C:\\a')}`,            // REG_MULTI_SZ, not a PATH
+      '"Path"=dword:00000001',                         // wrong shape entirely
+      '"Path"="unterminated',                          // no closing quote
+    ];
+    for (const section of bad) {
+      expect(parseRegExportValue(regFile(section), 'Path')).toBeNull();
+    }
+    expect(parseRegExportValue('', 'Path')).toBeNull();
+    expect(parseRegExportValue(regFile('"TEMP"="C:\\\\t"'), 'Path')).toBeNull();
+  });
+});
+
+/**
+ * The regression that matters: every other test here injects
+ * `deps.readRegistryPath`, so the real reader — the function that held the
+ * encoding bug — was never executed by the suite. This one spawns the real
+ * reg.exe against a scratch key under HKCU\Software. It never touches
+ * HKCU\Environment.
+ */
+describe.runIf(process.platform === 'win32')('readRegistryEnvPath (live reg.exe)', () => {
+  const KEY = `HKCU\\Software\\wmux-test-849-${process.pid}`;
+  const reg = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
+  const drop = () => {
+    try {
+      execFileSync(reg, ['delete', KEY, '/f'], { stdio: 'ignore' });
+    } catch {
+      /* not present */
+    }
+  };
+
+  it('round-trips a non-ASCII REG_EXPAND_SZ value byte for byte', () => {
+    const value = 'D:\\软件\\Python312;D:\\héllo;%SystemRoot%\\System32';
+    drop();
+    execFileSync(reg, ['add', KEY, '/v', 'Path', '/t', 'REG_EXPAND_SZ', '/d', value, '/f'], {
+      stdio: 'ignore',
+    });
+    try {
+      expect(readRegistryEnvPath(KEY)).toBe(value);
+    } finally {
+      drop();
+    }
+  });
+
+  it('leaves no temp file behind', () => {
+    const before = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith('wmux-regpath-'));
+    drop();
+    execFileSync(reg, ['add', KEY, '/v', 'Path', '/t', 'REG_SZ', '/d', 'C:\\a', '/f'], {
+      stdio: 'ignore',
+    });
+    try {
+      readRegistryEnvPath(KEY);
+      const after = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith('wmux-regpath-'));
+      expect(after.length).toBe(before.length);
+    } finally {
+      drop();
+    }
+  });
+
+  it('fails open (null) for a key that does not exist', () => {
+    expect(readRegistryEnvPath(`${KEY}-absent-xyz`)).toBeNull();
+  });
+});
 
 describe('expandPercentRefs', () => {
   it('expands known vars case-insensitively and leaves unknown literal', () => {

--- a/src/shared/__tests__/windowsPathEnv.test.ts
+++ b/src/shared/__tests__/windowsPathEnv.test.ts
@@ -122,16 +122,24 @@ describe.runIf(process.platform === 'win32')('readRegistryEnvPath (live reg.exe)
   });
 
   it('leaves no temp file behind', () => {
-    const before = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith('wmux-regpath-'));
+    // Point os.tmpdir() at a private directory for the duration. Counting
+    // `wmux-regpath-*` in the shared temp dir instead would go flaky the moment
+    // a real wmux is running alongside the suite — it writes the same prefix.
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-849-tmp-'));
+    const saved = { TEMP: process.env.TEMP, TMP: process.env.TMP };
+    process.env.TEMP = sandbox;
+    process.env.TMP = sandbox;
     drop();
     execFileSync(reg, ['add', KEY, '/v', 'Path', '/t', 'REG_SZ', '/d', 'C:\\a', '/f'], {
       stdio: 'ignore',
     });
     try {
-      readRegistryEnvPath(KEY);
-      const after = fs.readdirSync(os.tmpdir()).filter((f) => f.startsWith('wmux-regpath-'));
-      expect(after.length).toBe(before.length);
+      expect(readRegistryEnvPath(KEY)).toBe('C:\\a'); // it really ran
+      expect(fs.readdirSync(sandbox)).toEqual([]);
     } finally {
+      process.env.TEMP = saved.TEMP;
+      process.env.TMP = saved.TMP;
+      fs.rmSync(sandbox, { recursive: true, force: true });
       drop();
     }
   });

--- a/src/shared/windowsPathEnv.ts
+++ b/src/shared/windowsPathEnv.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from 'child_process';
+import { randomBytes } from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 /**
@@ -48,33 +51,138 @@ export function resetFreshPathCacheForTests(): void {
 }
 
 /**
+ * Ceiling on the exported `.reg` file. `query /v Path` was implicitly bounded by
+ * being one value; exporting the whole key is not, and this read is synchronous
+ * on the pty-create path. A user PATH is tens of KB at the outside.
+ */
+const MAX_EXPORT_BYTES = 1024 * 1024;
+
+/** Decode the two escapes `.reg` string values use. NOT JSON unescaping — a
+ *  literal `\n` in a path must survive as backslash-n, not become a newline. */
+function unescapeRegString(s: string): string {
+  let out = '';
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '\\' && (s[i + 1] === '\\' || s[i + 1] === '"')) {
+      out += s[i + 1];
+      i++;
+    } else {
+      out += s[i];
+    }
+  }
+  return out;
+}
+
+/**
+ * Pull one value out of a `reg export` file.
+ *
+ * ```
+ * Windows Registry Editor Version 5.00
+ *
+ * [HKEY_CURRENT_USER\Environment]     ← root section: the only one we read
+ * "Path"=hex(2):44,00,3a,00,…,\       ← REG_EXPAND_SZ, UTF-16LE, \-continued
+ *   5c,00,61,00,00,00
+ * "TEMP"="C:\\Users\\me\\Temp"        ← REG_SZ, \\ and \" escaped
+ *
+ * [HKEY_CURRENT_USER\Environment\Sub] ← a subkey's "Path" is NOT our value
+ * "Path"="C:\\decoy"
+ * ```
+ *
+ * Returns null for anything it cannot decode with certainty — a malformed
+ * export must fail open to the caller's existing PATH, never yield a partial
+ * one that would silently drop entries.
+ */
+export function parseRegExportValue(text: string, name: string): string | null {
+  const lines = text.split(/\r?\n/);
+  const open = lines.findIndex((l) => l.trimStart().startsWith('['));
+  if (open === -1) return null;
+  let close = lines.length;
+  for (let i = open + 1; i < lines.length; i++) {
+    if (lines[i].trimStart().startsWith('[')) {
+      close = i;
+      break;
+    }
+  }
+  const section = lines.slice(open + 1, close);
+
+  const prefix = `"${name.toLowerCase()}"=`;
+  const head = section.findIndex((l) => l.toLowerCase().startsWith(prefix));
+  if (head === -1) return null;
+
+  let body = section[head].slice(prefix.length);
+  for (let i = head; body.endsWith('\\'); ) {
+    i++;
+    if (i >= section.length) return null; // continuation runs off the section
+    const next = section[i].trim();
+    if (!next) return null; // a trailing `\` must be followed by more tokens
+    body = body.slice(0, -1) + next;
+  }
+
+  if (body.startsWith('"')) {
+    if (body.length < 2 || !body.endsWith('"')) return null;
+    return unescapeRegString(body.slice(1, -1));
+  }
+
+  const hex = body.match(/^hex\(([0-9a-f]+)\):(.*)$/i);
+  if (!hex) return null;
+  // 1 = REG_SZ, 2 = REG_EXPAND_SZ. Anything else (REG_MULTI_SZ, REG_BINARY…)
+  // is not a PATH and must not be decoded as one.
+  const type = parseInt(hex[1], 16);
+  if (type !== 1 && type !== 2) return null;
+
+  const tokens = hex[2].split(',').map((t) => t.trim()).filter(Boolean);
+  if (tokens.length === 0 || tokens.length % 2 !== 0) return null; // UTF-16 pairs
+  const bytes = Buffer.alloc(tokens.length);
+  for (let i = 0; i < tokens.length; i++) {
+    if (!/^[0-9a-f]{1,2}$/i.test(tokens[i])) return null;
+    bytes[i] = parseInt(tokens[i], 16);
+  }
+  return bytes.toString('ucs2').replace(/\0+$/, '');
+}
+
+/**
  * Read the raw `Path` value from a registry Environment key via `reg.exe`.
  * `reg.exe` is used (not a cmdlet/.NET call) because it is immune to PowerShell
  * language-mode lockdown and returns the value WITHOUT expanding `%VAR%` — we do
  * the expansion ourselves against the caller's env. Returns null on any failure
  * or when the key has no `Path` value (e.g. a user with no user-scoped PATH).
+ *
+ * `export` to a file, NOT `query` to a pipe (#849). `reg.exe` encodes piped text
+ * in the console/ANSI code page, so a PATH entry like `D:\软件\Python312` comes
+ * back with the characters that page cannot represent already replaced by `?`,
+ * and the rest as invalid UTF-8 → U+FFFD. That loss happens in reg.exe before
+ * Node sees a byte, so no choice of decoding recovers it. A `.reg` file is
+ * UTF-16LE, so no code page is involved at all.
+ *
+ * Exported so a test can drive the real reader against a sandbox key: the
+ * `deps.readRegistryPath` seam below means every existing test stubs this
+ * function out, which is precisely why the encoding bug shipped green.
  */
-function readRegistryEnvPath(root: string): string | null {
+export function readRegistryEnvPath(root: string): string | null {
+  const reg = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
+  const tmp = path.join(os.tmpdir(), `wmux-regpath-${randomBytes(8).toString('hex')}.reg`);
   try {
-    const reg = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'reg.exe');
-    // The read is synchronous because both callers sit on the synchronous
-    // pty-create path (PTYManager.create). A normal `reg query` returns in tens
-    // of ms; the timeout only bounds the pathological case (AV hooking child
-    // spawns), capping the worst-case main-process stall at 2×800ms per cache
-    // miss instead of hanging. On timeout we fail open to the existing PATH.
-    const out = execFileSync(reg, ['query', root, '/v', 'Path'], {
-      encoding: 'utf8',
+    // Synchronous because both callers sit on the synchronous pty-create path
+    // (PTYManager.create). The timeout bounds the pathological case (AV hooking
+    // child spawns), capping the worst-case main-process stall at 2×800ms per
+    // cache miss. `/y` so a leftover file from a crashed run can never turn
+    // this into an overwrite prompt that blocks until that timeout.
+    execFileSync(reg, ['export', root, tmp, '/y'], {
+      stdio: 'ignore',
       timeout: 800,
       windowsHide: true,
     });
-    for (const line of out.split(/\r?\n/)) {
-      // reg output row:  "    Path    REG_EXPAND_SZ    C:\a;C:\b"
-      const m = line.match(/^\s*Path\s+REG(?:_EXPAND)?_SZ\s+(.*\S)\s*$/i);
-      if (m) return m[1];
-    }
-    return null;
+    if (fs.statSync(tmp).size > MAX_EXPORT_BYTES) return null;
+    return parseRegExportValue(fs.readFileSync(tmp, 'ucs2'), 'Path');
   } catch {
     return null;
+  } finally {
+    // Best-effort and swallowed: a failed unlink must not mask a good result
+    // nor turn a caught failure into a throw.
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      /* already gone, or locked by a scanner — the OS reaps %TEMP% */
+    }
   }
 }
 

--- a/src/shared/windowsPathEnv.ts
+++ b/src/shared/windowsPathEnv.ts
@@ -172,7 +172,15 @@ export function readRegistryEnvPath(root: string): string | null {
       windowsHide: true,
     });
     if (fs.statSync(tmp).size > MAX_EXPORT_BYTES) return null;
-    return parseRegExportValue(fs.readFileSync(tmp, 'ucs2'), 'Path');
+    const raw = fs.readFileSync(tmp);
+    // `reg export` writes UTF-16LE with a BOM. Check it rather than decoding
+    // blind: without this the parser only skips a stray U+FEFF because it
+    // happens to scan for `[`, and a file that is not UTF-16 would decode to
+    // garbage that the parser might still find a `Path=` line in. Wrong
+    // encoding is exactly the failure this whole change is about, so it fails
+    // open instead of guessing.
+    if (raw.length < 2 || raw[0] !== 0xff || raw[1] !== 0xfe) return null;
+    return parseRegExportValue(raw.subarray(2).toString('ucs2'), 'Path');
   } catch {
     return null;
   } finally {


### PR DESCRIPTION
A PATH entry like `D:\软件\Python312` reached the shell as `D:\?<FFFD><FFFD>\Python312` — a directory that exists nowhere. bash skipped it and resolved `python` to a later entry, the Microsoft Store stub, which exits 49. The same PATH works in Windows Terminal and mintty, because the mangling was ours.

## Root cause

`readRegistryEnvPath` piped `reg.exe`'s text output and decoded it as UTF-8. `reg.exe` encodes a pipe in the console/ANSI code page. Measured on a CP949 host with a sandbox key:

```
wrote:      "D:\软件\Python312"
raw bytes:  44 3a 5c 3f cb ec 5c ...
            D  :  \  ?  <件>    \
read utf8:  "D:\?<FFFD><FFFD>\Python312"
```

Two losses, in order: `软` is absent from that code page and is already `?` (0x3F) when Node receives it, and the surviving `件` (0xCB 0xEC) is not valid UTF-8, hence U+FFFD. The first loss happens inside reg.exe, so **no choice of decoding recovers it**.

Not CJK-specific — the same probe turned `héllo` into `hello`.

It also explains the duplicate the reporter saw in `$PATH`: `mergeFreshPathWithBase` leads with the fresh registry PATH and appends the process's own entries, and the mangled and intact spellings differ, so the case-insensitive dedup kept both.

## Why CI was green

Every existing test injects `deps.readRegistryPath`. The real reader — the function holding the bug — was never executed by the suite.

```
        withFreshWindowsPath(base, deps)
                 │
        deps.readRegistryPath ?  ──── yes ──▶ fake reader   ← every test
                 │ no
                 ▼
        readRegistryEnvPath()  ← the bug lived here, untested
```

## Change

`reg export` writes UTF-16LE, so no code page is involved. Measured against the alternatives on a REG_EXPAND_SZ value (the real type of `HKCU\Environment\Path`):

| candidate | round-trips? | cost |
|---|---|---|
| current: `reg query` piped as utf8 | FAIL | 29ms |
| **`reg export` → UTF-16LE file** | **PASS** | 33ms |
| PowerShell `Get-ItemProperty` | PASS | slow, ConstrainedLanguage risk |

`reg.exe` is kept rather than switching to a cmdlet, so the ConstrainedLanguage immunity this code was written for still holds. The 4ms sits behind the existing 5s cache.

- `parseRegExportValue` is pure and unit-tested. It reads the **root section only** — `reg export` includes subkeys, and a subkey's `Path` is not this value. It returns `null` for anything it cannot decode with certainty, because a malformed export must fail open to the caller's PATH rather than yield a partial one that silently drops entries.
- `.reg` escaping is decoded as `.reg`, not as JSON: only `\` and `\"`. A literal backslash-n in a path stays two characters.
- The UTF-16LE BOM is verified rather than assumed. Decoding text as the wrong encoding is the exact failure this PR fixes.
- Whole-key export removes the implicit size bound `query /v Path` had, and this is synchronous I/O on the pty path, so there is a size ceiling. Temp file gets a `crypto.randomBytes` name and `/y` (so a leftover file can never turn this into an overwrite prompt that blocks to the timeout), and its cleanup is swallowed so a failed unlink can neither mask a good result nor convert a caught failure into a throw.
- `readRegistryEnvPath` is exported so a test can drive the real reader.

## Verification

Both halves of the chain, measured:

- **registry → string**: a live test writes a non-ASCII `REG_EXPAND_SZ` value to a scratch key under `HKCU\Software` (never `HKCU\Environment`), calls the real reader, and asserts a byte-exact round trip.
- **env → node-pty → shell**: a real directory named `软件`, an executable inside it, passed through PATH — `which` returned `/tmp/.../软件/Python312/wmux849tool` intact and the tool ran. No loss in that half, so the registry read was the only break.

20 tests pass (8 parser failure cases: subkey-only `Path`, malformed hex, odd-length hex, truncated continuation, `hex(7)`, unterminated string, wrong shape, missing value). `tsc --noEmit` clean.

Reviewed by plan-eng-review plus a three-way independent pass (Claude / Codex / GLM-5.2). No P1 or P2 against this change; the two P3s that were actionable are fixed in the second commit.

## Not in scope

The daemon replays a persisted create-time env verbatim on reboot, so a session created before this fix keeps the mangled PATH until a pane is recreated. New panes are correct immediately. Touching daemon persistence carries its own regression risk and wants its own verification.

Closes #849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows terminal environment handling for non-ASCII `PATH` directories, including CJK characters and accented Latin characters.
  - Improved compatibility with paths affected by code-page encoding and replacement characters.
  - Added safer handling for malformed or unavailable registry data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->