### PR TITLE
fix(daemon): make pushed control-pipe events opt-in

### DIFF
--- a/changelog.d/856.md
+++ b/changelog.d/856.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **The daemon control pipe no longer pushes events at clients that never asked for
+  them.** Events used to reach every connection from the moment it opened, so a tool
+  that wrote a request and read one line back could read an event instead of its
+  reply — and since an event frame carries no error text, report a failure with an
+  empty message while quietly dropping the real answer. Events are now opt-in:
+  a connection gets replies and nothing else until it calls
+  `daemon.events.subscribe`. Tools that only make requests, including the wmux CLI
+  and the MCP server, need no change and can no longer hit that failure. A tool that
+  did rely on unsolicited events must now subscribe. See `docs/PROTOCOL.md` §2.9.
+  (#856)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -252,21 +252,25 @@ Wire shape: `channelId`, `seq` (per-channel monotonic), `senderWorkspaceId`, `re
 
 ### 2.9 The control connection is multiplexed — correlate on `id`
 
-A control connection carries **two kinds of frame in the same newline-delimited JSON stream**: replies to requests you sent, and unsolicited events the daemon pushes to every connected client. There is no subscription step — a client receives pushed events from the moment it connects, whether or not it ever asked for any. See `DaemonPipeServer.broadcast` in `src/daemon/DaemonPipeServer.ts`.
+A control connection can carry **two kinds of frame in the same newline-delimited JSON stream**: replies to requests you sent, and events the daemon pushes. See `DaemonPipeServer.broadcast` in `src/daemon/DaemonPipeServer.ts`.
 
-The two are told apart by `id`:
+**Events are opt-in.** A connection receives replies and nothing else until it calls `daemon.events.subscribe`; `daemon.events.unsubscribe` turns them off again. The subscription is per-connection and dies with the socket, so a client that reconnects MUST subscribe again. A client that only makes requests — the CLI and the MCP server are both in this category — never needs to touch either method, and its stream is then a plain request/reply stream.
+
+Once subscribed, the two frame kinds are told apart by `id`:
 
 - **Replies always echo the `id` of the request they answer**, and always carry `ok`. This holds on every path, including `unauthorized`, `rate limited`, and `Invalid RPC request`. A reply to a request that could not be parsed at all carries `"id": null`.
 - **Pushed events never carry an `id`.** They carry a `type` (e.g. `title.changed`, `lanlink.remote.received`) and their own payload fields.
 
-Therefore a client **MUST**:
+Therefore a **subscribed** client **MUST**:
 
 1. Read frames until it sees one whose `id` matches the `id` it sent — that frame, and only that frame, is its response.
 2. Ignore (or route to an event handler) any frame with no `id`. Never treat one as a response.
 
-**Writing one request and reading exactly one line back is incorrect**, even though it appears to work: it succeeds until an event happens to be pushed between the request and its reply, at which point the client reads the event instead. An event frame has no `ok` and no `error`, so a client that assumes otherwise typically reports a failure with an empty error message and then discards the real reply when it arrives.
+**Once subscribed, writing one request and reading exactly one line back is incorrect**, even though it appears to work: it succeeds until an event happens to be pushed between the request and its reply, at which point the client reads the event instead. An event frame has no `ok` and no `error`, so a client that assumes otherwise typically reports a failure with an empty error message and then discards the real reply when it arrives.
 
 Note the asymmetry when debugging: this mistake can **fabricate failures but never successes**. A phantom failure with an empty error message, on an operation that appears not to have happened, is a symptom of reading the wrong frame — not of the daemon failing the request.
+
+Historical note, because it changes how you read an old bug report: before events were opt-in, every connection was pushed events from the moment it connected, so the failure above could hit a client that had never asked for an event at all. Two teams lost pairing windows to it and published root-cause analyses they had to retract (#659). If you are debugging against a daemon older than this section, assume every connection is subscribed.
 
 ## 3. Snapshot envelope (`pane.list`)
 

--- a/scripts/bridge-dogfood.mjs
+++ b/scripts/bridge-dogfood.mjs
@@ -97,7 +97,12 @@ function broadcastListener() {
   const frames = [];
   const s = net.createConnection(readPipeName());
   let buf = '';
-  s.on('connect', () => s.write(`${JSON.stringify({ id: `sub-${TAG}`, token: readToken(), method: 'daemon.listSessions', params: {} })}\n`));
+  // Events are opt-in on the daemon side — without the subscribe this listener
+  // collects nothing and every waitFor below burns its full timeout.
+  s.on('connect', () => {
+    s.write(`${JSON.stringify({ id: `sub-${TAG}`, token: readToken(), method: 'daemon.events.subscribe', params: {} })}\n`);
+    s.write(`${JSON.stringify({ id: `ping-${TAG}`, token: readToken(), method: 'daemon.listSessions', params: {} })}\n`);
+  });
   s.on('data', (d) => {
     buf += d.toString();
     let nl;

--- a/scripts/d1-osc-notification-dynamic.mjs
+++ b/scripts/d1-osc-notification-dynamic.mjs
@@ -135,6 +135,10 @@ try {
     }
   });
 
+  // Events are opt-in on the daemon side — without this the notification.event
+  // frames this probe exists to assert on are never sent.
+  await rpc(control, 'daemon.events.subscribe', {});
+
   const SESSION_ID = 'd1-osc-test';
   await rpc(control, 'daemon.createSession', {
     id: SESSION_ID,

--- a/scripts/hooks-daemon-dynamic.mjs
+++ b/scripts/hooks-daemon-dynamic.mjs
@@ -184,7 +184,11 @@ class PipeClient {
       s.once('connect', () => { clearTimeout(t); resolve(s); });
       s.once('error', (e) => { clearTimeout(t); reject(e); });
     });
-    return new PipeClient(socket, opts);
+    const client = new PipeClient(socket, opts);
+    // Events are opt-in on the daemon side, so a caller that passes onEvent has
+    // to ask for them or it waits forever on frames that are never sent.
+    if (opts?.onEvent) await client.rpc('daemon.events.subscribe');
+    return client;
   }
 
   rpc(method, params = {}, timeoutMs = 10_000) {

--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -73,6 +73,10 @@ export class DaemonPipeServer {
   private authToken: string = '';
   private readonly handlers = new Map<string, RpcHandler>();
   private readonly connectedSockets = new Set<net.Socket>();
+  // Clients that asked for pushed events via `daemon.events.subscribe`. Empty
+  // by default — see `broadcast`. Dies with the socket, so a reconnecting
+  // client must re-subscribe.
+  private readonly eventSubscribers = new Set<net.Socket>();
   // Per-client identity for unicast delivery. Both directions are kept because
   // `sendTo` resolves an id → socket while the RPC path needs socket → id.
   private readonly clientIds = new Map<net.Socket, string>();
@@ -306,6 +310,7 @@ export class DaemonPipeServer {
         this.socketsByClientId.set(clientId, socket);
         socket.on('close', () => {
           this.connectedSockets.delete(socket);
+          this.eventSubscribers.delete(socket);
           this.rateLimits.delete(socket);
           this.clientIds.delete(socket);
           this.socketsByClientId.delete(clientId);
@@ -363,6 +368,7 @@ export class DaemonPipeServer {
       socket.destroy();
     }
     this.connectedSockets.clear();
+    this.eventSubscribers.clear();
     this.clientIds.clear();
     this.socketsByClientId.clear();
     this.firstPartyClients.clear();
@@ -414,6 +420,7 @@ export class DaemonPipeServer {
       socket.destroy();
     }
     this.connectedSockets.clear();
+    this.eventSubscribers.clear();
     this.clientIds.clear();
     this.socketsByClientId.clear();
     this.firstPartyClients.clear();
@@ -423,10 +430,24 @@ export class DaemonPipeServer {
     return newToken;
   }
 
-  /** Broadcast an event to all connected clients as a newline-delimited JSON message. */
+  /**
+   * Push an event to every client that subscribed, as a newline-delimited JSON
+   * message.
+   *
+   * Events are OPT-IN (`daemon.events.subscribe`). They used to go to every
+   * connected socket the moment it connected, which made the obvious client —
+   * write a request, read one line back — intermittently read a pushed event
+   * instead of its reply. An event frame carries no `ok`/`error`, so such a
+   * client reported a failure with an EMPTY error message and then discarded
+   * the real reply when it arrived: a fabricated failure that looks like the
+   * daemon misbehaving rather than a client bug (issue #659). Correlating on
+   * `id` is still required of subscribers (docs/PROTOCOL.md §2.9) — but a
+   * client that never asks for events can no longer be hit by this at all,
+   * which is the safer default.
+   */
   broadcast(event: unknown): void {
     const msg = JSON.stringify(event) + '\n';
-    this.connectedSockets.forEach((socket) => {
+    this.eventSubscribers.forEach((socket) => {
       if (!socket.destroyed) {
         try {
           socket.write(msg);
@@ -594,6 +615,34 @@ export class DaemonPipeServer {
   /** Did this client claim the first-party role? See `markFirstParty`. */
   isFirstParty(clientId: string): boolean {
     return this.firstPartyClients.has(clientId);
+  }
+
+  /**
+   * Start delivering pushed events to this client. Returns false when the
+   * client is already gone.
+   *
+   * This is a delivery switch, not a permission check: every control-pipe
+   * client presents the same credential, and the events carried here are the
+   * same ones every client used to receive unconditionally. What it buys is a
+   * safe default for clients that never ask — see `broadcast`.
+   */
+  subscribeEvents(clientId: string): boolean {
+    const socket = this.socketsByClientId.get(clientId);
+    if (!socket || socket.destroyed) return false;
+    this.eventSubscribers.add(socket);
+    return true;
+  }
+
+  /** Stop delivering pushed events to this client. Idempotent. */
+  unsubscribeEvents(clientId: string): void {
+    const socket = this.socketsByClientId.get(clientId);
+    if (socket) this.eventSubscribers.delete(socket);
+  }
+
+  /** Is this client receiving pushed events? */
+  isEventSubscriber(clientId: string): boolean {
+    const socket = this.socketsByClientId.get(clientId);
+    return socket !== undefined && this.eventSubscribers.has(socket);
   }
 
   /**

--- a/src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts
@@ -1,0 +1,172 @@
+// Issue #659 — pushed events are opt-in.
+//
+// The control pipe carries replies and unsolicited events in one stream. While
+// events went to every socket on connect, the obvious client — write a request,
+// read one line back — intermittently read an event instead of its reply. An
+// event frame has no `ok` and no `error`, so that client reported a failure with
+// an EMPTY error message and discarded the real reply when it arrived. The
+// asymmetry is what made it expensive: it can fabricate failures but never
+// successes, so it looks like the daemon failing the request.
+//
+// These tests pin the default (a client that never subscribes is never pushed
+// to) rather than the delivery mechanics, because the default is the fix.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import net from 'node:net';
+import crypto from 'node:crypto';
+import os from 'node:os';
+import path from 'node:path';
+import { DaemonPipeServer } from '../DaemonPipeServer';
+import { waitFor } from '../../test-utils/waitFor';
+
+function testPipeName(suffix: string): string {
+  const id = crypto.randomUUID().slice(0, 8);
+  if (process.platform === 'win32') return `\\\\.\\pipe\\wmux-test-${suffix}-${id}`;
+  return path.join(os.tmpdir(), `wmux-test-${suffix}-${id}.sock`);
+}
+
+const servers: DaemonPipeServer[] = [];
+const clients: net.Socket[] = [];
+
+afterEach(async () => {
+  for (const c of clients.splice(0)) c.destroy();
+  for (const s of servers.splice(0)) await s.stop();
+});
+
+async function startServer(suffix: string): Promise<{ server: DaemonPipeServer; pipe: string; token: string }> {
+  const pipe = testPipeName(suffix);
+  const server = new DaemonPipeServer(pipe);
+  servers.push(server);
+  const token = 'test-token-' + crypto.randomUUID();
+  server.setAuthToken(token);
+  // Mirrors daemon/index.ts, so the switch is exercised through a real RPC
+  // rather than by poking the set directly.
+  server.onRpc('daemon.events.subscribe', async (_p, ctx) => ({ ok: server.subscribeEvents(ctx.clientId) }));
+  server.onRpc('daemon.events.unsubscribe', async (_p, ctx) => {
+    server.unsubscribeEvents(ctx.clientId);
+    return { ok: true };
+  });
+  server.onRpc('test.echo', async () => ({ echoed: true }));
+  await server.start();
+  return { server, pipe, token };
+}
+
+/** Connect, and collect every line the server sends back. */
+async function connectClient(pipe: string): Promise<{ socket: net.Socket; lines: string[] }> {
+  const socket = net.createConnection(pipe);
+  clients.push(socket);
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', () => resolve());
+    socket.once('error', reject);
+  });
+  const lines: string[] = [];
+  let buffer = '';
+  socket.setEncoding('utf8');
+  socket.on('data', (chunk: string) => {
+    buffer += chunk;
+    const parts = buffer.split('\n');
+    buffer = parts.pop() ?? '';
+    for (const p of parts) if (p.trim()) lines.push(p.trim());
+  });
+  return { socket, lines };
+}
+
+describe('DaemonPipeServer — pushed events are opt-in (#659)', () => {
+  it('does not push events to a client that never subscribed', async () => {
+    const { server, pipe, token } = await startServer('optin-default');
+    const { socket, lines } = await connectClient(pipe);
+
+    server.broadcast({ type: 'title.changed', sessionId: 's1' });
+
+    // A round-trip the client DID ask for, used as a fence: once its reply has
+    // landed, any broadcast the server sent first would already be in `lines`.
+    socket.write(JSON.stringify({ id: 'r1', method: 'test.echo', token }) + '\n');
+    await waitFor(() => lines.length > 0);
+
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({ id: 'r1', ok: true });
+  });
+
+  it('pushes events once the client subscribes', async () => {
+    const { server, pipe, token } = await startServer('optin-subscribed');
+    const { socket, lines } = await connectClient(pipe);
+
+    socket.write(JSON.stringify({ id: 'sub', method: 'daemon.events.subscribe', token }) + '\n');
+    await waitFor(() => lines.some((l) => l.includes('"id":"sub"')));
+
+    server.broadcast({ type: 'title.changed', sessionId: 's1' });
+    await waitFor(() => lines.some((l) => l.includes('title.changed')));
+
+    const event = JSON.parse(lines.find((l) => l.includes('title.changed'))!) as Record<string, unknown>;
+    // The frame shapes documented in PROTOCOL §2.9: events carry no `id`.
+    expect(event['id']).toBeUndefined();
+    expect(event['type']).toBe('title.changed');
+  });
+
+  it('stops pushing after unsubscribe', async () => {
+    const { server, pipe, token } = await startServer('optin-unsub');
+    const { socket, lines } = await connectClient(pipe);
+
+    socket.write(JSON.stringify({ id: 'sub', method: 'daemon.events.subscribe', token }) + '\n');
+    await waitFor(() => lines.some((l) => l.includes('"id":"sub"')));
+    socket.write(JSON.stringify({ id: 'unsub', method: 'daemon.events.unsubscribe', token }) + '\n');
+    await waitFor(() => lines.some((l) => l.includes('"id":"unsub"')));
+
+    const before = lines.length;
+    server.broadcast({ type: 'title.changed', sessionId: 's1' });
+    socket.write(JSON.stringify({ id: 'fence', method: 'test.echo', token }) + '\n');
+    await waitFor(() => lines.some((l) => l.includes('"id":"fence"')));
+
+    expect(lines.length).toBe(before + 1);
+  });
+
+  it('subscribes one client without touching another', async () => {
+    const { server, pipe, token } = await startServer('optin-isolation');
+    const subscriber = await connectClient(pipe);
+    const rpcOnly = await connectClient(pipe);
+
+    subscriber.socket.write(JSON.stringify({ id: 'sub', method: 'daemon.events.subscribe', token }) + '\n');
+    await waitFor(() => subscriber.lines.some((l) => l.includes('"id":"sub"')));
+
+    server.broadcast({ type: 'lanlink.remote.received', sessionId: 's1' });
+    await waitFor(() => subscriber.lines.some((l) => l.includes('lanlink.remote.received')));
+
+    rpcOnly.socket.write(JSON.stringify({ id: 'fence', method: 'test.echo', token }) + '\n');
+    await waitFor(() => rpcOnly.lines.length > 0);
+    expect(rpcOnly.lines).toHaveLength(1);
+    expect(JSON.parse(rpcOnly.lines[0]!)).toMatchObject({ id: 'fence', ok: true });
+  });
+
+  it('drops the subscription with the socket, so a reconnect must re-subscribe', async () => {
+    const { server, pipe, token } = await startServer('optin-close');
+    const { socket, lines } = await connectClient(pipe);
+
+    socket.write(JSON.stringify({ id: 'sub', method: 'daemon.events.subscribe', token }) + '\n');
+    await waitFor(() => lines.some((l) => l.includes('"id":"sub"')));
+
+    socket.destroy();
+    await waitFor(() => server.getConnectionCount() === 0);
+
+    // No subscriber left to write to, and a broadcast into an empty set is not
+    // an error — the daemon keeps emitting whether or not anyone is listening.
+    expect(() => server.broadcast({ type: 'title.changed', sessionId: 's1' })).not.toThrow();
+  });
+
+  it('refuses to subscribe a client that is already gone', async () => {
+    const { server, pipe, token } = await startServer('optin-dead');
+    const { socket } = await connectClient(pipe);
+    let clientId = '';
+    server.onRpc('test.whoami', async (_p, ctx) => {
+      clientId = ctx.clientId;
+      return {};
+    });
+    socket.write(JSON.stringify({ id: 'w', method: 'test.whoami', token }) + '\n');
+    await waitFor(() => clientId !== '');
+
+    socket.destroy();
+    await waitFor(() => server.getConnectionCount() === 0);
+
+    expect(server.subscribeEvents(clientId)).toBe(false);
+    expect(server.isEventSubscriber(clientId)).toBe(false);
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2809,6 +2809,21 @@ function registerRpcHandlers(
     const role = typeof params['role'] === 'string' ? params['role'] : '';
     if (role !== 'main') return { ok: false };
     pipeServer.markFirstParty(ctx.clientId);
+    // The app is the one client that must subscribe to events (#659). If it
+    // identified but never did, it is an older build talking to this daemon and
+    // it is about to sit there receiving nothing — the same silent, undiagnosable
+    // failure #659 was about, pointing the other way. Say so in the log, because
+    // a subscriber count of zero looks perfectly normal from in here. Only the
+    // app identifies as 'main', so this cannot fire for the CLI or MCP server.
+    const idleCheck = setTimeout(() => {
+      if (pipeServer.isFirstParty(ctx.clientId) && !pipeServer.isEventSubscriber(ctx.clientId)) {
+        log(
+          'warn',
+          `[events] first-party client ${ctx.clientId} identified but never subscribed — it will receive no events (pre-#659 app build?)`,
+        );
+      }
+    }, 5_000);
+    idleCheck.unref();
     return { ok: true };
   });
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2812,6 +2812,19 @@ function registerRpcHandlers(
     return { ok: true };
   });
 
+  // Pushed events are opt-in (issue #659). A client that never calls this reads
+  // nothing but replies to its own requests, so "write a request, read one line
+  // back" — the obvious client — can no longer read an event by mistake and
+  // report it as a failure with an empty error message.
+  pipeServer.onRpc('daemon.events.subscribe', async (_params, ctx) => {
+    return { ok: pipeServer.subscribeEvents(ctx.clientId) };
+  });
+
+  pipeServer.onRpc('daemon.events.unsubscribe', async (_params, ctx) => {
+    pipeServer.unsubscribeEvents(ctx.clientId);
+    return { ok: true };
+  });
+
   pipeServer.onRpc('daemon.transcript.status', async (params, ctx) => {
     if (!firstPartyOnly(ctx.clientId, 'status')) {
       return { available: false, reason: 'not-authorized' };

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -106,6 +106,15 @@ export class DaemonClient extends EventEmitter {
         this.controlPipe = socket;
         this.connected = true;
         this.setupControlPipe(socket);
+        // Pushed events are opt-in on the daemon side (issue #659), and this
+        // client is the one consumer that needs them. Sent here rather than
+        // from the connect callers so the request is the FIRST line on the
+        // socket: the daemon processes lines in order, so every event it
+        // generates after reading this one is delivered. Deliberately not
+        // awaited — waiting for the reply would only widen the gap, and an
+        // older daemon that has no such method just answers `Unknown method`
+        // while still pushing events to everyone, as it always did.
+        this.subscribeToEvents();
         finish({ ok: true });
       });
 
@@ -118,6 +127,18 @@ export class DaemonClient extends EventEmitter {
         console.warn(`[lifecycle] DaemonClient.connect error code=${err?.code ?? '?'} pipe=${this.pipeName} msg=${err?.message ?? String(err)}`);
         finish({ ok: false, code: err?.code });
       });
+    });
+  }
+
+  /**
+   * Ask the daemon to push events down this control pipe. Best-effort: the
+   * only failures are a daemon too old to know the method and a socket that
+   * died between connect and this write, and neither is actionable here — the
+   * respawn controller owns reconnection.
+   */
+  private subscribeToEvents(): void {
+    this.rpc('daemon.events.subscribe').catch(() => {
+      // Old daemon (no such method) or a socket that just went away.
     });
   }
 

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -131,15 +131,51 @@ export class DaemonClient extends EventEmitter {
   }
 
   /**
-   * Ask the daemon to push events down this control pipe. Best-effort: the
-   * only failures are a daemon too old to know the method and a socket that
-   * died between connect and this write, and neither is actionable here — the
-   * respawn controller owns reconnection.
+   * Ask the daemon to push events down this control pipe.
+   *
+   * Retried, because a swallowed failure here is silent and total: the app
+   * would keep running with no session, title, cwd, or notification events for
+   * the life of the connection, and nothing would ever ask again. The realistic
+   * failure is transient — the subscribe shares the daemon's RPC rate limit
+   * with every other client, so a boot-time burst can bounce it once.
+   *
+   * `Unknown method` is the one terminal answer worth recognizing: that daemon
+   * predates opt-in events and is already pushing to everyone, so retrying
+   * would only spend the rate limit re-asking a question already answered.
    */
+  private static readonly SUBSCRIBE_MAX_ATTEMPTS = 5;
+
+  // Bumped on every connect so a retry loop left over from a previous socket
+  // cannot resurrect itself and subscribe on behalf of a connection that is
+  // already gone.
+  private subscribeGeneration = 0;
+
   private subscribeToEvents(): void {
-    this.rpc('daemon.events.subscribe').catch(() => {
-      // Old daemon (no such method) or a socket that just went away.
-    });
+    const generation = ++this.subscribeGeneration;
+    void this.runSubscribeWithRetry(generation);
+  }
+
+  private async runSubscribeWithRetry(generation: number): Promise<void> {
+    for (let attempt = 1; attempt <= DaemonClient.SUBSCRIBE_MAX_ATTEMPTS; attempt++) {
+      if (generation !== this.subscribeGeneration || !this.connected) return;
+      try {
+        // The handler's own answer rides in `result`; the envelope's `ok` only
+        // says the RPC was dispatched, so checking it alone would read a
+        // refusal as a success.
+        const result = (await this.rpc('daemon.events.subscribe')) as { ok?: boolean } | null;
+        if (result?.ok === true) return;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('Unknown method')) return;
+        console.warn(`[lifecycle] DaemonClient events subscribe attempt ${attempt} failed: ${message}`);
+      }
+      if (attempt < DaemonClient.SUBSCRIBE_MAX_ATTEMPTS) {
+        await new Promise((resolve) => setTimeout(resolve, 250 * 2 ** (attempt - 1)));
+      }
+    }
+    console.error(
+      '[lifecycle] DaemonClient could not subscribe to daemon events — this connection will receive none',
+    );
   }
 
   /** Disconnect from daemon, cleaning up all pipes. */

--- a/src/main/__tests__/DaemonClient.test.ts
+++ b/src/main/__tests__/DaemonClient.test.ts
@@ -49,8 +49,16 @@ function createMockDaemonServer(
             continue;
           }
 
-          const result = handler(req.params || {});
-          socket.write(JSON.stringify({ id: req.id, ok: true, result }) + '\n');
+          // A throwing handler answers `{id, ok:false, error}` the way the real
+          // dispatch does. Replying with `id: null` here would leave the client's
+          // pending request unmatched and turn a plain error into a timeout.
+          try {
+            const result = handler(req.params || {});
+            socket.write(JSON.stringify({ id: req.id, ok: true, result }) + '\n');
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            socket.write(JSON.stringify({ id: req.id, ok: false, error: message }) + '\n');
+          }
         } catch (err) {
           socket.write(JSON.stringify({ id: null, ok: false, error: 'Invalid JSON' }) + '\n');
         }
@@ -766,5 +774,106 @@ describe('DaemonClient — LanLink PR-5 pairing/peer bridge', () => {
 
     expect(await client.lanlinkPeersRemove('u')).toEqual({ ok: true });
     expect(calls['remove']).toEqual({ peerUuid: 'u' });
+  });
+});
+
+// Issue #659 — the daemon only pushes events to clients that subscribed, and
+// this client is the app's only source of them. A silently-dropped subscribe
+// would leave the whole app event-blind for the life of the connection with
+// nothing in the logs, so the handshake is pinned here rather than assumed.
+describe('DaemonClient — event subscription (#659)', () => {
+  const AUTH_TOKEN = 'test-token-events';
+  let mockServer: ReturnType<typeof createMockDaemonServer>;
+  let client: DaemonClient;
+
+  afterEach(async () => {
+    try { await client?.disconnect(); } catch { /* ignore */ }
+    try { await mockServer?.stop(); } catch { /* ignore */ }
+  });
+
+  it('subscribes to events as the first RPC on a fresh control pipe', async () => {
+    const pipeName = testPipeName('evsub');
+    const methods: string[] = [];
+    mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {
+      'daemon.events.subscribe': () => { methods.push('daemon.events.subscribe'); return { ok: true }; },
+      'daemon.ping': () => { methods.push('daemon.ping'); return { status: 'ok' }; },
+    });
+    await mockServer.start();
+
+    client = new DaemonClient(pipeName, AUTH_TOKEN);
+    expect(await client.connect()).toBe(true);
+    await client.rpc('daemon.ping');
+
+    // Ordering is the point: events generated before the daemon reads the
+    // subscribe are lost, so it has to lead — not trail the first real call.
+    expect(methods[0]).toBe('daemon.events.subscribe');
+  });
+
+  it('re-emits a pushed event frame once subscribed', async () => {
+    const pipeName = testPipeName('evemit');
+    mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {
+      'daemon.events.subscribe': () => ({ ok: true }),
+    });
+    await mockServer.start();
+
+    client = new DaemonClient(pipeName, AUTH_TOKEN);
+    const seen: unknown[] = [];
+    client.on('event', (e) => seen.push(e));
+    await client.connect();
+
+    // Push an id-less frame the way the daemon's broadcast does.
+    await new Promise((r) => setTimeout(r, 50));
+    mockServer.sockets.forEach((s) => s.write(JSON.stringify({ type: 'title.changed', sessionId: 's1' }) + '\n'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(seen).toContainEqual(expect.objectContaining({ type: 'title.changed' }));
+  });
+
+  it('retries a subscribe the daemon rejected, instead of going event-blind', async () => {
+    const pipeName = testPipeName('evretry');
+    let attempts = 0;
+    mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {
+      // First answer mirrors a rate-limited boot: transient, and previously
+      // swallowed — the connection would then never receive a single event.
+      'daemon.events.subscribe': () => {
+        attempts++;
+        if (attempts === 1) throw new Error('rate limited');
+        return { ok: true };
+      },
+    });
+    await mockServer.start();
+
+    client = new DaemonClient(pipeName, AUTH_TOKEN);
+    const seen: unknown[] = [];
+    client.on('event', (e) => seen.push(e));
+    await client.connect();
+
+    // First attempt fails, backoff is 250ms, second succeeds.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(attempts).toBeGreaterThanOrEqual(2);
+
+    mockServer.sockets.forEach((s) => s.write(JSON.stringify({ type: 'title.changed', sessionId: 's1' }) + '\n'));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(seen).toContainEqual(expect.objectContaining({ type: 'title.changed' }));
+  });
+
+  it('stops asking a daemon that predates opt-in events', async () => {
+    const pipeName = testPipeName('evold');
+    let attempts = 0;
+    // No handler registered — the mock answers `Unknown method`, exactly as a
+    // pre-#659 daemon would. That daemon already pushes to everyone, so
+    // re-asking would just spend the rate limit.
+    mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {
+      'daemon.ping': () => { attempts++; return { status: 'ok' }; },
+    });
+    await mockServer.start();
+
+    client = new DaemonClient(pipeName, AUTH_TOKEN);
+    await client.connect();
+    await new Promise((r) => setTimeout(r, 600));
+
+    // Nothing threw, connect still succeeded, and no retry storm followed.
+    expect(await client.rpc('daemon.ping')).toEqual({ status: 'ok' });
+    expect(attempts).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

The daemon control pipe delivered broadcast events to every socket from the moment it connected, with no subscription step. A client that writes a request and reads one line back — the obvious implementation — therefore read an event instead of its reply whenever one happened to be pushed in between. An event frame carries no `ok` and no `error`, so such a client reported a failure with an empty error message and discarded the real reply when it arrived.

The asymmetry is what made it expensive: the mistake can fabricate failures but never successes, so it does not look like a client bug. It looks like the daemon intermittently failing whatever was asked of it, with no error text to go on. Two teams published root-cause analyses off the back of it and had to retract them.

`#662` documented the `id`-correlation rule, which was the cheap half of the fix. This is the design half: events are now opt-in, so the default is safe for a client that never reads the documentation.

## What changed

**`DaemonPipeServer`** — `broadcast()` now writes to an `eventSubscribers` set instead of every connected socket. `subscribeEvents` / `unsubscribeEvents` / `isEventSubscriber` manage it. The subscription is per-connection and dies with the socket (close, `stop()`, and `rotateToken()` all clear it), matching the lifetime rule `firstPartyClients` already uses, so a reconnecting client must subscribe again.

**RPC** — `daemon.events.subscribe` and `daemon.events.unsubscribe`, registered alongside the existing `daemon.transcript.subscribe` pair they are modelled on.

**`DaemonClient`** — the app is the one consumer that wants events, and it subscribes as the first line it writes on a fresh control pipe. That placement is deliberate: the daemon processes lines in order, so every event generated after it reads that line is delivered. The call is not awaited — waiting for the reply would only widen the gap.

**`docs/PROTOCOL.md` §2.9** — rewritten. The `id`-correlation rule still stands for subscribers; the section now leads with the opt-in and carries a note for anyone debugging against a daemon that predates it, where every connection is still implicitly subscribed.

## Compatibility

This changes the default for control-pipe clients: one that relied on events arriving unsolicited must now send `daemon.events.subscribe`. In-tree, nothing else does — the CLI (`src/cli/client.ts`) and the MCP server (`src/mcp/wmux-client.ts`) both correlate on `id` and read no events, so both are unaffected and both gain protection from the failure above. An older daemon answers `Unknown method` and keeps pushing to everyone as it always did, so a new app against an old daemon is unchanged.

## Test coverage

`src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts`, six cases. The one that pins the fix is the first: a connected-but-unsubscribed client sends a request after a broadcast fires and receives exactly one line, its own reply. The rest cover delivery after subscribe, unsubscribe, isolation between a subscriber and an RPC-only client on the same server, subscription death on socket close, and refusing to subscribe a client that is already gone.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `src/daemon` + `src/main`: 5854 passed, 0 failed (post-merge with `main`)
- [x] New opt-in suite: 6 passed

Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in daemon event delivery for control connections.
  * Clients can subscribe or unsubscribe from pushed events at any time.
  * Event subscriptions are isolated per connection and cleared when connections close or reconnect.
  * The client automatically enables event delivery when supported.
* **Documentation**
  * Clarified event subscription, response correlation, pushed-event routing, and compatibility with older daemon versions.
* **Tests**
  * Added coverage for subscription, unsubscription, isolation, disconnect handling, and event broadcasting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review round

A three-model review of this diff (Claude, Codex, GLM) found one real breakage the original change missed, plus two blind spots it created. All three are fixed in `4651f088`.

**Three in-repo dogfood gates consumed broadcasts without subscribing** — `scripts/hooks-daemon-dynamic.mjs`, `scripts/bridge-dogfood.mjs`, and `scripts/d1-osc-notification-dynamic.mjs` each open a dedicated connection to collect event frames. After the switch they collected nothing: wait asserts would burn their timeouts and "no event should arrive" asserts would pass vacuously. These are manual gates, not part of any vitest suite, which is why CI stayed green. Fixed by subscribing on each listener.

**`subscribeToEvents` discarded its own result** — the RPC envelope's `ok` only reports that the call was dispatched; the handler's answer rides in `result`, so a refusal read as a success. Worse, any transient failure was swallowed: the subscribe shares the daemon's RPC rate limit with every other client, so a boot-time burst could bounce it once and leave the app with no events for the life of the connection, nothing logged and nothing to retry. Now checks the handler's answer and retries with backoff, honoring `Unknown method` as terminal.

**A daemon with zero subscribers cannot tell correct clients from an old app** — an RPC-only CLI and an app too old to subscribe look identical from inside. The daemon now logs when a client identifies as `main` and still has not subscribed shortly after. Only the app identifies as `main`, so the CLI and MCP server cannot trip it.

Deferred to #858, none of them regressions from this PR: the accept-to-subscribe window (flagged by all three models), the missing backpressure guard on `broadcast` that `sendTo` already has, and whether `daemon.events.subscribe` should carry a first-party gate.

Also verified: `npm run test:parallel` excludes `*.runtime.test.ts`, so the runtime suite was run separately — 138 passed.
