### PR TITLE
fix(daemon): bound broadcast subscriber backpressure

### DIFF
--- a/changelog.d/862.md
+++ b/changelog.d/862.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A stalled event subscriber can no longer grow the daemon's write buffer
+  without bound.** Broadcast delivery now drops only that client's event
+  subscription after its buffered output crosses the existing safety cap. The
+  RPC connection stays open, and healthy subscribers continue receiving events.
+  (#862)

--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -14,8 +14,8 @@ const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clie
  * and the writable buffer has no ceiling. A subscriber that stops reading (a
  * hung renderer, a paused process, a phone on a dead link) would therefore grow
  * the daemon's heap by one full payload per append, indefinitely. Above this cap
- * per-subscriber events are REFUSED — `sendTo` returns false, and the caller's
- * contract is to drop that client's subscription rather than keep buffering.
+ * per-subscriber events are REFUSED — `sendTo` returns false, and `broadcast`
+ * drops the stalled event subscription rather than keep buffering.
  */
 export const SUBSCRIBER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
 
@@ -449,6 +449,15 @@ export class DaemonPipeServer {
     const msg = JSON.stringify(event) + '\n';
     this.eventSubscribers.forEach((socket) => {
       if (!socket.destroyed) {
+        if (socket.writableLength > SUBSCRIBER_BACKPRESSURE_BYTES) {
+          this.eventSubscribers.delete(socket);
+          const clientId = this.clientIds.get(socket) ?? 'unknown';
+          console.warn(
+            `[DaemonPipeServer] dropping stalled event subscriber ${clientId}: `
+            + `${socket.writableLength} buffered bytes exceeds ${SUBSCRIBER_BACKPRESSURE_BYTES}`,
+          );
+          return;
+        }
         try {
           socket.write(msg);
         } catch {

--- a/src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts
@@ -1,13 +1,14 @@
 // The two guards the transcript subscription path leans on:
 //
-//   D6 — `sendTo` refuses once a client stops draining. Node's writable buffer
-//        has no ceiling, so "queue it anyway" is unbounded heap growth in the
-//        always-on process, one full append at a time.
+//   D6 — `sendTo` refuses and `broadcast` drops the event subscription once a
+//        client stops draining. Node's writable buffer has no ceiling, so
+//        "queue it anyway" is unbounded heap growth in the always-on process,
+//        one full event at a time.
 //   D7 — first-party CLASSIFICATION. The transcript RPCs return a pane's whole
 //        conversation, and the daemon previously handed that to any token-holding
 //        pipe client (CLI, MCP) despite the design note that says otherwise.
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import net from 'node:net';
 import crypto from 'node:crypto';
 import os from 'node:os';
@@ -25,6 +26,7 @@ const servers: DaemonPipeServer[] = [];
 const clients: net.Socket[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   for (const c of clients.splice(0)) c.destroy();
   for (const s of servers.splice(0)) await s.stop();
 });
@@ -105,6 +107,46 @@ describe('DaemonPipeServer — subscriber backpressure (D6)', () => {
     socket.destroy();
     await waitFor(() => server.getConnectionCount() === 0);
     expect(server.sendTo(clientId, { type: 'transcript.appended' })).toBe(false);
+  });
+
+  it('drops only the stalled broadcast subscriber once its buffer passes the cap', async () => {
+    const { server, pipe, token } = await startServer('broadcast-backpressure');
+    const stalled = await connectClient(server, pipe, token);
+    const draining = await connectClient(server, pipe, token);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    stalled.socket.pause();
+    let received = '';
+    draining.socket.setEncoding('utf8');
+    draining.socket.on('data', (chunk: string) => {
+      received += chunk;
+    });
+
+    // Prime only the paused socket so the broadcast below tests subscriber
+    // isolation without temporarily making the healthy socket look stalled too.
+    const payload = { type: 'transcript.appended', blob: 'z'.repeat(SUBSCRIBER_BACKPRESSURE_BYTES) };
+    expect(server.sendTo(stalled.clientId, payload)).toBe(true);
+    let refused = false;
+    for (let i = 0; i < 5 && !refused; i++) {
+      refused = server.sendTo(stalled.clientId, payload) === false;
+    }
+    expect(refused).toBe(true);
+
+    expect(server.subscribeEvents(stalled.clientId)).toBe(true);
+    expect(server.subscribeEvents(draining.clientId)).toBe(true);
+
+    server.broadcast({ type: 'title.changed', n: 'first' });
+    await waitFor(() => received.includes('"n":"first"'));
+
+    expect(server.isEventSubscriber(stalled.clientId)).toBe(false);
+    expect(server.isEventSubscriber(draining.clientId)).toBe(true);
+    expect(server.getConnectionCount()).toBe(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropping stalled event subscriber'));
+
+    server.broadcast({ type: 'title.changed', n: 'after-drop' });
+    await waitFor(() => received.includes('"n":"after-drop"'));
+    expect(server.isEventSubscriber(draining.clientId)).toBe(true);
   });
 });
 

--- a/src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts
@@ -140,6 +140,7 @@ describe('DaemonPipeServer — subscriber backpressure (D6)', () => {
 
     expect(server.isEventSubscriber(stalled.clientId)).toBe(false);
     expect(server.isEventSubscriber(draining.clientId)).toBe(true);
+    expect(stalled.socket.destroyed).toBe(false);
     expect(server.getConnectionCount()).toBe(2);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropping stalled event subscriber'));


### PR DESCRIPTION
## Summary

- apply the existing per-subscriber backpressure cap to broadcast event delivery
- drop only a stalled client's event subscription while keeping its RPC socket connected
- log the dropped subscription and cover stalled/healthy subscriber isolation

This addresses gap 2 from #858 only. Event resync/replay and the first-party subscription gate remain intentionally out of scope.

## Testing

- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts`
- `npm exec vitest run -- src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts` (13 passed)
- `npm run test:parallel` (723 files passed, 10,782 tests passed, 24 skipped)
- `npm run test:runtime` (10 files / 149 tests passed; 2 pre-existing `shellIntegration.runtime.test.ts` cases timed out because this host's node-pty helper reports `AttachConsole failed`)

Refs #858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event delivery under backpressure by removing only stalled event subscriptions when their output buffers exceed the safety limit.
  - RPC connections remain open, and healthy subscribers continue receiving events.
  - Added warning logs when a stalled subscription is dropped.

- **Documentation**
  - Clarified how broadcast behavior handles stalled subscribers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->