### PR TITLE
fix(updater): start the Windows installer against a dead tree

### DIFF
--- a/changelog.d/869.md
+++ b/changelog.d/869.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **Running the Windows installer while wmux is open can no longer destroy the
+  installation.** Squirrel's `Setup.exe` deletes the whole install folder as its
+  first step, and wmux used to start it without waiting to actually exit. With
+  the app fully up its loaded libraries are locked, the delete fails outright,
+  and the install stops half-finished — leaving blank shortcut icons and no
+  launcher to retry from. The installer is now started by a helper that waits
+  until nothing is using the folder any more, and refuses to start it at all if
+  something still is, so a failed update leaves your working version alone
+  instead of a broken one. The normal in-app update was not affected by this;
+  the failure needed the app to be fully running, as it is when the installer is
+  launched by hand. (#866)
+
+- **A failed update now says so.** If the installer could not be started safely,
+  wmux reports it the next time it opens instead of leaving you on the old
+  version with no explanation. (#866)
+
+### Changed
+
+- **Installing an update on Windows now ends running sessions, and says so
+  before you press the button.** The daemon holds the install folder open, so it
+  has to go down for the installer to run. The update panel previously implied
+  the opposite. (#866)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,6 +91,7 @@ import { setConfiguredFirstPartyClients } from './mcp/firstParty';
 import { readConfiguredFirstPartyClients } from './mcp/firstPartyConfig';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
+import { readDaemonPid } from './updater/installTeardown';
 import { McpRegistrar } from './mcp/McpRegistrar';
 import { BrokerSupervisor, isMcpBrokerEnabled } from './mcp/BrokerSupervisor';
 import { WebviewCdpManager } from './browser-session/WebviewCdpManager';
@@ -404,6 +405,11 @@ const ptyBridge = new PTYBridge(ptyManager, () => mainWindow, () => hookSignalRo
 const autoUpdater = new AutoUpdater(() => mainWindow, {
   onBeforeInstallQuit: () => prepareInstallQuit(),
   onInstallQuitAborted: () => abortInstallQuit(),
+  // #866: the Windows installer deletes the install root, and the daemon runs
+  // out of it. Flip the same flag the tray's "Shut down wmux" item uses so
+  // before-quit takes the daemon.shutdown branch instead of detaching.
+  onInstallRequiresFullShutdown: () => { fullShutdownRequested = true; },
+  getDaemonPid: () => readDaemonPid(getWmuxDir()),
 });
 
 const rpcRouter = new RpcRouter();

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -65,10 +65,6 @@ const INSTALL_STAGING_HEADROOM_BYTES = 200 * 1024 * 1024;
 // can hold files for a while, and waiting is free while refusing costs the user
 // their update.
 const INSTALL_LOCK_BUDGET_MS = 60_000;
-// The refused-install notice waits for the renderer to attach its update
-// listeners. Sending it at boot would drop it into a window that is not
-// listening yet, which is indistinguishable from never reporting at all.
-const REFUSED_INSTALL_NOTICE_DELAY_MS = 5_000;
 // Squirrel downloading and unpacking a ~120 MB bundle before it reports
 // 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
 // makes this minutes, and aborting a healthy update is worse than waiting.
@@ -177,6 +173,14 @@ export class AutoUpdater {
   constructor(getWindow: () => BrowserWindow | null, hooks: AutoUpdaterHooks) {
     this.getWindow = getWindow;
     this.hooks = hooks;
+    // #866. Registered HERE, not in start(): start() runs at the end of the
+    // ready sequence, which waits on the daemon bootstrap — measured at 39s on
+    // a cold boot. The renderer mounts and asks for a refused install at
+    // ~0.7s, so a handler registered in start() is not there yet and the
+    // invoke rejects with "no handler registered", which is how this notice
+    // silently went missing in live dogfood. The constructor runs during
+    // module evaluation, before the window exists at all.
+    ipcMain.handle(IPC.UPDATE_TAKE_REFUSED_INSTALL, () => this.takeRefusedInstall());
   }
 
   start(): void {
@@ -197,12 +201,12 @@ export class AutoUpdater {
     void this.sweepStaleArtifacts();
 
     // #866: if the last install was refused because the install root never
-    // cleared, the waiter left a marker instead of running Setup.exe. Say so.
-    // Without this the user pressed "Restart to install", watched wmux quit and
-    // come back on the SAME version, and has nothing to go on — which is how
-    // this class of failure stays invisible until someone files a bug about
-    // icons instead.
-    this.reportRefusedInstall();
+    // cleared, the waiter left a marker instead of running Setup.exe. The
+    // renderer TAKES that reason once it is mounted (UPDATE_TAKE_REFUSED_INSTALL,
+    // registered above) — main does not push it here. Without the notice the
+    // user pressed "Restart to install", watched wmux quit and come back on
+    // the SAME version, and has nothing to go on, which is how this class of
+    // failure stays invisible until someone files a bug about icons instead.
 
     // 앱 시작 후 15초 뒤 첫 번째 확인 (시작 부하 방지)
     setTimeout(() => this.check(), 15_000);
@@ -212,30 +216,28 @@ export class AutoUpdater {
   }
 
   /**
-   * Surface a refused install from the previous run, once (#866).
+   * Hand a refused install's reason to the renderer, once (#866).
    *
-   * Reading the marker CLEARS it, so the notice appears on the boot right after
-   * the refusal and never again — a sticky warning about a since-succeeded
-   * update would be worse than none. Deliberately delayed a few seconds so the
-   * renderer has attached its update listeners; an UPDATE_ERROR sent into a
-   * window that is not listening yet is the same as not sending it.
+   * PULL, not push. Pushing this on a timer at boot assumed a listener was
+   * attached by then; the only listener lived in the Settings panel, which is
+   * mounted only while the user has Settings OPEN. With Settings closed — the
+   * default — the notice went nowhere AND the marker was cleared anyway, so
+   * the refusal stayed exactly as invisible as before this feature existed.
+   *
+   * The renderer therefore asks when it is mounted and can show something.
+   * Taking the reason is what clears the marker, so a notice that was never
+   * collected (renderer crashed, window closed early) survives to the next
+   * boot rather than being consumed by the attempt to deliver it. Once taken
+   * it does not come back: a sticky warning about a since-succeeded update
+   * would be worse than none.
    */
-  private reportRefusedInstall(): void {
+  private takeRefusedInstall(): string | null {
     const markerPath = join(app.getPath('userData'), INSTALL_ABORT_MARKER);
     const reason = readAbortMarker(markerPath);
-    if (!reason) return;
+    if (!reason) return null;
     console.warn(`[AutoUpdater] previous install was refused: ${reason}`);
-    setTimeout(() => {
-      this.sendToRenderer(IPC.UPDATE_ERROR, {
-        status: 'error',
-        message:
-          'The last update did not install: something was still using the wmux install folder, so it was left untouched rather than half-replaced. Try again, or close wmux and run the installer from the releases page.',
-      });
-      // Cleared only now. Clearing on read would lose the refusal entirely if
-      // the app went away inside this delay — and the whole point of the marker
-      // is that the failure stops being invisible.
-      clearAbortMarker(markerPath);
-    }, REFUSED_INSTALL_NOTICE_DELAY_MS);
+    clearAbortMarker(markerPath);
+    return reason;
   }
 
   /**
@@ -556,6 +558,7 @@ export class AutoUpdater {
     ipcMain.on(IPC.AUTO_UPDATE_ENABLED, (_event, enabled: boolean) => {
       this.setEnabled(enabled);
     });
+
 
     ipcMain.handle(IPC.UPDATE_CHECK, async () => {
       if (process.env.NODE_ENV === 'development' || !isUpdaterSupported) {

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -21,7 +21,9 @@ import { isAllowedDownloadUrl, digestsEqual, validateManifest, type UpdateManife
 import { LocalUpdateFeed } from './LocalUpdateFeed';
 import {
   collectInstallRootPids,
+  consumeAbortMarker,
   freeSpaceShortfall,
+  INSTALL_ABORT_MARKER,
   probeVolume,
   spawnInstallWaiter,
   terminatePids,
@@ -62,8 +64,10 @@ const INSTALL_STAGING_HEADROOM_BYTES = 200 * 1024 * 1024;
 // can hold files for a while, and waiting is free while refusing costs the user
 // their update.
 const INSTALL_LOCK_BUDGET_MS = 60_000;
-/** Written by the waiter when it refuses to launch; read on the next boot. */
-const INSTALL_ABORT_MARKER = 'update-install-aborted.txt';
+// The refused-install notice waits for the renderer to attach its update
+// listeners. Sending it at boot would drop it into a window that is not
+// listening yet, which is indistinguishable from never reporting at all.
+const REFUSED_INSTALL_NOTICE_DELAY_MS = 5_000;
 // Squirrel downloading and unpacking a ~120 MB bundle before it reports
 // 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
 // makes this minutes, and aborting a healthy update is worse than waiting.
@@ -191,11 +195,42 @@ export class AutoUpdater {
 
     void this.sweepStaleArtifacts();
 
+    // #866: if the last install was refused because the install root never
+    // cleared, the waiter left a marker instead of running Setup.exe. Say so.
+    // Without this the user pressed "Restart to install", watched wmux quit and
+    // come back on the SAME version, and has nothing to go on — which is how
+    // this class of failure stays invisible until someone files a bug about
+    // icons instead.
+    this.reportRefusedInstall();
+
     // 앱 시작 후 15초 뒤 첫 번째 확인 (시작 부하 방지)
     setTimeout(() => this.check(), 15_000);
 
     // 이후 주기적 확인
     this.checkTimer = setInterval(() => this.check(), CHECK_INTERVAL_MS);
+  }
+
+  /**
+   * Surface a refused install from the previous run, once (#866).
+   *
+   * Reading the marker CLEARS it, so the notice appears on the boot right after
+   * the refusal and never again — a sticky warning about a since-succeeded
+   * update would be worse than none. Deliberately delayed a few seconds so the
+   * renderer has attached its update listeners; an UPDATE_ERROR sent into a
+   * window that is not listening yet is the same as not sending it.
+   */
+  private reportRefusedInstall(): void {
+    const markerPath = join(app.getPath('userData'), INSTALL_ABORT_MARKER);
+    const reason = consumeAbortMarker(markerPath);
+    if (!reason) return;
+    console.warn(`[AutoUpdater] previous install was refused: ${reason}`);
+    setTimeout(() => {
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message:
+          'The last update did not install: something was still using the wmux install folder, so it was left untouched rather than half-replaced. Try again, or close wmux and run the installer from the releases page.',
+      });
+    }, REFUSED_INSTALL_NOTICE_DELAY_MS);
   }
 
   /**

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -21,10 +21,11 @@ import { isAllowedDownloadUrl, digestsEqual, validateManifest, type UpdateManife
 import { LocalUpdateFeed } from './LocalUpdateFeed';
 import {
   collectInstallRootPids,
-  consumeAbortMarker,
+  clearAbortMarker,
   freeSpaceShortfall,
   INSTALL_ABORT_MARKER,
   probeVolume,
+  readAbortMarker,
   spawnInstallWaiter,
   terminatePids,
 } from './installTeardown';
@@ -221,7 +222,7 @@ export class AutoUpdater {
    */
   private reportRefusedInstall(): void {
     const markerPath = join(app.getPath('userData'), INSTALL_ABORT_MARKER);
-    const reason = consumeAbortMarker(markerPath);
+    const reason = readAbortMarker(markerPath);
     if (!reason) return;
     console.warn(`[AutoUpdater] previous install was refused: ${reason}`);
     setTimeout(() => {
@@ -230,6 +231,10 @@ export class AutoUpdater {
         message:
           'The last update did not install: something was still using the wmux install folder, so it was left untouched rather than half-replaced. Try again, or close wmux and run the installer from the releases page.',
       });
+      // Cleared only now. Clearing on read would lose the refusal entirely if
+      // the app went away inside this delay — and the whole point of the marker
+      // is that the failure stops being invisible.
+      clearAbortMarker(markerPath);
     }, REFUSED_INSTALL_NOTICE_DELAY_MS);
   }
 
@@ -691,12 +696,18 @@ export class AutoUpdater {
     const daemonPid = this.hooks.getDaemonPid();
     const forceKillPids = pids.filter((p) => p !== daemonPid);
 
-    // Ask for the daemon to actually go down on this quit, then take down the
-    // processes nothing else owns (the MCP servers belong to agent hosts, not
-    // to us, so a quit leaves them holding the tree open forever).
-    this.hooks.onInstallRequiresFullShutdown();
-    const killed = terminatePids(forceKillPids);
-
+    // ORDER MATTERS, and it is the reverse of the obvious one.
+    //
+    // The waiter starts FIRST, while everything is still alive: it captures a
+    // handle per pid up front, so it observes the processes we are about to end.
+    // Only once it exists do we mutate anything.
+    //
+    // Doing it the other way round leaves wreckage on the failure path. Both
+    // `onInstallRequiresFullShutdown` (a one-way latch — a later ordinary Quit
+    // would then tear the daemon down and close every session) and the
+    // force-kill are irreversible; if the waiter then failed to spawn we would
+    // have killed the user's agent tooling and armed a destructive quit for an
+    // install that never happened.
     const waiterPath = spawnInstallWaiter({
       pids,
       setupExePath: tempPath,
@@ -706,7 +717,8 @@ export class AutoUpdater {
     });
     if (!waiterPath) {
       // No waiter means no safe way to start the installer. Falling back to
-      // launching it directly is exactly the bug — refuse instead.
+      // launching it directly is exactly the bug — refuse instead, with nothing
+      // killed and no quit state armed.
       this.isInstalling = false;
       this.sendToRenderer(IPC.UPDATE_ERROR, {
         status: 'error',
@@ -714,6 +726,12 @@ export class AutoUpdater {
       });
       return;
     }
+
+    // Committed now: bring the daemon down gracefully (it flushes scrollback)
+    // and force-kill what nothing else owns — the MCP servers belong to agent
+    // hosts, so a quit leaves them holding the tree open forever.
+    this.hooks.onInstallRequiresFullShutdown();
+    const killed = terminatePids(forceKillPids);
 
     // Which path ran, and against what — the first question anyone asks when an
     // update goes wrong, and the log is the only place to answer it from.

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -14,11 +14,18 @@
 import { autoUpdater, app, type BrowserWindow, ipcMain, net, shell } from 'electron';
 import { createWriteStream } from 'node:fs';
 import { readdir, stat, unlink } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { IPC } from '../../shared/constants';
 import { isAllowedDownloadUrl, digestsEqual, validateManifest, type UpdateManifest } from './verifyUpdate';
 import { LocalUpdateFeed } from './LocalUpdateFeed';
+import {
+  collectInstallRootPids,
+  freeSpaceShortfall,
+  probeVolume,
+  spawnInstallWaiter,
+  terminatePids,
+} from './installTeardown';
 
 const REPO = 'openwong2kim/wmux';
 // update.electronjs.org keys releases by platform-arch. Only the two arches we
@@ -40,6 +47,23 @@ const CHECK_INTERVAL_MS = 30 * 60 * 1000;
 // waiting on a process that will never die — unwind instead of leaving the UI
 // silent forever (#update-hang).
 const INSTALL_HANDOFF_TIMEOUT_MS = 30_000;
+
+// #866 install-teardown budgets. The size figures come from a real 3.40.2
+// install: the expanded app directory is ~361 MB and Squirrel's package cache
+// holds a ~143 MB nupkg, so a clean install needs roughly 500 MB in the root.
+// Setup.exe additionally unpacks its embedded nupkg into SquirrelTemp on the
+// staging volume. Both are rounded up: refusing an update that would have just
+// fit costs the user a retry, while running out of room mid-install is the
+// half-deleted installation this whole change exists to prevent.
+const INSTALL_ROOT_HEADROOM_BYTES = 700 * 1024 * 1024;
+const INSTALL_STAGING_HEADROOM_BYTES = 200 * 1024 * 1024;
+// How long the waiter keeps re-checking the install root for locks before it
+// refuses. Generous on purpose: a daemon flushing large RingBuffers on shutdown
+// can hold files for a while, and waiting is free while refusing costs the user
+// their update.
+const INSTALL_LOCK_BUDGET_MS = 60_000;
+/** Written by the waiter when it refuses to launch; read on the next boot. */
+const INSTALL_ABORT_MARKER = 'update-install-aborted.txt';
 // Squirrel downloading and unpacking a ~120 MB bundle before it reports
 // 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
 // makes this minutes, and aborting a healthy update is worse than waiting.
@@ -98,6 +122,31 @@ export interface AutoUpdaterHooks {
    * that has not attached its listeners yet.
    */
   onInstallQuitAborted: () => void | Promise<void>;
+  /**
+   * Windows install path only (#866). Ask the main process to take the FULL
+   * shutdown branch on the coming quit — daemon.shutdown with the pid-kill
+   * backstop — instead of the default detach.
+   *
+   * Detaching is right for a normal quit and wrong here: the daemon runs out of
+   * `<root>\app-X.Y.Z\wmux.exe`, so leaving it alive means the installer can
+   * never delete the directory it has to replace. Sessions do not survive this
+   * install; that is the cost of the install completing at all.
+   */
+  onInstallRequiresFullShutdown: () => void;
+  /**
+   * The daemon's pid, or null when it cannot be determined.
+   *
+   * Injected rather than read here so this module stays free of the daemon
+   * config import: pulling `daemon/config` into the updater crashed the
+   * electron-mocked unit tests at module load, and the updater has no other
+   * reason to know where `~/.wmux` lives.
+   *
+   * Used only to EXCLUDE the daemon from the force-kill list — it gets the
+   * graceful shutdown so it can flush scrollback. A null therefore fails safe:
+   * the daemon is force-killed like anything else, costing a flush but not the
+   * install.
+   */
+  getDaemonPid: () => number | null;
 }
 
 export class AutoUpdater {
@@ -542,24 +591,107 @@ export class AutoUpdater {
       return;
     }
 
-    // Download + SHA-256 verify happened during detection (downloadUpdate); we
-    // never launch an unverified artifact.
-    const openErr = await shell.openPath(tempPath);
-    if (openErr) {
-      this.isInstalling = false; // launch failed — allow the user to retry
+    // #866 — Setup.exe is a first-INSTALL program, not an updater: its first
+    // action is a recursive delete of the whole install root. Launching it from
+    // here and quitting afterwards (what this function used to do) starts that
+    // delete while our own processes still hold the tree open, the delete
+    // throws, and the install aborts with the root already half-gone: no
+    // Update.exe, no stub, no launcher to retry from.
+    //
+    // That is not a race a faster quit could win. `app.quit()` takes the DETACH
+    // branch, which keeps the daemon alive by design, and the daemon's process
+    // image IS `<root>\app-X.Y.Z\wmux.exe`. A running image cannot be unlinked
+    // on Windows, so the delete is guaranteed to fail while it runs.
+    //
+    // So the installer is now started by a detached waiter that only proceeds
+    // once every process under the install root is confirmed gone AND the root
+    // is confirmed unlocked. See installTeardown.ts for why both checks are
+    // needed (the pid list cannot close the window in which an agent's MCP host
+    // spawns a fresh server into the directory we are about to delete).
+    // Packaged-only, and the guard is load-bearing rather than cosmetic. The
+    // teardown derives BOTH the image name and the install root from
+    // `process.execPath`; in an unpackaged run that is the node/electron binary,
+    // so the enumerate-and-kill would target unrelated processes that happen to
+    // live under the runtime's directory. (Caught by the unit suite, which lost
+    // its own worker to exactly that.) A dev build has no Squirrel install to
+    // update anyway.
+    if (!app.isPackaged) {
+      this.isInstalling = false;
       this.sendToRenderer(IPC.UPDATE_ERROR, {
         status: 'error',
-        message: `failed to launch verified installer: ${openErr}`,
+        message: 'In-app install is only available in an installed build. Download the latest release manually.',
       });
       return;
     }
-    // #502: Squirrel's installer crashes when it runs against a live instance
-    // (locked old-version files + a single-instance collision on the
-    // post-install relaunch). "Restart to install" means restart: quit NOW — a
-    // normal quit only detaches, so the daemon and every live session persist —
-    // and the --squirrel-updated/-install hook relaunches the updated app once
-    // the install completes.
-    console.log('[AutoUpdater] Installer launched — quitting so Squirrel can install (sessions persist in the daemon)');
+
+    const installRoot = resolve(dirname(process.execPath), '..');
+    const abortMarkerPath = join(app.getPath('userData'), INSTALL_ABORT_MARKER);
+
+    // Pre-flight: refuse BEFORE anything is written rather than dying halfway.
+    // Budgeted per volume — the staging download and the install root can live
+    // on different disks, so one aggregate number would be meaningless.
+    const shortfall = freeSpaceShortfall(
+      [
+        { dir: dirname(tempPath), neededBytes: INSTALL_STAGING_HEADROOM_BYTES },
+        { dir: installRoot, neededBytes: INSTALL_ROOT_HEADROOM_BYTES },
+      ],
+      probeVolume,
+    );
+    if (shortfall) {
+      this.isInstalling = false;
+      const needMb = Math.ceil(shortfall.neededBytes / 1024 / 1024);
+      const freeMb = Math.floor(shortfall.freeBytes / 1024 / 1024);
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: `Not enough free space on ${shortfall.volume} to install safely: ${needMb} MB needed, ${freeMb} MB free. Nothing was changed.`,
+      });
+      return;
+    }
+
+    // Everything running out of the install root, minus ourselves. The daemon
+    // is in here too: it is handed to the waiter so the installer waits for its
+    // graceful shutdown to finish, but it is NOT force-killed below — the full
+    // shutdown branch flushes its scrollback first.
+    const pids = collectInstallRootPids(installRoot);
+    const daemonPid = this.hooks.getDaemonPid();
+    const forceKillPids = pids.filter((p) => p !== daemonPid);
+
+    // Ask for the daemon to actually go down on this quit, then take down the
+    // processes nothing else owns (the MCP servers belong to agent hosts, not
+    // to us, so a quit leaves them holding the tree open forever).
+    this.hooks.onInstallRequiresFullShutdown();
+    const killed = terminatePids(forceKillPids);
+
+    const waiterPath = spawnInstallWaiter({
+      pids,
+      setupExePath: tempPath,
+      installRoot,
+      abortMarkerPath,
+      lockBudgetMs: INSTALL_LOCK_BUDGET_MS,
+    });
+    if (!waiterPath) {
+      // No waiter means no safe way to start the installer. Falling back to
+      // launching it directly is exactly the bug — refuse instead.
+      this.isInstalling = false;
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: 'Could not prepare the installer safely. The update was not started and your installation is unchanged.',
+      });
+      return;
+    }
+
+    // Which path ran, and against what — the first question anyone asks when an
+    // update goes wrong, and the log is the only place to answer it from.
+    console.log(
+      `[AutoUpdater] install handoff: waiter=${waiterPath} watching ${pids.length} process(es) under ${installRoot}; ` +
+      `force-killed ${killed.length}/${forceKillPids.length}, daemon pid ${daemonPid ?? 'unknown'} left to the graceful shutdown`,
+    );
+
+    // Sessions do NOT survive this install. The daemon holds the install root
+    // open, so it has to go down before Setup.exe can run — the old
+    // "sessions persist in the daemon" line was false on this path and is the
+    // reason the failure looked so surprising.
+    console.log('[AutoUpdater] quitting for install — the daemon goes down with us so the installer runs against a dead tree');
     app.quit();
   }
 

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -132,7 +132,8 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
     readDaemonPid: vi.fn((): number | null => 4243),
     // Boot-time refused-install notice: default to "nothing to report" so it
     // never leaks an UPDATE_ERROR into tests about other flows.
-    consumeAbortMarker: vi.fn((): string | null => null),
+    readAbortMarker: vi.fn((): string | null => null),
+    clearAbortMarker: vi.fn(),
     INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
   };
   vi.doMock('../installTeardown', () => teardown);

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -15,7 +15,12 @@ const GOOD_SHA = createHash('sha256').update(INSTALLER_BODY).digest('hex');
 
 /** Quit hooks every AutoUpdater requires (see AutoUpdaterHooks). */
 function quitHooks() {
-  return { onBeforeInstallQuit: vi.fn(), onInstallQuitAborted: vi.fn() };
+  return {
+    onBeforeInstallQuit: vi.fn(),
+    onInstallQuitAborted: vi.fn(),
+    onInstallRequiresFullShutdown: vi.fn(),
+    getDaemonPid: vi.fn(() => null),
+  };
 }
 
 const realPlatform = process.platform;
@@ -103,12 +108,29 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
   const unlinkMock = vi.fn(async (_path: string) => undefined);
   vi.doMock('node:fs/promises', () => ({ unlink: unlinkMock }));
 
+  // #866: the install path enumerates and force-kills every process under the
+  // install root, which is derived from process.execPath. Under test that is
+  // the node binary, so the real implementation would kill unrelated node
+  // processes — it took out this suite's own worker before this mock existed.
+  // Stubbed here so the ORDER and the refusal branches stay observable; the
+  // real thing is exercised against a sandbox in installTeardown.runtime.test.
+  const teardown = {
+    collectInstallRootPids: vi.fn((_root: string): number[] => [4242, 4243]),
+    terminatePids: vi.fn((pids: readonly number[]): number[] => [...pids]),
+    spawnInstallWaiter: vi.fn((_plan: { setupExePath: string }): string | null =>
+      'C:\\Temp\\waiter\\wait-and-install.ps1'),
+    freeSpaceShortfall: vi.fn(() => null),
+    probeVolume: vi.fn(() => ({ volume: 'C:\\', freeBytes: 9e12 })),
+    readDaemonPid: vi.fn((): number | null => 4243),
+  };
+  vi.doMock('../installTeardown', () => teardown);
+
   // #502: UPDATE_INSTALL now calls app.quit() after a successful launch so
   // Squirrel never installs against a live instance — the mock must provide it.
   const quit = vi.fn();
   vi.doMock('electron', () => ({
     autoUpdater: {},
-    app: { getVersion: () => FAKE_VERSION, getPath: () => '/tmp', quit },
+    app: { getVersion: () => FAKE_VERSION, getPath: () => '/tmp', quit, isPackaged: true },
     ipcMain: {
       on: vi.fn(),
       handle: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcHandlers.set(ch, cb); },
@@ -120,7 +142,7 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
   }));
 
   const mod = await import('../AutoUpdater');
-  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, sent, openPath, quit, win, feed, unlinkMock };
+  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, sent, openPath, quit, win, feed, unlinkMock, teardown };
 }
 
 /** Flush queued microtasks so the chained net responses (feed→manifest→download) settle. */
@@ -164,7 +186,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
   });
 
   it('a user-triggered check (UPDATE_CHECK) is one-shot: auto-installs once verified', async () => {
-    const { AutoUpdater, ipcHandlers, openPath, quit, win } = await loadWin32();
+    const { AutoUpdater, ipcHandlers, openPath, quit, win, teardown } = await loadWin32();
     const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
@@ -172,15 +194,20 @@ describe('AutoUpdater two-step flow (win32)', () => {
     // one-shot "update now": no second click needed to install.
     await ipcHandlers.get(IPC.UPDATE_CHECK)!();
     // performInstall runs fire-and-forget with a real 500ms session-save delay.
-    await until(() => openPath.mock.calls.length > 0);
+    await until(() => teardown.spawnInstallWaiter.mock.calls.length > 0);
 
-    expect(openPath).toHaveBeenCalledTimes(1);
-    expect(openPath.mock.calls[0][0]).toContain('wmux-update-');
+    // #866: the installer is handed to a waiter, never launched from here —
+    // launching it directly is what deletes the install root out from under a
+    // live daemon.
+    expect(openPath).not.toHaveBeenCalled();
+    expect(teardown.spawnInstallWaiter).toHaveBeenCalledTimes(1);
+    const plan = teardown.spawnInstallWaiter.mock.calls[0][0] as { setupExePath: string };
+    expect(plan.setupExePath).toContain('wmux-update-');
     expect(quit).toHaveBeenCalledTimes(1);
   });
 
-  it('UPDATE_INSTALL launches the downloaded file without re-fetching the manifest, then quits', async () => {
-    const { AutoUpdater, ipcHandlers, requestUrls, openPath, quit, win } = await loadWin32();
+  it('UPDATE_INSTALL hands off the downloaded file without re-fetching the manifest, then quits', async () => {
+    const { AutoUpdater, ipcHandlers, requestUrls, openPath, quit, win, teardown } = await loadWin32();
     const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
@@ -191,12 +218,15 @@ describe('AutoUpdater two-step flow (win32)', () => {
     await ipcHandlers.get(IPC.UPDATE_INSTALL)!();
     await flush();
 
-    // Launched the local installer, and made NO new network request.
-    expect(openPath).toHaveBeenCalledTimes(1);
-    expect(openPath.mock.calls[0][0]).toContain('wmux-update-');
+    // Handed the local installer to the waiter, and made NO new network request.
+    expect(openPath).not.toHaveBeenCalled();
+    expect(teardown.spawnInstallWaiter).toHaveBeenCalledTimes(1);
     expect(requestUrls.length).toBe(urlsAfterDownload);
-    // #502: quit after launch so Squirrel installs against a dead instance.
+    // #502 + #866: quit so Squirrel installs against a dead instance — and the
+    // daemon has to go with us, so the full-shutdown branch is requested first.
     expect(quit).toHaveBeenCalledTimes(1);
+    // The daemon is spared the force-kill; it gets the graceful shutdown.
+    expect(teardown.terminatePids).toHaveBeenCalledWith([4242]);
   });
 
   it('rejects on sha256 mismatch: emits error, no downloaded path, install is a no-op', async () => {
@@ -244,8 +274,8 @@ describe('AutoUpdater two-step flow (win32)', () => {
     // The in-flight poll now finishes its download → it honors the intent and installs.
     internals.isChecking = false;
     await internals.downloadUpdate();
-    await until(() => openPath.mock.calls.length > 0);
-    expect(openPath).toHaveBeenCalledTimes(1);
+    await until(() => teardown.spawnInstallWaiter.mock.calls.length > 0);
+    expect(openPath).not.toHaveBeenCalled();
     expect(quit).toHaveBeenCalledTimes(1);
   });
 

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -13,13 +13,21 @@ const DL_URL = `https://github.com/openwong2kim/wmux/releases/download/v${NEW_VE
 const INSTALLER_BODY = Buffer.from('FAKE-INSTALLER-BYTES');
 const GOOD_SHA = createHash('sha256').update(INSTALLER_BODY).digest('hex');
 
-/** Quit hooks every AutoUpdater requires (see AutoUpdaterHooks). */
+/**
+ * Quit hooks every AutoUpdater requires (see AutoUpdaterHooks).
+ *
+ * `getDaemonPid` returns 4243, which is one of the two pids the mocked
+ * enumeration reports. That is deliberate: it is what lets a test see the
+ * daemon being EXCLUDED from the force-kill list (it gets the graceful
+ * shutdown instead). A null here would silently pass the exclusion assertion
+ * by never exercising it.
+ */
 function quitHooks() {
   return {
     onBeforeInstallQuit: vi.fn(),
     onInstallQuitAborted: vi.fn(),
     onInstallRequiresFullShutdown: vi.fn(),
-    getDaemonPid: vi.fn(() => null),
+    getDaemonPid: vi.fn((): number | null => 4243),
   };
 }
 
@@ -122,6 +130,10 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
     freeSpaceShortfall: vi.fn(() => null),
     probeVolume: vi.fn(() => ({ volume: 'C:\\', freeBytes: 9e12 })),
     readDaemonPid: vi.fn((): number | null => 4243),
+    // Boot-time refused-install notice: default to "nothing to report" so it
+    // never leaks an UPDATE_ERROR into tests about other flows.
+    consumeAbortMarker: vi.fn((): string | null => null),
+    INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
   };
   vi.doMock('../installTeardown', () => teardown);
 
@@ -251,7 +263,7 @@ describe('AutoUpdater two-step flow (win32)', () => {
   });
 
   it('a manual press mid-poll preserves the one-shot intent so the in-flight download installs', async () => {
-    const { AutoUpdater, openPath, quit, win } = await loadWin32();
+    const { AutoUpdater, openPath, quit, win, teardown } = await loadWin32();
     const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
@@ -280,8 +292,11 @@ describe('AutoUpdater two-step flow (win32)', () => {
   });
 
   it('a failed one-shot fast-path install clears the intent (no unattended restart later)', async () => {
-    const { AutoUpdater, openPath, quit, win } = await loadWin32();
-    openPath.mockResolvedValueOnce('launch failed'); // shell.openPath resolves with an error string, never throws
+    const { AutoUpdater, quit, win, teardown } = await loadWin32();
+    // #866: the failure mode is now "the waiter could not be prepared". When
+    // that happens the install must be ABANDONED — falling back to launching
+    // Setup.exe directly is the bug this change exists to remove.
+    teardown.spawnInstallWaiter.mockReturnValueOnce(null);
     const updater = new AutoUpdater(() => win as never, quitHooks());
     updater.start();
 
@@ -295,13 +310,13 @@ describe('AutoUpdater two-step flow (win32)', () => {
     internals.downloadedPath = 'C:/tmp/wmux-update-9.9.10.Setup.exe';
     internals.pendingUpdate = { name: NEW_VERSION, notes: 'n', url: DL_URL };
 
-    // Manual press → fast path → performInstall, whose launch fails.
+    // Manual press → fast path → performInstall, whose handoff fails.
     await internals.check(true);
-    await until(() => openPath.mock.calls.length > 0);
+    await until(() => teardown.spawnInstallWaiter.mock.calls.length > 0);
     await flush();
 
-    // The failed launch must NOT quit, and must have cleared the intent so a
-    // later background download can't auto-restart the app.
+    // A refused handoff must NOT quit (the user keeps a working app), and must
+    // have cleared the intent so a later background download can't auto-restart.
     expect(quit).not.toHaveBeenCalled();
     expect(internals.oneShotInstall).toBe(false);
   });

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -720,55 +720,69 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
 });
 
 describe('AutoUpdater #866 — a refused install is reported on the next boot', () => {
-  it('win32: surfaces UPDATE_ERROR once when the waiter left an abort marker', async () => {
-    vi.useFakeTimers();
+  // The renderer PULLS this. The push-on-a-timer version it replaced sent
+  // UPDATE_ERROR into a window whose only listener lived in the Settings
+  // panel — mounted only while Settings is open — so with Settings closed the
+  // notice went nowhere AND the marker was cleared anyway. Live dogfood:
+  // marker planted, app booted, main logged the refusal, marker gone, nothing
+  // shown. These tests pin the take contract instead.
+  const takeHandler = (loaded: Awaited<ReturnType<typeof loadForPlatform>>) => {
+    const h = loaded.ipcHandlers.get(IPC.UPDATE_TAKE_REFUSED_INSTALL);
+    if (!h) throw new Error('UPDATE_TAKE_REFUSED_INSTALL handler was never registered');
+    return h;
+  };
+
+  it('win32: hands the reason to the renderer that asks, and clears the marker only then', async () => {
     const loaded = await loadForPlatform('win32');
     loaded.teardown.readAbortMarker.mockReturnValueOnce(
       'install-aborted: install root still locked',
     );
 
-    const sent: Array<{ channel: string }> = [];
-    const win = {
-      isDestroyed: () => false,
-      webContents: {
-        isCrashed: () => false,
-        send: (channel: string) => sent.push({ channel }),
-        executeJavaScript: vi.fn(async () => undefined),
-      },
-    };
-
-    const updater = new loaded.AutoUpdater(() => win as never, quitHooks());
+    const updater = new loaded.AutoUpdater(() => null, quitHooks());
     updater.start();
 
-    // Nothing yet: the notice waits for the renderer to attach its listeners.
-    expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(false);
+    // Registering the handler must not consume the marker on its own.
+    expect(loaded.teardown.clearAbortMarker).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(5_000);
-    expect(sent.filter((m) => m.channel === IPC.UPDATE_ERROR)).toHaveLength(1);
+    const reason = await takeHandler(loaded)();
+    expect(reason).toBe('install-aborted: install root still locked');
+    expect(loaded.teardown.clearAbortMarker).toHaveBeenCalledTimes(1);
 
     updater.stop();
   });
 
-  it('win32: stays silent when there is no marker', async () => {
-    vi.useFakeTimers();
+  it('win32: answers null and clears nothing when no install was refused', async () => {
     const loaded = await loadForPlatform('win32');
-    // consumeAbortMarker defaults to null in the stub — nothing was refused.
+    // readAbortMarker defaults to null in the stub — nothing was refused.
 
-    const sent: Array<{ channel: string }> = [];
-    const win = {
-      isDestroyed: () => false,
-      webContents: {
-        isCrashed: () => false,
-        send: (channel: string) => sent.push({ channel }),
-        executeJavaScript: vi.fn(async () => undefined),
-      },
-    };
-
-    const updater = new loaded.AutoUpdater(() => win as never, quitHooks());
+    const updater = new loaded.AutoUpdater(() => null, quitHooks());
     updater.start();
-    await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(false);
+    expect(await takeHandler(loaded)()).toBeNull();
+    expect(loaded.teardown.clearAbortMarker).not.toHaveBeenCalled();
+
     updater.stop();
+  });
+
+  it('the handler exists even where in-app updates are unsupported, so the invoke never rejects', async () => {
+    const loaded = await loadForPlatform('linux');
+    const updater = new loaded.AutoUpdater(() => null, quitHooks());
+    updater.start();
+
+    expect(await takeHandler(loaded)()).toBeNull();
+    updater.stop();
+  });
+
+  it('registers the handler at CONSTRUCTION, before start() — the renderer asks first', async () => {
+    // start() runs at the end of the ready sequence, which waits on the daemon
+    // bootstrap (39s on a cold boot in dogfood). The renderer mounts and asks
+    // at ~0.7s, so a handler registered in start() is not there yet and the
+    // invoke rejects — which is exactly how this notice went missing live.
+    const loaded = await loadForPlatform('win32');
+    loaded.teardown.readAbortMarker.mockReturnValueOnce('install-aborted: install root still locked');
+
+    const updater = new loaded.AutoUpdater(() => null, quitHooks());
+    // No start() call anywhere in this test.
+    expect(await takeHandler(loaded)()).toBe('install-aborted: install root still locked');
   });
 });

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -33,7 +33,12 @@ const EXPECTED_DARWIN_FEED = `https://update.electronjs.org/openwong2kim/wmux/da
  * so a construction that forgets to wire it must not compile.
  */
 function quitHooks() {
-  return { onBeforeInstallQuit: vi.fn(), onInstallQuitAborted: vi.fn() };
+  return {
+    onBeforeInstallQuit: vi.fn(),
+    onInstallQuitAborted: vi.fn(),
+    onInstallRequiresFullShutdown: vi.fn(),
+    getDaemonPid: vi.fn(() => null),
+  };
 }
 
 /** Platforms with no in-app updater: [platform, arch]. */
@@ -140,7 +145,7 @@ async function loadForPlatform(
 
   vi.doMock('electron', () => ({
     autoUpdater: nativeUpdater,
-    app: { getVersion: () => FAKE_VERSION, getPath: () => tempPathDir, quit: appQuit },
+    app: { getVersion: () => FAKE_VERSION, getPath: () => tempPathDir, quit: appQuit, isPackaged: false },
     ipcMain: {
       on: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcListeners.set(ch, cb); },
       handle: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcHandlers.set(ch, cb); },

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -75,6 +75,7 @@ async function loadForPlatform(
   platform: NodeJS.Platform,
   routes?: (url: string) => FakeRoute | undefined,
   arch: string = platform === 'darwin' ? 'arm64' : 'x64',
+  { isPackaged = true }: { isPackaged?: boolean } = {},
 ) {
   vi.resetModules();
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
@@ -143,9 +144,27 @@ async function loadForPlatform(
     },
   };
 
+  // #866: the win32 install path enumerates and force-kills every process
+  // under the install root, which it derives from process.execPath. Under test
+  // that is the node binary, so the real implementation would target unrelated
+  // node processes. Stubbed so the handoff stays observable; the real thing is
+  // exercised against a sandbox in installTeardown.runtime.test.
+  const teardown = {
+    collectInstallRootPids: vi.fn((_root: string): number[] => [4242]),
+    terminatePids: vi.fn((pids: readonly number[]): number[] => [...pids]),
+    spawnInstallWaiter: vi.fn((_plan: { setupExePath: string }): string | null =>
+      'C:\\Temp\\waiter\\wait-and-install.ps1'),
+    freeSpaceShortfall: vi.fn(() => null),
+    probeVolume: vi.fn(() => ({ volume: 'C:\\', freeBytes: 9e12 })),
+    readDaemonPid: vi.fn((): number | null => null),
+    consumeAbortMarker: vi.fn((): string | null => null),
+    INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
+  };
+  vi.doMock('../installTeardown', () => teardown);
+
   vi.doMock('electron', () => ({
     autoUpdater: nativeUpdater,
-    app: { getVersion: () => FAKE_VERSION, getPath: () => tempPathDir, quit: appQuit, isPackaged: false },
+    app: { getVersion: () => FAKE_VERSION, getPath: () => tempPathDir, quit: appQuit, isPackaged },
     ipcMain: {
       on: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcListeners.set(ch, cb); },
       handle: (ch: string, cb: (...a: unknown[]) => unknown) => { ipcHandlers.set(ch, cb); },
@@ -157,7 +176,7 @@ async function loadForPlatform(
   }));
 
   const mod = await import('../AutoUpdater');
-  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, ipcListeners, request, appQuit, shellOpenPath, nativeUpdater };
+  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, ipcListeners, request, appQuit, shellOpenPath, nativeUpdater, teardown };
 }
 
 describe('AutoUpdater platform gating', () => {
@@ -350,31 +369,56 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
     return { updater, installHandler, sent };
   }
 
-  it('win32: UPDATE_INSTALL launches the verified installer, then quits the app', async () => {
+  it('win32: UPDATE_INSTALL hands the verified installer to the waiter, then quits the app', async () => {
     const loaded = await loadForPlatform('win32', downloadRoutes);
     const { installHandler } = await downloadUpdateFor(loaded);
 
     await installHandler();
 
-    expect(loaded.shellOpenPath).toHaveBeenCalledTimes(1);
-    const openedPath = String(loaded.shellOpenPath.mock.calls[0]![0]);
-    expect(openedPath).toContain(`wmux-update-${UPDATE_VERSION}-`);
-    expect(openedPath).toContain('.Setup.exe');
-    // The quit is the fix: Squirrel must never run against a live instance.
+    // #866: the installer is never started from here. Setup.exe deletes the
+    // install root as its first action, so it has to be launched by something
+    // that outlives us and can confirm the tree is dead first.
+    expect(loaded.shellOpenPath).not.toHaveBeenCalled();
+    expect(loaded.teardown.spawnInstallWaiter).toHaveBeenCalledTimes(1);
+    const plan = loaded.teardown.spawnInstallWaiter.mock.calls[0]![0] as { setupExePath: string };
+    expect(plan.setupExePath).toContain(`wmux-update-${UPDATE_VERSION}-`);
+    expect(plan.setupExePath).toContain('.Setup.exe');
+    // #502 + #866: quit so Squirrel never runs against a live instance, and ask
+    // for the full shutdown so the daemon goes down with us.
     expect(loaded.appQuit).toHaveBeenCalledTimes(1);
   });
 
-  it('win32: a failed installer launch reports UPDATE_ERROR and does NOT quit', async () => {
+  it('win32: a handoff that cannot be prepared reports UPDATE_ERROR and does NOT quit', async () => {
     const loaded = await loadForPlatform('win32', downloadRoutes);
     const { installHandler, sent } = await downloadUpdateFor(loaded);
 
-    loaded.shellOpenPath.mockResolvedValueOnce('access denied');
+    loaded.teardown.spawnInstallWaiter.mockReturnValueOnce(null);
     await installHandler();
 
     expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(true);
-    // Quitting after a failed launch would close the app with no installer
-    // running — the user would just find wmux gone.
+    // Two things must NOT happen here. Quitting would close the app with no
+    // installer running — the user just finds wmux gone. And falling back to
+    // starting Setup.exe ourselves is the #866 bug, so the installer must stay
+    // untouched when the safe path is unavailable.
     expect(loaded.appQuit).not.toHaveBeenCalled();
+    expect(loaded.shellOpenPath).not.toHaveBeenCalled();
+  });
+
+  it('win32: refuses to install from an unpackaged build instead of killing stray processes', async () => {
+    // The teardown derives the install root from process.execPath. Unpackaged
+    // that is the runtime binary, so enumerate-and-kill would target unrelated
+    // processes under it — this suite lost its own worker to exactly that
+    // before the guard existed.
+    const loaded = await loadForPlatform('win32', downloadRoutes, 'x64', { isPackaged: false });
+    const { installHandler, sent } = await downloadUpdateFor(loaded);
+
+    await installHandler();
+
+    expect(loaded.teardown.collectInstallRootPids).not.toHaveBeenCalled();
+    expect(loaded.teardown.terminatePids).not.toHaveBeenCalled();
+    expect(loaded.teardown.spawnInstallWaiter).not.toHaveBeenCalled();
+    expect(loaded.appQuit).not.toHaveBeenCalled();
+    expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(true);
   });
 
   it('win32: UPDATE_INSTALL with no downloaded installer neither launches nor quits', async () => {
@@ -670,6 +714,60 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
     await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
     expect(requestUrls).toContain(EXPECTED_WIN32_FEED);
 
+    updater.stop();
+  });
+});
+
+describe('AutoUpdater #866 — a refused install is reported on the next boot', () => {
+  it('win32: surfaces UPDATE_ERROR once when the waiter left an abort marker', async () => {
+    vi.useFakeTimers();
+    const loaded = await loadForPlatform('win32');
+    loaded.teardown.consumeAbortMarker.mockReturnValueOnce(
+      'install-aborted: install root still locked',
+    );
+
+    const sent: Array<{ channel: string }> = [];
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        isCrashed: () => false,
+        send: (channel: string) => sent.push({ channel }),
+        executeJavaScript: vi.fn(async () => undefined),
+      },
+    };
+
+    const updater = new loaded.AutoUpdater(() => win as never, quitHooks());
+    updater.start();
+
+    // Nothing yet: the notice waits for the renderer to attach its listeners.
+    expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(sent.filter((m) => m.channel === IPC.UPDATE_ERROR)).toHaveLength(1);
+
+    updater.stop();
+  });
+
+  it('win32: stays silent when there is no marker', async () => {
+    vi.useFakeTimers();
+    const loaded = await loadForPlatform('win32');
+    // consumeAbortMarker defaults to null in the stub — nothing was refused.
+
+    const sent: Array<{ channel: string }> = [];
+    const win = {
+      isDestroyed: () => false,
+      webContents: {
+        isCrashed: () => false,
+        send: (channel: string) => sent.push({ channel }),
+        executeJavaScript: vi.fn(async () => undefined),
+      },
+    };
+
+    const updater = new loaded.AutoUpdater(() => win as never, quitHooks());
+    updater.start();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sent.some((m) => m.channel === IPC.UPDATE_ERROR)).toBe(false);
     updater.stop();
   });
 });

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -157,7 +157,8 @@ async function loadForPlatform(
     freeSpaceShortfall: vi.fn(() => null),
     probeVolume: vi.fn(() => ({ volume: 'C:\\', freeBytes: 9e12 })),
     readDaemonPid: vi.fn((): number | null => null),
-    consumeAbortMarker: vi.fn((): string | null => null),
+    readAbortMarker: vi.fn((): string | null => null),
+    clearAbortMarker: vi.fn(),
     INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
   };
   vi.doMock('../installTeardown', () => teardown);
@@ -722,7 +723,7 @@ describe('AutoUpdater #866 — a refused install is reported on the next boot', 
   it('win32: surfaces UPDATE_ERROR once when the waiter left an abort marker', async () => {
     vi.useFakeTimers();
     const loaded = await loadForPlatform('win32');
-    loaded.teardown.consumeAbortMarker.mockReturnValueOnce(
+    loaded.teardown.readAbortMarker.mockReturnValueOnce(
       'install-aborted: install root still locked',
     );
 

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -1,0 +1,189 @@
+// End-to-end proof of the two properties that keep an installation alive
+// (#866), against real processes, real file locks and the real waiter script:
+//
+//   1. the waiter does not start the installer while anything still holds the
+//      install root open,
+//   2. when the root never clears, it ABORTS and says so, instead of launching
+//      into a live tree.
+//
+// The waiter runs in the FOREGROUND here (spawnSync) rather than detached. Same
+// script, but the test observes an exit code instead of racing a background
+// process against afterEach teardown — an earlier detached version of this file
+// produced inverted, timing-dependent results that said nothing about the code.
+// Exit codes are the contract: 0 = installer launched, 2 = refused.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { spawn, spawnSync, execFileSync, type ChildProcess } from 'node:child_process';
+import {
+  buildWaiterScript,
+  spawnInstallWaiter,
+  collectInstallRootPids,
+  probeVolume,
+  type WaiterPlan,
+} from '../installTeardown';
+
+const onWindows = process.platform === 'win32';
+const PS = path.join(
+  process.env.SystemRoot || 'C:\\Windows',
+  'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+);
+
+function q(p: string): string {
+  return `'${p.replace(/'/g, "''")}'`;
+}
+
+describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () => {
+  let sandbox: string;
+  let root: string;
+  let heldExe: string;
+  let setupStamp: string;
+  let fakeSetup: string;
+  let abortMarker: string;
+  let scriptPath: string;
+  const children: ChildProcess[] = [];
+
+  beforeEach(() => {
+    sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-waiter-')));
+    root = path.join(sandbox, 'wmux');
+    fs.mkdirSync(path.join(root, 'app-1.0.0'), { recursive: true });
+    heldExe = path.join(root, 'app-1.0.0', 'held.exe');
+    fs.writeFileSync(heldExe, 'x');
+    setupStamp = path.join(sandbox, 'setup-ran.txt');
+    abortMarker = path.join(sandbox, 'abort.txt');
+    fakeSetup = path.join(sandbox, 'fake-setup.cmd');
+    // Stand-in for Setup.exe: proves it ran without installing anything.
+    fs.writeFileSync(fakeSetup, `@echo off\r\necho ran > "${setupStamp}"\r\n`);
+    scriptPath = path.join(sandbox, 'waiter.ps1');
+  });
+
+  afterEach(() => {
+    for (const c of children.splice(0)) { try { c.kill(); } catch { /* already gone */ } }
+    try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch { /* lock lingers */ }
+  });
+
+  /** Holds heldExe open until killed. Returns once the lock is actually taken. */
+  function holdRoot(seconds = 120): ChildProcess {
+    const child = spawn(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-Command',
+        `$s=[System.IO.File]::Open(${q(heldExe)},'Open','Read','None'); Start-Sleep -Seconds ${seconds}; $s.Close()`],
+      { windowsHide: true, stdio: 'ignore' },
+    );
+    children.push(child);
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      try { const fd = fs.openSync(heldExe, 'r+'); fs.closeSync(fd); } catch { return child; }
+      execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 200'], { windowsHide: true });
+    }
+    throw new Error('holder never took the lock');
+  }
+
+  function writeWaiter(plan: WaiterPlan): void {
+    const script = buildWaiterScript(plan);
+    expect(script).not.toBeNull();
+    fs.writeFileSync(scriptPath, script as string, 'utf-8');
+  }
+
+  const plan = (pids: number[], lockBudgetMs: number): WaiterPlan => ({
+    pids, setupExePath: fakeSetup, installRoot: root, abortMarkerPath: abortMarker, lockBudgetMs,
+  });
+
+  function runWaiter(timeoutMs: number): { status: number | null; timedOut: boolean } {
+    const res = spawnSync(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptPath],
+      { encoding: 'utf-8', timeout: timeoutMs, windowsHide: true },
+    );
+    return { status: res.status, timedOut: res.status === null };
+  }
+
+  it('blocks while a tracked process is alive, and never launches meanwhile', () => {
+    const holder = holdRoot();
+    writeWaiter(plan([holder.pid as number], 5_000));
+
+    // The holder outlives our patience on purpose: the waiter must still be
+    // waiting when we give up, and must not have launched the installer.
+    const { timedOut } = runWaiter(12_000);
+    expect(timedOut).toBe(true);
+    expect(fs.existsSync(setupStamp)).toBe(false);
+    expect(fs.existsSync(abortMarker)).toBe(false);
+  }, 90_000);
+
+  it('launches the installer once the tracked process is gone and the root is clear', () => {
+    const holder = holdRoot();
+    holder.kill();
+    // Wait for the lock to actually drop before starting the waiter, so this
+    // test measures the launch path rather than kill latency.
+    const deadline = Date.now() + 15_000;
+    let released = false;
+    while (Date.now() < deadline && !released) {
+      try { const fd = fs.openSync(heldExe, 'r+'); fs.closeSync(fd); released = true; }
+      catch { execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 200'], { windowsHide: true }); }
+    }
+    expect(released).toBe(true);
+
+    writeWaiter(plan([holder.pid as number], 5_000));
+    expect(runWaiter(60_000).status).toBe(0);
+
+    const stampDeadline = Date.now() + 20_000;
+    while (Date.now() < stampDeadline && !fs.existsSync(setupStamp)) {
+      execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 200'], { windowsHide: true });
+    }
+    expect(fs.existsSync(setupStamp)).toBe(true);
+    expect(fs.existsSync(abortMarker)).toBe(false);
+  }, 120_000);
+
+  it('aborts instead of launching when an UNTRACKED process still holds the root', () => {
+    // The TOCTOU case: an MCP host spawned a fresh server into the directory
+    // after we took our pid snapshot. Every pid we know about is gone, so the
+    // handle waits pass — only the lock probe stands between us and destroying
+    // the install.
+    holdRoot();
+    const doomed = spawn(PS, ['-NoProfile', '-NonInteractive', '-Command', 'exit'], {
+      windowsHide: true, stdio: 'ignore',
+    });
+    children.push(doomed);
+    execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Seconds 2'], { windowsHide: true });
+
+    writeWaiter(plan([doomed.pid as number], 3_000));
+    expect(runWaiter(60_000).status).toBe(2);
+
+    expect(fs.existsSync(abortMarker)).toBe(true);
+    expect(fs.readFileSync(abortMarker, 'utf-8')).toContain('install-aborted');
+    // The whole point of the change.
+    expect(fs.existsSync(setupStamp)).toBe(false);
+  }, 120_000);
+
+  it('places the waiter script OUTSIDE the install root', () => {
+    // Setup.exe deletes the install root. A waiter living inside it would be
+    // deleting itself mid-run.
+    const written = spawnInstallWaiter(plan([process.pid], 1_000));
+    expect(written).not.toBeNull();
+    expect((written as string).toLowerCase().startsWith(root.toLowerCase())).toBe(false);
+  }, 30_000);
+
+  it('enumerates nothing for a root no process runs from', () => {
+    expect(collectInstallRootPids(root)).toEqual([]);
+  }, 30_000);
+});
+
+describe.skipIf(!onWindows)('probeVolume', () => {
+  it('agrees with the OS on free space (guards a blocks-vs-bytes mistake)', () => {
+    const info = probeVolume(os.tmpdir());
+    expect(info).not.toBeNull();
+    expect(info?.volume).toMatch(/^[A-Za-z]:\\$/);
+
+    const osFree = Number(execFileSync(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-Command',
+        `(New-Object System.IO.DriveInfo(${q(info?.volume ?? 'C:\\')})).AvailableFreeSpace`],
+      { encoding: 'utf-8', windowsHide: true },
+    ).trim());
+
+    const ratio = (info?.freeBytes ?? 0) / osFree;
+    expect(ratio).toBeGreaterThan(0.9);
+    expect(ratio).toBeLessThan(1.1);
+  }, 30_000);
+});

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -101,15 +101,27 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
 
   it('blocks while a tracked process is alive, and never launches meanwhile', () => {
     const holder = holdRoot();
-    writeWaiter(plan([holder.pid as number], 5_000));
-
-    // The holder outlives our patience on purpose: the waiter must still be
+    // Budget comfortably longer than our patience: the waiter must still be
     // waiting when we give up, and must not have launched the installer.
+    writeWaiter(plan([holder.pid as number], 90_000));
+
     const { timedOut } = runWaiter(12_000);
     expect(timedOut).toBe(true);
     expect(fs.existsSync(setupStamp)).toBe(false);
     expect(fs.existsSync(abortMarker)).toBe(false);
-  }, 90_000);
+  }, 120_000);
+
+  it('gives up instead of waiting forever on a process that will not die', () => {
+    // taskkill is best-effort. Before the wait was bounded, a survivor left the
+    // waiter blocked forever — and wmux had already quit, so the update stalled
+    // with nothing to show for it on the next boot.
+    const holder = holdRoot();
+    writeWaiter(plan([holder.pid as number], 3_000));
+
+    expect(runWaiter(60_000).status).toBe(3);
+    expect(fs.readFileSync(abortMarker, 'utf-8')).toContain('would not exit');
+    expect(fs.existsSync(setupStamp)).toBe(false);
+  }, 120_000);
 
   it('launches the installer once the tracked process is gone and the root is clear', () => {
     const holder = holdRoot();
@@ -153,6 +165,42 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     expect(fs.existsSync(abortMarker)).toBe(true);
     expect(fs.readFileSync(abortMarker, 'utf-8')).toContain('install-aborted');
     // The whole point of the change.
+    expect(fs.existsSync(setupStamp)).toBe(false);
+  }, 120_000);
+
+  it('aborts when only a DLL is locked — the file the field failure actually died on', () => {
+    // The install that destroyed a real machine threw deleting `ffmpeg.dll`,
+    // not an .exe. An .exe-only probe reports "clear" here and launches into a
+    // live tree; this is the regression guard for that narrowing.
+    const heldDll = path.join(root, 'app-1.0.0', 'ffmpeg.dll');
+    fs.writeFileSync(heldDll, 'x');
+    const holder = spawn(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-Command',
+        `$s=[System.IO.File]::Open(${q(heldDll)},'Open','Read','None'); Start-Sleep -Seconds 120; $s.Close()`],
+      { windowsHide: true, stdio: 'ignore' },
+    );
+    children.push(holder);
+    const deadline = Date.now() + 15_000;
+    let taken = false;
+    while (Date.now() < deadline && !taken) {
+      try { const fd = fs.openSync(heldDll, 'r+'); fs.closeSync(fd); }
+      catch { taken = true; }
+      if (!taken) execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 200'], { windowsHide: true });
+    }
+    expect(taken).toBe(true);
+
+    // Every pid the waiter knows about is already gone, so only the lock probe
+    // stands between it and Setup.exe.
+    const doomed = spawn(PS, ['-NoProfile', '-NonInteractive', '-Command', 'exit'], {
+      windowsHide: true, stdio: 'ignore',
+    });
+    children.push(doomed);
+    execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Seconds 2'], { windowsHide: true });
+
+    writeWaiter(plan([doomed.pid as number], 3_000));
+    expect(runWaiter(60_000).status).toBe(2);
+    expect(fs.existsSync(abortMarker)).toBe(true);
     expect(fs.existsSync(setupStamp)).toBe(false);
   }, 120_000);
 

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -5,7 +5,9 @@
 //   2. a still-locked root aborts instead of launching.
 //
 // Everything else (enumeration, volume budgeting, quoting) feeds those two.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   isSafePsPathLiteral,
@@ -13,6 +15,10 @@ import {
   selectInstallRootPids,
   parseProcessRows,
   buildWaiterScript,
+  readDaemonPid,
+  terminatePids,
+  consumeAbortMarker,
+  INSTALL_ABORT_MARKER,
   type WaiterPlan,
 } from '../installTeardown';
 
@@ -175,5 +181,93 @@ describe('freeSpaceShortfall — budgets per volume, not in aggregate', () => {
     expect(
       freeSpaceShortfall([{ dir: 'X', neededBytes: 1e12 }], () => null),
     ).toBeNull();
+  });
+});
+
+describe('readDaemonPid', () => {
+  const dirs: string[] = [];
+  const tempDir = (): string => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-daemonpid-'));
+    dirs.push(d);
+    return d;
+  };
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  it('reads the pid, tolerating the trailing newline the daemon writes', () => {
+    const dir = tempDir();
+    fs.writeFileSync(path.join(dir, 'daemon.pid'), '4321\n');
+    expect(readDaemonPid(dir)).toBe(4321);
+  });
+
+  it.each([
+    ['no file at all', null],
+    ['', ''],
+    ['not-a-number', 'abcd'],
+    ['zero', '0'],
+    ['negative', '-7'],
+    ['float', '12.5'],
+  ])('returns null for %s', (_label, contents) => {
+    const dir = tempDir();
+    if (contents !== null) fs.writeFileSync(path.join(dir, 'daemon.pid'), contents);
+    expect(readDaemonPid(dir)).toBeNull();
+  });
+
+  it('null fails safe: the caller force-kills the daemon rather than skipping it', () => {
+    // Documented contract. If this ever flips to "skip on null", a daemon we
+    // could not identify would be left holding the install root open, which is
+    // the failure this module exists to prevent.
+    const dir = tempDir();
+    const daemonPid = readDaemonPid(dir); // null — no pid file
+    const pids = [111, 222];
+    expect(pids.filter((p) => p !== daemonPid)).toEqual([111, 222]);
+  });
+});
+
+describe('terminatePids', () => {
+  it('ignores non-positive and non-integer pids instead of shelling out for them', () => {
+    // taskkill /PID 0 would be a nonsense call, and a float would be coerced
+    // into some other process's pid. Neither should ever reach the shell.
+    expect(terminatePids([0, -1, 1.5, NaN])).toEqual([]);
+  });
+
+  it('returns an empty list for an empty input', () => {
+    expect(terminatePids([])).toEqual([]);
+  });
+});
+
+describe('consumeAbortMarker', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+  const tempDir = (): string => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-abortmarker-'));
+    dirs.push(d);
+    return d;
+  };
+
+  it('returns the reason and CLEARS the marker so the notice fires once', () => {
+    const dir = tempDir();
+    const marker = path.join(dir, INSTALL_ABORT_MARKER);
+    fs.writeFileSync(marker, 'install-aborted: install root still locked\n');
+
+    expect(consumeAbortMarker(marker)).toBe('install-aborted: install root still locked');
+    expect(fs.existsSync(marker)).toBe(false);
+    // A sticky warning about a since-succeeded update is worse than none.
+    expect(consumeAbortMarker(marker)).toBeNull();
+  });
+
+  it('returns null when there is no marker', () => {
+    expect(consumeAbortMarker(path.join(tempDir(), INSTALL_ABORT_MARKER))).toBeNull();
+  });
+
+  it('still reports a refusal when the marker is empty', () => {
+    const dir = tempDir();
+    const marker = path.join(dir, INSTALL_ABORT_MARKER);
+    fs.writeFileSync(marker, '   \n');
+    expect(consumeAbortMarker(marker)).toBe('install-aborted');
+    expect(fs.existsSync(marker)).toBe(false);
   });
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -17,7 +17,8 @@ import {
   buildWaiterScript,
   readDaemonPid,
   terminatePids,
-  consumeAbortMarker,
+  readAbortMarker,
+  clearAbortMarker,
   INSTALL_ABORT_MARKER,
   type WaiterPlan,
 } from '../installTeardown';
@@ -248,26 +249,55 @@ describe('consumeAbortMarker', () => {
     return d;
   };
 
-  it('returns the reason and CLEARS the marker so the notice fires once', () => {
+  it('reads WITHOUT clearing, so a crash before the notice cannot lose the refusal', () => {
     const dir = tempDir();
     const marker = path.join(dir, INSTALL_ABORT_MARKER);
     fs.writeFileSync(marker, 'install-aborted: install root still locked\n');
 
-    expect(consumeAbortMarker(marker)).toBe('install-aborted: install root still locked');
+    expect(readAbortMarker(marker)).toBe('install-aborted: install root still locked');
+    // Still there: clearing on read would drop the only record of the refusal
+    // if the app died before the renderer saw it, and it is then unreportable
+    // forever. Reads are idempotent.
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(readAbortMarker(marker)).toBe('install-aborted: install root still locked');
+  });
+
+  it('clears only when asked, and a sticky warning cannot outlive the clear', () => {
+    const dir = tempDir();
+    const marker = path.join(dir, INSTALL_ABORT_MARKER);
+    fs.writeFileSync(marker, 'install-aborted: install root still locked\n');
+
+    clearAbortMarker(marker);
     expect(fs.existsSync(marker)).toBe(false);
-    // A sticky warning about a since-succeeded update is worse than none.
-    expect(consumeAbortMarker(marker)).toBeNull();
+    expect(readAbortMarker(marker)).toBeNull();
+  });
+
+  it('clearing a marker that is already gone is not an error', () => {
+    expect(() => clearAbortMarker(path.join(tempDir(), INSTALL_ABORT_MARKER))).not.toThrow();
   });
 
   it('returns null when there is no marker', () => {
-    expect(consumeAbortMarker(path.join(tempDir(), INSTALL_ABORT_MARKER))).toBeNull();
+    expect(readAbortMarker(path.join(tempDir(), INSTALL_ABORT_MARKER))).toBeNull();
   });
 
   it('still reports a refusal when the marker is empty', () => {
     const dir = tempDir();
     const marker = path.join(dir, INSTALL_ABORT_MARKER);
     fs.writeFileSync(marker, '   \n');
-    expect(consumeAbortMarker(marker)).toBe('install-aborted');
-    expect(fs.existsSync(marker)).toBe(false);
+    expect(readAbortMarker(marker)).toBe('install-aborted');
+  });
+});
+
+describe('buildWaiterScript — the lock probe covers loadable images, not just .exe', () => {
+  it('probes dll/node/asar as well, because the failure in the field was a dll', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    // The install that destroyed a real machine died deleting ffmpeg.dll. On a
+    // live install 1 .exe is locked but 9 binaries are, so an .exe-only probe
+    // would have reported "clear" and launched Setup.exe into a live tree.
+    expect(s).toContain(".exe");
+    expect(s).toContain(".dll");
+    expect(s).toContain(".node");
+    expect(s).toContain(".asar");
+    expect(s).not.toContain('-Filter *.exe');
   });
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -119,7 +119,17 @@ describe('selectInstallRootPids', () => {
 
   it('matches case-insensitively and tolerates a trailing separator on the root', () => {
     const rows = [{ pid: 5, executablePath: `${root.toUpperCase()}\\APP-3.40.2\\WMUX.EXE` }];
-    expect(selectInstallRootPids(rows, root + path.sep, 999)).toEqual([5]);
+    // Both separator spellings, because the caller derives the root from
+    // process.execPath and node normalizes inconsistently across APIs.
+    expect(selectInstallRootPids(rows, `${root}\\`, 999)).toEqual([5]);
+    expect(selectInstallRootPids(rows, `${root}/`, 999)).toEqual([5]);
+    expect(selectInstallRootPids(rows, root, 999)).toEqual([5]);
+  });
+
+  it('does not match a sibling whose name merely starts with the root', () => {
+    // `wmux-dev` must not be swept up by a prefix test against `wmux`.
+    const rows = [{ pid: 6, executablePath: `${root}-dev\\app-1.0.0\\wmux.exe` }];
+    expect(selectInstallRootPids(rows, root, 999)).toEqual([]);
   });
 });
 

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -1,0 +1,179 @@
+// Pure-logic coverage for the #866 install teardown. The two properties that
+// actually keep an installation alive are asserted here:
+//
+//   1. the waiter waits on HANDLES and probes for locks BEFORE Setup.exe,
+//   2. a still-locked root aborts instead of launching.
+//
+// Everything else (enumeration, volume budgeting, quoting) feeds those two.
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import {
+  isSafePsPathLiteral,
+  freeSpaceShortfall,
+  selectInstallRootPids,
+  parseProcessRows,
+  buildWaiterScript,
+  type WaiterPlan,
+} from '../installTeardown';
+
+const PLAN: WaiterPlan = {
+  pids: [111, 222],
+  setupExePath: 'C:\\Temp\\wmux-3.41.0.Setup.exe',
+  installRoot: 'C:\\Users\\u\\AppData\\Local\\wmux',
+  abortMarkerPath: 'C:\\Users\\u\\AppData\\Roaming\\wmux\\install-abort.txt',
+  lockBudgetMs: 30_000,
+};
+
+describe('isSafePsPathLiteral', () => {
+  it.each(["'", '"', '$', '`'])('accepts the legal path character %j', (ch) => {
+    expect(isSafePsPathLiteral(`C:\\Users\\O${ch}Connor\\wmux`)).toBe(true);
+  });
+
+  it.each(['\n', '\r'])('refuses the line terminator %j', (ch) => {
+    expect(isSafePsPathLiteral(`C:\\wmux${ch}x`)).toBe(false);
+  });
+});
+
+describe('buildWaiterScript — ordering is the whole contract', () => {
+  it('waits on handles, probes locks, and only then starts Setup.exe', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const handleWait = s.indexOf('WaitForExit');
+    const lockProbe = s.indexOf('Test-RootLocked');
+    const start = s.indexOf('Start-Process -FilePath $setup');
+
+    expect(handleWait).toBeGreaterThan(-1);
+    expect(lockProbe).toBeGreaterThan(-1);
+    expect(start).toBeGreaterThan(-1);
+    // The regression this whole change exists to prevent: launching the
+    // installer while anything still holds the install root.
+    expect(handleWait).toBeLessThan(start);
+    expect(lockProbe).toBeLessThan(start);
+  });
+
+  it('aborts with a marker instead of launching when the root stays locked', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const abortIdx = s.indexOf('install-aborted');
+    const start = s.indexOf('Start-Process -FilePath $setup');
+    expect(abortIdx).toBeGreaterThan(-1);
+    expect(abortIdx).toBeLessThan(start);
+    expect(s).toContain('exit 2');
+  });
+
+  it('captures handles by pid up front rather than polling pids', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    expect(s).toContain('GetProcessById');
+    expect(s).toContain('@(111,222)');
+    // A pid poll would look like this; it must not appear.
+    expect(s).not.toContain('Get-Process -Id');
+  });
+
+  it('doubles apostrophes in every embedded path', () => {
+    const s = buildWaiterScript({ ...PLAN, installRoot: "C:\\Users\\O'Connor\\wmux" }) ?? '';
+    expect(s).toContain("$root = 'C:\\Users\\O''Connor\\wmux'");
+  });
+
+  it('refuses to build on a line terminator or a bogus pid', () => {
+    expect(buildWaiterScript({ ...PLAN, installRoot: 'C:\\a\nb' })).toBeNull();
+    expect(buildWaiterScript({ ...PLAN, pids: [0] })).toBeNull();
+    expect(buildWaiterScript({ ...PLAN, pids: [-3] })).toBeNull();
+    expect(buildWaiterScript({ ...PLAN, pids: [1.5] })).toBeNull();
+  });
+});
+
+describe('selectInstallRootPids', () => {
+  const root = 'C:\\Users\\u\\AppData\\Local\\wmux';
+
+  it('takes every process running from under the root, including MCP servers', () => {
+    const rows = [
+      { pid: 1, executablePath: `${root}\\app-3.40.2\\wmux.exe` },   // GUI
+      { pid: 2, executablePath: `${root}\\app-3.40.2\\wmux.exe` },   // daemon
+      { pid: 3, executablePath: `${root}\\app-3.40.2\\wmux.exe` },   // MCP server
+      { pid: 4, executablePath: `${root}\\wmux.exe` },               // root stub
+    ];
+    expect(selectInstallRootPids(rows, root, 999)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('excludes ourselves — killing the process doing the update is self-defeating', () => {
+    const rows = [
+      { pid: 7, executablePath: `${root}\\app-3.40.2\\wmux.exe` },
+      { pid: 8, executablePath: `${root}\\app-3.40.2\\wmux.exe` },
+    ];
+    expect(selectInstallRootPids(rows, root, 7)).toEqual([8]);
+  });
+
+  it('leaves a dev build and a sibling directory alone', () => {
+    const rows = [
+      { pid: 1, executablePath: 'D:\\wmux\\out\\wmux-win32-x64\\wmux.exe' },
+      { pid: 2, executablePath: `${root}-dev\\app-1.0.0\\wmux.exe` },
+      { pid: 3, executablePath: '' },
+    ];
+    expect(selectInstallRootPids(rows, root, 999)).toEqual([]);
+  });
+
+  it('matches case-insensitively and tolerates a trailing separator on the root', () => {
+    const rows = [{ pid: 5, executablePath: `${root.toUpperCase()}\\APP-3.40.2\\WMUX.EXE` }];
+    expect(selectInstallRootPids(rows, root + path.sep, 999)).toEqual([5]);
+  });
+});
+
+describe('parseProcessRows', () => {
+  it('parses the array form and the single-object form', () => {
+    expect(parseProcessRows('[{"ProcessId":1,"ExecutablePath":"C:\\\\a.exe"}]')).toEqual([
+      { pid: 1, executablePath: 'C:\\a.exe' },
+    ]);
+    expect(parseProcessRows('{"ProcessId":2,"ExecutablePath":"C:\\\\b.exe"}')).toEqual([
+      { pid: 2, executablePath: 'C:\\b.exe' },
+    ]);
+  });
+
+  it('drops malformed rows and survives empty or non-JSON output', () => {
+    expect(parseProcessRows('')).toEqual([]);
+    expect(parseProcessRows('nope')).toEqual([]);
+    expect(parseProcessRows('[{"ProcessId":0},{"ExecutablePath":"x"}]')).toEqual([]);
+    // A null ExecutablePath (access denied) still yields a row, with '' — which
+    // selectInstallRootPids then filters out rather than treating as a match.
+    expect(parseProcessRows('[{"ProcessId":9,"ExecutablePath":null}]')).toEqual([
+      { pid: 9, executablePath: '' },
+    ]);
+  });
+});
+
+describe('freeSpaceShortfall — budgets per volume, not in aggregate', () => {
+  const probe = (map: Record<string, [string, number]>) => (dir: string) => {
+    const hit = map[dir];
+    return hit ? { volume: hit[0], freeBytes: hit[1] } : null;
+  };
+
+  it('returns null when every volume has room', () => {
+    expect(
+      freeSpaceShortfall(
+        [{ dir: 'T', neededBytes: 100 }, { dir: 'R', neededBytes: 100 }],
+        probe({ T: ['T:\\', 500], R: ['C:\\', 500] }),
+      ),
+    ).toBeNull();
+  });
+
+  it('sums budgets that land on the SAME volume', () => {
+    // 100 + 100 on one volume with 150 free is short, even though neither
+    // budget alone would be.
+    const short = freeSpaceShortfall(
+      [{ dir: 'T', neededBytes: 100 }, { dir: 'R', neededBytes: 100 }],
+      probe({ T: ['C:\\', 150], R: ['C:\\', 150] }),
+    );
+    expect(short).toEqual({ volume: 'C:\\', neededBytes: 200, freeBytes: 150 });
+  });
+
+  it('does not let a roomy volume mask a full one', () => {
+    const short = freeSpaceShortfall(
+      [{ dir: 'T', neededBytes: 10 }, { dir: 'R', neededBytes: 900 }],
+      probe({ T: ['T:\\', 10_000], R: ['C:\\', 100] }),
+    );
+    expect(short?.volume).toBe('C:\\');
+  });
+
+  it('never invents a refusal from an unreadable volume', () => {
+    expect(
+      freeSpaceShortfall([{ dir: 'X', neededBytes: 1e12 }], () => null),
+    ).toBeNull();
+  });
+});

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -1,0 +1,341 @@
+/**
+ * Windows install teardown (#866).
+ *
+ * Squirrel's `Setup.exe` is a first-install program, not an updater: its first
+ * action is a recursive delete of the whole install root ("burning it to the
+ * ground" in its own log). Today `performInstall` launches it and only THEN
+ * calls `app.quit()`, so the delete starts while our processes still have the
+ * install root open. The delete throws, the exception escapes
+ * `Squirrel.Update.Program.Install`, and the install aborts with the root
+ * already half-deleted: no Update.exe, no stub, no launcher to retry from.
+ *
+ * This is not a race that a faster quit could win. Measured on a live install:
+ *
+ *   - `app.quit()` takes the DETACH branch (index.ts before-quit), which keeps
+ *     the daemon running BY DESIGN — that is the persistence promise.
+ *   - the daemon's own process image is `<root>\app-X.Y.Z\wmux.exe`, and a
+ *     running image cannot be unlinked on Windows.
+ *   - killing only the GUI left `DAEMON + 3 MCP servers` alive and the exe
+ *     still reporting "being used by another process".
+ *
+ * So the install has to start against a genuinely dead tree. This module owns
+ * that: enumerate everything running out of the install root, take it down,
+ * and hand off to a detached waiter that starts Setup.exe only after every
+ * process is confirmed gone AND the root is confirmed unlocked.
+ *
+ *      performInstall
+ *          │  freeSpaceShortfall()  ── short ──► refuse, nothing written
+ *          │
+ *          │  collectInstallRootPids()   (self excluded)
+ *          │  daemon.shutdown → pid-kill backstop  (caller)
+ *          ▼
+ *      spawnInstallWaiter(pids, setupExe)
+ *          │   detached PowerShell, living OUTSIDE the install root
+ *          │   (Setup.exe deletes that root — a waiter inside it deletes itself)
+ *          │
+ *          ├─ WaitForExit on a HANDLE captured per pid, not a pid poll.
+ *          │  A pid poll is wrong twice over: Windows recycles pids, and a
+ *          │  recycled pid reads as "still alive" forever.
+ *          │
+ *          ├─ then probe the root for locks. Killing a snapshot of pids does
+ *          │  NOT stop the MCP hosts (claude.exe and friends) from spawning a
+ *          │  fresh server into the directory we are about to delete — that is
+ *          │  a TOCTOU window the pid list cannot close.
+ *          │
+ *          ├─ still locked after the budget? ABORT — never launch Setup.exe
+ *          │  against a live tree. Aborting leaves the user on a working old
+ *          │  version; proceeding is what destroys the installation.
+ *          │
+ *          └─ clear? start Setup.exe.
+ *
+ * The abort path writes a marker file the app reads on next boot, so a refused
+ * update is diagnosable instead of looking like "the update button did nothing".
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn, execFileSync } from 'child_process';
+
+/** Result of the pre-flight space check. `null` when there is enough room. */
+export interface SpaceShortfall {
+  volume: string;
+  neededBytes: number;
+  freeBytes: number;
+}
+
+/** What the waiter is asked to do, and where it reports back. */
+export interface WaiterPlan {
+  pids: number[];
+  setupExePath: string;
+  installRoot: string;
+  /** Marker written when the waiter refuses to launch. Read on next boot. */
+  abortMarkerPath: string;
+  /** How long to keep re-checking the root for locks before giving up. */
+  lockBudgetMs: number;
+}
+
+/**
+ * Paths land inside single-quoted PowerShell literals, where `$`, a backtick
+ * and `"` are all literal and an apostrophe escapes by doubling. Only the line
+ * terminators can break the statement-per-line script this module builds.
+ * (Same rule, same reasoning as shortcutHygiene — an over-strict guard there
+ * silently disabled the repair for `C:\Users\O'Connor`.)
+ */
+export function isSafePsPathLiteral(p: string): boolean {
+  return p.length > 0 && !/[\r\n]/.test(p);
+}
+
+function psQuote(p: string): string {
+  return `'${p.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Volume-aware free-space check. The staging download and the install root can
+ * live on different volumes (a redirected AppData, a mapped drive), so a single
+ * "is there room" number is meaningless — each volume is budgeted separately
+ * and the FIRST shortfall is reported.
+ *
+ * `probe` is injected so tests do not depend on the host's actual disks.
+ */
+export function freeSpaceShortfall(
+  budgets: Array<{ dir: string; neededBytes: number }>,
+  probe: (dir: string) => { volume: string; freeBytes: number } | null,
+): SpaceShortfall | null {
+  const perVolume = new Map<string, { needed: number; free: number }>();
+  for (const b of budgets) {
+    const info = probe(b.dir);
+    if (!info) continue; // unreadable volume — do not invent a refusal
+    const acc = perVolume.get(info.volume) ?? { needed: 0, free: info.freeBytes };
+    acc.needed += b.neededBytes;
+    acc.free = info.freeBytes;
+    perVolume.set(info.volume, acc);
+  }
+  for (const [volume, { needed, free }] of perVolume) {
+    if (free < needed) return { volume, neededBytes: needed, freeBytes: free };
+  }
+  return null;
+}
+
+/** Real disk probe. Separated from the pure logic above so tests can stub it. */
+export function probeVolume(dir: string): { volume: string; freeBytes: number } | null {
+  try {
+    const volume = path.parse(path.resolve(dir)).root;
+    const stats = fs.statfsSync(dir);
+    return { volume, freeBytes: stats.bavail * stats.bsize };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every process running out of the install root, minus ourselves.
+ *
+ * NOT the same query as squirrelTeardown's: that one classifies by role and
+ * deliberately SPARES the daemon (the persistence promise). Here the daemon is
+ * the main offender — the point is that nothing at all may hold the tree open.
+ * Matching on the executable path rather than the image name also catches the
+ * MCP servers, which are our exe but are owned by agent processes.
+ */
+export function selectInstallRootPids(
+  rows: ReadonlyArray<{ pid: number; executablePath: string }>,
+  installRoot: string,
+  ownPid: number,
+): number[] {
+  const prefix = installRoot.endsWith(path.sep) ? installRoot : installRoot + path.sep;
+  return rows
+    .filter((r) => r.pid !== ownPid && r.pid > 0)
+    .filter((r) => r.executablePath.toLowerCase().startsWith(prefix.toLowerCase()))
+    .map((r) => r.pid);
+}
+
+/** Parse `Get-CimInstance ... | ConvertTo-Json` rows. Tolerates the single-object form. */
+export function parseProcessRows(stdout: string): Array<{ pid: number; executablePath: string }> {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+  const items = Array.isArray(parsed) ? parsed : [parsed];
+  const out: Array<{ pid: number; executablePath: string }> = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const o = item as Record<string, unknown>;
+    const pid = typeof o.ProcessId === 'number' ? o.ProcessId : NaN;
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    out.push({
+      pid,
+      executablePath: typeof o.ExecutablePath === 'string' ? o.ExecutablePath : '',
+    });
+  }
+  return out;
+}
+
+/**
+ * The waiter script. Pure so its ordering guarantees are unit-testable — the
+ * one property that matters is that Setup.exe is never started before both the
+ * handle waits and the lock probe have passed.
+ */
+export function buildWaiterScript(plan: WaiterPlan): string | null {
+  const paths = [plan.setupExePath, plan.installRoot, plan.abortMarkerPath];
+  if (!paths.every(isSafePsPathLiteral)) return null;
+  if (!plan.pids.every((p) => Number.isInteger(p) && p > 0)) return null;
+
+  const pidList = plan.pids.join(',');
+  return [
+    `$ErrorActionPreference = 'SilentlyContinue'`,
+    `$root = ${psQuote(plan.installRoot)}`,
+    `$setup = ${psQuote(plan.setupExePath)}`,
+    `$marker = ${psQuote(plan.abortMarkerPath)}`,
+    `$budget = ${plan.lockBudgetMs}`,
+    // Capture HANDLES first. GetProcessById opens a handle now, so a later pid
+    // recycle cannot make an exited process look alive (or a stranger's
+    // process look like ours).
+    `$handles = @()`,
+    `foreach ($id in @(${pidList})) { try { $handles += [System.Diagnostics.Process]::GetProcessById($id) } catch { } }`,
+    `foreach ($h in $handles) { try { $h.WaitForExit() } catch { } }`,
+    // Everything we knew about is gone. That is necessary, not sufficient: the
+    // MCP hosts can have spawned a replacement into the root meanwhile.
+    `function Test-RootLocked {`,
+    `  $files = @(Get-ChildItem -LiteralPath $root -Recurse -Filter *.exe -File -ErrorAction SilentlyContinue)`,
+    `  foreach ($f in $files) {`,
+    `    try { $s = [System.IO.File]::Open($f.FullName, 'Open', 'ReadWrite', 'None'); $s.Close() } catch { return $true }`,
+    `  }`,
+    `  return $false`,
+    `}`,
+    `$deadline = [Environment]::TickCount + $budget`,
+    `while ((Test-RootLocked) -and ([Environment]::TickCount -lt $deadline)) { Start-Sleep -Milliseconds 500 }`,
+    `if (Test-RootLocked) {`,
+    // Refusing leaves a working old version. Launching anyway is precisely the
+    // failure this module exists to prevent, so there is no "best effort" here.
+    `  Set-Content -LiteralPath $marker -Value 'install-aborted: install root still locked' -Encoding utf8`,
+    `  exit 2`,
+    `}`,
+    `Start-Process -FilePath $setup`,
+    `exit 0`,
+  ].join('\n');
+}
+
+/** Enumerate, best-effort. win32-only; never throws into the update path. */
+export function collectInstallRootPids(installRoot: string): number[] {
+  if (process.platform !== 'win32') return [];
+  try {
+    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+    const powershell = path.join(
+      systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+    );
+    const exeName = path.basename(process.execPath);
+    if (!/^[\w][\w .-]*\.exe$/i.test(exeName)) return [];
+    const stdout = execFileSync(
+      powershell,
+      [
+        '-NoProfile', '-NonInteractive', '-Command',
+        `Get-CimInstance Win32_Process -Filter "Name='${exeName}'" -ErrorAction SilentlyContinue | Select-Object ProcessId,ExecutablePath | ConvertTo-Json -Compress`,
+      ],
+      { encoding: 'utf-8', timeout: 10_000, windowsHide: true },
+    );
+    return selectInstallRootPids(parseProcessRows(stdout), installRoot, process.pid);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Write the waiter to a temp directory and start it detached.
+ *
+ * The script deliberately does NOT live under the install root: Setup.exe
+ * deletes that root, and a waiter inside it would be deleting itself while
+ * running. Returns the script path on success, null when it could not start —
+ * and a null MUST make the caller abandon the install rather than fall back to
+ * launching Setup.exe directly.
+ */
+export function spawnInstallWaiter(plan: WaiterPlan): string | null {
+  if (process.platform !== 'win32') return null;
+  const script = buildWaiterScript(plan);
+  if (!script) return null;
+  try {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-install-waiter-'));
+    const scriptPath = path.join(dir, 'wait-and-install.ps1');
+    fs.writeFileSync(scriptPath, script, 'utf-8');
+    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+    const powershell = path.join(
+      systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+    );
+    const child = spawn(
+      powershell,
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptPath],
+      { detached: true, stdio: 'ignore', windowsHide: true },
+    );
+    child.unref();
+    return scriptPath;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The daemon's pid, or null when it cannot be read.
+ *
+ * Only used to EXCLUDE it from the force-kill list — the daemon is taken down
+ * gracefully so it can flush scrollback first. A null here therefore fails in
+ * the safe direction on the install path (the daemon gets force-killed like
+ * anything else, losing a flush but not the install), which is why this does
+ * not reach for the launcher's verify-before-kill machinery.
+ */
+export function readDaemonPid(wmuxDir: string): number | null {
+  try {
+    const pid = parseInt(fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Force-kill the given pids (tree-kill, so Chromium helpers go with their
+ * parent). Returns the pids actually killed.
+ *
+ * Used for the processes nothing else takes down on the install path: the MCP
+ * servers run out of the install root but are owned by agent hosts, not by us,
+ * so a normal quit leaves them holding the tree open. The daemon is NOT in this
+ * list — it gets the graceful `daemon.shutdown` path, which flushes scrollback
+ * before exiting.
+ *
+ * Best-effort by construction: a survivor is caught by the waiter's lock probe,
+ * which refuses the install rather than destroying it.
+ */
+export function terminatePids(pids: readonly number[]): number[] {
+  if (process.platform !== 'win32') return [];
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const taskkill = path.join(systemRoot, 'System32', 'taskkill.exe');
+  const killed: number[] = [];
+  for (const pid of pids) {
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    try {
+      execFileSync(taskkill, ['/PID', String(pid), '/T', '/F'], {
+        timeout: 10_000,
+        windowsHide: true,
+        stdio: 'ignore',
+      });
+      killed.push(pid);
+    } catch {
+      /* already gone, or access denied — the lock probe is the real gate */
+    }
+  }
+  return killed;
+}
+
+/** Read + clear the abort marker. Called at boot so a refusal is reportable. */
+export function consumeAbortMarker(markerPath: string): string | null {
+  try {
+    if (!fs.existsSync(markerPath)) return null;
+    const text = fs.readFileSync(markerPath, 'utf-8').trim();
+    fs.unlinkSync(markerPath);
+    return text || 'install-aborted';
+  } catch {
+    return null;
+  }
+}

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -57,6 +57,17 @@ import * as os from 'os';
 import * as path from 'path';
 import { spawn, execFileSync } from 'child_process';
 
+/**
+ * Marker the waiter writes when it refuses to launch, relative to userData.
+ *
+ * Lives here rather than in AutoUpdater because two different processes need
+ * the same name: the updater hands the path to the waiter, and the next boot
+ * reads it back. A refused install is otherwise indistinguishable from "the
+ * update button did nothing", which is the state this whole change is trying
+ * to stop shipping.
+ */
+export const INSTALL_ABORT_MARKER = 'update-install-aborted.txt';
+
 /** Result of the pre-flight space check. `null` when there is enough room. */
 export interface SpaceShortfall {
   volume: string;
@@ -287,8 +298,13 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
  */
 export function readDaemonPid(wmuxDir: string): number | null {
   try {
-    const pid = parseInt(fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim(), 10);
-    return Number.isInteger(pid) && pid > 0 ? pid : null;
+    const raw = fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim();
+    // Strict digits rather than parseInt: parseInt('12.5') is 12, so a
+    // malformed pid file would silently name a DIFFERENT process — and the one
+    // thing this value does is decide which process to spare from a kill.
+    if (!/^\d+$/.test(raw)) return null;
+    const pid = Number(raw);
+    return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
   } catch {
     return null;
   }

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -194,6 +194,10 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
   const paths = [plan.setupExePath, plan.installRoot, plan.abortMarkerPath];
   if (!paths.every(isSafePsPathLiteral)) return null;
   if (!plan.pids.every((p) => Number.isInteger(p) && p > 0)) return null;
+  // Same check the pids get. A zero, negative or NaN budget would put the
+  // deadline in the past, so the lock loop would fall through on its first
+  // pass — turning the gate that makes this whole change work into a no-op.
+  if (!Number.isInteger(plan.lockBudgetMs) || plan.lockBudgetMs <= 0) return null;
 
   const pidList = plan.pids.join(',');
   return [
@@ -207,11 +211,35 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // process look like ours).
     `$handles = @()`,
     `foreach ($id in @(${pidList})) { try { $handles += [System.Diagnostics.Process]::GetProcessById($id) } catch { } }`,
-    `foreach ($h in $handles) { try { $h.WaitForExit() } catch { } }`,
+    // Bounded, and the bound is the point. taskkill is best-effort: a process
+    // it could not terminate would make an unbounded WaitForExit block forever,
+    // and by then wmux has already quit — so the update would silently stall
+    // with no marker and nothing to tell the user on the next boot. The whole
+    // wait shares one deadline rather than giving each handle a fresh budget.
+    `$waitDeadline = [Environment]::TickCount + $budget`,
+    `$stuck = $false`,
+    `foreach ($h in $handles) {`,
+    `  $left = $waitDeadline - [Environment]::TickCount`,
+    `  if ($left -le 0) { $stuck = $true; break }`,
+    `  try { if (-not $h.WaitForExit($left)) { $stuck = $true; break } } catch { }`,
+    `}`,
+    `if ($stuck) {`,
+    `  Set-Content -LiteralPath $marker -Value 'install-aborted: a process under the install root would not exit' -Encoding utf8`,
+    `  exit 3`,
+    `}`,
     // Everything we knew about is gone. That is necessary, not sufficient: the
     // MCP hosts can have spawned a replacement into the root meanwhile.
+    // Probe the loadable images, not just the .exe files. The delete that
+    // failed in the field died on `ffmpeg.dll`, and measuring a live install
+    // shows why: with the app running, 1 .exe is locked but 9 binaries are.
+    // Probing every file instead would be the complete answer and costs 10.8 s
+    // per pass against 0.7 s here — far too slow for a loop that re-checks
+    // twice a second. Binaries are a sound proxy: a process holds its own image
+    // and every module it loaded, so "no binary is locked" means the processes
+    // are gone, and their handles on data files went with them.
+    `$binExt = @('.exe', '.dll', '.node', '.asar')`,
     `function Test-RootLocked {`,
-    `  $files = @(Get-ChildItem -LiteralPath $root -Recurse -Filter *.exe -File -ErrorAction SilentlyContinue)`,
+    `  $files = @(Get-ChildItem -LiteralPath $root -Recurse -File -ErrorAction SilentlyContinue | Where-Object { $binExt -contains $_.Extension })`,
     `  foreach ($f in $files) {`,
     `    try { $s = [System.IO.File]::Open($f.FullName, 'Open', 'ReadWrite', 'None'); $s.Close() } catch { return $true }`,
     `  }`,
@@ -225,7 +253,16 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `  Set-Content -LiteralPath $marker -Value 'install-aborted: install root still locked' -Encoding utf8`,
     `  exit 2`,
     `}`,
-    `Start-Process -FilePath $setup`,
+    // A verified installer can still be gone by now — quarantined by AV,
+    // swept by a temp cleaner. Under SilentlyContinue that failure is invisible
+    // and the script would exit 0, leaving a user who just watched wmux quit
+    // with no update and no explanation on the next boot.
+    `$started = $true`,
+    `try { Start-Process -FilePath $setup -ErrorAction Stop } catch { $started = $false }`,
+    `if (-not $started) {`,
+    `  Set-Content -LiteralPath $marker -Value 'install-aborted: the installer could not be started' -Encoding utf8`,
+    `  exit 4`,
+    `}`,
     `exit 0`,
   ].join('\n');
 }
@@ -270,7 +307,13 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
   try {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-install-waiter-'));
     const scriptPath = path.join(dir, 'wait-and-install.ps1');
-    fs.writeFileSync(scriptPath, script, 'utf-8');
+    // The BOM is load-bearing. Windows PowerShell 5.1 decodes a BOM-less file
+    // as the system ANSI code page, so on a Korean install every path we
+    // embedded — all of them under the user profile — comes back mangled.
+    // Measured: with `C:\Users\홍길동\...` the BOM-less script still exits 0
+    // while writing to the wrong path, which is the worst shape a failure can
+    // take here (silent success). With the BOM it behaves.
+    fs.writeFileSync(scriptPath, '\uFEFF' + script, 'utf-8');
     const systemRoot = process.env.SystemRoot || 'C:\\Windows';
     const powershell = path.join(
       systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
@@ -344,14 +387,31 @@ export function terminatePids(pids: readonly number[]): number[] {
   return killed;
 }
 
-/** Read + clear the abort marker. Called at boot so a refusal is reportable. */
-export function consumeAbortMarker(markerPath: string): string | null {
+/**
+ * Read the abort marker without clearing it. Pair with `clearAbortMarker`
+ * AFTER the notice has actually been delivered — clearing on read loses the
+ * only record of the refusal if the app dies before the renderer sees it, and
+ * then it is never reportable again.
+ */
+export function readAbortMarker(markerPath: string): string | null {
   try {
     if (!fs.existsSync(markerPath)) return null;
-    const text = fs.readFileSync(markerPath, 'utf-8').trim();
-    fs.unlinkSync(markerPath);
-    return text || 'install-aborted';
+    return fs.readFileSync(markerPath, 'utf-8').trim() || 'install-aborted';
   } catch {
+    // A read failure is not a refusal — say nothing rather than invent one.
     return null;
+  }
+}
+
+/**
+ * Drop the marker so the notice fires once. Separate from the read so an
+ * unlink failure (permissions, AV holding the file) cannot swallow a reason we
+ * already have in hand; the marker simply survives to the next boot.
+ */
+export function clearAbortMarker(markerPath: string): void {
+  try {
+    fs.unlinkSync(markerPath);
+  } catch {
+    /* best-effort — a surviving marker re-reports, which beats losing it */
   }
 }

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -153,10 +153,16 @@ export function selectInstallRootPids(
   installRoot: string,
   ownPid: number,
 ): number[] {
-  const prefix = installRoot.endsWith(path.sep) ? installRoot : installRoot + path.sep;
+  // Backslash explicitly, not `path.sep`. Every input here is a Windows path
+  // read out of Win32_Process, and this only ever runs on win32 — but the
+  // function is pure, so it is unit-tested on the Linux and macOS CI legs too,
+  // where `path.sep` is `/` and the prefix would match nothing. The separator
+  // belongs to the DATA, not to the host.
+  const trimmed = installRoot.replace(/[\\/]+$/, '');
+  const prefix = `${trimmed}\\`.toLowerCase();
   return rows
     .filter((r) => r.pid !== ownPid && r.pid > 0)
-    .filter((r) => r.executablePath.toLowerCase().startsWith(prefix.toLowerCase()))
+    .filter((r) => r.executablePath.toLowerCase().startsWith(prefix))
     .map((r) => r.pid);
 }
 

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1066,6 +1066,11 @@ const electronAPI = {
       ipcRenderer.invoke(IPC.UPDATE_CHECK) as Promise<{ status: string }>,
     installUpdate: () =>
       ipcRenderer.invoke(IPC.UPDATE_INSTALL),
+    // #866 — collect (and clear) the reason a previous install was refused.
+    // Pulled by an always-mounted renderer surface, because the push-on-boot
+    // version landed in a window whose only listener was the Settings panel.
+    takeRefusedInstall: () =>
+      ipcRenderer.invoke(IPC.UPDATE_TAKE_REFUSED_INSTALL) as Promise<string | null>,
     onUpdateAvailable: (callback: (data: { status: string; releaseName?: string }) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, data: { status: string; releaseName?: string }) =>
         callback(data);

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -297,6 +297,38 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
  * handler's fixed 36. Mirrors useTitleBarOverlaySync's color read. Safe under
  * jsdom: bails when electronAPI is absent.
  */
+/**
+ * #866 — collect a refused install's reason and say so, once, at mount.
+ *
+ * PULL rather than a main-side push: the push version fired on a boot timer
+ * and the only listener lived in the Settings panel, which is mounted only
+ * while Settings is OPEN. With Settings closed — the default — nothing
+ * received it and the marker was cleared anyway, so a failed update stayed as
+ * invisible as it was before the feature existed. This runs from AppLayout,
+ * which is always mounted, and the take is what clears the marker: a notice
+ * nobody could receive survives to the next boot instead.
+ */
+function useRefusedInstallNotice(t: (key: string) => string): void {
+  useEffect(() => {
+    const take = window.electronAPI?.updater?.takeRefusedInstall;
+    if (!take) return; // tests / non-electron / stale preload
+    let cancelled = false;
+    void take()
+      .then((reason) => {
+        if (cancelled || !reason) return;
+        useStore.getState().pushToast({ level: 'error', message: t('update.refusedInstall') });
+      })
+      .catch((err) => {
+        // Loud on purpose. The first version of this failed exactly here — the
+        // main-side handler was registered late and the invoke rejected — and
+        // a silent catch is what made a missing notice look like "no refusal
+        // happened". Never break mount over it, but never hide it either.
+        console.warn('[update] could not collect a refused-install notice:', err);
+      });
+    return () => { cancelled = true; };
+  }, [t]);
+}
+
 function useUiScaleSync(uiScale: number): void {
   useEffect(() => {
     const send = window.electronAPI?.window?.setUiScale;
@@ -403,6 +435,7 @@ export default function AppLayout() {
   const [showAutoUpdatePrompt, setShowAutoUpdatePrompt] = useState(false);
   const t = useT();
 
+  useRefusedInstallNotice(t);
   useKeyboard();
   // NOTE: useActivePaneFocus() now runs inside <FocusManager> (a render-null
   // child), NOT here. Its focusKey subscription embeds activeWorkspaceId and

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -1848,6 +1848,15 @@ function UpdateStatus() {
         {state === 'error' && errorMsg && (
           <p className="text-[10px] mt-0.5" style={{ color: 'var(--text-muted)' }}>{errorMsg}</p>
         )}
+        {/* #866: the Windows install has to run against a dead tree, so the
+            daemon goes down with the app and live panes do not survive it.
+            Said before the button is pressed, not after — the old copy
+            promised the opposite ("sessions persist in the daemon"). */}
+        {state === 'downloaded' && (
+          <p className="text-[10px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            {t('settings.updateEndsSessions')}
+          </p>
+        )}
         {state === 'downloading' && (
           <div className="mt-1.5 h-1 w-40 rounded-full overflow-hidden" style={{ backgroundColor: 'var(--bg-surface)' }}>
             <div

--- a/src/renderer/i18n/__tests__/updateSessionsLocale.test.ts
+++ b/src/renderer/i18n/__tests__/updateSessionsLocale.test.ts
@@ -1,0 +1,85 @@
+// The update widget warns that installing ends running sessions (#866). A
+// missing key does not throw — t() renders a placeholder — so a locale that
+// forgot this string would silently promise nothing at the exact moment the
+// user is about to lose their panes. Every locale owns it, or this fails.
+import { describe, expect, it } from 'vitest';
+import { LOCALE_OPTIONS, type Locale } from '../index';
+import { ar } from '../locales/ar';
+import { bs } from '../locales/bs';
+import { da } from '../locales/da';
+import { de } from '../locales/de';
+import { en } from '../locales/en';
+import { es } from '../locales/es';
+import { fr } from '../locales/fr';
+import { hi } from '../locales/hi';
+import { id } from '../locales/id';
+import { it as italian } from '../locales/it';
+import { ja } from '../locales/ja';
+import { ko } from '../locales/ko';
+import { ms } from '../locales/ms';
+import { nb } from '../locales/nb';
+import { pl } from '../locales/pl';
+import { ptBR } from '../locales/pt-BR';
+import { ru } from '../locales/ru';
+import { th } from '../locales/th';
+import { tr } from '../locales/tr';
+import { uk } from '../locales/uk';
+import { vi } from '../locales/vi';
+import { zhTW } from '../locales/zh-TW';
+import { zh } from '../locales/zh';
+
+const KEY = 'settings.updateEndsSessions';
+
+const LOCALE_TRANSLATIONS = {
+  en,
+  ko,
+  ja,
+  zh,
+  'zh-TW': zhTW,
+  ar,
+  bs,
+  da,
+  de,
+  es,
+  fr,
+  hi,
+  id,
+  it: italian,
+  ms,
+  nb,
+  pl,
+  'pt-BR': ptBR,
+  ru,
+  th,
+  tr,
+  uk,
+  vi,
+} satisfies Record<Locale, Partial<Record<typeof KEY, string>>>;
+
+describe('update session-loss warning locale contract', () => {
+  for (const { value: locale } of LOCALE_OPTIONS) {
+    it(`${locale}: owns the session-loss warning instead of relying on fallback`, () => {
+      const translations = LOCALE_TRANSLATIONS[locale];
+
+      expect(
+        Object.prototype.hasOwnProperty.call(translations, KEY),
+        `${locale} falls back for "${KEY}"`,
+      ).toBe(true);
+
+      const copy = translations[KEY];
+      if (typeof copy !== 'string') throw new Error(`${locale} missing "${KEY}"`);
+      expect(copy).toBeTruthy();
+      expect(copy).not.toBe(KEY);
+      // An untranslated placeholder or a stray interpolation token would render
+      // as literal braces to the user.
+      expect(copy).not.toMatch(/\{[a-zA-Z]+\}/);
+    });
+  }
+
+  it('every locale is distinct from at least the key itself and non-trivially long', () => {
+    for (const [locale, translations] of Object.entries(LOCALE_TRANSLATIONS)) {
+      const copy = (translations as Record<string, string>)[KEY];
+      expect(copy.length, `${locale} copy is suspiciously short`).toBeGreaterThan(8);
+    }
+  });
+});

--- a/src/renderer/i18n/locales/ar.ts
+++ b/src/renderer/i18n/locales/ar.ts
@@ -153,6 +153,7 @@ export const ar = {
   'settings.sidebarLeft': 'يسار',
   'settings.sidebarRight': 'يمين',
   'settings.updateReady': 'التحديث جاهز',
+  'settings.updateEndsSessions': 'سيؤدي التثبيت إلى إغلاق الجلسات قيد التشغيل.',
   'settings.checkFailed': 'فشل التحقق',
   'settings.unknownError': 'خطأ غير معروف',
   'settings.notificationBehavior': 'سلوك الإشعارات',

--- a/src/renderer/i18n/locales/bs.ts
+++ b/src/renderer/i18n/locales/bs.ts
@@ -153,6 +153,7 @@ export const bs = {
   'settings.sidebarLeft': 'Lijevo',
   'settings.sidebarRight': 'Desno',
   'settings.updateReady': 'Ažuriranje spremno',
+  'settings.updateEndsSessions': 'Instalacija zatvara sve pokrenute sesije.',
   'settings.checkFailed': 'Provjera neuspjela',
   'settings.unknownError': 'Nepoznata greška',
   'settings.notificationBehavior': 'Ponašanje obavještenja',

--- a/src/renderer/i18n/locales/da.ts
+++ b/src/renderer/i18n/locales/da.ts
@@ -153,6 +153,7 @@ export const da = {
   'settings.sidebarLeft': 'Venstre',
   'settings.sidebarRight': 'Højre',
   'settings.updateReady': 'Opdatering klar',
+  'settings.updateEndsSessions': 'Installation lukker dine kørende sessioner.',
   'settings.checkFailed': 'Tjek mislykkedes',
   'settings.unknownError': 'Ukendt fejl',
   'settings.notificationBehavior': 'Notifikationsadfærd',

--- a/src/renderer/i18n/locales/de.ts
+++ b/src/renderer/i18n/locales/de.ts
@@ -153,6 +153,7 @@ export const de = {
   'settings.sidebarLeft': 'Links',
   'settings.sidebarRight': 'Rechts',
   'settings.updateReady': 'Update bereit',
+  'settings.updateEndsSessions': 'Die Installation beendet alle laufenden Sitzungen.',
   'settings.checkFailed': 'Prüfung fehlgeschlagen',
   'settings.unknownError': 'Unbekannter Fehler',
   'settings.notificationBehavior': 'Benachrichtigungsverhalten',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -608,6 +608,7 @@ export const en = {
   'settings.paneActionsVisible': 'Pane action buttons',
   'settings.paneActionsVisibleDesc': 'Show new-terminal, split, and new-browser buttons in each pane\'s tab strip.',
   'settings.updateReady': 'Update ready',
+  'settings.updateEndsSessions': 'Installing closes your running sessions.',
   'settings.checkFailed': 'Check failed',
   'settings.unknownError': 'Unknown error',
   'settings.notificationBehavior': 'Notification behavior',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1023,6 +1023,8 @@ export const en = {
     'Channels were updated, but the background daemon is still running the old version. Quit wmux fully and start it again to finish the update.',
   'daemon.replacingToast':
     'Updating the background daemon to this version — panes may pause briefly and restore automatically.',
+  'update.refusedInstall':
+    'The last update did not install: something was still using the wmux install folder, so it was left untouched rather than half-replaced. Try again, or close wmux and run the installer from the releases page.',
   'channels.alreadyMemberToast': '{workspace} is already in #{channel}',
   'channels.joinFailedToast': "Couldn't add {workspace} to the channel",
   'channels.leftToast': 'Left #{channel}',

--- a/src/renderer/i18n/locales/es.ts
+++ b/src/renderer/i18n/locales/es.ts
@@ -153,6 +153,7 @@ export const es = {
   'settings.sidebarLeft': 'Izquierda',
   'settings.sidebarRight': 'Derecha',
   'settings.updateReady': 'Actualización lista',
+  'settings.updateEndsSessions': 'La instalación cierra las sesiones en ejecución.',
   'settings.checkFailed': 'Comprobación fallida',
   'settings.unknownError': 'Error desconocido',
   'settings.notificationBehavior': 'Comportamiento de notificaciones',

--- a/src/renderer/i18n/locales/fr.ts
+++ b/src/renderer/i18n/locales/fr.ts
@@ -153,6 +153,7 @@ export const fr = {
   'settings.sidebarLeft': 'Gauche',
   'settings.sidebarRight': 'Droite',
   'settings.updateReady': 'Mise à jour prête',
+  'settings.updateEndsSessions': 'L’installation ferme vos sessions en cours.',
   'settings.checkFailed': 'Vérification échouée',
   'settings.unknownError': 'Erreur inconnue',
   'settings.notificationBehavior': 'Comportement des notifications',

--- a/src/renderer/i18n/locales/hi.ts
+++ b/src/renderer/i18n/locales/hi.ts
@@ -153,6 +153,7 @@ export const hi = {
   'settings.sidebarLeft': 'बाएँ',
   'settings.sidebarRight': 'दाएँ',
   'settings.updateReady': 'अपडेट तैयार',
+  'settings.updateEndsSessions': 'इंस्टॉल करने पर आपके चल रहे सेशन बंद हो जाएंगे।',
   'settings.checkFailed': 'जाँच विफल',
   'settings.unknownError': 'अज्ञात त्रुटि',
   'settings.notificationBehavior': 'सूचना व्यवहार',

--- a/src/renderer/i18n/locales/id.ts
+++ b/src/renderer/i18n/locales/id.ts
@@ -153,6 +153,7 @@ export const id = {
   'settings.sidebarLeft': 'Kiri',
   'settings.sidebarRight': 'Kanan',
   'settings.updateReady': 'Pembaruan siap',
+  'settings.updateEndsSessions': 'Pemasangan akan menutup sesi yang sedang berjalan.',
   'settings.checkFailed': 'Pemeriksaan gagal',
   'settings.unknownError': 'Galat tidak diketahui',
   'settings.notificationBehavior': 'Perilaku notifikasi',

--- a/src/renderer/i18n/locales/it.ts
+++ b/src/renderer/i18n/locales/it.ts
@@ -153,6 +153,7 @@ export const it = {
   'settings.sidebarLeft': 'Sinistra',
   'settings.sidebarRight': 'Destra',
   'settings.updateReady': 'Aggiornamento pronto',
+  'settings.updateEndsSessions': 'L’installazione chiude le sessioni in esecuzione.',
   'settings.checkFailed': 'Verifica fallita',
   'settings.unknownError': 'Errore sconosciuto',
   'settings.notificationBehavior': 'Comportamento notifiche',

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -155,6 +155,7 @@ export const ja = {
   'settings.sidebarLeft': '左',
   'settings.sidebarRight': '右',
   'settings.updateReady': 'アップデート準備完了',
+  'settings.updateEndsSessions': 'インストールすると実行中のセッションはすべて終了します。',
   'settings.checkFailed': '確認に失敗しました',
   'settings.unknownError': '不明なエラー',
   'settings.notificationBehavior': '通知の動作',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -814,6 +814,8 @@ export const ko = {
     '채널이 업데이트되었지만 백그라운드 데몬이 이전 버전으로 실행 중입니다. wmux를 완전히 종료한 뒤 다시 시작하면 적용됩니다.',
   'daemon.replacingToast':
     '백그라운드 데몬을 이 버전으로 업데이트하는 중입니다 — 판이 잠시 멈췄다가 자동으로 복원될 수 있습니다.',
+  'update.refusedInstall':
+    '지난 업데이트가 설치되지 않았습니다: 무언가가 wmux 설치 폴더를 계속 사용 중이어서, 반쯤 교체되는 대신 그대로 두었습니다. 다시 시도하거나, wmux를 종료한 뒤 릴리스 페이지의 설치 프로그램을 실행하세요.',
   'channels.alreadyMemberToast': '{workspace}은(는) 이미 #{channel}에 있습니다',
   'channels.joinFailedToast': '{workspace} 추가에 실패했습니다',
   'channels.leftToast': '#{channel}에서 나갔습니다',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -436,6 +436,7 @@ export const ko = {
   'settings.sidebarLeft': '왼쪽',
   'settings.sidebarRight': '오른쪽',
   'settings.updateReady': '업데이트 준비 완료',
+  'settings.updateEndsSessions': '설치하면 실행 중인 세션이 모두 종료됩니다.',
   'settings.checkFailed': '확인 실패',
   'settings.unknownError': '알 수 없는 오류',
   'settings.notificationBehavior': '알림 동작',

--- a/src/renderer/i18n/locales/ms.ts
+++ b/src/renderer/i18n/locales/ms.ts
@@ -153,6 +153,7 @@ export const ms = {
   'settings.sidebarLeft': 'Kiri',
   'settings.sidebarRight': 'Kanan',
   'settings.updateReady': 'Kemas kini sedia',
+  'settings.updateEndsSessions': 'Pemasangan akan menutup sesi yang sedang berjalan.',
   'settings.checkFailed': 'Pemeriksaan gagal',
   'settings.unknownError': 'Ralat tidak diketahui',
   'settings.notificationBehavior': 'Kelakuan pemberitahuan',

--- a/src/renderer/i18n/locales/nb.ts
+++ b/src/renderer/i18n/locales/nb.ts
@@ -153,6 +153,7 @@ export const nb = {
   'settings.sidebarLeft': 'Venstre',
   'settings.sidebarRight': 'Høyre',
   'settings.updateReady': 'Oppdatering klar',
+  'settings.updateEndsSessions': 'Installasjonen lukker øktene som kjører.',
   'settings.checkFailed': 'Sjekk mislyktes',
   'settings.unknownError': 'Ukjent feil',
   'settings.notificationBehavior': 'Varselatferd',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -153,6 +153,7 @@ export const pl = {
   'settings.sidebarLeft': 'Lewo',
   'settings.sidebarRight': 'Prawo',
   'settings.updateReady': 'Aktualizacja gotowa',
+  'settings.updateEndsSessions': 'Instalacja zamknie uruchomione sesje.',
   'settings.checkFailed': 'Sprawdzanie nie powiodło się',
   'settings.unknownError': 'Nieznany błąd',
   'settings.notificationBehavior': 'Zachowanie powiadomień',

--- a/src/renderer/i18n/locales/pt-BR.ts
+++ b/src/renderer/i18n/locales/pt-BR.ts
@@ -153,6 +153,7 @@ export const ptBR = {
   'settings.sidebarLeft': 'Esquerda',
   'settings.sidebarRight': 'Direita',
   'settings.updateReady': 'Atualização pronta',
+  'settings.updateEndsSessions': 'A instalação encerra as sessões em execução.',
   'settings.checkFailed': 'Verificação falhou',
   'settings.unknownError': 'Erro desconhecido',
   'settings.notificationBehavior': 'Comportamento das notificações',

--- a/src/renderer/i18n/locales/ru.ts
+++ b/src/renderer/i18n/locales/ru.ts
@@ -153,6 +153,7 @@ export const ru = {
   'settings.sidebarLeft': 'Слева',
   'settings.sidebarRight': 'Справа',
   'settings.updateReady': 'Обновление готово',
+  'settings.updateEndsSessions': 'Установка закроет запущенные сессии.',
   'settings.checkFailed': 'Проверка не удалась',
   'settings.unknownError': 'Неизвестная ошибка',
   'settings.notificationBehavior': 'Поведение уведомлений',

--- a/src/renderer/i18n/locales/th.ts
+++ b/src/renderer/i18n/locales/th.ts
@@ -153,6 +153,7 @@ export const th = {
   'settings.sidebarLeft': 'ซ้าย',
   'settings.sidebarRight': 'ขวา',
   'settings.updateReady': 'การอัปเดตพร้อมแล้ว',
+  'settings.updateEndsSessions': 'การติดตั้งจะปิดเซสชันที่กำลังทำงานอยู่',
   'settings.checkFailed': 'การตรวจสอบล้มเหลว',
   'settings.unknownError': 'ข้อผิดพลาดที่ไม่รู้จัก',
   'settings.notificationBehavior': 'พฤติกรรมการแจ้งเตือน',

--- a/src/renderer/i18n/locales/tr.ts
+++ b/src/renderer/i18n/locales/tr.ts
@@ -153,6 +153,7 @@ export const tr = {
   'settings.sidebarLeft': 'Sol',
   'settings.sidebarRight': 'Sağ',
   'settings.updateReady': 'Güncelleme hazır',
+  'settings.updateEndsSessions': 'Kurulum çalışan oturumlarınızı kapatır.',
   'settings.checkFailed': 'Denetim başarısız',
   'settings.unknownError': 'Bilinmeyen hata',
   'settings.notificationBehavior': 'Bildirim davranışı',

--- a/src/renderer/i18n/locales/uk.ts
+++ b/src/renderer/i18n/locales/uk.ts
@@ -153,6 +153,7 @@ export const uk = {
   'settings.sidebarLeft': 'Ліворуч',
   'settings.sidebarRight': 'Праворуч',
   'settings.updateReady': 'Оновлення готове',
+  'settings.updateEndsSessions': 'Встановлення закриє запущені сесії.',
   'settings.checkFailed': 'Перевірку не вдалося',
   'settings.unknownError': 'Невідома помилка',
   'settings.notificationBehavior': 'Поведінка сповіщень',

--- a/src/renderer/i18n/locales/vi.ts
+++ b/src/renderer/i18n/locales/vi.ts
@@ -153,6 +153,7 @@ export const vi = {
   'settings.sidebarLeft': 'Trái',
   'settings.sidebarRight': 'Phải',
   'settings.updateReady': 'Cập nhật sẵn sàng',
+  'settings.updateEndsSessions': 'Cài đặt sẽ đóng các phiên đang chạy.',
   'settings.checkFailed': 'Kiểm tra thất bại',
   'settings.unknownError': 'Lỗi không xác định',
   'settings.notificationBehavior': 'Hành vi thông báo',

--- a/src/renderer/i18n/locales/zh-TW.ts
+++ b/src/renderer/i18n/locales/zh-TW.ts
@@ -153,6 +153,7 @@ export const zhTW = {
   'settings.sidebarLeft': '左側',
   'settings.sidebarRight': '右側',
   'settings.updateReady': '更新已就緒',
+  'settings.updateEndsSessions': '安裝將關閉所有正在執行的工作階段。',
   'settings.checkFailed': '檢查失敗',
   'settings.unknownError': '未知錯誤',
   'settings.notificationBehavior': '通知行為',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -155,6 +155,7 @@ export const zh = {
   'settings.sidebarLeft': '左',
   'settings.sidebarRight': '右',
   'settings.updateReady': '更新已准备就绪',
+  'settings.updateEndsSessions': '安装将关闭所有正在运行的会话。',
   'settings.checkFailed': '检查失败',
   'settings.unknownError': '未知错误',
   'settings.notificationBehavior': '通知行为',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -320,6 +320,12 @@ export const IPC = {
   UPDATE_ERROR: 'update:error',
   UPDATE_DOWNLOAD: 'update:download',
   UPDATE_INSTALL: 'update:install',
+  // #866 — the renderer PULLS a refused install's reason once it is mounted
+  // and can actually show it. Main pushing on a timer raced the mount and
+  // dropped the notice into a window with no listener; the take is what
+  // clears the on-disk marker, so a notice nobody received survives to the
+  // next boot instead of being consumed by the attempt.
+  UPDATE_TAKE_REFUSED_INSTALL: 'update:take-refused-install',
   // Settings sync (renderer → main)
   TOAST_ENABLED: 'settings:toast-enabled',
   // #516 — renderer mirrors the muted notification categories so the


### PR DESCRIPTION
## What this is, and what it is not

Squirrel's `Setup.exe` is a first-install program, not an updater: it deletes the whole install root as its first action. `performInstall` launched it and only then called `app.quit()`, so the delete began while our own processes still held the tree open.

**It is not the widespread breakage I first claimed.** I measured the real path end to end — installed 3.40.2, left the daemon and four MCP servers running, pressed Check for updates — and it worked. The delete failed and Squirrel simply carried on:

```
warn:  Install path ...\wmux already exists, burning it to the ground
error: DeleteDirectory: could not delete - app-3.40.2: IOException (in use by another process)
error: DeleteDirectory: could not delete - wmux: IOException (directory not empty)
info:  Writing files to app directory: ...\app-3.41.0
info:  Finished Squirrel Updater
```

The exception TYPE decides it, not the lock:

| scenario | exception | outcome |
|---|---|---|
| Setup.exe run against a fully live app | `UnauthorizedAccessException` on a FILE (`ffmpeg.dll`) | escapes `Program.Install` — fatal, root half-deleted, no launcher left |
| in-app update (app is quitting) | `IOException` on a DIRECTORY in use | caught, logged, install continues |

So this PR closes two narrower things:

1. **The manual-launch destruction.** Running the installer while wmux is fully up produces the file-level access-denied that Squirrel does not survive. That is the #502 scenario, and it is still reachable today.
2. **A window where the app has no launcher.** Watching the successful update, the root stub was missing for 4 seconds (10:15:08 → 10:15:11) before Squirrel re-rigged it. An install that dies in there strands the user with blank icons and nothing to run.

Nobody's routine update has been at risk. Issue lowered to P2 accordingly.

## Approach

The installer is started by a **detached waiter** that proceeds only once every process under the install root is confirmed gone AND the root is confirmed unlocked. Both checks are needed: the pid list cannot close the window in which an agent's MCP host spawns a fresh server into the directory we are about to delete.

A root that never clears **aborts and leaves a marker** rather than launching. Refusing costs the user a retry; proceeding is what costs them the installation.

```
performInstall (win32, packaged only)
  ├─ free-space preflight, budgeted per volume ── short ──► refuse, nothing written
  ├─ spawn waiter FIRST (captures a handle per pid)
  │     └─ null ──► refuse, nothing killed, no quit state armed
  ├─ ask for the full-shutdown branch (daemon flushes scrollback, then exits)
  ├─ force-kill what nothing else owns (MCP servers belong to agent hosts)
  └─ quit
        waiter: wait handles (bounded) → probe locks → launch, or abort with a marker
```

Also here:

- **Packaged-only guard.** The teardown derives the install root from `process.execPath`, which unpackaged is the runtime binary. Without the guard the enumerate-and-kill targets unrelated processes under it — the unit suite lost its own worker to exactly that before it existed.
- **The daemon is spared the force-kill** and gets the graceful shutdown so it flushes scrollback, via a new `onInstallRequiresFullShutdown` hook that reuses the tray's existing full-teardown branch.
- **A refusal is reported on the next boot** instead of looking like the update button did nothing.
- **The update widget now says installing ends running sessions**, in all 23 locales. The previous copy promised the opposite ("sessions persist in the daemon"), which is false on this path.

## Three-way review

Reviewed independently by Codex, GLM-5.2 and this session. Seven findings, all reproduced before being fixed:

- **BOM-less UTF-8 script** (GLM). Windows PowerShell 5.1 decodes a BOM-less file as the system ANSI code page. Measured with a Korean profile path: the waiter exits 0 while writing to a mangled path — silent success, the worst shape this failure can take, on the maintainer's own locale.
- **`.exe`-only lock probe** (all three). The delete that destroyed a machine died on `ffmpeg.dll`. Measured on a live install: 1 `.exe` locked vs 9 binaries. Probing every file is the complete answer at 10.8 s per pass against 0.7 s for binaries — far too slow for a loop that re-checks twice a second — so the probe covers `exe/dll/node/asar`.
- **Unbounded `WaitForExit`** (Codex). `taskkill` is best-effort; a survivor left the waiter blocked forever with wmux already gone, so the update stalled silently.
- **Full-shutdown latch set before the handoff was known to exist** (Codex). A failed handoff left the one-way flag armed, so a later ordinary Quit would tear the daemon down and close every session — for an install that never happened.
- **`Start-Process` failure swallowed** (Codex + GLM), reported as exit 0.
- **Marker cleared on read** (GLM) — a crash inside the notice delay lost the refusal permanently.
- **`lockBudgetMs` unvalidated** (GLM) — a zero budget turns the lock gate into a no-op.

## Testing

- `vitest run src/main/updater/__tests__/ src/renderer/i18n/__tests__/updateSessionsLocale.test.ts` — **118 passed**
- `vitest run --config vitest.runtime.config.ts src/main/updater/__tests__/installTeardown.runtime.test.ts` — **8 passed**, against real processes, real file locks and the real waiter script: blocks while a tracked process lives, aborts when an untracked process holds the root (the TOCTOU case), aborts when only a DLL is locked (the file the field failure died on), gives up rather than waiting forever, and keeps the script outside the root Setup.exe deletes.
- `tsc --noEmit` clean; eslint adds no errors.

Not covered: a packaged N→N+1 run driven from the fixed build's own update button. The fix cannot be exercised that way until it ships in a release, since the code that runs during an upgrade belongs to the version being upgraded *from*.

Refs #866


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows update installation by safely closing active sessions, waiting for files and processes to become available, and verifying installation readiness.
  * Updates no longer launch when preparation fails, insufficient disk space is detected, or the installation directory remains in use.
  * Failed installation handoffs now display a notice on the next launch.

* **New Features**
  * Added localized warnings explaining that installing an update closes active sessions, available in all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #866
