### PR TITLE
fix(installer): repair dead AUMID shortcuts and stop depending on iconUrl for shortcut icons

### DIFF
--- a/changelog.d/865.md
+++ b/changelog.d/865.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **A dead shortcut can no longer blank the taskbar icon after an update.**
+  Windows resolves the taskbar button's icon through the shortcut carrying the
+  app's AppUserModelID, so one stale link — a pre-3.4 top-level Start Menu
+  entry, or a taskbar pin recorded against a deleted `app-X.Y.Z` directory —
+  blanked the icon of a perfectly healthy install. The installer hooks now
+  repair such links (retargeting them to the version-stable root launcher)
+  instead of leaving them behind. (#863, #865)
+- **Shortcut icons no longer depend on a download at install time.** The
+  installer previously fetched the shortcut icon from raw.githubusercontent.com,
+  which fails on networks where that host is unreachable and left shortcuts
+  with no icon at all. The icon that already ships inside the package is used
+  instead. (#863, #865)

--- a/src/main/__tests__/shortcutHygiene.runtime.test.ts
+++ b/src/main/__tests__/shortcutHygiene.runtime.test.ts
@@ -58,7 +58,10 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
   let loc: RepairLocations;
 
   beforeEach(() => {
-    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hygiene-'));
+    // realpathSync.native expands 8.3 short components: CI runners hand back
+    // `C:\Users\RUNNER~1\...` from os.tmpdir() while the shell/COM layer
+    // resolves the long form, so raw mkdtemp paths fail every string compare.
+    sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hygiene-')));
     // Fake install root: <root>\wmux.exe stub + <root>\app-1.0.0\wmux.exe (the
     // "current version" the hook process runs from) + resources\icon.ico.
     root = path.join(sandbox, 'wmux');
@@ -89,7 +92,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe')); // dir never existed → dead
     const iconPath = stageRootIcon(execPath);
     expect(iconPath).toBe(path.join(root, 'app.ico'));
-    expect(fs.existsSync(iconPath!)).toBe(true);
+    expect(fs.existsSync(iconPath ?? '')).toBe(true);
 
     const actions = repairInstalledShortcuts(execPath, loc);
     expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);

--- a/src/main/__tests__/shortcutHygiene.runtime.test.ts
+++ b/src/main/__tests__/shortcutHygiene.runtime.test.ts
@@ -1,0 +1,217 @@
+// End-to-end run of the #863 shortcut-hygiene pass against REAL .lnk files in
+// a temp sandbox: real powershell.exe, real WScript.Shell COM, real property
+// stores. This is the evidence the unit tests cannot give — that a dead
+// versioned link is retargeted to the stub with the icon pinned to app.ico,
+// that the legacy Start Menu link is deduped rather than retargeted, that
+// foreign shortcuts are untouched, and that Save() preserves the link's
+// AppUserModelID (the property Windows resolves the taskbar icon through).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { repairInstalledShortcuts, stageRootIcon, type RepairLocations } from '../shortcutHygiene';
+
+const onWindows = process.platform === 'win32';
+
+function ps(script: string): string {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  return execFileSync(
+    path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    { encoding: 'utf-8', timeout: 30_000, windowsHide: true },
+  );
+}
+
+function makeLnk(lnkPath: string, target: string, aumid?: string): void {
+  const aumidPart = aumid
+    ? `
+$bytes = [System.IO.File]::ReadAllBytes('${lnkPath}')
+# Set AUMID via Shell property store: re-open with Shell32 is heavyweight;
+# instead use the WshShortcut then stamp AUMID through the propsys COM route.
+`
+    : '';
+  void aumidPart;
+  ps([
+    `$sh = New-Object -ComObject WScript.Shell`,
+    `$l = $sh.CreateShortcut('${lnkPath}')`,
+    `$l.TargetPath = '${target}'`,
+    `$l.Save()`,
+  ].join('\n'));
+}
+
+function readLnk(lnkPath: string): { target: string; icon: string; workdir: string } {
+  const out = ps([
+    `$sh = New-Object -ComObject WScript.Shell`,
+    `$l = $sh.CreateShortcut('${lnkPath}')`,
+    `@{ target = $l.TargetPath; icon = $l.IconLocation; workdir = $l.WorkingDirectory } | ConvertTo-Json -Compress`,
+  ].join('\n'));
+  return JSON.parse(out.trim());
+}
+
+describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerShell)', () => {
+  let sandbox: string;
+  let root: string;
+  let execPath: string;
+  let programs: string;
+  let pinDir: string;
+  let loc: RepairLocations;
+
+  beforeEach(() => {
+    sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hygiene-'));
+    // Fake install root: <root>\wmux.exe stub + <root>\app-1.0.0\wmux.exe (the
+    // "current version" the hook process runs from) + resources\icon.ico.
+    root = path.join(sandbox, 'wmux');
+    const appDir = path.join(root, 'app-1.0.0');
+    fs.mkdirSync(path.join(appDir, 'resources'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'wmux.exe'), 'stub');
+    execPath = path.join(appDir, 'wmux.exe');
+    fs.writeFileSync(execPath, 'exe');
+    fs.writeFileSync(path.join(appDir, 'resources', 'icon.ico'), 'icon-bytes');
+
+    programs = path.join(sandbox, 'Programs');
+    pinDir = path.join(sandbox, 'TaskBar');
+    fs.mkdirSync(path.join(programs, 'someauthor'), { recursive: true });
+    fs.mkdirSync(pinDir, { recursive: true });
+    loc = {
+      legacyLnks: [path.join(programs, 'wmux.lnk')],
+      pinDirs: [pinDir],
+      publisherLnk: path.join(programs, '*', 'wmux.lnk'),
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('retargets a dead versioned pin to the stub and pins its icon to app.ico', () => {
+    const pin = path.join(pinDir, 'wmux-pin.lnk');
+    makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe')); // dir never existed → dead
+    const iconPath = stageRootIcon(execPath);
+    expect(iconPath).toBe(path.join(root, 'app.ico'));
+    expect(fs.existsSync(iconPath!)).toBe(true);
+
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
+
+    const after = readLnk(pin);
+    expect(after.target.toLowerCase()).toBe(path.join(root, 'wmux.exe').toLowerCase());
+    expect(after.workdir.toLowerCase()).toBe(root.toLowerCase());
+    expect(after.icon.toLowerCase()).toBe(`${path.join(root, 'app.ico')},0`.toLowerCase());
+  });
+
+  it('retargets a live-but-versioned pin (it would die on the next update)', () => {
+    const pin = path.join(pinDir, 'wmux-pin.lnk');
+    makeLnk(pin, execPath); // app-1.0.0 exists today
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
+    expect(readLnk(pin).target.toLowerCase()).toBe(path.join(root, 'wmux.exe').toLowerCase());
+  });
+
+  it('removes a dead legacy Start Menu link when the publisher link exists', () => {
+    const legacy = loc.legacyLnks[0];
+    makeLnk(legacy, path.join(root, 'app-0.5.0', 'wmux.exe'));
+    makeLnk(path.join(programs, 'someauthor', 'wmux.lnk'), path.join(root, 'wmux.exe'));
+
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([{ path: legacy, action: 'removed' }]);
+    expect(fs.existsSync(legacy)).toBe(false);
+  });
+
+  it('retargets (not removes) a dead legacy link when no publisher link exists', () => {
+    const legacy = loc.legacyLnks[0];
+    makeLnk(legacy, path.join(root, 'app-0.5.0', 'wmux.exe'));
+
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([{ path: legacy, action: 'retargeted' }]);
+    expect(fs.existsSync(legacy)).toBe(true);
+    expect(readLnk(legacy).target.toLowerCase()).toBe(path.join(root, 'wmux.exe').toLowerCase());
+  });
+
+  it('leaves healthy stub-targeted links and foreign shortcuts alone', () => {
+    const healthy = path.join(pinDir, 'wmux-good.lnk');
+    makeLnk(healthy, path.join(root, 'wmux.exe'));
+    const foreign = path.join(pinDir, 'other-app.lnk');
+    const foreignTarget = path.join(sandbox, 'other', 'other.exe');
+    fs.mkdirSync(path.dirname(foreignTarget), { recursive: true });
+    fs.writeFileSync(foreignTarget, 'x');
+    makeLnk(foreign, foreignTarget);
+
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([]);
+    expect(readLnk(foreign).target.toLowerCase()).toBe(foreignTarget.toLowerCase());
+  });
+
+  it('does nothing when the root stub is missing (burned root — nothing sane to point at)', () => {
+    fs.rmSync(path.join(root, 'wmux.exe'));
+    const pin = path.join(pinDir, 'wmux-pin.lnk');
+    makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe'));
+    expect(repairInstalledShortcuts(execPath, loc)).toEqual([]);
+    expect(readLnk(pin).target.toLowerCase()).toContain('app-0.9.0');
+  });
+
+  it('preserves the AppUserModelID across a retargeting Save()', () => {
+    // Stamp an AUMID on a fresh link via the shell property store, repair it,
+    // then read the AUMID back. This is the property the taskbar icon
+    // resolution hangs off — losing it would break pin grouping (#863).
+    const pin = path.join(pinDir, 'wmux-aumid.lnk');
+    makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe'));
+    ps([
+      `$code = @'`,
+      `using System;`,
+      `using System.Runtime.InteropServices;`,
+      `namespace H {`,
+      `  [StructLayout(LayoutKind.Sequential, Pack = 4)] public struct PROPERTYKEY { public Guid fmtid; public uint pid; }`,
+      `  [StructLayout(LayoutKind.Explicit)] public struct PROPVARIANT { [FieldOffset(0)] public ushort vt; [FieldOffset(8)] public IntPtr p; }`,
+      `  [ComImport, Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]`,
+      `  public interface IPropertyStore { void GetCount(out uint c); void GetAt(uint i, out PROPERTYKEY k); void GetValue(ref PROPERTYKEY k, ref PROPVARIANT v); void SetValue(ref PROPERTYKEY k, ref PROPVARIANT v); void Commit(); }`,
+      `  [ComImport, Guid("0000010b-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]`,
+      `  public interface IPersistFile { void GetClassID(out Guid p); [PreserveSig] int IsDirty(); void Load([MarshalAs(UnmanagedType.LPWStr)] string f, uint m); void Save([MarshalAs(UnmanagedType.LPWStr)] string f, [MarshalAs(UnmanagedType.Bool)] bool r); void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string f); void GetCurFile(out IntPtr p); }`,
+      `  [ComImport, Guid("00021401-0000-0000-C000-000000000046")]`,
+      `  public class ShellLink { }`,
+      `  public static class Api {`,
+      `    public static void SetAumid(string lnk, string aumid) {`,
+      `      object sl = new ShellLink();`,
+      `      ((IPersistFile)sl).Load(lnk, 2);`, // 2 = STGM_READWRITE — 0 loads a read-only store (STG_E_ACCESSDENIED on SetValue)
+      `      IPropertyStore store = (IPropertyStore)sl;`,
+      `      PROPERTYKEY k = new PROPERTYKEY { fmtid = new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"), pid = 5 };`,
+      `      PROPVARIANT v = new PROPVARIANT { vt = 31, p = Marshal.StringToCoTaskMemUni(aumid) };`,
+      `      store.SetValue(ref k, ref v);`,
+      `      store.Commit();`,
+      `      ((IPersistFile)sl).Save(lnk, true);`,
+      `      Marshal.ReleaseComObject(sl);`,
+      `    }`,
+      `  }`,
+      `}`,
+      `'@`,
+      `Add-Type -TypeDefinition $code`,
+      `[H.Api]::SetAumid('${pin}', 'com.squirrel.wmux.wmux')`,
+    ].join('\n'));
+
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
+
+    const aumid = ps([
+      `$sh = New-Object -ComObject Shell.Application`,
+      `$item = $sh.NameSpace('${pinDir}').ParseName('${path.basename(pin)}')`,
+      `$item.ExtendedProperty('System.AppUserModel.ID')`,
+    ].join('\n')).trim();
+    expect(aumid).toBe('com.squirrel.wmux.wmux');
+  });
+});
+
+describe.skipIf(!onWindows)('stageRootIcon', () => {
+  it('returns null when the packaged icon is missing, without touching the root', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hygiene-'));
+    try {
+      const appDir = path.join(sandbox, 'wmux', 'app-1.0.0');
+      fs.mkdirSync(appDir, { recursive: true });
+      const exec = path.join(appDir, 'wmux.exe');
+      fs.writeFileSync(exec, 'exe');
+      expect(stageRootIcon(exec)).toBeNull();
+      expect(fs.existsSync(path.join(sandbox, 'wmux', 'app.ico'))).toBe(false);
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/main/__tests__/shortcutHygiene.runtime.test.ts
+++ b/src/main/__tests__/shortcutHygiene.runtime.test.ts
@@ -23,19 +23,17 @@ function ps(script: string): string {
   );
 }
 
-function makeLnk(lnkPath: string, target: string, aumid?: string): void {
-  const aumidPart = aumid
-    ? `
-$bytes = [System.IO.File]::ReadAllBytes('${lnkPath}')
-# Set AUMID via Shell property store: re-open with Shell32 is heavyweight;
-# instead use the WshShortcut then stamp AUMID through the propsys COM route.
-`
-    : '';
-  void aumidPart;
+/** Single-quoted PS literal with the apostrophe doubled — same rule the module
+ *  under test uses, and required for the O'Connor sandbox below. */
+function q(p: string): string {
+  return `'${p.replace(/'/g, "''")}'`;
+}
+
+function makeLnk(lnkPath: string, target: string): void {
   ps([
     `$sh = New-Object -ComObject WScript.Shell`,
-    `$l = $sh.CreateShortcut('${lnkPath}')`,
-    `$l.TargetPath = '${target}'`,
+    `$l = $sh.CreateShortcut(${q(lnkPath)})`,
+    `$l.TargetPath = ${q(target)}`,
     `$l.Save()`,
   ].join('\n'));
 }
@@ -43,7 +41,7 @@ $bytes = [System.IO.File]::ReadAllBytes('${lnkPath}')
 function readLnk(lnkPath: string): { target: string; icon: string; workdir: string } {
   const out = ps([
     `$sh = New-Object -ComObject WScript.Shell`,
-    `$l = $sh.CreateShortcut('${lnkPath}')`,
+    `$l = $sh.CreateShortcut(${q(lnkPath)})`,
     `@{ target = $l.TargetPath; icon = $l.IconLocation; workdir = $l.WorkingDirectory } | ConvertTo-Json -Compress`,
   ].join('\n'));
   return JSON.parse(out.trim());
@@ -145,6 +143,78 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     expect(readLnk(foreign).target.toLowerCase()).toBe(foreignTarget.toLowerCase());
   });
 
+  it('leaves IconLocation empty when app.ico was never staged', () => {
+    // Regression guard: writing an IconLocation that resolves to nothing is
+    // exactly the #863 symptom. With no icon staged the link must fall back to
+    // the stub's embedded icon instead of pointing at a missing app.ico.
+    const pin = path.join(pinDir, 'wmux-pin.lnk');
+    makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe'));
+    expect(fs.existsSync(path.join(root, 'app.ico'))).toBe(false); // not staged
+
+    const actions = repairInstalledShortcuts(execPath, loc);
+    expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
+
+    const after = readLnk(pin);
+    expect(after.target.toLowerCase()).toBe(path.join(root, 'wmux.exe').toLowerCase());
+    expect(after.icon).toBe(',0'); // empty → shell resolves the target's icon
+  });
+
+  it('does not report a retarget it could not write to disk', () => {
+    // Save() on a read-only .lnk fails without flipping $?, so a naive
+    // implementation reports success for an edit that never landed. The caller
+    // (and the next person debugging a blank icon) would be misled.
+    const pin = path.join(pinDir, 'wmux-pin.lnk');
+    const deadTarget = path.join(root, 'app-0.9.0', 'wmux.exe');
+    makeLnk(pin, deadTarget);
+    fs.chmodSync(pin, 0o444);
+    ps(`Set-ItemProperty -LiteralPath ${q(pin)} -Name IsReadOnly -Value $true`);
+    try {
+      expect(repairInstalledShortcuts(execPath, loc)).toEqual([]);
+      expect(readLnk(pin).target.toLowerCase()).toBe(deadTarget.toLowerCase());
+    } finally {
+      ps(`Set-ItemProperty -LiteralPath ${q(pin)} -Name IsReadOnly -Value $false`);
+    }
+  });
+
+  it("repairs under a profile path containing an apostrophe and a dollar sign", () => {
+    // C:\Users\O'Connor and a folder named $app are legal Windows paths. An
+    // over-strict quoting guard would make the repair a silent no-op for those
+    // users — the same class of invisible failure this module removes.
+    const oddSandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-hyg-odd-')));
+    try {
+      const oddRoot = path.join(oddSandbox, "O'Connor $app", 'wmux');
+      const oddAppDir = path.join(oddRoot, 'app-1.0.0');
+      fs.mkdirSync(path.join(oddAppDir, 'resources'), { recursive: true });
+      fs.writeFileSync(path.join(oddRoot, 'wmux.exe'), 'stub');
+      const oddExec = path.join(oddAppDir, 'wmux.exe');
+      fs.writeFileSync(oddExec, 'exe');
+      fs.writeFileSync(path.join(oddAppDir, 'resources', 'icon.ico'), 'icon-bytes');
+
+      const oddPins = path.join(oddSandbox, "O'Connor $app", 'TaskBar');
+      const oddPrograms = path.join(oddSandbox, "O'Connor $app", 'Programs');
+      fs.mkdirSync(oddPins, { recursive: true });
+      fs.mkdirSync(oddPrograms, { recursive: true });
+      const oddLoc: RepairLocations = {
+        legacyLnks: [path.join(oddPrograms, 'wmux.lnk')],
+        pinDirs: [oddPins],
+        publisherLnk: path.join(oddPrograms, '*', 'wmux.lnk'),
+      };
+
+      const pin = path.join(oddPins, 'wmux-pin.lnk');
+      makeLnk(pin, path.join(oddRoot, 'app-0.9.0', 'wmux.exe'));
+      expect(stageRootIcon(oddExec)).toBe(path.join(oddRoot, 'app.ico'));
+
+      expect(repairInstalledShortcuts(oddExec, oddLoc)).toEqual([
+        { path: pin, action: 'retargeted' },
+      ]);
+      const after = readLnk(pin);
+      expect(after.target.toLowerCase()).toBe(path.join(oddRoot, 'wmux.exe').toLowerCase());
+      expect(after.icon.toLowerCase()).toBe(`${path.join(oddRoot, 'app.ico')},0`.toLowerCase());
+    } finally {
+      fs.rmSync(oddSandbox, { recursive: true, force: true });
+    }
+  });
+
   it('does nothing when the root stub is missing (burned root — nothing sane to point at)', () => {
     fs.rmSync(path.join(root, 'wmux.exe'));
     const pin = path.join(pinDir, 'wmux-pin.lnk');
@@ -188,7 +258,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
       `}`,
       `'@`,
       `Add-Type -TypeDefinition $code`,
-      `[H.Api]::SetAumid('${pin}', 'com.squirrel.wmux.wmux')`,
+      `[H.Api]::SetAumid(${q(pin)}, 'com.squirrel.wmux.wmux')`,
     ].join('\n'));
 
     const actions = repairInstalledShortcuts(execPath, loc);
@@ -196,7 +266,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
 
     const aumid = ps([
       `$sh = New-Object -ComObject Shell.Application`,
-      `$item = $sh.NameSpace('${pinDir}').ParseName('${path.basename(pin)}')`,
+      `$item = $sh.NameSpace(${q(pinDir)}).ParseName(${q(path.basename(pin))})`,
       `$item.ExtendedProperty('System.AppUserModel.ID')`,
     ].join('\n')).trim();
     expect(aumid).toBe('com.squirrel.wmux.wmux');

--- a/src/main/__tests__/shortcutHygiene.test.ts
+++ b/src/main/__tests__/shortcutHygiene.test.ts
@@ -3,6 +3,7 @@
 // build), and output parsing. The effectful end-to-end run against real .lnk
 // files lives in shortcutHygiene.runtime.test.ts.
 import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
 import {
   isSafePsPathLiteral,
   buildRepairScript,
@@ -53,7 +54,7 @@ describe('buildRepairScript', () => {
   });
 
   it('only ever repairs toward the root stub and app.ico', () => {
-    const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC)!;
+    const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC) ?? '';
     expect(s).toContain("Join-Path $root 'wmux.exe'");
     expect(s).toContain("Join-Path $root 'app.ico'");
     // Deletion is reserved for the legacy list; pins are never removed.
@@ -85,17 +86,20 @@ describe('parseRepairOutput', () => {
 });
 
 describe('defaultRepairLocations', () => {
+  // Expectations are composed with path.join, not literal backslashes: the
+  // helper joins with the HOST separator, so hardcoding '\' fails the
+  // cross-platform CI leg even though the code is Windows-only at runtime.
   it('derives every location from %APPDATA%', () => {
-    const loc = defaultRepairLocations('C:\\Users\\u\\AppData\\Roaming');
-    expect(loc.legacyLnks).toEqual([
-      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\wmux.lnk',
-    ]);
+    const appData = path.join('C:\\Users', 'u', 'AppData', 'Roaming');
+    const programs = path.join(appData, 'Microsoft', 'Windows', 'Start Menu', 'Programs');
+    const pinned = path.join(appData, 'Microsoft', 'Internet Explorer', 'Quick Launch', 'User Pinned');
+    const loc = defaultRepairLocations(appData);
+
+    expect(loc.legacyLnks).toEqual([path.join(programs, 'wmux.lnk')]);
     expect(loc.pinDirs).toEqual([
-      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar',
-      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\StartMenu',
+      path.join(pinned, 'TaskBar'),
+      path.join(pinned, 'StartMenu'),
     ]);
-    expect(loc.publisherLnk).toBe(
-      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\*\\wmux.lnk',
-    );
+    expect(loc.publisherLnk).toBe(path.join(programs, '*', 'wmux.lnk'));
   });
 });

--- a/src/main/__tests__/shortcutHygiene.test.ts
+++ b/src/main/__tests__/shortcutHygiene.test.ts
@@ -22,7 +22,14 @@ describe('isSafePsPathLiteral', () => {
     expect(isSafePsPathLiteral('C:\\Users\\a b\\AppData\\Local\\wmux')).toBe(true);
   });
 
-  it.each(["'", '"', '$', '`', '\n', '\r'])('refuses %j', (ch) => {
+  // These are legal Windows path characters. Rejecting them would silently
+  // disable the repair for real profiles (O'Connor) and folders named $app —
+  // the single-quoted PS literal handles all of them.
+  it.each(["'", '"', '$', '`'])('accepts the legal path character %j', (ch) => {
+    expect(isSafePsPathLiteral(`C:\\Users\\O${ch}Connor\\wmux`)).toBe(true);
+  });
+
+  it.each(['\n', '\r'])('refuses the line terminator %j', (ch) => {
     expect(isSafePsPathLiteral(`C:\\wmux${ch}x`)).toBe(false);
   });
 
@@ -43,14 +50,21 @@ describe('buildRepairScript', () => {
     expect(s).toContain("if (-not (Test-Path $stub)) { Write-Output '[]'; exit 0 }");
   });
 
-  it('refuses to build when any embedded path could escape its quoting', () => {
-    expect(buildRepairScript("C:\\wmux'x", LOC)).toBeNull();
+  it('doubles an embedded apostrophe rather than refusing the path', () => {
+    const s = buildRepairScript("C:\\Users\\O'Connor\\wmux", LOC);
+    expect(s).not.toBeNull();
+    expect(s).toContain("$root = 'C:\\Users\\O''Connor\\wmux'");
+    // A doubled apostrophe must never leave an odd number of quotes behind.
+    const quotes = (s ?? '').split("$root = ")[1].split('\n')[0];
+    expect((quotes.match(/'/g) ?? []).length % 2).toBe(0);
+  });
+
+  it('refuses to build only when a path carries a line terminator', () => {
+    expect(buildRepairScript('C:\\wmux\nx', LOC)).toBeNull();
     expect(
-      buildRepairScript('C:\\wmux', { ...LOC, legacyLnks: ["C:\\a'b\\wmux.lnk"] }),
+      buildRepairScript('C:\\wmux', { ...LOC, legacyLnks: ['C:\\a\rb\\wmux.lnk'] }),
     ).toBeNull();
-    expect(
-      buildRepairScript('C:\\wmux', { ...LOC, pinDirs: ['C:\\p$in'] }),
-    ).toBeNull();
+    expect(buildRepairScript('C:\\wmux', { ...LOC, pinDirs: ['C:\\p$in'] })).not.toBeNull();
   });
 
   it('only ever repairs toward the root stub and app.ico', () => {

--- a/src/main/__tests__/shortcutHygiene.test.ts
+++ b/src/main/__tests__/shortcutHygiene.test.ts
@@ -1,0 +1,101 @@
+// Pure-logic coverage for the #863 shortcut-hygiene pass: the PS-literal
+// safety guard, script construction (what gets embedded and what refuses to
+// build), and output parsing. The effectful end-to-end run against real .lnk
+// files lives in shortcutHygiene.runtime.test.ts.
+import { describe, it, expect } from 'vitest';
+import {
+  isSafePsPathLiteral,
+  buildRepairScript,
+  parseRepairOutput,
+  defaultRepairLocations,
+} from '../shortcutHygiene';
+
+const LOC = {
+  legacyLnks: ['C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\wmux.lnk'],
+  pinDirs: ['C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar'],
+  publisherLnk: 'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\*\\wmux.lnk',
+};
+
+describe('isSafePsPathLiteral', () => {
+  it('accepts ordinary Windows paths, including spaces', () => {
+    expect(isSafePsPathLiteral('C:\\Users\\a b\\AppData\\Local\\wmux')).toBe(true);
+  });
+
+  it.each(["'", '"', '$', '`', '\n', '\r'])('refuses %j', (ch) => {
+    expect(isSafePsPathLiteral(`C:\\wmux${ch}x`)).toBe(false);
+  });
+
+  it('refuses the empty string', () => {
+    expect(isSafePsPathLiteral('')).toBe(false);
+  });
+});
+
+describe('buildRepairScript', () => {
+  it('embeds root, legacy links, pin dirs, and the publisher wildcard', () => {
+    const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC);
+    expect(s).not.toBeNull();
+    expect(s).toContain("'C:\\Users\\u\\AppData\\Local\\wmux'");
+    expect(s).toContain(LOC.legacyLnks[0]);
+    expect(s).toContain(LOC.pinDirs[0]);
+    expect(s).toContain(LOC.publisherLnk);
+    // The no-stub bail-out must precede any mutation.
+    expect(s).toContain("if (-not (Test-Path $stub)) { Write-Output '[]'; exit 0 }");
+  });
+
+  it('refuses to build when any embedded path could escape its quoting', () => {
+    expect(buildRepairScript("C:\\wmux'x", LOC)).toBeNull();
+    expect(
+      buildRepairScript('C:\\wmux', { ...LOC, legacyLnks: ["C:\\a'b\\wmux.lnk"] }),
+    ).toBeNull();
+    expect(
+      buildRepairScript('C:\\wmux', { ...LOC, pinDirs: ['C:\\p$in'] }),
+    ).toBeNull();
+  });
+
+  it('only ever repairs toward the root stub and app.ico', () => {
+    const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC)!;
+    expect(s).toContain("Join-Path $root 'wmux.exe'");
+    expect(s).toContain("Join-Path $root 'app.ico'");
+    // Deletion is reserved for the legacy list; pins are never removed.
+    expect(s).toContain('$legacy -icontains $p');
+  });
+});
+
+describe('parseRepairOutput', () => {
+  it('parses an array of actions', () => {
+    expect(
+      parseRepairOutput('[{"path":"C:\\\\a.lnk","action":"retargeted"},{"path":"C:\\\\b.lnk","action":"removed"}]'),
+    ).toEqual([
+      { path: 'C:\\a.lnk', action: 'retargeted' },
+      { path: 'C:\\b.lnk', action: 'removed' },
+    ]);
+  });
+
+  it('accepts the bare-object form ConvertTo-Json emits for one item', () => {
+    expect(parseRepairOutput('{"path":"C:\\\\a.lnk","action":"retargeted"}')).toEqual([
+      { path: 'C:\\a.lnk', action: 'retargeted' },
+    ]);
+  });
+
+  it('returns [] on empty, non-JSON, or malformed rows', () => {
+    expect(parseRepairOutput('')).toEqual([]);
+    expect(parseRepairOutput('not json')).toEqual([]);
+    expect(parseRepairOutput('[{"path":1,"action":"retargeted"},{"action":"removed"},{"path":"x","action":"exploded"}]')).toEqual([]);
+  });
+});
+
+describe('defaultRepairLocations', () => {
+  it('derives every location from %APPDATA%', () => {
+    const loc = defaultRepairLocations('C:\\Users\\u\\AppData\\Roaming');
+    expect(loc.legacyLnks).toEqual([
+      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\wmux.lnk',
+    ]);
+    expect(loc.pinDirs).toEqual([
+      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\TaskBar',
+      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Internet Explorer\\Quick Launch\\User Pinned\\StartMenu',
+    ]);
+    expect(loc.publisherLnk).toBe(
+      'C:\\Users\\u\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\*\\wmux.lnk',
+    );
+  });
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -121,6 +121,7 @@ import { terminateRunningAppInstances } from './squirrelTeardown';
 // Squirrel events entirely (issue #463).
 import * as autostart from './autostart';
 import * as cliShim from './cliShim';
+import * as shortcutHygiene from './shortcutHygiene';
 import {
   refreshStatuslineScript,
   defaultPaths as defaultStatuslinePaths,
@@ -203,7 +204,16 @@ if (process.platform === 'win32') {
       // user PATH. Internally best-effort — never blocks the install.
       try { cliShim.installCliShim(process.execPath); } catch { /* best-effort */ }
 
-      spawn(updateExe, ['--createShortcut', target, '--shortcut-locations', 'Desktop,StartMenu'], { detached: true, windowsHide: true })
+      // #863: stage <root>\app.ico from the packaged icon (kills the iconUrl
+      // network dependency) and repair dead/versioned shortcuts carrying our
+      // AUMID before Update.exe writes the fresh ones. Both best-effort.
+      let installIcon: string | null = null;
+      try { installIcon = shortcutHygiene.stageRootIcon(process.execPath); } catch { /* best-effort */ }
+      try { shortcutHygiene.repairInstalledShortcuts(process.execPath); } catch { /* best-effort */ }
+
+      const installShortcutArgs = ['--createShortcut', target, '--shortcut-locations', 'Desktop,StartMenu'];
+      if (installIcon) installShortcutArgs.push('--icon', installIcon);
+      spawn(updateExe, installShortcutArgs, { detached: true, windowsHide: true })
         .on('close', () => {
           // Auto-launch app after install
           spawn(process.execPath, [], { detached: true, stdio: 'ignore', windowsHide: true }).unref();
@@ -220,7 +230,15 @@ if (process.platform === 'win32') {
       // which changes on every update.
       try { cliShim.installCliShim(process.execPath); } catch { /* best-effort */ }
 
-      spawn(updateExe, ['--createShortcut', target], { detached: true, windowsHide: true })
+      // #863: same shortcut hygiene as the install hook — an update is when
+      // versioned shortcut targets (old app-X.Y.Z paths) actually die.
+      let updateIcon: string | null = null;
+      try { updateIcon = shortcutHygiene.stageRootIcon(process.execPath); } catch { /* best-effort */ }
+      try { shortcutHygiene.repairInstalledShortcuts(process.execPath); } catch { /* best-effort */ }
+
+      const updateShortcutArgs = ['--createShortcut', target];
+      if (updateIcon) updateShortcutArgs.push('--icon', updateIcon);
+      spawn(updateExe, updateShortcutArgs, { detached: true, windowsHide: true })
         .on('close', () => {
           // #502: relaunch the updated app — the pre-update instance was
           // taken down above (or quit itself in the in-app "Restart to

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -204,17 +204,22 @@ if (process.platform === 'win32') {
       // user PATH. Internally best-effort — never blocks the install.
       try { cliShim.installCliShim(process.execPath); } catch { /* best-effort */ }
 
-      // #863: stage <root>\app.ico from the packaged icon (kills the iconUrl
-      // network dependency) and repair dead/versioned shortcuts carrying our
-      // AUMID before Update.exe writes the fresh ones. Both best-effort.
+      // #863: stage <root>\app.ico from the packaged icon so shortcut icons
+      // stop depending on Squirrel's iconUrl download. Best-effort.
       let installIcon: string | null = null;
       try { installIcon = shortcutHygiene.stageRootIcon(process.execPath); } catch { /* best-effort */ }
-      try { shortcutHygiene.repairInstalledShortcuts(process.execPath); } catch { /* best-effort */ }
 
       const installShortcutArgs = ['--createShortcut', target, '--shortcut-locations', 'Desktop,StartMenu'];
       if (installIcon) installShortcutArgs.push('--icon', installIcon);
       spawn(updateExe, installShortcutArgs, { detached: true, windowsHide: true })
         .on('close', () => {
+          // #863: repair leftover shortcuts AFTER Update.exe has written the
+          // canonical ones. Order matters: the legacy top-level Start Menu
+          // link is only deduped when the publisher-folder link exists, and on
+          // an install over a <=3.3.x layout that link does not exist until
+          // --createShortcut has run. Repairing first would retarget the legacy
+          // link instead of removing it and leave two Start Menu entries.
+          try { shortcutHygiene.repairInstalledShortcuts(process.execPath); } catch { /* best-effort */ }
           // Auto-launch app after install
           spawn(process.execPath, [], { detached: true, stdio: 'ignore', windowsHide: true }).unref();
           process.exit(0);
@@ -234,12 +239,14 @@ if (process.platform === 'win32') {
       // versioned shortcut targets (old app-X.Y.Z paths) actually die.
       let updateIcon: string | null = null;
       try { updateIcon = shortcutHygiene.stageRootIcon(process.execPath); } catch { /* best-effort */ }
-      try { shortcutHygiene.repairInstalledShortcuts(process.execPath); } catch { /* best-effort */ }
 
       const updateShortcutArgs = ['--createShortcut', target];
       if (updateIcon) updateShortcutArgs.push('--icon', updateIcon);
       spawn(updateExe, updateShortcutArgs, { detached: true, windowsHide: true })
         .on('close', () => {
+          // Repair after the canonical links are written — see the install
+          // branch for why the ordering is load-bearing.
+          try { shortcutHygiene.repairInstalledShortcuts(process.execPath); } catch { /* best-effort */ }
           // #502: relaunch the updated app — the pre-update instance was
           // taken down above (or quit itself in the in-app "Restart to
           // install" flow), and the single-instance lock dedupes if

--- a/src/main/shortcutHygiene.ts
+++ b/src/main/shortcutHygiene.ts
@@ -79,17 +79,23 @@ export interface RepairLocations {
 }
 
 /**
- * Paths are embedded in a single-quoted PowerShell literal. Refuse anything
- * that could escape the quoting instead of attempting to sanitize (the
- * squirrelTeardown rule). Windows paths never legitimately contain quotes,
- * newlines, `$` or backticks.
+ * Paths are embedded in a single-quoted PowerShell literal, where `$`, a
+ * backtick and `"` are all literal and an apostrophe is escaped by doubling
+ * (measured). So the only characters that can break out are the line
+ * terminators, which would split the statement-per-line script this module
+ * assembles.
+ *
+ * Rejecting more than that is not "extra safety" — it silently disables the
+ * repair for legitimate Windows profiles (`C:\Users\O'Connor\...`, a folder
+ * named `$app`), which is the failure mode this whole module exists to remove.
  */
 export function isSafePsPathLiteral(p: string): boolean {
-  return p.length > 0 && !/[\r\n'"$`]/.test(p);
+  return p.length > 0 && !/[\r\n]/.test(p);
 }
 
+/** Single-quoted PS literal; an embedded apostrophe is doubled. */
 function psQuote(p: string): string {
-  return `'${p}'`;
+  return `'${p.replace(/'/g, "''")}'`;
 }
 
 export function defaultRepairLocations(appData: string): RepairLocations {
@@ -128,7 +134,12 @@ export function buildRepairScript(rootDir: string, loc: RepairLocations): string
     `$root = ${psQuote(rootDir)}`,
     `$stub = Join-Path $root 'wmux.exe'`,
     `if (-not (Test-Path $stub)) { Write-Output '[]'; exit 0 }`,
+    // Only pin the icon when the file is actually there. Writing an
+    // IconLocation that resolves to nothing reproduces the very bug this pass
+    // exists to fix; with no icon staged, leaving IconLocation empty makes the
+    // shell fall back to the (version-stable) stub's embedded icon.
     `$icon = Join-Path $root 'app.ico'`,
+    `$haveIcon = Test-Path -LiteralPath $icon`,
     `$legacy = @(${legacyArray})`,
     `$cands = @() + $legacy`,
     `foreach ($d in @(${pinArray})) { if (Test-Path $d) { $cands += @(Get-ChildItem -LiteralPath $d -Filter *.lnk | ForEach-Object { $_.FullName }) } }`,
@@ -146,10 +157,17 @@ export function buildRepairScript(rootDir: string, loc: RepairLocations): string
     `  if ($dead -and $pubExists -and ($legacy -icontains $p)) { Remove-Item -LiteralPath $p -Force; $out += @{ path = $p; action = 'removed' }; continue }`,
     `  $l.TargetPath = $stub`,
     `  $l.WorkingDirectory = $root`,
-    `  $l.IconLocation = "$icon,0"`,
-    `  $l.Save()`,
+    `  if ($haveIcon) { $l.IconLocation = "$icon,0" }`,
+    // Save() on a read-only/locked .lnk fails WITHOUT setting $false on $? —
+    // measured — so only try/catch tells us whether the edit reached disk.
+    // Reporting a retarget that never happened would send the caller (and the
+    // next debugger of a blank icon) down the wrong path.
+    `  $saved = $true`,
+    `  try { $l.Save() } catch { $saved = $false }`,
+    `  if (-not $saved) { continue }`,
     `  $out += @{ path = $p; action = 'retargeted' }`,
     `}`,
+    `[System.Runtime.InteropServices.Marshal]::ReleaseComObject($sh) | Out-Null`,
     `ConvertTo-Json @($out) -Compress`,
   ].join('\n');
 }

--- a/src/main/shortcutHygiene.ts
+++ b/src/main/shortcutHygiene.ts
@@ -1,0 +1,229 @@
+/**
+ * Squirrel.Windows install-time shortcut hygiene (#863).
+ *
+ * Windows resolves a taskbar button's icon through the shortcut that carries
+ * the window's AppUserModelID (`com.squirrel.wmux.wmux`, set in index.ts) —
+ * NOT through the window or exe icon. One dead shortcut carrying that AUMID is
+ * therefore enough to blank the running app's taskbar icon even when the exe,
+ * the window icon, and every other shortcut are healthy. Verified A/B/A on a
+ * live install: removing the dead link fixed the icon, restoring it broke the
+ * icon again (issue #863).
+ *
+ * Two ways such dead links arise, both observed:
+ *
+ *  1. LEGACY layout — installs from <=3.3.x wrote the Start Menu link at
+ *     `Programs\wmux.lnk` (top level). Squirrel now writes
+ *     `Programs\<author>\wmux.lnk` and `--createShortcut` never revisits the
+ *     old location, so the legacy link survives every update pointing at an
+ *     `app-X.Y.Z` directory that no longer exists. Measured: one such link
+ *     survived three installs untouched (its target, app-3.3.0, was deleted
+ *     over a year of updates ago).
+ *
+ *  2. VERSIONED pins — pinning a running window records the live exe path
+ *     (`<root>\app-X.Y.Z\wmux.exe`) into the pin's .lnk. The next update
+ *     deletes that directory and the pin dies. Squirrel's own
+ *     fixPinnedExecutables did not repair these in practice (same measurement
+ *     as above).
+ *
+ * The repair is one PowerShell pass (the squirrelTeardown.ts pattern — hook
+ * processes already shell out to powershell.exe, and WScript.Shell edits are
+ * the one .lnk API available without native modules; measured to preserve the
+ * link's PropertyStore, including the AUMID, across Save()):
+ *
+ *   - candidates: the legacy top-level Start Menu link + every *.lnk in the
+ *     taskbar/Start "User Pinned" folders. Desktop and publisher-folder links
+ *     are NOT touched here — `Update.exe --createShortcut` owns and rewrites
+ *     those on every install/update.
+ *   - only links whose target lies under OUR install root are considered;
+ *     anything else is someone else's shortcut and is left alone.
+ *   - a link whose target is not the root stub (`<root>\wmux.exe`) is
+ *     retargeted to the stub, with the working dir set to the root and the
+ *     icon pinned to `<root>\app.ico` (version-independent on both axes).
+ *     Retargeting, not deletion, is the default: pinned items cannot be
+ *     re-created programmatically (Windows blocks pin automation), so a
+ *     deleted pin is unrecoverable while a repaired one keeps working.
+ *   - the one deletion: the LEGACY top-level link, when dead AND the
+ *     publisher-folder link exists — retargeting it would leave two identical
+ *     Start Menu entries forever.
+ *
+ * `stageRootIcon` covers the second half of #863: Squirrel materializes
+ * `<root>\app.ico` by DOWNLOADING the nuspec iconUrl (raw.githubusercontent.com)
+ * at install time, which fails on networks where that host is unreachable
+ * (observed from the issue reporter's region) — leaving shortcuts with no icon
+ * source at all. The same .ico already ships inside the package
+ * (`resources\icon.ico`, byte-identical), so the hook copies it into place and
+ * passes it to `--createShortcut --icon`, removing the network dependency.
+ *
+ * Everything here is best-effort and must never block the install: all entry
+ * points swallow failures and return what they managed to do (the
+ * squirrelTeardown contract).
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+export interface ShortcutRepairAction {
+  path: string;
+  action: 'retargeted' | 'removed';
+}
+
+/** Locations the repair pass reads. Overridable so tests use temp dirs. */
+export interface RepairLocations {
+  /** Explicit .lnk paths to examine (the legacy top-level link). */
+  legacyLnks: string[];
+  /** Directories whose *.lnk children are examined (pin folders). */
+  pinDirs: string[];
+  /** Publisher-folder link whose existence allows deleting a dead legacy link. */
+  publisherLnk: string;
+}
+
+/**
+ * Paths are embedded in a single-quoted PowerShell literal. Refuse anything
+ * that could escape the quoting instead of attempting to sanitize (the
+ * squirrelTeardown rule). Windows paths never legitimately contain quotes,
+ * newlines, `$` or backticks.
+ */
+export function isSafePsPathLiteral(p: string): boolean {
+  return p.length > 0 && !/[\r\n'"$`]/.test(p);
+}
+
+function psQuote(p: string): string {
+  return `'${p}'`;
+}
+
+export function defaultRepairLocations(appData: string): RepairLocations {
+  const programs = path.join(appData, 'Microsoft', 'Windows', 'Start Menu', 'Programs');
+  const pinned = path.join(appData, 'Microsoft', 'Internet Explorer', 'Quick Launch', 'User Pinned');
+  return {
+    legacyLnks: [path.join(programs, 'wmux.lnk')],
+    pinDirs: [path.join(pinned, 'TaskBar'), path.join(pinned, 'StartMenu')],
+    // Any one-level subfolder of Programs holding a wmux.lnk counts as the
+    // publisher link — the author name is Squirrel metadata, not ours to
+    // hardcode. Checked via wildcard inside the script.
+    publisherLnk: path.join(programs, '*', 'wmux.lnk'),
+  };
+}
+
+/**
+ * Build the repair script. Pure — exported for unit tests.
+ *
+ * The script's contract: examine each candidate .lnk; skip links whose target
+ * is missing/empty or not under `<root>\`; retarget the rest to the stub
+ * unless the target already IS the stub; delete (not retarget) a legacy link
+ * whose target is dead while a publisher link exists. Emits a compact JSON
+ * array of {path, action} — empty output means nothing needed repair.
+ */
+export function buildRepairScript(rootDir: string, loc: RepairLocations): string | null {
+  const paths = [rootDir, ...loc.legacyLnks, ...loc.pinDirs, loc.publisherLnk];
+  if (!paths.every(isSafePsPathLiteral)) return null;
+
+  const legacyArray = loc.legacyLnks.map(psQuote).join(', ');
+  const pinArray = loc.pinDirs.map(psQuote).join(', ');
+
+  // ASCII-only, single statement per line: this travels through execFileSync
+  // argv into powershell -Command.
+  return [
+    `$ErrorActionPreference = 'SilentlyContinue'`,
+    `$root = ${psQuote(rootDir)}`,
+    `$stub = Join-Path $root 'wmux.exe'`,
+    `if (-not (Test-Path $stub)) { Write-Output '[]'; exit 0 }`,
+    `$icon = Join-Path $root 'app.ico'`,
+    `$legacy = @(${legacyArray})`,
+    `$cands = @() + $legacy`,
+    `foreach ($d in @(${pinArray})) { if (Test-Path $d) { $cands += @(Get-ChildItem -LiteralPath $d -Filter *.lnk | ForEach-Object { $_.FullName }) } }`,
+    `$pubExists = @(Get-Item ${psQuote(loc.publisherLnk)}).Count -gt 0`,
+    `$sh = New-Object -ComObject WScript.Shell`,
+    `$out = @()`,
+    `foreach ($p in $cands) {`,
+    `  if (-not (Test-Path -LiteralPath $p)) { continue }`,
+    `  $l = $sh.CreateShortcut($p)`,
+    `  $t = $l.TargetPath`,
+    `  if (-not $t) { continue }`,
+    `  if (-not $t.StartsWith($root + '\\', [System.StringComparison]::OrdinalIgnoreCase)) { continue }`,
+    `  if ($t -ieq $stub) { continue }`,
+    `  $dead = -not (Test-Path -LiteralPath $t)`,
+    `  if ($dead -and $pubExists -and ($legacy -icontains $p)) { Remove-Item -LiteralPath $p -Force; $out += @{ path = $p; action = 'removed' }; continue }`,
+    `  $l.TargetPath = $stub`,
+    `  $l.WorkingDirectory = $root`,
+    `  $l.IconLocation = "$icon,0"`,
+    `  $l.Save()`,
+    `  $out += @{ path = $p; action = 'retargeted' }`,
+    `}`,
+    `ConvertTo-Json @($out) -Compress`,
+  ].join('\n');
+}
+
+/** Parse the script's JSON output. Tolerates empty/garbage (returns []). */
+export function parseRepairOutput(stdout: string): ShortcutRepairAction[] {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  const out: ShortcutRepairAction[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    if (typeof o.path !== 'string') continue;
+    if (o.action !== 'retargeted' && o.action !== 'removed') continue;
+    out.push({ path: o.path, action: o.action });
+  }
+  return out;
+}
+
+/** `<root>` from the hook process's own exe (`<root>\app-X.Y.Z\wmux.exe`). */
+function rootFromExecPath(execPath: string): string {
+  return path.resolve(path.dirname(execPath), '..');
+}
+
+/**
+ * Copy the packaged `resources\icon.ico` to `<root>\app.ico` so shortcut
+ * icons never depend on Squirrel's iconUrl download. Returns the staged path,
+ * or null when nothing could be staged (missing source — nothing to do).
+ */
+export function stageRootIcon(execPath: string): string | null {
+  try {
+    const src = path.join(path.dirname(execPath), 'resources', 'icon.ico');
+    if (!fs.existsSync(src)) return null;
+    const dest = path.join(rootFromExecPath(execPath), 'app.ico');
+    fs.copyFileSync(src, dest);
+    return dest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the repair pass. win32-only, best-effort, never throws — a hygiene
+ * failure must never block the install itself.
+ */
+export function repairInstalledShortcuts(
+  execPath: string,
+  locations?: RepairLocations,
+): ShortcutRepairAction[] {
+  if (process.platform !== 'win32') return [];
+  try {
+    const appData = process.env.APPDATA;
+    const loc = locations ?? (appData ? defaultRepairLocations(appData) : null);
+    if (!loc) return [];
+    const script = buildRepairScript(rootFromExecPath(execPath), loc);
+    if (!script) return [];
+    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+    const powershell = path.join(
+      systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+    );
+    const stdout = execFileSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      windowsHide: true,
+    });
+    return parseRepairOutput(stdout);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

Windows resolves a taskbar button's icon through the shortcut that carries the window's AppUserModelID (`com.squirrel.wmux.wmux`) — not through the window or exe icon. One dead shortcut carrying that AUMID is enough to blank the running app's taskbar icon while the exe, the window icon, and every other shortcut stay healthy.

Root-caused with an A/B/A experiment on a live install: a Start Menu link left behind by a <=3.3.x install (the old top-level `Programs\wmux.lnk` layout) still pointed at `app-3.3.0\`, a directory deleted many updates ago. Removing it and restarting fixed the icon; restoring it broke the icon again. That legacy link had survived three installs untouched — `--createShortcut` only writes the Desktop and `Programs\<author>\` links, and Squirrel's own `fixPinnedExecutables` did not repair it either.

The same mechanism covers the reported repro (pin while running → update → blank pin): pinning a running window records the live `app-X.Y.Z` exe path into the pin's `.lnk`, and the next update deletes that directory.

## Fix

The `--squirrel-install` / `--squirrel-updated` hooks now run a shortcut-hygiene pass (best-effort, never blocks the install):

- **Repair, don't delete.** Links whose target lies under our install root but is not the version-stable root stub (`<root>\wmux.exe`) are retargeted to the stub with the icon pinned to `<root>\app.ico`. Pins cannot be re-created programmatically (Windows blocks pin automation), so a repaired pin keeps working where a deleted one is unrecoverable. Scope: the legacy top-level Start Menu link + the `User Pinned` folders; Desktop/publisher links stay owned by `Update.exe --createShortcut`.
- **One deletion:** the legacy top-level link, when dead and duplicated by the publisher-folder link — retargeting it would leave two identical Start Menu entries forever.
- **Kill the icon's network dependency.** Squirrel materializes `<root>\app.ico` by downloading the nuspec `iconUrl` (raw.githubusercontent.com) at install time — unreachable from some networks, including the reporter's region, leaving no icon source at all. The byte-identical `.ico` already ships in the package (`resources\icon.ico`), so the hooks stage it to `<root>\app.ico` and pass it to `--createShortcut --icon`.
- Foreign shortcuts (target outside our root) are never touched; a burned root (missing stub) disables the pass entirely.

WScript.Shell `Save()` was measured to preserve the link's property store, including the AUMID — the repair does not break pin grouping.

## Testing

- `vitest run src/main/__tests__/shortcutHygiene.test.ts` — 15 passed (script construction, PS-literal injection guard, output parsing)
- `vitest run --config vitest.runtime.config.ts src/main/__tests__/shortcutHygiene.runtime.test.ts` — 8 passed, end-to-end against **real `.lnk` files** via real PowerShell/COM: dead-pin retarget, live-but-versioned retarget, legacy dedupe/retarget both ways, foreign-shortcut isolation, burned-root bail-out, and AUMID preservation across `Save()`
- `vitest run src/main/__tests__/squirrel*.test.ts` — 37 passed (hook wiring semantics untouched)
- `tsc --noEmit` clean; eslint adds no new findings on touched files

Not covered here (tracked separately): the in-app updater launches `Setup.exe` before `app.quit()` completes, which can race Squirrel's install-root wipe against live file locks — reproduced and logged during this investigation, filing as its own issue.

Closes #863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale Windows shortcuts that could cause blank taskbar icons after updates.
  * Existing shortcuts are now repaired or removed when necessary while preserving healthy shortcuts.
  * Installer updates now use the packaged application icon instead of downloading one externally.
* **Chores**
  * Added Windows-specific validation for shortcut repair, icon handling, and installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->