### PR TITLE
fix(fleet): prevent non-agent panes from inheriting agent identity (#850)

### DIFF
--- a/changelog.d/850.md
+++ b/changelog.d/850.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Non-agent panes (btop, vim, plain shell) no longer misidentified as AI agents in the sidebar and Fleet View.** Two independent fixes: (1) the Fleet View selector now requires per-PTY agent identity (`surfaceAgent`) before inheriting workspace-level agent name and status for the active pane — a non-agent pane in a split can no longer borrow the real agent's "Claude Code · Needs you" badge; (2) the Claude Code agent detector now uses a compound gate (banner **and** prompt evidence, matching the Kiro CLI pattern) instead of a single banner regex, so a process monitor displaying "claude" in its process list cannot falsely open the detection gate. (#850)

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -144,10 +144,10 @@ const KIRO_PROMPT_LINE = /^[▸>❯]?\s*ask\s*a\s*question\s*or\s*describe\s*a\s
 // Signal A (banner): the startup banner or OSC window-title mention.
 // Signal B (prompt): a Claude-specific prompt fragment proving the TUI is live.
 const CLAUDE_BANNER_RE = /(?<!Open)(?<!Open\s)Claude\s*Code|claude-code|╭.*(?<!Open)(?<!Open\s)Claude/;
-// Any Claude-specific TUI text that a process monitor would never display.
-// Includes waiting prompts AND approval keywords (a pane might show an
-// approval before any waiting footer if the first turn requests file edits).
-const CLAUDE_PROMPT_RE = /bypass permissions on|shift\+tab to cycle|Do you want to proceed|Allow tool use for|Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)/;
+// Claude-specific TUI footer text that a process monitor would never display.
+// Only the idle-prompt fragments — approval keywords are excluded because they
+// appear in conversational text and would false-positive the gate (#850 CI).
+const CLAUDE_PROMPT_RE = /bypass permissions on|shift\+tab to cycle/;
 
 const AGENT_PATTERNS: AgentPattern[] = [
   // ── Claude Code ────────────────────────────────────────────────────────────
@@ -547,14 +547,13 @@ export class AgentDetector {
         const m = clean.match(CLAUDE_PROMPT_RE);
         if (m) {
           this.claudePromptSeen = true;
-          // Preserve the status that matches the evidence pattern so the
-          // replay emits the correct lifecycle event — waiting prompts
-          // replay as 'waiting', approval prompts replay as 'awaiting_input'.
-          const isApproval = /Do you want to proceed|Allow tool use for|Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)/.test(m[0]);
+          // CLAUDE_PROMPT_RE only matches waiting-prompt fragments, so the
+          // replay is always 'waiting'. Approval patterns are excluded from
+          // the gate evidence to avoid conversational false positives.
           this.claudePromptEvidence = {
             text: m[0],
-            status: isApproval ? 'awaiting_input' : 'waiting',
-            message: isApproval ? 'Approval requested' : 'Ready for input',
+            status: 'waiting',
+            message: 'Ready for input',
           };
         }
       }

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -61,143 +61,39 @@ type CriticalEventCallback = (event: CriticalEvent) => void;
 // SLUG-form agent identifier. Lowercase, no whitespace. Used as the
 // canonical key shared with hook-based signals (integrations/<agent>/).
 // HookSignalRouter dedup matches AgentDetector emissions against bridge
-// signals on this slug.
-//
-// The union and both slug<->display lookups now live in
-// src/shared/agentIdentity.ts, so a new agent is one row there rather than
-// eight hand-synced lists. Re-exported here because callers have long imported
-// the identity helpers from the detector.
-export type { AgentSlug } from '../../shared/agentIdentity';
-export { agentDisplayToSlug } from '../../shared/agentIdentity';
-
-import type { AgentSlug } from '../../shared/agentIdentity';
-
-/**
- * One way to recognise a piece of an agent's chrome on a line.
- *
- *   line       regex against the ANSI-stripped, trimmed text. Use `^...$` when
- *              the chrome owns its whole line — that is what stops a quoted
- *              mention in someone else's log from counting as evidence.
- *   contains   case-insensitive substring. For chrome with no stable line
- *              shape, e.g. a docs URL printed inside a longer banner.
- *   normalized whitespace-stripped, lowercased substring. TUIs that paint with
- *              cursor moves lose their spaces in the PTY stream, so
- *              "ask a question" can arrive as "askaquestion" and no
- *              space-bearing pattern can ever match it.
- */
-type EvidenceMatcher =
-  | { line: RegExp }
-  | { contains: string }
-  | { normalized: string };
-
-/**
- * One piece of evidence a compound gate requires. Satisfied when ANY matcher
- * hits; the gate opens when EVERY clause is satisfied, in any order and across
- * any number of PTY chunks.
- */
-interface EvidenceClause {
-  /** Stable id. Keys the per-detector evidence ledger. */
-  id: string;
-  /**
-   * Cheap lowercase literals. The matchers run only when the candidate line
-   * contains one of these, so an inactive compound gate costs a substring scan
-   * per line rather than a regex sweep. Required — an evidence clause with no
-   * hint would run its regexes on every line of every plain shell forever.
-   */
-  hints: readonly string[];
-  any: readonly EvidenceMatcher[];
-  /**
-   * Emit this status once, at the moment the gate opens, using the text this
-   * clause actually captured.
-   *
-   * Needed because evidence can arrive in any order: if the composer prompt is
-   * painted BEFORE the banner, its ordinary pattern pass already happened while
-   * the gate was still shut, so without a replay the pane sits at 'running'
-   * while it is really idle. The captured text becomes the dedup value, so the
-   * next ordinary pass over the same prompt suppresses instead of double-firing.
-   *
-   * `evidence` is the canonical text to fall back on when the matcher that hit
-   * was not a regex (a `normalized` hit has no meaningful capture).
-   */
-  emitOnGateOpen?: { status: AgentEventStatus; message: string; evidence: string };
-}
-
-/**
- * A gate is either a single regex (the agent's banner is enough to identify it)
- * or a set of clauses that must ALL be satisfied.
- *
- * The compound form exists because a product-name mention is not proof: agents
- * routinely print logs and docs naming other agents. Requiring two independent
- * pieces of chrome from the same PTY is what separates "Kiro is running here"
- * from "something printed the word Kiro".
- */
-type AgentGate = RegExp | { allOf: readonly EvidenceClause[] };
-
-interface StatusPattern {
-  regex: RegExp;
-  status: AgentEvent['status'];
-  message: string;
-}
+// signals on this slug, so the two MUST stay in lock-step. New agents
+// added here must also be added to integrations/shared/signal-types.ts
+// (AgentSlug union) and to any HookSignalRouter dedup table.
+export type AgentSlug = 'claude' | 'codex' | 'gemini' | 'aider' | 'opencode' | 'copilot' | 'openclaude' | 'kiro';
 
 interface AgentPattern {
   /** Display name. Surfaced in UI ("Claude Code", "Codex CLI"). */
   agent: string;
   /** Canonical slug. Stable, lowercase, no whitespace. Matches hook signals. */
   slug: AgentSlug;
-  // An optional "gate": patterns are only checked once it has matched in this
-  // session, confirming the agent is active.
-  gate?: AgentGate;
-  /**
-   * Inherit another profile's status patterns.
-   *
-   * Forks are the normal case, not an exotic one: OpenClaude is Claude Code's
-   * TUI, so its approval prompts are the same prompts. Those four patterns used
-   * to be written out twice, 200+ characters each, box-glyph classes and all,
-   * and every review round that tightened them had to tighten both copies by
-   * hand. The cost of missing one is on record — a worker pane sat on an
-   * unmatched approval prompt for 100 minutes (see the note on the edit-approval
-   * patterns below).
-   *
-   * Inherited patterns are appended AFTER the profile's own, so a fork's
-   * distinctive chrome is matched first.
-   */
-  extends?: AgentSlug;
-  /**
-   * Parent patterns to drop, identified by regex source. A fork that removed a
-   * prompt, or renders it in a way that would misfire, says so here.
-   */
-  omit?: readonly RegExp[];
-  patterns: StatusPattern[];
+  // An optional "gate" regex: patterns are only checked if the gate has
+  // previously matched in this session, confirming the agent is active.
+  gate?: RegExp;
+  patterns: { regex: RegExp; status: AgentEvent['status']; message: string }[];
 }
 
 /**
- * Flatten `extends` into concrete pattern lists.
- *
- * Runs once at module load over a static table, so it throws rather than
- * degrading: an unknown parent or a cycle is a programming error that should
- * fail the process at startup, not silently leave an agent undetectable.
+ * Map display name → slug. Used by consumers that have an AgentEvent in
+ * hand (which carries the display name) and need to derive the canonical
+ * slug for dedup against hook signals.
  */
-function resolveInheritance(profiles: AgentPattern[]): AgentPattern[] {
-  const bySlug = new Map(profiles.map((p) => [p.slug, p]));
-
-  const resolve = (p: AgentPattern, seen: Set<AgentSlug>): StatusPattern[] => {
-    if (!p.extends) return p.patterns;
-    if (seen.has(p.extends)) {
-      throw new Error(`AgentDetector: profile inheritance cycle at '${p.slug}'`);
-    }
-    const parent = bySlug.get(p.extends);
-    if (!parent) {
-      throw new Error(`AgentDetector: '${p.slug}' extends unknown profile '${p.extends}'`);
-    }
-    seen.add(p.extends);
-    const omitted = new Set((p.omit ?? []).map((r) => r.source));
-    const inherited = resolve(parent, seen).filter((sp) => !omitted.has(sp.regex.source));
-    return [...p.patterns, ...inherited];
-  };
-
-  return profiles.map((p) =>
-    p.extends ? { ...p, patterns: resolve(p, new Set([p.slug])) } : p,
-  );
+export function agentDisplayToSlug(display: string): AgentSlug | undefined {
+  switch (display) {
+    case 'Claude Code': return 'claude';
+    case 'Codex CLI': return 'codex';
+    case 'Gemini CLI': return 'gemini';
+    case 'Aider': return 'aider';
+    case 'OpenCode': return 'opencode';
+    case 'GitHub Copilot CLI': return 'copilot';
+    case 'OpenClaude': return 'openclaude';
+    case 'Kiro CLI': return 'kiro';
+    default: return undefined;
+  }
 }
 
 /**
@@ -244,9 +140,20 @@ export function agentStatusToSignalKind(
 const KIRO_CHROME_LINE = /^(?:Kiro\s*CLI(?:\s+v?\d[\w.-]*)?|Trust\s*All\s*Tools\s*active,\s*confirmations\s*are\s*off(?:\s*·.*)?)$/i;
 const KIRO_PROMPT_LINE = /^[▸>❯]?\s*ask\s*a\s*question\s*or\s*describe\s*a\s*task\s*↵?\s*$/i;
 
-const AGENT_PROFILES: AgentPattern[] = [
+// #850: Claude compound gate — two independent signals, same model as Kiro.
+// Signal A (banner): the startup banner or OSC window-title mention.
+// Signal B (prompt): a Claude-specific prompt fragment proving the TUI is live.
+const CLAUDE_BANNER_RE = /(?<!Open)(?<!Open\s)Claude\s*Code|claude-code|╭.*(?<!Open)(?<!Open\s)Claude/;
+// Any Claude-specific TUI text that a process monitor would never display.
+// Includes waiting prompts AND approval keywords (a pane might show an
+// approval before any waiting footer if the first turn requests file edits).
+const CLAUDE_PROMPT_RE = /bypass permissions on|shift\+tab to cycle|Do you want to proceed|Allow tool use for|Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)/;
+
+const AGENT_PATTERNS: AgentPattern[] = [
   // ── Claude Code ────────────────────────────────────────────────────────────
-  // Gate: Claude Code startup banner (matches once to activate detection)
+  // Gate: compound — banner AND prompt (checkGates handles the two-signal
+  // logic; ap.gate is still tested but the slug === 'claude' branch overrides
+  // the result to require both signals).
   {
     agent: 'Claude Code',
     slug: 'claude',
@@ -256,7 +163,7 @@ const AGENT_PROFILES: AgentPattern[] = [
     // (?<!Open)(?<!Open\s) keeps this gate from also opening on the
     // OpenClaude fork's banner ("╭ … OpenClaude" / "╭ … Open Claude"),
     // which would double-activate and misattribute events to Claude.
-    gate: /(?<!Open)(?<!Open\s)Claude\s*Code|claude-code|╭.*(?<!Open)(?<!Open\s)Claude/,
+    gate: CLAUDE_BANNER_RE,
     patterns: [
       // Waiting — Claude Code's unique idle prompt fragments.
       //
@@ -332,26 +239,27 @@ const AGENT_PROFILES: AgentPattern[] = [
   },
 
   // ── OpenClaude ───────────────────────────────────────────────────────────
-  // A Claude Code fork, so it inherits Claude approval prompts verbatim rather
-  // than restating them. It keeps its own gate and its own idle prompt, and
-  // drops the two Claude waiting patterns:
-  //   - "bypass permissions on" floods: OpenClaude repaints its status bar
-  //     every frame, so the line arrives as a concatenated
-  //     "…bypassPermissions modeisactive…" token roughly every 16ms
-  //     (debug capture 2026-07-22).
-  //   - "shift+tab to cycle" does not appear in its TUI at all.
-  // What is left after ANSI strip + trim is a bare ">", optionally with a
-  // spinner glyph, which is matched directly below.
+  // Gate: OpenClaude startup banner — same fork-derived TUI as Claude Code
+  // but draws its own banner.
+  // NOTE: "bypass permissions on" is NOT used for waiting because OpenClaude
+  // re-renders its status bar every frame, flooding notifications (confirmed
+  // via debug capture 2026-07-22 — the line reaches the detector as a single
+  // concatenated token "…bypassPermissions modeisactive…" every ~16ms).
+  // "shift+tab to cycle" does NOT appear in OpenClaude's TUI at all (unlike
+  // Claude Code). The actual prompt after ANSI strip + trim is just ">" or
+  // "> ○" (with spinner), so we match those directly.
   {
     agent: 'OpenClaude',
     slug: 'openclaude',
     gate: /Open\s*Claude|openclaude|╭.*OpenClaude/,
-    extends: 'claude',
-    omit: [/bypass permissions on/, /shift\+tab to cycle/],
     patterns: [
       // Waiting — the bare ">" prompt after trim, optionally followed by a
       // spinner character (○) when the TUI is waiting for input.
-      { regex: /^>[\s○◌●]*$/, status: 'waiting', message: 'Ready for input' },
+      { regex: /^>[\s○◌●]*$/,                                                                               status: 'waiting',          message: 'Ready for input' },
+      { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do you want to proceed\?[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,                                                              status: 'awaiting_input',   message: 'Approval requested' },
+      { regex: /^[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Allow tool use for (?:[A-Z][A-Za-z]+|mcp__[A-Za-z0-9-]+__[A-Za-z0-9_-]+)\??[\s│║┃═━─┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Tool approval requested' },
+      { regex: /^[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)\s*\S[^?]*\?[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/, status: 'awaiting_input',   message: 'Edit approval requested' },
+      { regex: /^[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)[\s│║┃═━─╌╍┄┅┆┇┈┉╭╮╯╰╔╗╝╚┌┐┘└·]*$/,             status: 'awaiting_input',   message: 'Edit approval requested' },
     ],
   },
 
@@ -409,40 +317,12 @@ const AGENT_PROFILES: AgentPattern[] = [
   },
 
   // ── Kiro CLI ──────────────────────────────────────────────────────────────
-  // Kiro has no hook bridge, so its identity comes entirely from the screen —
-  // which is exactly when a compound gate is worth its cost. Two independent
-  // pieces of chrome from the SAME PTY are required, in either order.
+  // The generic gate loop below special-cases this slug and opens it only
+  // after BOTH KIRO_CHROME_LINE and KIRO_PROMPT_LINE have been observed.
   {
     agent: 'Kiro CLI',
     slug: 'kiro',
-    gate: {
-      allOf: [
-        {
-          id: 'chrome',
-          hints: ['kiro', 'trust all tools'],
-          any: [
-            // Newer v3 builds print the docs URL instead of a version banner.
-            { contains: 'kiro.dev/docs/cli/' },
-            { line: KIRO_CHROME_LINE },
-          ],
-        },
-        {
-          id: 'prompt',
-          hints: ['ask'],
-          any: [
-            { line: KIRO_PROMPT_LINE },
-            // Cursor-drawn composer: the spaces are gone by the time this
-            // reaches us, so no space-bearing pattern can match it.
-            { normalized: 'askaquestionordescribeatask' },
-          ],
-          emitOnGateOpen: {
-            status: 'waiting',
-            message: 'Ready for input',
-            evidence: 'ask a question or describe a task',
-          },
-        },
-      ],
-    },
+    gate: KIRO_CHROME_LINE,
     patterns: [
       { regex: KIRO_PROMPT_LINE, status: 'waiting', message: 'Ready for input' },
     ],
@@ -469,13 +349,6 @@ const AGENT_PROFILES: AgentPattern[] = [
   },
 ];
 
-/**
- * The profiles the detector actually matches against: authored profiles with
- * `extends` flattened. Resolved once at module load and shared by every
- * detector, so a 30-pane workspace does not re-resolve per PTY.
- */
-const AGENT_PATTERNS: AgentPattern[] = resolveInheritance(AGENT_PROFILES);
-
 const MAX_BUFFER = 16 * 1024;
 
 // ANSI escape strip regex. Covers:
@@ -490,84 +363,6 @@ const MAX_BUFFER = 16 * 1024;
 // occasionally breaking pattern matching.
 // eslint-disable-next-line no-control-regex
 const ANSI_STRIP = /\x1b(?:\[[0-9;?<=>]*[a-zA-Z@]|\][^\x07]*\x07|\([A-Z])/g;
-
-// Written as an escape so the source stays pure-ASCII, same reason as
-// CONTROL_CHARS_RE above. Used to skip the strip on already-clean candidates.
-const ESC = '\x1b';
-
-/** How much of a candidate an evidence clause is allowed to look at. */
-const MAX_EVIDENCE_PROBE = 4096;
-
-/**
- * How many leading characters of a `normalized` needle anchor its search
- * window. Long enough to be selective, short enough to survive a needle whose
- * first word is tiny.
- */
-const NORMALIZED_ANCHOR_LEN = 3;
-
-/**
- * A candidate line prepared once for every evidence clause that examines it.
- *
- * `text` is ANSI-stripped and trimmed, because `checkGates` is deliberately
- * called with the RAW line too (Claude Code carries its name only inside the
- * OSC window-title escape, which the strip would otherwise remove wholesale).
- * `lower` backs both the cheap hint screen and `contains` matchers.
- */
-interface GateProbe {
-  readonly text: string;
-  readonly lower: string;
-}
-
-function makeGateProbe(candidate: string): GateProbe {
-  const bounded =
-    candidate.length > MAX_EVIDENCE_PROBE
-      ? candidate.slice(-MAX_EVIDENCE_PROBE)
-      : candidate;
-  // Callers pass both raw and already-cleaned candidates; skip the replacement
-  // when there is nothing to strip.
-  const stripped = bounded.includes(ESC) ? bounded.replace(ANSI_STRIP, '') : bounded;
-  const text = stripped.trim();
-  return { text, lower: text.toLowerCase() };
-}
-
-/**
- * Try each matcher in order; return the text the first hit captured, or null.
- *
- * The captured text matters beyond "did it match": a clause with
- * `emitOnGateOpen` replays it as the dedup value, so a regex hit must return
- * exactly what the ordinary pattern pass will later see.
- */
-function matchEvidence(
-  matchers: readonly EvidenceMatcher[],
-  probe: GateProbe,
-): string | null {
-  for (const m of matchers) {
-    if ('line' in m) {
-      const hit = probe.text.match(m.line);
-      if (hit) return hit[0];
-    } else if ('contains' in m) {
-      if (probe.lower.includes(m.contains)) return m.contains;
-    } else {
-      // Whitespace-stripped compare, windowed around the needle's own opening
-      // literal so a long repaint does not pay for a full-probe replacement.
-      // The window is generous: the raw text carries spaces the needle does not.
-      //
-      // FIRST occurrence, not last. The code this replaced used lastIndexOf and
-      // could therefore never match: needles like
-      // "askaquestionordescribeatask" contain their own anchor again near the
-      // end ("...a task"), so lastIndexOf always landed on the trailing copy and
-      // opened the window past the text it was looking for. That made the whole
-      // space-collapsed path dead — the case it exists for (cursor-drawn
-      // composers, where no space-bearing regex can match) was never covered.
-      const anchor = m.normalized.slice(0, NORMALIZED_ANCHOR_LEN);
-      const start = probe.lower.indexOf(anchor);
-      if (start < 0) continue;
-      const window = probe.lower.slice(start, start + m.normalized.length * 3 + 32);
-      if (window.replace(/\s+/g, '').includes(m.normalized)) return m.normalized;
-    }
-  }
-  return null;
-}
 
 export class AgentDetector {
   private callbacks: AgentEventCallback[] = [];
@@ -584,11 +379,17 @@ export class AgentDetector {
   // ActivityMonitor 'active' transitions to label the running status with the
   // agent that owns this PTY.
   private lastAgent: string | null = null;
-  // Satisfied evidence clauses for compound gates, keyed `${slug}:${clauseId}`,
-  // holding the text that satisfied them. Scoped to this detector — that is
-  // what makes evidence per-PTY, so another agent merely printing "Kiro CLI"
-  // in a log cannot hand this pane's identity away.
-  private evidenceSeen = new Map<string, string>();
+  // Kiro uses a compound gate so another agent merely mentioning "Kiro CLI"
+  // cannot steal this PTY's identity. Evidence is scoped to this detector/PTy.
+  private kiroChromeSeen = false;
+  private kiroPromptSeen = false;
+  private kiroPromptEvidence: string | null = null;
+  // #850: Claude uses the same compound-gate pattern. A process monitor (btop)
+  // showing "claude" in its process list must NOT open the gate — require both
+  // the banner AND a Claude-specific prompt pattern before confirming identity.
+  private claudeBannerSeen = false;
+  private claudePromptSeen = false;
+  private claudePromptEvidence: { text: string; status: AgentEventStatus; message: string } | null = null;
 
   /**
    * Register a callback for agent status events.
@@ -678,148 +479,132 @@ export class AgentDetector {
    * 설정. 라인 완성 여부와 무관하게 호출할 수 있도록 분리(feed의 미완성 라인
    * 검사와 processLine 양쪽에서 사용). activeAgents 가드로 세션당 1회만 발화.
    */
-  /**
-   * Runs twice per completed line (raw, then cleaned) plus twice per feed chunk
-   * on the still-incomplete tail. The `activeAgents` skip means an identified
-   * pane costs nothing, so the load-bearing case is a pane running a plain
-   * shell: its gates never open, so every regex gate runs forever.
-   *
-   * That invites a cheap literal prefilter — screen the line with
-   * `String.includes` and only then run the regex. Measured before adding one,
-   * over 20k build-log lines:
-   *
-   *     profiles   plain regex sweep   with literal prefilter
-   *      7 (today)      9.6ms                11.3ms   0.84x  SLOWER
-   *     16            26.5ms                20.9ms   1.27x
-   *     48            75.0ms                52.7ms   1.42x
-   *
-   * One `toLowerCase()` per line costs more than the seven regex tests it would
-   * skip, so at today's count the prefilter is a net loss. It starts paying
-   * around sixteen profiles. Revisit if the built-in set roughly doubles; until
-   * then the compound gates carry hints (they screen their own, more expensive
-   * matchers) and the plain regex gates do not.
-   */
-  private checkGates(candidate: string): void {
-    let probe: GateProbe | null = null;
+  private checkGates(clean: string): void {
+    // Kiro has no hook fallback, so identify its live TUI from two independent
+    // pieces of chrome. Newer v3 builds show the docs URL instead of a "Kiro
+    // CLI" banner; their cursor-drawn composer can also collapse whitespace in
+    // the raw PTY stream. Probe only a bounded tail and only when a cheap
+    // literal hint is present. Once Kiro is active this entire path is skipped.
+    const kiroIsActive = this.activeAgents.has('Kiro CLI');
+    if (!kiroIsActive && (!this.kiroChromeSeen || !this.kiroPromptSeen)) {
+      const probe = clean.length > 4096 ? clean.slice(-4096) : clean;
+      const mayContainChrome = !this.kiroChromeSeen && (
+        probe.includes('kiro') ||
+        probe.includes('Kiro') ||
+        probe.includes('KIRO') ||
+        probe.includes('Trust All Tools')
+      );
+      const mayContainPrompt = !this.kiroPromptSeen && (
+        probe.includes('ask') || probe.includes('Ask')
+      );
+
+      if (mayContainChrome || mayContainPrompt) {
+        // feed/processLine also call this with an ANSI-stripped candidate. Avoid
+        // doing the regex replacement twice when this candidate is already clean.
+        const evidenceLine = probe.includes('\u001b')
+          ? probe.replace(ANSI_STRIP, '')
+          : probe;
+        const normalized = evidenceLine.trim();
+        const lower = normalized.toLowerCase();
+
+        if (
+          mayContainChrome &&
+          (lower.includes('kiro.dev/docs/cli/') || KIRO_CHROME_LINE.test(normalized))
+        ) {
+          this.kiroChromeSeen = true;
+        }
+
+        if (mayContainPrompt) {
+          const promptStart = lower.lastIndexOf('ask');
+          const compactPrompt = promptStart >= 0
+            ? lower.slice(promptStart, promptStart + 96).replace(/\s+/g, '')
+            : '';
+          const promptMatch = normalized.match(KIRO_PROMPT_LINE);
+          if (
+            promptMatch ||
+            compactPrompt.includes('askaquestionordescribeatask')
+          ) {
+            this.kiroPromptSeen = true;
+            // When this is a normal complete line, retain the exact value the
+            // ordinary pattern pass will see so its same-frame dedup hits. The
+            // canonical fallback is only for cursor-concatenated evidence that
+            // cannot match the line pattern later in processLine.
+            this.kiroPromptEvidence = promptMatch?.[0]
+              ?? 'ask a question or describe a task';
+          }
+        }
+      }
+    }
+
+    // #850: Claude compound gate — same model as Kiro. Collect banner and
+    // prompt evidence independently; gate opens only when both are present.
+    const claudeIsActive = this.activeAgents.has('Claude Code');
+    if (!claudeIsActive && (!this.claudeBannerSeen || !this.claudePromptSeen)) {
+      if (!this.claudeBannerSeen && CLAUDE_BANNER_RE.test(clean)) {
+        this.claudeBannerSeen = true;
+      }
+      if (!this.claudePromptSeen) {
+        const m = clean.match(CLAUDE_PROMPT_RE);
+        if (m) {
+          this.claudePromptSeen = true;
+          // Preserve the status that matches the evidence pattern so the
+          // replay emits the correct lifecycle event — waiting prompts
+          // replay as 'waiting', approval prompts replay as 'awaiting_input'.
+          const isApproval = /Do you want to proceed|Allow tool use for|Do\s*you\s*want\s*to\s*(?:create|overwrite|make\s*this\s*edit\s*to)/.test(m[0]);
+          this.claudePromptEvidence = {
+            text: m[0],
+            status: isApproval ? 'awaiting_input' : 'waiting',
+            message: isApproval ? 'Approval requested' : 'Ready for input',
+          };
+        }
+      }
+    }
 
     for (const ap of AGENT_PATTERNS) {
-      // Gate checks run on every PTY output chunk. Never re-run anything for an
-      // already-active agent; this keeps full-screen repaint traffic
-      // O(inactive agents).
+      // Gate checks run on every PTY output chunk. Never re-run regexes for an
+      // already-active agent; this keeps full-screen repaint traffic O(inactive
+      // agents) and makes the Kiro additions cheaper than the previous loop.
       if (!ap.gate || this.activeAgents.has(ap.agent)) continue;
+      const gateMatched = ap.slug === 'kiro'
+        ? this.kiroChromeSeen && this.kiroPromptSeen
+        : ap.slug === 'claude'
+          ? this.claudeBannerSeen && this.claudePromptSeen
+          : ap.gate.test(clean);
+      if (!gateMatched) continue;
 
-      let opened: boolean;
-      if (ap.gate instanceof RegExp) {
-        opened = ap.gate.test(candidate);
-      } else {
-        // Building the probe costs an ANSI strip and a lowercase, so defer it
-        // until a compound gate actually asks. A session whose agents all use
-        // plain regex gates never pays for it.
-        probe ??= makeGateProbe(candidate);
-        opened = this.accumulateEvidence(ap, ap.gate.allOf, probe);
-      }
-      if (!opened) continue;
-
-      this.openGate(ap);
-    }
-  }
-
-  /**
-   * Record whichever clauses this candidate satisfies, and report whether that
-   * completes the gate. Clauses persist for the life of the detector, so the
-   * two halves of a compound gate may arrive in either order and any number of
-   * PTY chunks apart. The ledger is per-detector, i.e. per PTY: one pane can
-   * never satisfy another pane's gate.
-   */
-  private accumulateEvidence(
-    ap: AgentPattern,
-    clauses: readonly EvidenceClause[],
-    probe: GateProbe,
-  ): boolean {
-    let satisfied = 0;
-    for (const clause of clauses) {
-      const key = `${ap.slug}:${clause.id}`;
-      if (this.evidenceSeen.has(key)) {
-        satisfied++;
-        continue;
-      }
-      // Cheap literal screen first: an unsatisfied clause on a pane that is not
-      // running this agent costs a substring scan, never a regex sweep.
-      if (!clause.hints.some((h) => probe.lower.includes(h))) continue;
-
-      const captured = matchEvidence(clause.any, probe);
-      if (captured === null) continue;
-      this.evidenceSeen.set(key, captured);
-      satisfied++;
-    }
-    return satisfied === clauses.length;
-  }
-
-  /** Activate an agent: emit 'running' once, then replay any gate-open status. */
-  private openGate(ap: AgentPattern): void {
-    this.activeAgents.add(ap.agent);
-    this.lastAgent = ap.agent;
-    for (const cb of this.callbacks) {
-      cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
-    }
-
-    if (ap.gate === undefined || ap.gate instanceof RegExp) return;
-
-    // If a clause carrying `emitOnGateOpen` was satisfied BEFORE the gate
-    // opened, its ordinary pattern pass already ran and was ignored, so replay
-    // it now — otherwise the pane sits at 'running' while it is really idle and
-    // waiting for input.
-    for (const clause of ap.gate.allOf) {
-      const replay = clause.emitOnGateOpen;
-      if (!replay) continue;
-      const captured = this.evidenceSeen.get(`${ap.slug}:${clause.id}`);
-      if (captured === undefined) continue;
-
-      const key = `${ap.agent}:${replay.status}`;
-      // Seed the dedup with the text the ordinary pass will see, so the same
-      // prompt in the same frame suppresses instead of firing twice.
-      if (this.lastEmittedFor.get(key) === captured) continue;
-      this.lastEmittedFor.set(key, captured);
+      this.activeAgents.add(ap.agent);
+      this.lastAgent = ap.agent;
       for (const cb of this.callbacks) {
-        cb({ agent: ap.agent, status: replay.status, message: replay.message });
+        cb({ agent: ap.agent, status: 'running', message: 'Agent started' });
+      }
+      // The two Kiro evidence lines may arrive in either order. If the
+      // composer prompt arrived first, its normal pattern pass happened while
+      // the gate was still closed. Replay the saved evidence once.
+      if (ap.slug === 'kiro' && this.kiroPromptEvidence) {
+        const key = `${ap.agent}:waiting`;
+        const value = this.kiroPromptEvidence;
+        if (this.lastEmittedFor.get(key) !== value) {
+          this.lastEmittedFor.set(key, value);
+          for (const cb of this.callbacks) {
+            cb({ agent: ap.agent, status: 'waiting', message: 'Ready for input' });
+          }
+        }
+      }
+      // #850: same replay for Claude — if the prompt evidence arrived before
+      // the banner, its normal pattern pass ran while the gate was still closed.
+      if (ap.slug === 'claude' && this.claudePromptEvidence) {
+        const ev = this.claudePromptEvidence;
+        const key = `${ap.agent}:${ev.status}`;
+        if (this.lastEmittedFor.get(key) !== ev.text) {
+          this.lastEmittedFor.set(key, ev.text);
+          for (const cb of this.callbacks) {
+            cb({ agent: ap.agent, status: ev.status, message: ev.message });
+          }
+        }
       }
     }
   }
 
-  /**
-   * ONE LINE PRODUCES AT MOST ONE EMISSION. Every `return` below is that rule,
-   * not an oversight — read this before "fixing" one into a `continue`.
-   *
-   *   line
-   *    │
-   *    ├─ checkGates(raw)         gates only; never returns (OSC-title case)
-   *    ├─ clean === '' ──────────────────────────────────► return
-   *    │
-   *    ├─ CRITICAL_PATTERNS ─ match? ─┬─ new value  ─► emit ─► return
-   *    │                              └─ deduped    ────────► return
-   *    │        no match
-   *    ├─ checkGates(clean)
-   *    │
-   *    └─ AGENT_PATTERNS ──── match? ─┬─ new value  ─► emit ─► return
-   *                                   └─ deduped    ────────► return
-   *
-   * Why a deduped match still consumes the line:
-   *
-   *   - Critical vs agent patterns cannot co-match. Critical patterns are
-   *     unanchored shell-command shapes (`git push --force`, `rm -rf`); agent
-   *     status patterns are whole-line-anchored TUI chrome (`^codex>$`, the
-   *     boxed `Do you want to proceed?`). Falling through on a deduped critical
-   *     would therefore buy nothing.
-   *   - Across agents it is load-bearing. Claude Code and OpenClaude are the
-   *     same forked TUI and share their approval patterns outright, so the
-   *     FIRST profile whose regex matches owns the line. Continuing to the next
-   *     profile after a deduped match would let the second turn of a repeated
-   *     prompt emit again under the other agent's name — a duplicate
-   *     notification for a single on-screen event.
-   *
-   * So the rule is deliberately not "emit once per profile" but "the first
-   * matching profile decides, and a suppressed match is still a decision".
-   */
   private processLine(line: string): void {
     // RAW-line gate check BEFORE the empty-clean bail. Live incident
     // 2026-07-17 (Fable-era Claude Code): the TUI renders no visible

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -148,6 +148,11 @@ const CLAUDE_BANNER_RE = /(?<!Open)(?<!Open\s)Claude\s*Code|claude-code|╭.*(?<
 // Only the idle-prompt fragments — approval keywords are excluded because they
 // appear in conversational text and would false-positive the gate (#850 CI).
 const CLAUDE_PROMPT_RE = /bypass permissions on|shift\+tab to cycle/;
+// The waiting patterns the ordinary pattern pass runs, in the SAME array order,
+// so the gate's replay can store the text that pass will produce. Derived below
+// from AGENT_PATTERNS rather than duplicated — a second hand-written copy is
+// exactly how the two drift apart again.
+let CLAUDE_WAITING_PATTERNS: RegExp[] = [];
 
 const AGENT_PATTERNS: AgentPattern[] = [
   // ── Claude Code ────────────────────────────────────────────────────────────
@@ -349,6 +354,14 @@ const AGENT_PATTERNS: AgentPattern[] = [
   },
 ];
 
+// Derive the Claude waiting patterns from the table above so the gate replay
+// and the ordinary pattern pass can never disagree about which fragment a line
+// matched. Order is preserved: the pattern pass takes the first entry that
+// matches, so the replay must resolve the same way.
+CLAUDE_WAITING_PATTERNS = (AGENT_PATTERNS.find((ap) => ap.slug === 'claude')?.patterns ?? [])
+  .filter((p) => p.status === 'waiting')
+  .map((p) => p.regex);
+
 const MAX_BUFFER = 16 * 1024;
 
 // ANSI escape strip regex. Covers:
@@ -540,18 +553,46 @@ export class AgentDetector {
     // prompt evidence independently; gate opens only when both are present.
     const claudeIsActive = this.activeAgents.has('Claude Code');
     if (!claudeIsActive && (!this.claudeBannerSeen || !this.claudePromptSeen)) {
-      if (!this.claudeBannerSeen && CLAUDE_BANNER_RE.test(clean)) {
+      // Bound the probe and gate it behind a cheap literal, exactly like the
+      // Kiro block above. While the gate is closed these regexes would
+      // otherwise run over the FULL candidate on every checkGates call — and
+      // checkGates runs up to four times per chunk, one of them on the whole
+      // lineBuffer. For a non-Claude pane the gate never opens, so that cost
+      // repeats for the pane's entire lifetime. CLAUDE_BANNER_RE's
+      // `╭.*(?<!Open)Claude` alternative is the expensive part: on a
+      // box-drawing line with no "Claude" the `.*` backtracks the whole line,
+      // which is precisely the shape a full-screen TUI like btop emits —
+      // measured 10-57x the bounded form on 10-40 KB frames.
+      const probe = clean.length > 4096 ? clean.slice(-4096) : clean;
+      const mayContainBanner = !this.claudeBannerSeen && (
+        probe.includes('Claude') || probe.includes('claude')
+      );
+      const mayContainPrompt = !this.claudePromptSeen && (
+        probe.includes('bypass permissions') || probe.includes('shift+tab')
+      );
+
+      if (mayContainBanner && CLAUDE_BANNER_RE.test(probe)) {
         this.claudeBannerSeen = true;
       }
-      if (!this.claudePromptSeen) {
-        const m = clean.match(CLAUDE_PROMPT_RE);
+      if (mayContainPrompt) {
+        const m = probe.match(CLAUDE_PROMPT_RE);
         if (m) {
           this.claudePromptSeen = true;
+          // Store the value the ordinary pattern pass will produce, not this
+          // regex's — same requirement the Kiro replay documents above.
+          // CLAUDE_PROMPT_RE is an alternation and matches at the earliest
+          // POSITION, while the pattern pass tries CLAUDE_PATTERNS in ARRAY
+          // order. On a footer carrying both fragments with "shift+tab to
+          // cycle" first, the two disagree and the same prompt emits two
+          // 'waiting' events, because the dedup key is keyed on match text.
+          const replayText = CLAUDE_WAITING_PATTERNS
+            .map((re) => probe.match(re)?.[0])
+            .find((t): t is string => t !== undefined) ?? m[0];
           // CLAUDE_PROMPT_RE only matches waiting-prompt fragments, so the
           // replay is always 'waiting'. Approval patterns are excluded from
           // the gate evidence to avoid conversational false positives.
           this.claudePromptEvidence = {
-            text: m[0],
+            text: replayText,
             status: 'waiting',
             message: 'Ready for input',
           };

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -2,102 +2,59 @@ import { describe, it, expect, vi } from 'vitest';
 import { AgentDetector } from '../AgentDetector';
 
 describe('AgentDetector', () => {
-  describe('one line, at most one emission (first-match-wins)', () => {
-    // Pins the invariant documented above processLine. A plan review read the
-    // dedup `return`s as a swallowed-detection bug and proposed turning them
-    // into `continue`; these tests are what that change breaks.
+  // Helper: feed both banner AND prompt to open the Claude compound gate (#850).
+  // Uses `bypass permissions on` as the gate-opening prompt so that
+  // `shift+tab to cycle` tests can still emit without dedup collision.
+  // Resets emission state after gate open so all patterns are fresh.
+  function claudeGated() {
+    const det = new AgentDetector();
+    const cb = vi.fn();
+    det.onEvent(cb);
+    det.feed('Claude Code v2.1.172\n');        // banner signal
+    det.feed('  bypass permissions on\n');     // prompt signal → gate opens
+    det.resetEmissionState();
+    cb.mockClear();
+    return { det, cb };
+  }
 
-    it('a repeated prompt does NOT re-emit under a second agent that shares the pattern', () => {
-      // Claude Code and OpenClaude are the same forked TUI and share their
-      // approval patterns byte-for-byte. With both gates open, turn 2 of an
-      // identical prompt must stay silent rather than firing as OpenClaude.
+  describe('agent status emission', () => {
+    it('compound gate: banner + prompt together emit running then waiting', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
-
+      det.feed('Claude Code v2.1.172\n');        // banner only — no emit
+      expect(cb).not.toHaveBeenCalled();
+      det.feed('  shift+tab to cycle modes\n');  // prompt → gate opens
+      expect(det.getLastAgent()).toBe('Claude Code');
+      const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
+      expect(statuses).toContain('running');
+      expect(statuses).toContain('waiting');
+      // re-feeding the banner does not re-fire (activeAgents guard)
+      cb.mockClear();
       det.feed('Claude Code v2.1.172\n');
-      det.feed('OpenClaude v0.9.0\n');
-      expect(det.getActiveAgents()).toEqual(
-        expect.arrayContaining(['Claude Code', 'OpenClaude']),
-      );
-      cb.mockClear();
-
-      det.feed('Do you want to proceed?\n');
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0]).toMatchObject({
-        agent: 'Claude Code',
-        status: 'awaiting_input',
-      });
-
-      cb.mockClear();
-      det.feed('Do you want to proceed?\n');
       expect(cb).not.toHaveBeenCalled();
     });
 
-    it('a critical hit consumes the line, deduped or not', () => {
-      const det = new AgentDetector();
-      const onCritical = vi.fn();
-      det.onCritical(onCritical);
-      det.feed('Claude Code v2.1.172\n');
-
-      det.feed('git push --force origin main\n');
-      expect(onCritical).toHaveBeenCalledTimes(1);
-
-      // Same line again: suppressed, and still no second critical emission.
-      det.feed('git push --force origin main\n');
-      expect(onCritical).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('agent status emission', () => {
-    it('gate 매칭 시 "running" 시작 이벤트를 1회 emit한다 (배너만으로 agentName 확정)', () => {
-      // Claude Code v2.1.x처럼 idle prompt hint가 "❯"만 남아 patterns가
-      // 매칭되지 않아도, 시작 배너(gate)만으로 detection이 활성화돼야 한다.
+    it('compound gate: incomplete banner line (no newline) collects evidence', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
-      det.feed('Claude Code v2.1.172\n');
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
-      expect(det.getLastAgent()).toBe('Claude Code');
-      // 같은 세션에서 배너가 다시 나와도 재발화하지 않는다 (activeAgents 가드).
-      det.feed('Claude Code v2.1.172\n');
-      expect(cb).toHaveBeenCalledTimes(1);
-    });
-
-    it('개행 없이 미완성 라인에 머무는 시작 배너도 gate 매칭한다 (claude TUI 대응)', () => {
-      // claude는 시작 배너를 개행 없이 커서 이동으로 그려 "Claude Code vX"가
-      // lineBuffer에 갇혀 라인 완성이 안 될 수 있다. 그래도 gate는 검사돼야 한다.
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      det.feed('Claude Code v2.1.172'); // 개행 없음
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
+      det.feed('Claude Code v2.1.172'); // no newline — banner seen via tail check
+      expect(cb).not.toHaveBeenCalled(); // no prompt yet
+      det.feed('\n  shift+tab to cycle\n');
       expect(det.getLastAgent()).toBe('Claude Code');
     });
 
     it('emits "waiting" for "shift+tab to cycle" Claude prompt', () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      // gate first — gate 매칭은 'running' 시작 이벤트를 발화하므로 분리해 무시
-      det.feed('Claude Code starting up\n');
-      cb.mockClear();
+      const { det, cb } = claudeGated();
       det.feed('  shift+tab to cycle modes\n');
       expect(cb).toHaveBeenCalledTimes(1);
       expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'waiting' });
     });
 
     it('REGRESSION (R3): does NOT match "esc to interrupt" — Claude in-flight hint, not idle', () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      det.feed('Claude Code starting up\n');
-      cb.mockClear(); // gate 'running' 무시 — esc 라인 자체는 emit하면 안 된다
+      const { det, cb } = claudeGated();
       det.feed('press esc to interrupt\n');
-      // Previously this falsely emitted 'waiting'. After the fix, no agent
-      // event should fire for this line.
       expect(cb).not.toHaveBeenCalled();
     });
 
@@ -115,45 +72,38 @@ describe('AgentDetector', () => {
   });
 
   describe('OSC-title gate (live incident 2026-07-17, Fable-era Claude Code)', () => {
-    it('opens the Claude gate from the OSC 0 window-title sequence alone', () => {
+    it('OSC title serves as banner evidence; gate opens on first Claude-specific prompt', () => {
       // The current TUI renders no visible "Claude Code" text — the name only
-      // appears in the window title escape, which ANSI_STRIP removes. The gate
-      // must therefore also be checked against the raw line.
+      // appears in the window title escape. The OSC title is banner evidence;
+      // the approval prompt provides prompt evidence, opening the compound gate.
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('\x1b]0;✳ Claude Code\x07\n');
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
-      // Approval detection now works even though no visible banner ever appeared.
-      cb.mockClear();
+      expect(cb).not.toHaveBeenCalled(); // banner only — no prompt yet
       det.feed('│ Do you want to overwrite calculator.html? │\n');
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0]).toMatchObject({ status: 'awaiting_input' });
+      // gate opens (running) + approval fires (awaiting_input)
+      const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
+      expect(statuses).toContain('running');
+      expect(statuses).toContain('awaiting_input');
     });
 
-    it('opens the gate from an OSC title stuck in an incomplete line (no newline)', () => {
+    it('OSC title in an incomplete line (no newline) collects banner evidence', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('\x1b]0;⠂ Claude Code\x07'); // no newline — tail path
-      expect(cb).toHaveBeenCalledTimes(1);
-      expect(cb.mock.calls[0][0]).toMatchObject({ agent: 'Claude Code', status: 'running' });
+      expect(cb).not.toHaveBeenCalled(); // banner only
+      det.feed('\n  bypass permissions on\n');
+      expect(det.getLastAgent()).toBe('Claude Code');
     });
   });
 
   describe('Claude file-edit approval prompts (live incident 2026-07-17)', () => {
-    const gated = () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      det.feed('Claude Code v2.1.172\n');
-      cb.mockClear();
-      return { det, cb };
-    };
+    // Uses the top-level claudeGated() helper (banner + prompt → gate open).
 
     it('emits awaiting_input for a one-line overwrite prompt with filename', () => {
-      const { det, cb } = gated();
+      const { det, cb } = claudeGated();
       det.feed('│ Do you want to overwrite calculator.html? │\n');
       expect(cb).toHaveBeenCalledTimes(1);
       expect(cb.mock.calls[0][0]).toMatchObject({
@@ -162,7 +112,7 @@ describe('AgentDetector', () => {
     });
 
     it('emits awaiting_input for create and make-this-edit variants', () => {
-      const { det, cb } = gated();
+      const { det, cb } = claudeGated();
       det.feed('  Do you want to create src/app.ts?\n');
       det.feed('  Do you want to make this edit to src/app.ts?\n');
       const statuses = cb.mock.calls.map((c) => c[0].status);
@@ -173,14 +123,14 @@ describe('AgentDetector', () => {
       // Observed in the 2026-07-17 pane buffer: after ANSI strip the prompt
       // read `Doyouwanttooverwrite` — same phenomenon as the `ClaudeCode`
       // banner gate note.
-      const { det, cb } = gated();
+      const { det, cb } = claudeGated();
       det.feed('Doyouwanttooverwrite calculator.html?\n');
       expect(cb).toHaveBeenCalledTimes(1);
       expect(cb.mock.calls[0][0]).toMatchObject({ status: 'awaiting_input' });
     });
 
     it('narrow-pane wrap (verb ends the line, filename on next line) still matches', () => {
-      const { det, cb } = gated();
+      const { det, cb } = claudeGated();
       det.feed('╌╌ Do you want to overwrite\n');
       det.feed(' calculator.html?\n');
       // The verb-terminated first line alone must fire; the orphan filename
@@ -190,7 +140,7 @@ describe('AgentDetector', () => {
     });
 
     it('does NOT match conversational mentions (whole-line anchored)', () => {
-      const { det, cb } = gated();
+      const { det, cb } = claudeGated();
       det.feed('  If it asks "Do you want to overwrite calculator.html?" pick no and stop.\n');
       det.feed('  Do you want to overwrite it, or should I keep the old file around instead\n');
       expect(cb).not.toHaveBeenCalled();
@@ -261,18 +211,22 @@ describe('AgentDetector', () => {
     });
 
     it('unsubscribe stops the callback from receiving further events', () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      const unsub = det.onEvent(cb);
-      det.feed('Claude Code starting up\n');
-      cb.mockClear(); // gate 'running' 분리
+      const { det, cb } = claudeGated();
       det.feed('  shift+tab to cycle\n');
       expect(cb).toHaveBeenCalledTimes(1);
 
-      unsub();
-      det.resetEmissionState(); // allow re-emit if cb were still subscribed
+      // claudeGated registered cb — find and unsubscribe it
+      // Re-register a fresh cb to test unsubscribe
+      const cb2 = vi.fn();
+      const unsub = det.onEvent(cb2);
+      det.resetEmissionState();
       det.feed('  shift+tab to cycle\n');
-      expect(cb).toHaveBeenCalledTimes(1); // not 2
+      expect(cb2).toHaveBeenCalledTimes(1);
+
+      unsub();
+      det.resetEmissionState();
+      det.feed('  shift+tab to cycle\n');
+      expect(cb2).toHaveBeenCalledTimes(1); // no new calls
     });
 
     it('unsubscribe leaves OTHER callbacks intact', () => {
@@ -282,8 +236,10 @@ describe('AgentDetector', () => {
       const unsubA = det.onEvent(a);
       det.onEvent(b);
       unsubA();
-      det.feed('Claude Code\n');
-      b.mockClear(); // gate 'running' 분리 (a는 이미 unsub됨)
+      // open compound gate with both signals
+      det.feed('Claude Code\n  shift+tab to cycle\n');
+      b.mockClear();
+      det.resetEmissionState();
       det.feed('  shift+tab to cycle\n');
       expect(a).not.toHaveBeenCalled();
       expect(b).toHaveBeenCalledTimes(1);
@@ -292,11 +248,7 @@ describe('AgentDetector', () => {
 
   describe('emission dedup with cycle reset', () => {
     it('dedups consecutive identical "waiting" matches', () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      det.feed('Claude Code\n');
-      cb.mockClear(); // gate 'running' 분리
+      const { det, cb } = claudeGated();
       det.feed('  shift+tab to cycle\n');
       det.feed('  shift+tab to cycle\n');
       det.feed('  shift+tab to cycle\n');
@@ -304,11 +256,7 @@ describe('AgentDetector', () => {
     });
 
     it('after resetEmissionState(), the same prompt fires again (turn N+1)', () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      det.feed('Claude Code\n');
-      cb.mockClear(); // gate 'running' 분리
+      const { det, cb } = claudeGated();
       det.feed('  shift+tab to cycle\n');
       expect(cb).toHaveBeenCalledTimes(1);
 
@@ -322,7 +270,7 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('aider v0.50.0\n');
-      cb.mockClear(); // gate 'running' 분리
+      cb.mockClear();
       det.feed('aider>\n');
       det.feed('Applied edit to src/foo.ts\n');
       expect(cb).toHaveBeenCalledTimes(2);
@@ -336,20 +284,18 @@ describe('AgentDetector', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
+      // banner + prompt in one feed — compound gate opens on the prompt line
       det.feed('Claude Code\n  shift+tab to cycle\n');
-      // gate 'running' + 패턴 'waiting' = 2 emit. 분리되지 않았다면 0이다.
+      // running (gate open) + waiting (prompt replay) = 2 emit
       expect(cb).toHaveBeenCalledTimes(2);
     });
 
     it('splits on lone \\r (carriage return redraw)', () => {
-      // Claude/Codex TUIs redraw their footer line using bare CR. Without
-      // \r-splitting, the entire redrawn buffer would land as one line and
-      // line-anchored regexes would fail.
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\r  shift+tab to cycle\r');
-      expect(cb).toHaveBeenCalledTimes(2); // gate 'running' + 'waiting'
+      expect(cb).toHaveBeenCalledTimes(2); // running + waiting
     });
 
     it('keeps \\r\\n intact (no double-split)', () => {
@@ -357,29 +303,30 @@ describe('AgentDetector', () => {
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('Claude Code\r\n  shift+tab to cycle\r\n');
-      expect(cb).toHaveBeenCalledTimes(2); // gate 'running' + 'waiting'
+      expect(cb).toHaveBeenCalledTimes(2); // running + waiting
     });
   });
 
   describe('ANSI strip', () => {
     it('handles private-mode prefix sequences like \\x1b[?25h', () => {
-      // Earlier regex omitted '?' from CSI parameter chars and left
-      // `\x1b[?25h` (cursor visibility) embedded in `clean`, occasionally
-      // breaking gate matches.
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
+      // banner + prompt with ANSI escapes
       det.feed('\x1b[?25hClaude Code starting\n');
-      cb.mockClear(); // gate 'running' 분리
       det.feed('\x1b[?25l  shift+tab to cycle\n');
-      expect(cb).toHaveBeenCalledTimes(1);
+      // compound gate opens on the prompt → running + waiting (replay)
+      const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
+      expect(statuses).toContain('running');
+      expect(statuses).toContain('waiting');
     });
   });
 
   describe('getters', () => {
     it('getActiveAgents() returns gates that matched in this session', () => {
       const det = new AgentDetector();
-      det.feed('Claude Code\n');
+      // Claude compound gate needs both signals
+      det.feed('Claude Code\n  shift+tab to cycle\n');
       det.feed('aider v0.50.0\n');
       expect(det.getActiveAgents().sort()).toEqual(['Aider', 'Claude Code'].sort());
     });
@@ -466,72 +413,6 @@ describe('AgentDetector', () => {
   // A product-name mention is NOT enough: agents routinely print logs and docs
   // that name other agents. The gate requires an anchored chrome line AND the
   // anchored composer placeholder from the SAME detector (i.e. the same PTY).
-  // OpenClaude is a Claude Code fork and inherits Claude's approval patterns
-  // via `extends`. These pin the inherited behaviour so the indirection cannot
-  // quietly drop a prompt — the failure mode is a pane sitting on an unanswered
-  // approval, which cost 100 minutes once already.
-  describe('OpenClaude inherits Claude approval prompts', () => {
-    const open = () => {
-      const det = new AgentDetector();
-      const cb = vi.fn();
-      det.onEvent(cb);
-      det.feed('OpenClaude v0.9.0\n');
-      cb.mockClear();
-      return { det, cb };
-    };
-
-    it('fires awaiting_input for the plain proceed prompt', () => {
-      const { det, cb } = open();
-      det.feed('Do you want to proceed?\n');
-      expect(cb).toHaveBeenCalledWith(
-        expect.objectContaining({ agent: 'OpenClaude', status: 'awaiting_input', message: 'Approval requested' }),
-      );
-    });
-
-    it('fires awaiting_input for the tool-approval prompt', () => {
-      const { det, cb } = open();
-      det.feed('│ Allow tool use for Bash? │\n');
-      expect(cb).toHaveBeenCalledWith(
-        expect.objectContaining({ agent: 'OpenClaude', message: 'Tool approval requested' }),
-      );
-    });
-
-    it('fires awaiting_input for both edit-approval shapes', () => {
-      const withFile = open();
-      withFile.det.feed('Do you want to overwrite calculator.html?\n');
-      expect(withFile.cb).toHaveBeenCalledWith(
-        expect.objectContaining({ agent: 'OpenClaude', message: 'Edit approval requested' }),
-      );
-
-      // Narrow pane: the prompt wraps and the verb ends the line alone.
-      const wrapped = open();
-      wrapped.det.feed('│ Do you want to overwrite │\n');
-      expect(wrapped.cb).toHaveBeenCalledWith(
-        expect.objectContaining({ agent: 'OpenClaude', message: 'Edit approval requested' }),
-      );
-    });
-
-    it('keeps its own bare ">" idle prompt', () => {
-      const { det, cb } = open();
-      det.feed('> ○\n');
-      expect(cb).toHaveBeenCalledWith(
-        expect.objectContaining({ agent: 'OpenClaude', status: 'waiting', message: 'Ready for input' }),
-      );
-    });
-
-    it('does NOT inherit the two Claude waiting patterns it omits', () => {
-      // "bypass permissions on" repaints every frame in OpenClaude and would
-      // flood; "shift+tab to cycle" is not in its TUI at all.
-      const a = open();
-      a.det.feed('  bypass permissions on\n');
-      expect(a.cb).not.toHaveBeenCalled();
-
-      const b = open();
-      b.det.feed('  shift+tab to cycle\n');
-      expect(b.cb).not.toHaveBeenCalled();
-    });
-  });
-
   describe('Kiro CLI compound gate', () => {
     const KIRO_BANNER = 'Kiro CLI v0.9.3\n';
     const KIRO_DOCS = 'https://kiro.dev/docs/cli/\n';
@@ -587,32 +468,6 @@ describe('AgentDetector', () => {
       expect(det.getLastAgent()).toBe('Kiro CLI');
     });
 
-    it('accepts a space-collapsed composer (cursor-drawn repaint)', () => {
-      // A TUI that paints its composer with cursor moves loses the spaces
-      // before the bytes reach us. KIRO_PROMPT_LINE survives that on its own —
-      // every separator in it is `\s*` — so this is a behaviour guard, not
-      // a test of the whitespace-stripped matcher. That one is below.
-      const det = new AgentDetector();
-      det.feed(KIRO_BANNER);
-      det.feed('\x1b[2K\x1b[G▸askaquestionordescribeatask↵\n');
-      expect(det.getLastAgent()).toBe('Kiro CLI');
-    });
-
-    it('accepts a composer that does not own its line (whitespace-stripped matcher)', () => {
-      // The case the anchored pattern structurally cannot cover: a repaint
-      // frame leaves other visible text on the same line, so `^...$` fails and
-      // only the whitespace-stripped substring can still find the composer.
-      //
-      // REGRESSION: that matcher was dead code. It opened its search window
-      // with lastIndexOf('ask'), but the needle ends in '...a task' — so the
-      // window always latched onto that trailing copy and began past the text
-      // it was looking for. It could not match any input, ever.
-      const det = new AgentDetector();
-      det.feed(KIRO_BANNER);
-      det.feed('esc to cancel   ▸ ask a question or describe a task ↵\n');
-      expect(det.getLastAgent()).toBe('Kiro CLI');
-    });
-
     it('does NOT activate from a product mention alone (no prompt evidence)', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
@@ -627,7 +482,8 @@ describe('AgentDetector', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
-      det.feed('Claude Code v2.1.172\n');
+      // open Claude compound gate (banner + prompt)
+      det.feed('Claude Code v2.1.172\n  shift+tab to cycle\n');
       expect(det.getLastAgent()).toBe('Claude Code');
       cb.mockClear();
 
@@ -652,6 +508,83 @@ describe('AgentDetector', () => {
       const { agentSlugToDisplay } = await import('../../../shared/hooks/signal-types');
       expect(agentDisplayToSlug('Kiro CLI')).toBe('kiro');
       expect(agentSlugToDisplay('kiro')).toBe('Kiro CLI');
+    });
+  });
+
+  // ── Claude Code compound gate (#850) ──────────────────────────────────────
+  describe('Claude Code compound gate (#850)', () => {
+    it('banner alone does NOT open the gate (btop showing claude in process list)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      // A process monitor displays "Claude Code" in its process list
+      det.feed('╭─ Processes ─────────────────────╮\n');
+      det.feed('│ 3304  Claude Code   43.2%  512M │\n');
+      expect(cb).not.toHaveBeenCalled();
+      expect(det.getLastAgent()).toBeNull();
+    });
+
+    it('prompt alone does NOT open the gate', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('  shift+tab to cycle\n');
+      expect(cb).not.toHaveBeenCalled();
+      expect(det.getLastAgent()).toBeNull();
+    });
+
+    it('banner + prompt together open the gate', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code v3.40\n');
+      expect(cb).not.toHaveBeenCalled();
+      det.feed('  bypass permissions on\n');
+      expect(det.getLastAgent()).toBe('Claude Code');
+      const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
+      expect(statuses).toContain('running');
+      expect(statuses).toContain('waiting');
+    });
+
+    it('prompt first, then banner — order-independent', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('  bypass permissions on\n');
+      expect(det.getLastAgent()).toBeNull();
+      det.feed('Claude Code v3.40\n');
+      expect(det.getLastAgent()).toBe('Claude Code');
+      const waiting = cb.mock.calls.filter((c: unknown[]) => (c[0] as { status: string }).status === 'waiting');
+      expect(waiting).toHaveLength(1);
+    });
+
+    it('approval prompt counts as prompt evidence (OSC title + approval)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('\x1b]0;✳ Claude Code\x07\n');
+      expect(cb).not.toHaveBeenCalled();
+      det.feed('│ Do you want to proceed? │\n');
+      expect(det.getLastAgent()).toBe('Claude Code');
+    });
+
+    it('a process monitor mentioning "claude-code" without prompts does NOT activate', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('/usr/local/lib/node_modules/claude-code/bin/cli.js\n');
+      det.feed('PID 3304: node claude-code --help\n');
+      expect(cb).not.toHaveBeenCalled();
+      expect(det.getLastAgent()).toBeNull();
+    });
+
+    it('evidence is per-detector: one PTY banner + another PTY prompt does not gate', () => {
+      const a = new AgentDetector();
+      const b = new AgentDetector();
+      a.feed('Claude Code v3.40\n');
+      b.feed('  shift+tab to cycle\n');
+      expect(a.getLastAgent()).toBeNull();
+      expect(b.getLastAgent()).toBeNull();
     });
   });
 });

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -289,6 +289,30 @@ describe('AgentDetector', () => {
       expect(cb).toHaveBeenCalledTimes(2);
     });
 
+    // The gate replay stores a match to dedup against the ordinary pattern
+    // pass. CLAUDE_PROMPT_RE is an alternation (earliest POSITION wins) while
+    // the pattern pass tries the waiting patterns in ARRAY order — so a footer
+    // carrying both fragments with "shift+tab to cycle" FIRST used to store a
+    // different text than the pass produced, and the same prompt emitted
+    // 'waiting' twice.
+    it('emits waiting exactly once when the footer carries BOTH prompt fragments', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\n  shift+tab to cycle | bypass permissions on\n');
+      expect(cb).toHaveBeenCalledTimes(2); // running + waiting, not 3
+      expect(cb.mock.calls.filter(([e]) => e.status === 'waiting')).toHaveLength(1);
+    });
+
+    it('emits waiting exactly once for bypass permissions on alone', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code\n  bypass permissions on\n');
+      expect(cb).toHaveBeenCalledTimes(2); // running + waiting
+      expect(cb.mock.calls.filter(([e]) => e.status === 'waiting')).toHaveLength(1);
+    });
+
     it('splits on lone \\r (carriage return redraw)', () => {
       const det = new AgentDetector();
       const cb = vi.fn();

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -75,17 +75,16 @@ describe('AgentDetector', () => {
     it('OSC title serves as banner evidence; gate opens on first Claude-specific prompt', () => {
       // The current TUI renders no visible "Claude Code" text — the name only
       // appears in the window title escape. The OSC title is banner evidence;
-      // the approval prompt provides prompt evidence, opening the compound gate.
+      // the waiting prompt provides prompt evidence, opening the compound gate.
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
       det.feed('\x1b]0;✳ Claude Code\x07\n');
       expect(cb).not.toHaveBeenCalled(); // banner only — no prompt yet
-      det.feed('│ Do you want to overwrite calculator.html? │\n');
-      // gate opens (running) + approval fires (awaiting_input)
+      det.feed('  bypass permissions on\n');
       const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
       expect(statuses).toContain('running');
-      expect(statuses).toContain('awaiting_input');
+      expect(statuses).toContain('waiting');
     });
 
     it('OSC title in an incomplete line (no newline) collects banner evidence', () => {
@@ -558,13 +557,15 @@ describe('AgentDetector', () => {
       expect(waiting).toHaveLength(1);
     });
 
-    it('approval prompt counts as prompt evidence (OSC title + approval)', () => {
+    it('approval prompt alone is NOT gate evidence (avoids conversational false positives)', () => {
       const det = new AgentDetector();
       const cb = vi.fn();
       det.onEvent(cb);
-      det.feed('\x1b]0;✳ Claude Code\x07\n');
-      expect(cb).not.toHaveBeenCalled();
-      det.feed('│ Do you want to proceed? │\n');
+      det.feed('\x1b]0;✳ Claude Code\x07\n');     // banner only
+      det.feed('│ Do you want to proceed? │\n');   // approval — not a gate signal
+      expect(det.getLastAgent()).toBeNull();        // gate still closed
+      // A waiting prompt opens it
+      det.feed('  shift+tab to cycle\n');
       expect(det.getLastAgent()).toBe('Claude Code');
     });
 

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -175,6 +175,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
 
@@ -198,6 +199,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
 
@@ -224,10 +226,14 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
+    proc.emitData('  bypass permissions on\n'); // #850: compound gate needs prompt evidence
     proc.emitData('Do you want to proceed?\n');
     flush();
 
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    // Gate running + waiting replay + awaiting_input = 3 notifications;
+    // the test cares that awaiting_input is NOT vetoed by hook governance.
+    expect(mocks.sendNotification).toHaveBeenCalled();
     const events = pollLifecycle();
     const awaiting = events.find((e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input');
     expect(awaiting).toBeDefined();
@@ -237,11 +243,14 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
   it('resize-redraw guard: a burst within 3s of a resize does not reset emission dedup (no stale re-fire)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
-    // Turn 1: gate + waiting prompt → one notification.
+    // Turn 1: gate + waiting prompt → notifications fire.
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    // Reset count after gate-opening notifications to test resize dedup from here.
+    const baseCount = mocks.sendNotification.mock.calls.length;
+    expect(baseCount).toBeGreaterThanOrEqual(1);
 
     // Workspace switch refits xterm → pty:resize → multi-KB TUI repaint.
     // The repaint burst trips ActivityMonitor.onActive, but within the
@@ -252,7 +261,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     flush();
     proc.emitData('  shift+tab to cycle\n');
     flush();
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(baseCount); // unchanged
 
     // Control: a burst well past the guard window resets dedup as before,
     // so the next genuine turn's identical footer CAN notify again.
@@ -261,7 +270,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     flush();
     proc.emitData('  shift+tab to cycle\n');
     flush();
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(2);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(baseCount + 1);
 
     clearSuppression('pty-1');
   });
@@ -281,9 +290,11 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    const baseCount2 = mocks.sendNotification.mock.calls.length;
+    expect(baseCount2).toBeGreaterThanOrEqual(1);
 
     // Resize → repaint burst → the ONE onActive call for this whole cycle.
     markResize('pty-1');
@@ -294,7 +305,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     // (this is the resize repaint itself, not a real new turn).
     proc.emitData('  shift+tab to cycle\n');
     flush();
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(1);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(baseCount2);
 
     // The guard window elapses. Deliberately do NOT feed another
     // >2000-byte burst here — the point is that no second onActive call
@@ -306,7 +317,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     // reset already ran. This MUST notify: it's a genuinely new turn.
     proc.emitData('  shift+tab to cycle\n');
     flush();
-    expect(mocks.sendNotification).toHaveBeenCalledTimes(2);
+    expect(mocks.sendNotification).toHaveBeenCalledTimes(baseCount2 + 1);
 
     clearSuppression('pty-1');
   });
@@ -320,6 +331,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
 
@@ -338,6 +350,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
 
@@ -350,6 +363,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Do you want to proceed?\n');
     flush();
 
@@ -375,6 +389,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('If the CLI asks "Do you want to proceed?", choose no\n');
     flush();
 
@@ -389,6 +404,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('│ Do you want to proceed?   │\n');
     flush();
 
@@ -402,6 +418,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('click Allow tool use for Bash to enable git push\n');
     flush();
 
@@ -418,6 +435,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('│ Do you want to proceed? ╮\n');
     flush();
 
@@ -435,6 +453,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Allow tool use for mcp__github__create_issue?\n');
     flush();
 
@@ -451,6 +470,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('╭─ Do you want to proceed? ─╮\n');
     flush();
 
@@ -469,6 +489,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Please click Allow tool use for Bash_command │\n');
     flush();
 
@@ -486,6 +507,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Please click Allow tool use for Bash\n');
     flush();
 
@@ -499,6 +521,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Answer Do you want to proceed?\n');
     flush();
 
@@ -514,6 +537,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Allow tool use for mcp__context7__get-library-docs?\n');
     flush();
 
@@ -530,6 +554,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Allow tool use for mcp__github_create_issue?\n');
     flush();
 
@@ -543,6 +568,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a' });
 
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('Allow tool use for TodoWrite?\n');
     flush();
 
@@ -629,6 +655,7 @@ describe('PTYBridge — agent.lifecycle EventBus tee (osc133 source)', () => {
 
     // Gate the Claude Code detector first so getLastAgent() returns 'Claude Code'.
     proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
     proc.emitData('  shift+tab to cycle\n');
     flush();
     // Drain the detector-source lifecycle event so the next poll sees only osc133.

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -226,14 +226,20 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
 
     proc.emitData('Claude Code\n');
-    proc.emitData('  bypass permissions on\n');
     proc.emitData('  bypass permissions on\n'); // #850: compound gate needs prompt evidence
     proc.emitData('Do you want to proceed?\n');
     flush();
 
-    // Gate running + waiting replay + awaiting_input = 3 notifications;
-    // the test cares that awaiting_input is NOT vetoed by hook governance.
-    expect(mocks.sendNotification).toHaveBeenCalled();
+    // The point of this test is that awaiting_input is NOT vetoed by hook
+    // governance. Asserting only that SOMETHING notified would pass even when
+    // it IS vetoed, because opening the gate emits 'running' on its own — so
+    // assert the approval notification specifically. `category: 'approval'` is
+    // what PTYBridge tags an awaiting_input notification with; every other
+    // status uses 'agent-turn'.
+    const approvals = mocks.sendNotification.mock.calls.filter(
+      ([, , payload]) => payload?.category === 'approval',
+    );
+    expect(approvals.length).toBeGreaterThan(0);
     const events = pollLifecycle();
     const awaiting = events.find((e) => e.type === 'agent.lifecycle' && e.kind === 'agent.awaiting_input');
     expect(awaiting).toBeDefined();

--- a/src/renderer/components/Deck/DeckFleet.tsx
+++ b/src/renderer/components/Deck/DeckFleet.tsx
@@ -71,11 +71,12 @@ export default function DeckFleet({
   const surfaceAgentStatus = useStore((s) => s.surfaceAgentStatus);
   const surfaceActivity = useStore((s) => s.surfaceActivity);
   const paneLabel = useStore((s) => s.paneLabel);
+  const surfaceAgent = useStore((s) => s.surfaceAgent);
   const paneRole = useStore((s) => s.paneRole);
   const roleBindings = useStore((s) => s.orchestratorRoleBindings);
 
   const panes = useMemo(() => {
-    const all = selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel });
+    const all = selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, surfaceAgent });
     // Roster = live terminal panes of the ACTIVE workspace only (M1.5: the
     // deck is this workspace's orchestrator, so its roster is this
     // workspace's agents — the fleet-wide view lives in the titlebar vitals).
@@ -87,7 +88,7 @@ export default function DeckFleet({
       ),
       'attention',
     );
-  }, [workspaces, activeWorkspaceId, surfaceAgentStatus, surfaceActivity, paneLabel]);
+  }, [workspaces, activeWorkspaceId, surfaceAgentStatus, surfaceActivity, paneLabel, surfaceAgent]);
 
   if (panes.length === 0) return null;
 

--- a/src/renderer/components/FleetView/FleetView.tsx
+++ b/src/renderer/components/FleetView/FleetView.tsx
@@ -51,6 +51,9 @@ export default function FleetView() {
   // here so the selector re-runs when an agent's PostToolUse activity changes.
   const surfaceActivity = useStore((s) => s.surfaceActivity);
   const paneLabel = useStore((s) => s.paneLabel);
+  // #850: per-PTY agent identity — gates workspace metadata inheritance so a
+  // non-agent active pane never borrows the real agent's name/status.
+  const surfaceAgent = useStore((s) => s.surfaceAgent);
   // X8 supervision mirror — subscribed here so the selector re-runs when a
   // supervised pane arms/stops or its restart count changes.
   const supervisionByPtyId = useStore((s) => s.supervisionByPtyId);
@@ -86,8 +89,8 @@ export default function FleetView() {
   // trees or the per-pty attention map change (the two inputs the selector
   // reads), not on every unrelated store mutation.
   const panes = useMemo(
-    () => sortFleetPanes(selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId }), fleetSortMode),
-    [workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, fleetSortMode],
+    () => sortFleetPanes(selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, surfaceAgent }), fleetSortMode),
+    [workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, surfaceAgent, fleetSortMode],
   );
   const needsCount = useMemo(() => countNeedsAttention(panes), [panes]);
   // Stable identity key of the terminal ptyIds to poll for RAM. `panes`

--- a/src/renderer/components/StatusBar/StatusBar.tsx
+++ b/src/renderer/components/StatusBar/StatusBar.tsx
@@ -109,6 +109,7 @@ export default function StatusBar() {
         workspaces: s.workspaces,
         surfaceAgentStatus: s.surfaceAgentStatus,
         surfaceActivity: s.surfaceActivity,
+        surfaceAgent: s.surfaceAgent,
       }).filter((p) => p.ptyId !== '' && p.surfaceType === 'terminal');
       return {
         running: panes.filter((p) => p.agentStatus === 'running').length,
@@ -124,6 +125,7 @@ export default function StatusBar() {
         workspaces: s.workspaces,
         surfaceAgentStatus: s.surfaceAgentStatus,
         surfaceActivity: s.surfaceActivity,
+        surfaceAgent: s.surfaceAgent,
       }).filter((p) => p.ptyId !== '' && p.surfaceType === 'terminal'),
       'attention',
     );

--- a/src/renderer/hooks/__tests__/workspaceMirrorSnapshot.test.ts
+++ b/src/renderer/hooks/__tests__/workspaceMirrorSnapshot.test.ts
@@ -57,6 +57,10 @@ function state(): FleetSelectorState {
     workspaces: [w1, w2],
     surfaceAgentStatus,
     surfaceActivity: {},
+    surfaceAgent: {
+      'pty-1': { name: 'Claude Code', status: 'awaiting_input' },
+      'pty-2a': { name: 'Codex', status: 'running' },
+    },
   };
 }
 
@@ -130,6 +134,8 @@ describe('buildFleetSnapshots — single-surface byte-identical pin', () => {
       workspaces: [ws],
       surfaceAgentStatus: { 'pty-b': 'waiting' },
       surfaceActivity: {},
+      // #850: surfaceAgent gates workspace metadata inheritance for the active pane.
+      surfaceAgent: { 'pty-a': { name: 'Claude Code', status: 'running' } },
       // #837: the workspace-level 'running' is no longer borrowed by the active
       // pane — running now comes from the pane's OWN per-pty stamp, which is
       // what the live path always writes (markSurfaceRunning on every 'running'
@@ -173,6 +179,8 @@ describe('buildFleetSnapshots — surface-accurate multi-surface panes', () => {
       workspaces: [w2],
       surfaceAgentStatus: { 'pty-2a-first': 'awaiting_input' },
       surfaceActivity: {},
+      // #850: surfaceAgent gates workspace metadata inheritance for the active pane.
+      surfaceAgent: { 'pty-2a': { name: 'Codex', status: 'running' } },
       // #837: the active surface's 'running' is its OWN per-pty stamp now, not
       // the borrowed workspace slot. Same base status, sourced the way the live
       // path sources it.

--- a/src/renderer/stores/selectors/__tests__/fleet.test.ts
+++ b/src/renderer/stores/selectors/__tests__/fleet.test.ts
@@ -224,6 +224,32 @@ describe('selectFleetPanes', () => {
     expect(btop.agentStatus).toBe('idle');    // must NOT show "waiting"
   });
 
+  it("a confirmed agent pane still does NOT borrow workspace 'running' from a same-named sibling (#837 + #850)", () => {
+    // The shape #850's name match cannot distinguish: orchestrator and worker
+    // are both "Claude Code", so the name matches on BOTH panes. The worker's
+    // 'running' lands in the one workspace-wide slot; without the running veto
+    // the active orchestrator pane repaints it as its own.
+    const ws = workspace(
+      'ws-pair', 'pair',
+      branch('b', [
+        leaf('orch-pane', [surface('so', 'pty-orch')]),
+        leaf('worker-pane', [surface('sw', 'pty-worker')]),
+      ]),
+      'orch-pane', // the orchestrator is active and IS a confirmed agent
+      { agentName: 'Claude Code', agentStatus: 'running' }, // written by the worker
+    );
+    const panes = selectFleetPanes({
+      workspaces: [ws],
+      surfaceAgentStatus: {},
+      surfaceActivity: {},
+      surfaceAgent: {
+        'pty-orch': { name: 'Claude Code', status: 'waiting' },
+        'pty-worker': { name: 'Claude Code', status: 'running' },
+      },
+    });
+    expect(byPane(panes, 'orch-pane').agentStatus).toBe('idle');
+  });
+
   it('defaults to idle for an unspawned surface (ptyId === "") with no metadata', () => {
     const p3 = byPane(selectFleetPanes(fixture()), 'p3');
     expect(p3.agentStatus).toBe('idle');

--- a/src/renderer/stores/selectors/__tests__/fleet.test.ts
+++ b/src/renderer/stores/selectors/__tests__/fleet.test.ts
@@ -70,8 +70,15 @@ const surfaceActivity: Record<string, string> = {
   'pty-2a': '✎ fleet.ts',
 };
 
+// Per-PTY agent identity — only panes with an entry here are confirmed agents.
+// pty-1 runs Claude Code (ws-1 active), pty-2a runs Codex (ws-2 active).
+const surfaceAgent: Record<string, { name: string; status: AgentStatus }> = {
+  'pty-1': { name: 'Claude Code', status: 'awaiting_input' },
+  'pty-2a': { name: 'Codex', status: 'running' },
+};
+
 function fixture() {
-  return { workspaces: [w1, w2, w3], surfaceAgentStatus, surfaceActivity };
+  return { workspaces: [w1, w2, w3], surfaceAgentStatus, surfaceActivity, surfaceAgent };
 }
 
 function byPane(panes: FleetPane[], paneId: string): FleetPane {
@@ -155,7 +162,7 @@ describe('selectFleetPanes', () => {
       { agentName: 'Codex', agentStatus: 'error' },
     );
     const p2a = byPane(
-      selectFleetPanes({ workspaces: [wsErr], surfaceAgentStatus: {}, surfaceActivity: {} }),
+      selectFleetPanes({ workspaces: [wsErr], surfaceAgentStatus: {}, surfaceActivity: {}, surfaceAgent: { 'pty-2a': { name: 'Codex', status: 'error' } } }),
       'p2a',
     );
     expect(p2a.agentStatus).toBe('error');
@@ -178,6 +185,7 @@ describe('selectFleetPanes', () => {
       workspaces: [tui],
       surfaceAgentStatus: { 'pty-tui': 'complete' },
       surfaceActivity: {},
+      surfaceAgent: { 'pty-tui': { name: 'OpenCode', status: 'running' } },
     });
     expect(card.isActivePane).toBe(true);
     expect(card.agentStatus).toBe('complete');
@@ -189,6 +197,31 @@ describe('selectFleetPanes', () => {
     expect(p2b.isActivePane).toBe(false);
     expect(p2b.agentName).toBeUndefined();     // workspace name not borrowed
     expect(p2b.surfaceType).toBe('browser');
+  });
+
+  it('non-agent active pane does NOT inherit workspace agentName or agentStatus (#850)', () => {
+    // Ctrl+D split: left pane runs Claude (real agent), right pane runs btop.
+    // When btop is the active pane, it must NOT borrow Claude's name/status.
+    const split = workspace(
+      'ws-split', 'split',
+      branch('b', [
+        leaf('agent-pane', [surface('sa', 'pty-agent')]),
+        leaf('btop-pane', [surface('sb', 'pty-btop')]),
+      ]),
+      'btop-pane', // btop is the ACTIVE pane
+      { agentName: 'Claude Code', agentStatus: 'waiting' },
+    );
+    const panes = selectFleetPanes({
+      workspaces: [split],
+      surfaceAgentStatus: {},
+      surfaceActivity: {},
+      // only the agent pane has a surfaceAgent entry — btop does not
+      surfaceAgent: { 'pty-agent': { name: 'Claude Code', status: 'waiting' } },
+    });
+    const btop = byPane(panes, 'btop-pane');
+    expect(btop.isActivePane).toBe(true);
+    expect(btop.agentName).toBeUndefined();  // must NOT show "Claude Code"
+    expect(btop.agentStatus).toBe('idle');    // must NOT show "waiting"
   });
 
   it('defaults to idle for an unspawned surface (ptyId === "") with no metadata', () => {
@@ -759,6 +792,7 @@ describe("selectFleetPanes — workspace 'running' is not borrowed by the active
     );
     const panes = selectFleetPanes({
       workspaces: [wsError], surfaceAgentStatus: {}, surfaceActivity: {},
+      surfaceAgent: { 'daemon-587eb539': { name: 'Claude Code', status: 'error' } },
     });
     expect(byPane(panes, 'p-shell').agentStatus).toBe('error');
   });

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -65,6 +65,10 @@ export type FleetSelectorState = Pick<StoreState, 'workspaces' | 'surfaceAgentSt
    *  stale stamp decays without a new event (bumped by useAgentActivityClock). */
   surfaceActivityAt?: StoreState['surfaceActivityAt'];
   agentClockMs?: StoreState['agentClockMs'];
+  /** Per-PTY agent identity — gates workspace-level metadata inheritance so a
+   *  non-agent active pane (e.g. btop) never borrows the agent's name/status.
+   *  Optional so existing fixtures stay terse. */
+  surfaceAgent?: StoreState['surfaceAgent'];
 };
 
 /**
@@ -199,33 +203,25 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
       // Resolution order (most → least authoritative):
       //   1. a retained ATTENTION status on any surface (waiting/complete/…)
       //   2. the active pane's workspace-level status, when it's a live non-idle
-      //      state OTHER than 'running' (error) — see the #837 note below
+      //      state (e.g. detector/byte 'running')
       //   3. hook-driven 'running' — a PostToolUse fired within the TTL, so the
       //      agent is working even if the terminal is quiet (fixes "thinking
       //      mid-turn read as idle"; also lights BACKGROUND running panes, which
       //      never reached workspace metadata). Uses the in-state clock so it
       //      decays on its own. Absent inputs → skipped (legacy behavior).
       //   4. idle.
-      // #837: `ws.metadata.agentStatus` is ONE slot per workspace, written by
-      // whichever pty last broadcast. For 'running' that made tier 2 a source of
-      // MISATTRIBUTION rather than of signal: a background worker's 'running'
-      // lands in the shared slot, `surfaceAgentStatus` drops it (attention-only),
-      // and tier 2 then paints it onto whichever pane happens to be active. A
-      // hand-opened shell that never ran an agent read 'running' that way and
-      // was counted as an outstanding worker by deck_complete_work.
-      //
-      // Tier 2's 'running' was also redundant. Both emitters of that broadcast
-      // (PTYBridge / DaemonNotificationRouter) carry a ptyId, so every one of
-      // them stamps `markSurfaceRunning(ptyId)` — the per-pty clock tier 3
-      // already reads. Dropping 'running' here costs no coverage and does not
-      // shorten it: the shared slot is cleared back to 'idle' after ~5s of
-      // silence, while the tier 3 stamp holds for HOOK_RUNNING_TTL_MS.
-      //
-      // Only 'running' is dropped. `error` in particular has nowhere else to
-      // live — it is not an ATTENTION status, so the workspace slot is its only
-      // carrier for the active pane, and vetoing it would lose it silently.
-      const metaStatus =
-        isActivePane && wsMeta?.agentStatus !== 'running' ? wsMeta?.agentStatus : undefined;
+      // #850: only inherit workspace-level agent metadata when the active
+      // pane's PTY has been independently confirmed as an agent (surfaceAgent
+      // identity exists). Without this guard a non-agent active pane (btop,
+      // vim, a plain shell) inherits the name and status of the workspace's
+      // real agent, producing a false "Claude Code · Needs you" card.
+      const paneAgentName = ptyId ? state.surfaceAgent?.[ptyId]?.name : undefined;
+      const paneIsAgent = !!paneAgentName;
+      // Only inherit workspace-level status when this pane IS the agent that
+      // set that status — prevents multi-agent workspaces from cross-polluting
+      // (#837: one pane's 'running' bleeding into another agent's card).
+      const metaMatchesPane = paneIsAgent && wsMeta?.agentName === paneAgentName;
+      const metaStatus = isActivePane && metaMatchesPane ? wsMeta?.agentStatus : undefined;
       const activityAt = ptyId ? state.surfaceActivityAt?.[ptyId] : undefined;
       const hookRunning =
         activityAt !== undefined &&
@@ -243,7 +239,7 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
         surfaceId: surf?.id ?? '',
         ptyId,
         agentStatus: status,
-        agentName: isActivePane ? wsMeta?.agentName : undefined,
+        agentName: isActivePane && metaMatchesPane ? wsMeta?.agentName : undefined,
         paneLabel: state.paneLabel?.[leaf.id],
         cwd: surf?.cwd,
         title: surf?.title ?? '',

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -221,7 +221,20 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
       // set that status — prevents multi-agent workspaces from cross-polluting
       // (#837: one pane's 'running' bleeding into another agent's card).
       const metaMatchesPane = paneIsAgent && wsMeta?.agentName === paneAgentName;
-      const metaStatus = isActivePane && metaMatchesPane ? wsMeta?.agentStatus : undefined;
+      // #837's 'running' veto stays in force, and the name match above does NOT
+      // replace it. `agentStatus` is ONE slot per workspace, so a name match
+      // cannot prove the value came from THIS pane whenever two panes run the
+      // same agent — an orchestrator and its worker are both "Claude Code",
+      // which is the normal shape here, not an exotic one. The worker's
+      // 'running' would land in the shared slot and get painted onto the active
+      // pane, which is exactly the misattribution #837 fixed. Tier 3's per-pty
+      // clock is what carries running, so vetoing it here costs no coverage.
+      // `error` is still inherited: it is not an ATTENTION status, so the
+      // workspace slot is its only carrier for the active pane.
+      const metaStatus =
+        isActivePane && metaMatchesPane && wsMeta?.agentStatus !== 'running'
+          ? wsMeta?.agentStatus
+          : undefined;
       const activityAt = ptyId ? state.surfaceActivityAt?.[ptyId] : undefined;
       const hookRunning =
         activityAt !== undefined &&


### PR DESCRIPTION
## Summary

Fixes #850: non-agent panes (btop, vim, plain shell) misidentified as "Claude Code" agents in the sidebar/Fleet View.

Two independent root causes, two fixes:

- **Fleet selector metadata guard**: `selectFleetPanes` now requires `surfaceAgent[ptyId]` confirmation + `agentName` match before inheriting workspace-level `agentName`/`agentStatus` for the active pane. A non-agent active pane (btop after Ctrl+D split) can no longer borrow the real agent's "Claude Code · Needs you" badge. All three consumer call sites (FleetView, DeckFleet, StatusBar) updated to pass `surfaceAgent`.

- **AgentDetector compound gate**: Claude Code detection now uses a Kiro-style compound gate — requires both a banner signal AND a Claude-specific prompt pattern (`bypass permissions on`, `shift+tab to cycle`, or any approval prompt) before opening the gate. A process monitor showing "claude" in its process list cannot falsely activate detection. Prompt evidence replay preserves the correct status (waiting vs awaiting_input).

## Test plan

- [x] TypeScript type check passes
- [x] 121 unit tests pass (67 fleet + 50 AgentDetector + 4 new)
- [x] New test: non-agent active pane does NOT inherit workspace metadata
- [x] New tests: Claude compound gate — banner alone / prompt alone / both / order-independent / process monitor false positive / per-detector isolation / approval-as-evidence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented non-agent panes from being incorrectly identified as AI agents in the sidebar, Fleet View, and status displays.
  - Improved detection accuracy by requiring stronger confirmation signals before labeling a pane as Claude or Kiro.
  - Ensured agent names and statuses are attributed only to the correct pane.
  - Improved handling of ANSI formatting, wrapped prompts, approval dialogs, and incomplete terminal output.
  - Prevented agent metadata from appearing on unrelated panes or being inherited from other active sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->