### PR TITLE
test(installer): stop the shortcut-hygiene runtime suite timing out on CI

### DIFF
--- a/src/main/__tests__/shortcutHygiene.runtime.test.ts
+++ b/src/main/__tests__/shortcutHygiene.runtime.test.ts
@@ -5,7 +5,7 @@
 // that the legacy Start Menu link is deduped rather than retargeted, that
 // foreign shortcuts are untouched, and that Save() preserves the link's
 // AppUserModelID (the property Windows resolves the taskbar icon through).
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -13,6 +13,15 @@ import { execFileSync } from 'node:child_process';
 import { repairInstalledShortcuts, stageRootIcon, type RepairLocations } from '../shortcutHygiene';
 
 const onWindows = process.platform === 'win32';
+
+// Every test here spawns real powershell.exe and drives real COM, and one of
+// them compiles C# through Add-Type. On this developer machine that test runs
+// in ~1.7 s, so the 5 s default looked fine — on a cold CI runner the csc
+// invocation alone blew past it and turned main red after the change had
+// already merged green. The work is IO-bound and machine-dependent, so it gets
+// a ceiling that reflects the slowest realistic runner rather than the fastest
+// laptop. A genuine hang still fails, just later.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 60_000 });
 
 function ps(script: string): string {
   const systemRoot = process.env.SystemRoot || 'C:\\Windows';


### PR DESCRIPTION
## Summary

`main` went red right after #865 merged. The failure is mine, and it is a test defect rather than a product one:

```
FAIL src/main/__tests__/shortcutHygiene.runtime.test.ts
  > preserves the AppUserModelID across a retargeting Save()
  Error: Test timed out in 5000ms
```

Every test in that file spawns real `powershell.exe` and drives real COM, and the AUMID one compiles C# through `Add-Type`. None of them declared a timeout, so they all inherited vitest's 5 s default. On the machine they were written on the slowest took ~1.7 s, and the PR run passed, so the margin never showed up — until a cold runner where the `csc` invocation alone exceeded the budget.

The work is IO-bound and machine-dependent, so a 5 s bound was not measuring anything useful in the first place. This raises the file's ceiling to something the slowest realistic runner can meet. A genuine hang still fails the suite, just later.

## Testing

- `vitest run --config vitest.runtime.config.ts src/main/__tests__/shortcutHygiene.runtime.test.ts` — 11 passed, 13.9 s total
- `tsc --noEmit` clean

Note this only touches the test file; the shipped behaviour from #865 is unchanged, and 3.41.0 (already tagged) is unaffected.
