### PR TITLE
perf(main): resolve PTY ownership and role bindings mirror-first

### DIFF
--- a/changelog.d/870.md
+++ b/changelog.d/870.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Terminal ownership checks stop waiting on the UI.** Every MCP call an agent
+  makes — sending to a pane, polling events, resolving its own identity — used
+  to ask the renderer who owns a terminal, once per check. That question was
+  slowest to answer exactly when the app was busiest. Main now answers from the
+  workspace snapshot the renderer already pushes it, and falls back to asking
+  whenever the snapshot is stale, missing, or disagrees. Cross-workspace access
+  is still refused on the renderer's word, never on a cached guess. (#870)

--- a/src/main/ipc/handlers/__tests__/workspaceMirror.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/workspaceMirror.handler.test.ts
@@ -91,3 +91,36 @@ describe('parseWorkspaceMirrorPayload — defensive renderer-trust validation', 
     expect(pane?.cwd).toBeUndefined();
   });
 });
+
+describe('parseWorkspaceMirrorPayload — roleBindings passthrough (3-way review: Codex)', () => {
+  // The original fast-path change validated the mirror by calling setSnapshot
+  // directly, bypassing this parser — which silently DROPPED roleBindings, so
+  // the resolver fell back to the round-trip on every call. These tests pin
+  // the production path: whatever reaches setSnapshot must carry the field.
+  const base = { ts: 1, entries: [], fleets: [] };
+
+  it('forwards a present roleBindings map (values opaque, keys validated)', () => {
+    const parsed = parseWorkspaceMirrorPayload({
+      ...base,
+      roleBindings: { 'pty-1': { agent: 'claude', model: 'haiku' }, '': { dropped: true } },
+    });
+    expect(parsed?.roleBindings).toEqual({ 'pty-1': { agent: 'claude', model: 'haiku' } });
+  });
+
+  it('an ABSENT field stays absent (old renderer ⇒ resolver must round-trip)', () => {
+    const parsed = parseWorkspaceMirrorPayload({ ...base });
+    expect(parsed).not.toBeNull();
+    expect('roleBindings' in (parsed as object)).toBe(false);
+  });
+
+  it('an EMPTY map survives as empty (authoritative "nothing bound")', () => {
+    const parsed = parseWorkspaceMirrorPayload({ ...base, roleBindings: {} });
+    expect(parsed?.roleBindings).toEqual({});
+  });
+
+  it('a non-record roleBindings is dropped, not fatal', () => {
+    const parsed = parseWorkspaceMirrorPayload({ ...base, roleBindings: 'junk' });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.roleBindings).toBeUndefined();
+  });
+});

--- a/src/main/ipc/handlers/workspaceMirror.handler.ts
+++ b/src/main/ipc/handlers/workspaceMirror.handler.ts
@@ -130,7 +130,22 @@ export function parseWorkspaceMirrorPayload(raw: unknown): WorkspaceMirrorPushPa
     .map(parseFleet)
     .filter((f): f is FleetSnapshot => f !== null);
   const ts = typeof raw.ts === 'number' ? raw.ts : 0;
-  return { ts, entries, fleets };
+  const out: WorkspaceMirrorPushPayload = { ts, entries, fleets };
+  // D2 role bindings (perf root-fix P1): forward the map so the mirror-first
+  // binding resolver actually receives it — dropping the field here silently
+  // disables the fast path (every push would look like an old renderer and
+  // force the round-trip forever). Values stay opaque: ptyOwnership.ts
+  // re-normalizes them at the read boundary, so the parser only guards the
+  // container shape. Field ABSENT (old renderer) stays absent — the resolver
+  // must keep treating that as "unknown", never as "no bindings".
+  if (isRecord(raw.roleBindings)) {
+    const bindings: Record<string, unknown> = {};
+    for (const [ptyId, value] of Object.entries(raw.roleBindings)) {
+      if (typeof ptyId === 'string' && ptyId.length > 0) bindings[ptyId] = value;
+    }
+    out.roleBindings = bindings;
+  }
+  return out;
 }
 
 /**

--- a/src/main/pipe/handlers/a2a.channel.rpc.ts
+++ b/src/main/pipe/handlers/a2a.channel.rpc.ts
@@ -51,7 +51,7 @@ import type { RpcRouter } from '../RpcRouter';
 import type { RpcContext } from '../../../shared/rpc';
 import type { DaemonClient } from '../../DaemonClient';
 import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
-import { sendToRenderer } from './_bridge';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -70,12 +70,9 @@ async function resolveCallerWorkspace(getWindow: GetWindow, params: unknown): Pr
       : '';
   if (!senderPtyId) return '';
   try {
-    const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: senderPtyId });
-    const wsId =
-      owner && typeof owner === 'object' && 'workspaceId' in owner
-        ? (owner as Record<string, unknown>).workspaceId
-        : null;
-    return typeof wsId === 'string' && wsId ? wsId : '';
+    // Mirror-first (workspace/ptyOwnership.ts); renderer round-trip fallback.
+    const wsId = await resolvePtyOwnerWorkspace(getWindow, senderPtyId);
+    return wsId ?? '';
   } catch {
     // Renderer unavailable (early boot / reload) — treat as unresolvable.
     return '';

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -1,6 +1,7 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { sendToRenderer } from './_bridge';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 import type { ClaudeWorker } from '../../a2a/ClaudeWorker';
 import type { DaemonClient } from '../../DaemonClient';
 import * as fs from 'fs';
@@ -228,11 +229,10 @@ export function registerA2aRpc(
         // scope — a snapshot-only liveness signal can be incomplete and would
         // risk deleting a LIVE pane's anchor (3-way review consensus).
         try {
-          const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: value });
-          const wsId =
-            owner && typeof owner === 'object' && 'workspaceId' in owner
-              ? (owner as Record<string, unknown>)['workspaceId']
-              : null;
+          // Mirror-first (workspace/ptyOwnership.ts) — this loop pays one
+          // lookup per live pid-map anchor, so a fresh mirror collapses N
+          // renderer round-trips into zero.
+          const wsId = await resolvePtyOwnerWorkspace(getWindow, value);
           if (typeof wsId === 'string' && wsId) {
             mappings[file] = wsId;
             entries.push({ pid: file, ptyId: value, workspaceId: wsId });

--- a/src/main/pipe/handlers/deck.rpc.ts
+++ b/src/main/pipe/handlers/deck.rpc.ts
@@ -20,7 +20,7 @@
 
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
-import { sendToRenderer } from './_bridge';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 import { commanderTokenWorkspace } from '../../deck/commanderTrust';
 import {
   loadWorkspaceDecision,
@@ -69,13 +69,12 @@ export function registerDeckRpc(router: RpcRouter, getWindow: GetWindow): void {
     if (typeof ptyId !== 'string' || ptyId.length === 0) {
       throw new Error('deck.resolvePaneRoute: missing required param "ptyId"');
     }
-    // Same ownership oracle assertWorkspaceOwnsPty consults — the renderer's
-    // live workspace tree.
-    const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
-    const owner =
-      result && typeof result === 'object' && 'workspaceId' in result
-        ? ((result as Record<string, unknown>)['workspaceId'] as string | null)
-        : null;
+    // Same ownership oracle assertWorkspaceOwnsPty consults — mirror-first
+    // with the renderer's live workspace tree as fallback/deny authority
+    // (workspace/ptyOwnership.ts).
+    const owner = await resolvePtyOwnerWorkspace(getWindow, ptyId, {
+      expected: tokenWorkspaceId,
+    });
     if (typeof owner !== 'string' || owner.length === 0) {
       throw new Error(`deck.resolvePaneRoute: no workspace owns PTY "${ptyId}"`);
     }

--- a/src/main/pipe/handlers/events.rpc.ts
+++ b/src/main/pipe/handlers/events.rpc.ts
@@ -11,7 +11,7 @@ import {
   type ChannelCatalogEvent,
 } from '../../../shared/events';
 import type { PluginIdentityRecord } from '../../../shared/rpc';
-import { sendToRenderer } from './_bridge';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -53,12 +53,10 @@ async function resolveCallerWorkspace(
   const senderPtyId = typeof raw === 'string' ? raw.trim() : '';
   if (!senderPtyId) return '';
   try {
-    const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: senderPtyId });
-    const wsId =
-      owner && typeof owner === 'object' && 'workspaceId' in owner
-        ? (owner as Record<string, unknown>).workspaceId
-        : null;
-    return typeof wsId === 'string' && wsId ? wsId : '';
+    // Mirror-first (workspace/ptyOwnership.ts) — this runs on every private-
+    // scoped agent poll, so the renderer round-trip is fallback, not hot path.
+    const wsId = await resolvePtyOwnerWorkspace(getWindow, senderPtyId);
+    return wsId ?? '';
   } catch {
     // Renderer unavailable (early boot / reload) — treat as unresolvable.
     return '';

--- a/src/main/pipe/handlers/fanout.rpc.ts
+++ b/src/main/pipe/handlers/fanout.rpc.ts
@@ -82,6 +82,7 @@ import {
   WORKTASK_IDEMPOTENCY_CAP,
 } from '../../../shared/workTask';
 import { sendToRenderer } from './_bridge';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 import { git as runGit } from '../../git/git';
 import type { FanOutRequest, FanOutService } from '../../worktask/FanOutService';
 
@@ -239,12 +240,9 @@ async function repoRootOf(dir: string): Promise<string | null> {
 async function resolveCallerWorkspace(getWindow: GetWindow, senderPtyId: string): Promise<string> {
   if (!senderPtyId) return '';
   try {
-    const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: senderPtyId });
-    const wsId =
-      owner && typeof owner === 'object' && 'workspaceId' in owner
-        ? (owner as Record<string, unknown>)['workspaceId']
-        : null;
-    return typeof wsId === 'string' && wsId ? wsId : '';
+    // Mirror-first (workspace/ptyOwnership.ts); renderer round-trip fallback.
+    const wsId = await resolvePtyOwnerWorkspace(getWindow, senderPtyId);
+    return wsId ?? '';
   } catch {
     // Renderer unavailable (early boot / reload) — unresolvable, fail closed.
     return '';

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -4,8 +4,12 @@ import type { PTYManager } from '../../pty/PTYManager';
 import type { DaemonClient } from '../../DaemonClient';
 import { sendToRenderer } from './_bridge';
 import { sanitizePtyText } from '../../../shared/types';
-import { applyRoleBinding, normalizeRoleBinding, type RoleBinding } from '../../../shared/orchestratorRole';
+import { applyRoleBinding, type RoleBinding } from '../../../shared/orchestratorRole';
 import { isGateHeldOn } from '../../deck/stopGateState';
+import {
+  assertWorkspaceOwnsPty,
+  resolveRoleBindingForPty,
+} from '../../workspace/ptyOwnership';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -94,42 +98,9 @@ async function resolveActivePtyId(getWindow: GetWindow, callerWs?: string): Prom
 }
 
 /**
- * Verify that `ptyId` belongs to a surface inside `expectedWorkspaceId`.
- * Throws when the PTY is owned by a different workspace (or no workspace at
- * all). Returns silently when `expectedWorkspaceId` is undefined — internal
- * callers (CLI, UI) skip this check.
- *
- * Closes the cross-workspace bypass where the metadata layer enforced
- * isolation but the PTY-id-keyed terminal IO layer didn't: any caller that
- * learned a foreign PTY id (via leaks, screenshots, surface_list) could
- * read or write that workspace's terminal at will.
- */
-async function assertWorkspaceOwnsPty(
-  getWindow: GetWindow,
-  ptyId: string,
-  expectedWorkspaceId: string | undefined,
-  rpcName: string,
-): Promise<void> {
-  if (!expectedWorkspaceId) return;
-  const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
-  const owner =
-    result && typeof result === 'object' && 'workspaceId' in result
-      ? ((result as Record<string, unknown>)['workspaceId'] as string | null)
-      : null;
-  if (owner !== expectedWorkspaceId) {
-    throw new Error(
-      `${rpcName}: PTY "${ptyId}" is not owned by workspace "${expectedWorkspaceId}" ` +
-        `(actual owner: ${owner ?? 'none'}). Cross-workspace terminal access is not allowed.`,
-    );
-  }
-}
-
-/**
- * Resolve a pane's enforced role→model binding for a ptyId, via the SAME
- * renderer oracle assertWorkspaceOwnsPty already consults (input.findOwnerWorkspace,
- * extended in D2 to also return the owning paneId + resolved roleBinding). Both
- * the role mirror and the operator binding map live in the renderer store, so
- * the renderer resolves the pair; main just applies the pure transform.
+ * Resolve a pane's enforced role→model binding for a ptyId. Mirror-first with
+ * a renderer round-trip fallback — see workspace/ptyOwnership.ts (which also
+ * hosts assertWorkspaceOwnsPty, shared with the other ownership call sites).
  *
  * Returns undefined on any miss (no owner, unbound role, malformed reply) — the
  * caller fails OPEN, never blocking a legitimate send because a lookup raced.
@@ -137,13 +108,8 @@ async function assertWorkspaceOwnsPty(
 export type RoleBindingResolver = (ptyId: string) => Promise<RoleBinding | undefined>;
 
 export function makeRoleBindingResolver(getWindow: GetWindow): RoleBindingResolver {
-  return async (ptyId: string): Promise<RoleBinding | undefined> => {
-    const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
-    if (!result || typeof result !== 'object' || !('roleBinding' in result)) return undefined;
-    // Re-normalize at the read boundary — the renderer store is hand-editable
-    // via session.json, so treat the binding as untrusted even here.
-    return normalizeRoleBinding((result as Record<string, unknown>)['roleBinding']);
-  };
+  return (ptyId: string): Promise<RoleBinding | undefined> =>
+    resolveRoleBindingForPty(getWindow, ptyId);
 }
 
 /**

--- a/src/main/pipe/handlers/meta.rpc.ts
+++ b/src/main/pipe/handlers/meta.rpc.ts
@@ -3,7 +3,7 @@ import type { RpcRouter } from '../RpcRouter';
 import type { RpcContext } from '../../../shared/rpc';
 import type { MetadataUpdatePayload } from '../../../shared/types';
 import { broadcastMetadataUpdate } from '../../ipc/handlers/metadata.handler';
-import { sendToRenderer } from './_bridge';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -18,12 +18,9 @@ async function resolveCallerWorkspace(getWindow: GetWindow, params: Record<strin
     typeof params['senderPtyId'] === 'string' ? params['senderPtyId'] : '';
   if (!senderPtyId) return '';
   try {
-    const owner = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId: senderPtyId });
-    const wsId =
-      owner && typeof owner === 'object' && 'workspaceId' in owner
-        ? (owner as Record<string, unknown>)['workspaceId']
-        : null;
-    return typeof wsId === 'string' && wsId ? wsId : '';
+    // Mirror-first (workspace/ptyOwnership.ts); renderer round-trip fallback.
+    const wsId = await resolvePtyOwnerWorkspace(getWindow, senderPtyId);
+    return wsId ?? '';
   } catch {
     return '';
   }

--- a/src/main/workspace/WorkspaceMirror.ts
+++ b/src/main/workspace/WorkspaceMirror.ts
@@ -81,15 +81,18 @@ export class WorkspaceMirror {
   }
 
   /**
-   * The mirrored role-binding map plus its age, WITHOUT mutating anything.
-   * null when nothing was ever pushed OR the last push predates the
+   * ONE pty's mirrored role binding plus the snapshot's age, WITHOUT mutating
+   * anything. null when nothing was ever pushed OR the last push predates the
    * roleBindings field (old renderer) — both mean "unknown, round-trip".
-   * Returns the raw (untrusted) values; callers re-normalize at the read
-   * boundary. The record is copied so a mutating caller can't corrupt it.
+   * A non-null result with `binding: undefined` means the map is PRESENT and
+   * this pty is authoritatively unbound. Single-key on purpose: the caller
+   * (input.send hot path) reads one entry per call, so copying the whole map
+   * per lookup would tax exactly the path this mirror exists to speed up.
+   * The value is raw (untrusted); callers re-normalize at the read boundary.
    */
-  peekRoleBindings(): { bindings: Record<string, unknown>; ageMs: number } | null {
+  peekRoleBinding(ptyId: string): { binding: unknown; ageMs: number } | null {
     if (this.roleBindings === null) return null;
-    return { bindings: { ...this.roleBindings }, ageMs: this.now() - this.setAt };
+    return { binding: this.roleBindings[ptyId], ageMs: this.now() - this.setAt };
   }
 
   /** The per-workspace agent-status snapshot, or null when unknown. */

--- a/src/main/workspace/WorkspaceMirror.ts
+++ b/src/main/workspace/WorkspaceMirror.ts
@@ -31,6 +31,9 @@ export type {
 export class WorkspaceMirror {
   private entries: WorkspaceListEntry[] | null = null;
   private fleets = new Map<string, FleetSnapshot>();
+  // null ⇒ the last push carried no roleBindings field (old renderer) — callers
+  // must treat the bindings as UNKNOWN and round-trip, never as "unbound".
+  private roleBindings: Record<string, unknown> | null = null;
   private setAt = 0;
   private populated = false;
   private readonly now: () => number;
@@ -46,6 +49,7 @@ export class WorkspaceMirror {
   setSnapshot(payload: WorkspaceMirrorPushPayload): void {
     this.entries = payload.entries;
     this.fleets = new Map(payload.fleets.map((f) => [f.workspaceId, f]));
+    this.roleBindings = payload.roleBindings ?? null;
     // Stamp with our own clock, not the renderer's `payload.ts`: `peek().ageMs`
     // must be measured against the same clock the caller reads `now()` on, so a
     // clock skew between renderer and main can never make a snapshot look
@@ -74,6 +78,18 @@ export class WorkspaceMirror {
   peek(): { entries: WorkspaceListEntry[]; ageMs: number } | null {
     if (this.entries === null) return null;
     return { entries: [...this.entries], ageMs: this.now() - this.setAt };
+  }
+
+  /**
+   * The mirrored role-binding map plus its age, WITHOUT mutating anything.
+   * null when nothing was ever pushed OR the last push predates the
+   * roleBindings field (old renderer) — both mean "unknown, round-trip".
+   * Returns the raw (untrusted) values; callers re-normalize at the read
+   * boundary. The record is copied so a mutating caller can't corrupt it.
+   */
+  peekRoleBindings(): { bindings: Record<string, unknown>; ageMs: number } | null {
+    if (this.roleBindings === null) return null;
+    return { bindings: { ...this.roleBindings }, ageMs: this.now() - this.setAt };
   }
 
   /** The per-workspace agent-status snapshot, or null when unknown. */

--- a/src/main/workspace/__tests__/ptyOwnership.test.ts
+++ b/src/main/workspace/__tests__/ptyOwnership.test.ts
@@ -1,0 +1,172 @@
+// ptyOwnership — mirror-first ownership / role-binding resolution (T1~T6).
+//
+// Deliberately uses the REAL WorkspaceMirror singleton driven through
+// setSnapshot, never a mock of the mirror itself: when the guard under test IS
+// the suspected component, mocking it repeats the blindness (see the
+// DaemonNotificationRouter suppression-wedge postmortem). Only the renderer
+// bridge (sendToRenderer) is mocked — it is the round-trip boundary whose
+// call count is the observable under test.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getWorkspaceMirror,
+  __resetWorkspaceMirrorForTest,
+} from '../WorkspaceMirror';
+import {
+  resolvePtyOwnerWorkspace,
+  assertWorkspaceOwnsPty,
+  resolveRoleBindingForPty,
+} from '../ptyOwnership';
+import { STALE_TRUST_MS } from '../../pipe/handlers/hooks.rpc';
+
+vi.mock('../../pipe/handlers/_bridge', () => ({
+  sendToRenderer: vi.fn(),
+}));
+
+import { sendToRenderer } from '../../pipe/handlers/_bridge';
+
+const mockedSend = vi.mocked(sendToRenderer);
+const getWindow = () => null;
+
+/** Push a snapshot where ws-A owns pty-1/pty-2 and ws-B owns pty-3. */
+function pushSnapshot(overrides: { roleBindings?: Record<string, unknown> } = {}): void {
+  getWorkspaceMirror().setSnapshot({
+    ts: Date.now(),
+    entries: [
+      { id: 'ws-A', name: 'A', activePtyId: 'pty-1', ptyIds: ['pty-1', 'pty-2'] },
+      { id: 'ws-B', name: 'B', activePtyId: 'pty-3', ptyIds: ['pty-3'] },
+    ],
+    fleets: [],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetWorkspaceMirrorForTest();
+  mockedSend.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  __resetWorkspaceMirrorForTest();
+});
+
+describe('resolvePtyOwnerWorkspace — assert posture (expected given)', () => {
+  it('T1: fresh mirror agreeing with the expectation skips the round-trip', async () => {
+    pushSnapshot();
+    const owner = await resolvePtyOwnerWorkspace(getWindow, 'pty-1', { expected: 'ws-A' });
+    expect(owner).toBe('ws-A');
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it('T2: fresh mirror DISAGREEING falls back to the round-trip (deny authority)', async () => {
+    pushSnapshot();
+    // Mirror says pty-3 → ws-B, caller expects ws-A. The renderer (fresher)
+    // says the pane just moved into ws-A — the round-trip verdict wins.
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A' });
+    const owner = await resolvePtyOwnerWorkspace(getWindow, 'pty-3', { expected: 'ws-A' });
+    expect(owner).toBe('ws-A');
+    expect(mockedSend).toHaveBeenCalledWith(getWindow, 'input.findOwnerWorkspace', {
+      ptyId: 'pty-3',
+    });
+  });
+
+  it('T3: stale mirror (>STALE_TRUST_MS) is ignored even when it would agree', async () => {
+    pushSnapshot();
+    vi.advanceTimersByTime(STALE_TRUST_MS + 1);
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A' });
+    const owner = await resolvePtyOwnerWorkspace(getWindow, 'pty-1', { expected: 'ws-A' });
+    expect(owner).toBe('ws-A');
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('T4: never-populated mirror (cold boot) round-trips', async () => {
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A' });
+    const owner = await resolvePtyOwnerWorkspace(getWindow, 'pty-1', { expected: 'ws-A' });
+    expect(owner).toBe('ws-A');
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('assertWorkspaceOwnsPty', () => {
+  it('undefined expected workspace skips the check entirely (internal callers)', async () => {
+    await assertWorkspaceOwnsPty(getWindow, 'pty-1', undefined, 'input.send');
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it('mirror-hit allow does not round-trip; round-trip deny still throws', async () => {
+    pushSnapshot();
+    await assertWorkspaceOwnsPty(getWindow, 'pty-1', 'ws-A', 'input.send');
+    expect(mockedSend).not.toHaveBeenCalled();
+
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-B' });
+    await expect(
+      assertWorkspaceOwnsPty(getWindow, 'pty-3', 'ws-A', 'input.send'),
+    ).rejects.toThrow(/not owned by workspace "ws-A"/);
+  });
+
+  it('a deny is NEVER produced by the mirror alone — the round-trip confirms it', async () => {
+    pushSnapshot();
+    // Mirror would deny (pty-3 ∈ ws-B), but the renderer says ws-A: allowed.
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A' });
+    await expect(
+      assertWorkspaceOwnsPty(getWindow, 'pty-3', 'ws-A', 'input.send'),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('resolvePtyOwnerWorkspace — resolve posture (no expected)', () => {
+  it('T5: fresh mirror hit answers identity without a round-trip; miss round-trips', async () => {
+    pushSnapshot();
+    expect(await resolvePtyOwnerWorkspace(getWindow, 'pty-3')).toBe('ws-B');
+    expect(mockedSend).not.toHaveBeenCalled();
+
+    // Unknown pty: mirror miss must NOT be treated as authoritative "no owner"
+    // (a just-spawned pty can race the push) — it falls through to the renderer.
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-C' });
+    expect(await resolvePtyOwnerWorkspace(getWindow, 'pty-9')).toBe('ws-C');
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('round-trip null/absent owner resolves to null (fail-closed at call sites)', async () => {
+    mockedSend.mockResolvedValue({ workspaceId: null });
+    expect(await resolvePtyOwnerWorkspace(getWindow, 'pty-9')).toBeNull();
+    mockedSend.mockResolvedValue(undefined);
+    expect(await resolvePtyOwnerWorkspace(getWindow, 'pty-9')).toBeNull();
+  });
+});
+
+describe('resolveRoleBindingForPty (T6)', () => {
+  const binding = { agent: 'claude', model: 'haiku' };
+
+  it('fresh mirror with a bindings map answers bound AND unbound locally', async () => {
+    pushSnapshot({ roleBindings: { 'pty-1': binding } });
+    const hit = await resolveRoleBindingForPty(getWindow, 'pty-1');
+    expect(hit?.model).toBe('haiku');
+    // Absent from a present map = authoritatively unbound — still no round-trip.
+    expect(await resolveRoleBindingForPty(getWindow, 'pty-2')).toBeUndefined();
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
+  it('old-renderer push (no roleBindings field) round-trips instead of guessing', async () => {
+    pushSnapshot(); // no roleBindings key → peekRoleBindings() === null
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A', roleBinding: binding });
+    const resolved = await resolveRoleBindingForPty(getWindow, 'pty-1');
+    expect(resolved?.model).toBe('haiku');
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('stale mirror round-trips; malformed mirrored binding normalizes to undefined', async () => {
+    pushSnapshot({ roleBindings: { 'pty-1': binding } });
+    vi.advanceTimersByTime(STALE_TRUST_MS + 1);
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A', roleBinding: binding });
+    expect((await resolveRoleBindingForPty(getWindow, 'pty-1'))?.model).toBe('haiku');
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+
+    mockedSend.mockClear();
+    pushSnapshot({ roleBindings: { 'pty-1': { bogus: true } } });
+    expect(await resolveRoleBindingForPty(getWindow, 'pty-1')).toBeUndefined();
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/workspace/__tests__/ptyOwnership.test.ts
+++ b/src/main/workspace/__tests__/ptyOwnership.test.ts
@@ -157,6 +157,17 @@ describe('resolveRoleBindingForPty (T6)', () => {
     expect(mockedSend).toHaveBeenCalledTimes(1);
   });
 
+  it('a pty the snapshot has never seen ROUND-TRIPS instead of answering "unbound"', async () => {
+    // The push that would carry a just-spawned pane's binding may not have
+    // landed yet. Reading its absence as "no binding" would let the first
+    // submit after a split bypass the enforced model (Codex re-review).
+    pushSnapshot({ roleBindings: { 'pty-1': binding } });
+    mockedSend.mockResolvedValue({ workspaceId: 'ws-A', roleBinding: binding });
+    const resolved = await resolveRoleBindingForPty(getWindow, 'pty-just-spawned');
+    expect(resolved?.model).toBe('haiku');
+    expect(mockedSend).toHaveBeenCalledTimes(1);
+  });
+
   it('END-TO-END through the IPC parser: bindings survive parse→setSnapshot→resolve', async () => {
     // Regression for the 3-way-review Codex finding: the production push path
     // goes through parseWorkspaceMirrorPayload, which used to DROP the

--- a/src/main/workspace/__tests__/ptyOwnership.test.ts
+++ b/src/main/workspace/__tests__/ptyOwnership.test.ts
@@ -157,6 +157,27 @@ describe('resolveRoleBindingForPty (T6)', () => {
     expect(mockedSend).toHaveBeenCalledTimes(1);
   });
 
+  it('END-TO-END through the IPC parser: bindings survive parse→setSnapshot→resolve', async () => {
+    // Regression for the 3-way-review Codex finding: the production push path
+    // goes through parseWorkspaceMirrorPayload, which used to DROP the
+    // roleBindings field — so a setSnapshot-only test proved nothing about
+    // production. This test walks the real path.
+    const { parseWorkspaceMirrorPayload } = await import(
+      '../../ipc/handlers/workspaceMirror.handler'
+    );
+    const parsed = parseWorkspaceMirrorPayload({
+      ts: Date.now(),
+      entries: [{ id: 'ws-A', name: 'A', activePtyId: 'pty-1', ptyIds: ['pty-1'] }],
+      fleets: [],
+      roleBindings: { 'pty-1': binding },
+    });
+    expect(parsed).not.toBeNull();
+    getWorkspaceMirror().setSnapshot(parsed!);
+    const resolved = await resolveRoleBindingForPty(getWindow, 'pty-1');
+    expect(resolved?.model).toBe('haiku');
+    expect(mockedSend).not.toHaveBeenCalled();
+  });
+
   it('stale mirror round-trips; malformed mirrored binding normalizes to undefined', async () => {
     pushSnapshot({ roleBindings: { 'pty-1': binding } });
     vi.advanceTimersByTime(STALE_TRUST_MS + 1);

--- a/src/main/workspace/ptyOwnership.ts
+++ b/src/main/workspace/ptyOwnership.ts
@@ -117,11 +117,11 @@ export async function resolveRoleBindingForPty(
   getWindow: GetWindow,
   ptyId: string,
 ): Promise<RoleBinding | undefined> {
-  const peeked = getWorkspaceMirror().peekRoleBindings();
+  const peeked = getWorkspaceMirror().peekRoleBinding(ptyId);
   if (peeked && peeked.ageMs < STALE_TRUST_MS) {
     // Re-normalize at the read boundary — the renderer store is hand-editable
     // via session.json, so treat the mirrored binding as untrusted even here.
-    return normalizeRoleBinding(peeked.bindings[ptyId]);
+    return normalizeRoleBinding(peeked.binding);
   }
   const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
   if (!result || typeof result !== 'object' || !('roleBinding' in result)) return undefined;

--- a/src/main/workspace/ptyOwnership.ts
+++ b/src/main/workspace/ptyOwnership.ts
@@ -1,0 +1,129 @@
+// ptyOwnership — mirror-first resolution of "which workspace owns this PTY"
+// (and its D2 role binding) for main-process RPC handlers.
+//
+// WHY: every external MCP call used to pay a main→renderer round-trip
+// (`input.findOwnerWorkspace`) per ownership check / identity resolution /
+// role-binding lookup — 1-3 round-trips per call, and the renderer answers
+// late exactly when the app is busy (flush storm), which is the moment the
+// latency hurts. Main already holds a renderer-pushed WorkspaceMirror
+// (structural changes push immediately, status churn debounced 300ms, 30s
+// periodic — see useWorkspaceMirrorPush.ts), so a fresh mirror can answer
+// locally and the round-trip becomes the fallback, not the hot path.
+//
+// TRUST MODEL (documented for PR review):
+//   - The mirror and the round-trip have the SAME source of truth (the
+//     renderer store); the mirror is just earlier. The exposure is bounded to
+//     pushes lost/delayed within STALE_TRUST_MS (10s) after a pane moved
+//     workspaces — structural changes push immediately, so the realistic
+//     window is IPC delivery latency (ms).
+//   - assert-style checks (expected workspace known): the mirror can only
+//     SHORT-CIRCUIT AN ALLOW when it AGREES with the expectation. Any miss /
+//     stale / disagreement falls back to the round-trip, which remains the
+//     sole DENY authority — a stale mirror can never produce a false reject.
+//   - resolve-style checks (caller identity from a verified senderPtyId): the
+//     senderPtyId anchor is ADVISORY attribution under the #113 same-user
+//     ceiling by design (see events.rpc.ts resolveCallerWorkspace — the true
+//     unforgeable fix is peer-PID, deferred). A ≤10s-stale answer does not
+//     change that threat model. Misses still round-trip, and the fail-closed
+//     '' contract at the call sites is preserved.
+
+import type { BrowserWindow } from 'electron';
+import { sendToRenderer } from '../pipe/handlers/_bridge';
+import { findWorkspaceIdForPty, STALE_TRUST_MS } from '../pipe/handlers/hooks.rpc';
+import { normalizeRoleBinding, type RoleBinding } from '../../shared/orchestratorRole';
+import { getWorkspaceMirror } from './WorkspaceMirror';
+
+type GetWindow = () => BrowserWindow | null;
+
+/** Parse the renderer's `input.findOwnerWorkspace` reply into an owner id. */
+function parseOwner(result: unknown): string | null {
+  const owner =
+    result && typeof result === 'object' && 'workspaceId' in result
+      ? ((result as Record<string, unknown>)['workspaceId'] as string | null)
+      : null;
+  return typeof owner === 'string' && owner.length > 0 ? owner : null;
+}
+
+/**
+ * Resolve the workspace that owns `ptyId`. Mirror-first, renderer round-trip
+ * fallback. Throws only when the round-trip itself throws (renderer gone) —
+ * callers with a fail-closed contract keep their own try/catch.
+ *
+ * `opts.expected` selects the assert posture: the mirror may only answer when
+ * it AGREES with the expectation (allow short-circuit); any other mirror
+ * verdict falls through to the round-trip so DENY decisions always come from
+ * the freshest source. Without `expected` (resolve posture), any fresh mirror
+ * HIT answers; a fresh MISS still round-trips (a just-spawned pty may race
+ * the push).
+ */
+export async function resolvePtyOwnerWorkspace(
+  getWindow: GetWindow,
+  ptyId: string,
+  opts: { expected?: string } = {},
+): Promise<string | null> {
+  const peeked = getWorkspaceMirror().peek();
+  if (peeked && peeked.ageMs < STALE_TRUST_MS) {
+    const owner = findWorkspaceIdForPty(ptyId, peeked.entries);
+    if (opts.expected !== undefined ? owner === opts.expected : owner !== null) {
+      return owner;
+    }
+  }
+  const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
+  return parseOwner(result);
+}
+
+/**
+ * Verify that `ptyId` belongs to a surface inside `expectedWorkspaceId`.
+ * Throws when the PTY is owned by a different workspace (or no workspace at
+ * all). Returns silently when `expectedWorkspaceId` is undefined — internal
+ * callers (CLI, UI) skip this check.
+ *
+ * Closes the cross-workspace bypass where the metadata layer enforced
+ * isolation but the PTY-id-keyed terminal IO layer didn't (see the original
+ * input.rpc.ts rationale). The mirror fast path only ever short-circuits the
+ * ALLOW; every deny is confirmed by the renderer round-trip.
+ */
+export async function assertWorkspaceOwnsPty(
+  getWindow: GetWindow,
+  ptyId: string,
+  expectedWorkspaceId: string | undefined,
+  rpcName: string,
+): Promise<void> {
+  if (!expectedWorkspaceId) return;
+  const owner = await resolvePtyOwnerWorkspace(getWindow, ptyId, {
+    expected: expectedWorkspaceId,
+  });
+  if (owner !== expectedWorkspaceId) {
+    throw new Error(
+      `${rpcName}: PTY "${ptyId}" is not owned by workspace "${expectedWorkspaceId}" ` +
+        `(actual owner: ${owner ?? 'none'}). Cross-workspace terminal access is not allowed.`,
+    );
+  }
+}
+
+/**
+ * Resolve a pane's enforced role→model binding for a ptyId. Mirror-first: the
+ * push payload carries a COMPLETE ptyId→binding map (workspaceMirrorSnapshot
+ * buildRoleBindings — same resolution the round-trip performs), so a fresh
+ * mirror answers both "bound to X" and "unbound" locally. An old renderer that
+ * pushes no roleBindings field yields peekRoleBindings() === null — unknown,
+ * so we round-trip exactly as before.
+ *
+ * Returns undefined on any miss (no owner, unbound role, malformed reply) —
+ * the caller fails OPEN, never blocking a legitimate send because a lookup
+ * raced (unchanged contract from input.rpc.ts).
+ */
+export async function resolveRoleBindingForPty(
+  getWindow: GetWindow,
+  ptyId: string,
+): Promise<RoleBinding | undefined> {
+  const peeked = getWorkspaceMirror().peekRoleBindings();
+  if (peeked && peeked.ageMs < STALE_TRUST_MS) {
+    // Re-normalize at the read boundary — the renderer store is hand-editable
+    // via session.json, so treat the mirrored binding as untrusted even here.
+    return normalizeRoleBinding(peeked.bindings[ptyId]);
+  }
+  const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
+  if (!result || typeof result !== 'object' || !('roleBinding' in result)) return undefined;
+  return normalizeRoleBinding((result as Record<string, unknown>)['roleBinding']);
+}

--- a/src/main/workspace/ptyOwnership.ts
+++ b/src/main/workspace/ptyOwnership.ts
@@ -103,11 +103,19 @@ export async function assertWorkspaceOwnsPty(
 
 /**
  * Resolve a pane's enforced role→model binding for a ptyId. Mirror-first: the
- * push payload carries a COMPLETE ptyId→binding map (workspaceMirrorSnapshot
- * buildRoleBindings — same resolution the round-trip performs), so a fresh
- * mirror answers both "bound to X" and "unbound" locally. An old renderer that
- * pushes no roleBindings field yields peekRoleBindings() === null — unknown,
- * so we round-trip exactly as before.
+ * push payload carries a ptyId→binding map (workspaceMirrorSnapshot
+ * buildRoleBindings — the same resolution the round-trip performs), so a fresh
+ * mirror can answer both "bound to X" and "unbound" locally. An old renderer
+ * that pushes no roleBindings field yields peekRoleBinding() === null —
+ * unknown, so we round-trip exactly as before.
+ *
+ * The map is complete only for the PTYs THAT SNAPSHOT KNOWS ABOUT. A pane
+ * spawned after the last push is absent from it for a reason that has nothing
+ * to do with bindings, so answering "unbound" from its absence would let the
+ * first `terminal_send("claude", submit:true)` after a split escape the pane's
+ * enforced model — the exact bypass D2 exists to prevent (Codex re-review).
+ * Absence is therefore only authoritative when the ptyId is present in the
+ * SAME snapshot's ownership entries; otherwise we round-trip.
  *
  * Returns undefined on any miss (no owner, unbound role, malformed reply) —
  * the caller fails OPEN, never blocking a legitimate send because a lookup
@@ -117,11 +125,18 @@ export async function resolveRoleBindingForPty(
   getWindow: GetWindow,
   ptyId: string,
 ): Promise<RoleBinding | undefined> {
-  const peeked = getWorkspaceMirror().peekRoleBinding(ptyId);
+  const mirror = getWorkspaceMirror();
+  const peeked = mirror.peekRoleBinding(ptyId);
   if (peeked && peeked.ageMs < STALE_TRUST_MS) {
-    // Re-normalize at the read boundary — the renderer store is hand-editable
-    // via session.json, so treat the mirrored binding as untrusted even here.
-    return normalizeRoleBinding(peeked.binding);
+    // Same snapshot, read back-to-back (no await between) so the entries and
+    // the bindings map can never come from different pushes.
+    const snapshot = mirror.peek();
+    const knownPty = snapshot ? findWorkspaceIdForPty(ptyId, snapshot.entries) !== null : false;
+    if (knownPty) {
+      // Re-normalize at the read boundary — the renderer store is hand-editable
+      // via session.json, so treat the mirrored binding as untrusted even here.
+      return normalizeRoleBinding(peeked.binding);
+    }
   }
   const result = await sendToRenderer(getWindow, 'input.findOwnerWorkspace', { ptyId });
   if (!result || typeof result !== 'object' || !('roleBinding' in result)) return undefined;

--- a/src/renderer/hooks/useWorkspaceMirrorPush.ts
+++ b/src/renderer/hooks/useWorkspaceMirrorPush.ts
@@ -97,7 +97,12 @@ export function useWorkspaceMirrorPush(): void {
         s.surfaceActivity !== prev.surfaceActivity ||
         s.surfaceActivityAt !== prev.surfaceActivityAt ||
         s.paneLabel !== prev.paneLabel ||
-        s.supervisionByPtyId !== prev.supervisionByPtyId;
+        s.supervisionByPtyId !== prev.supervisionByPtyId ||
+        // Role→model bindings ride the mirror (D2 resolver fast path) — a
+        // binding edit must reach main within the debounce window, not wait
+        // for the 30s periodic refresh.
+        s.paneRole !== prev.paneRole ||
+        s.orchestratorRoleBindings !== prev.orchestratorRoleBindings;
       if (statusChurn) scheduleTrailing();
     };
 

--- a/src/renderer/hooks/workspaceMirrorSnapshot.ts
+++ b/src/renderer/hooks/workspaceMirrorSnapshot.ts
@@ -17,6 +17,7 @@ import type {
   WorkspaceMirrorPushPayload,
 } from '../../shared/workspaceMirror';
 import { normalizeRoleBinding } from '../../shared/orchestratorRole';
+import type { StoreState } from '../stores';
 import { selectFleetPanes, type FleetPane, type FleetSelectorState } from '../stores/selectors/fleet';
 
 /**
@@ -24,10 +25,15 @@ import { selectFleetPanes, type FleetPane, type FleetSelectorState } from '../st
  * maps the D2 binding resolution reads. Both are optional so states built for
  * fleet-only tests keep compiling — an absent map simply yields an empty
  * roleBindings payload (still COMPLETE: no roles bound means no bindings).
+ *
+ * INDEXED off StoreState (type-only import, same pattern as fleet.ts) so a
+ * store field rename breaks compilation here instead of silently producing an
+ * always-empty bindings map that main would trust as "nothing bound"
+ * (3-way review: Claude+GLM).
  */
 export type MirrorSnapshotState = FleetSelectorState & {
-  paneRole?: Record<string, string | undefined>;
-  orchestratorRoleBindings?: Record<string, unknown>;
+  paneRole?: StoreState['paneRole'];
+  orchestratorRoleBindings?: StoreState['orchestratorRoleBindings'];
 };
 
 /**
@@ -198,6 +204,9 @@ export function buildRoleBindings(state: MirrorSnapshotState): Record<string, un
   const out: Record<string, unknown> = {};
   const paneRole = state.paneRole ?? {};
   const bindings = state.orchestratorRoleBindings ?? {};
+  // Fast exit for the common case (no roles bound anywhere): skip the
+  // ws×leaf×surface walk this builder otherwise pays on every mirror push.
+  if (Object.keys(paneRole).length === 0 || Object.keys(bindings).length === 0) return out;
   for (const w of state.workspaces) {
     for (const leaf of getLeafPanes(w.rootPane)) {
       const role = paneRole[leaf.id];

--- a/src/renderer/hooks/workspaceMirrorSnapshot.ts
+++ b/src/renderer/hooks/workspaceMirrorSnapshot.ts
@@ -16,7 +16,19 @@ import type {
   FleetSnapshotPane,
   WorkspaceMirrorPushPayload,
 } from '../../shared/workspaceMirror';
+import { normalizeRoleBinding } from '../../shared/orchestratorRole';
 import { selectFleetPanes, type FleetPane, type FleetSelectorState } from '../stores/selectors/fleet';
+
+/**
+ * The snapshot builder's input: the fleet selector state plus the two role
+ * maps the D2 binding resolution reads. Both are optional so states built for
+ * fleet-only tests keep compiling — an absent map simply yields an empty
+ * roleBindings payload (still COMPLETE: no roles bound means no bindings).
+ */
+export type MirrorSnapshotState = FleetSelectorState & {
+  paneRole?: Record<string, string | undefined>;
+  orchestratorRoleBindings?: Record<string, unknown>;
+};
 
 /**
  * Resolve the ptyId of a workspace's active pane + active surface.
@@ -175,9 +187,34 @@ export function buildFleetSnapshots(state: FleetSelectorState, ts: number): Flee
   return [...byWs.values()];
 }
 
+/**
+ * ptyId → resolved role binding for every surface whose pane carries a bound
+ * role — the SAME resolution the `input.findOwnerWorkspace` reply performs
+ * (paneRole[leaf.id] → orchestratorRoleBindings[role], normalized), so the
+ * mirror and the round-trip can never disagree on a binding. The map is
+ * COMPLETE by construction: a ptyId absent from it has no binding.
+ */
+export function buildRoleBindings(state: MirrorSnapshotState): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const paneRole = state.paneRole ?? {};
+  const bindings = state.orchestratorRoleBindings ?? {};
+  for (const w of state.workspaces) {
+    for (const leaf of getLeafPanes(w.rootPane)) {
+      const role = paneRole[leaf.id];
+      if (!role) continue;
+      const binding = normalizeRoleBinding(bindings[role]);
+      if (!binding) continue;
+      for (const s of leaf.surfaces) {
+        if (s.ptyId) out[s.ptyId] = binding;
+      }
+    }
+  }
+  return out;
+}
+
 /** Assemble the full push payload from the live store state at `now()`. */
 export function buildWorkspaceMirrorPayload(
-  state: FleetSelectorState,
+  state: MirrorSnapshotState,
   now: () => number = Date.now,
 ): WorkspaceMirrorPushPayload {
   const ts = now();
@@ -185,5 +222,6 @@ export function buildWorkspaceMirrorPayload(
     ts,
     entries: buildWorkspaceListEntries(state.workspaces),
     fleets: buildFleetSnapshots(state, ts),
+    roleBindings: buildRoleBindings(state),
   };
 }

--- a/src/shared/workspaceMirror.ts
+++ b/src/shared/workspaceMirror.ts
@@ -64,4 +64,14 @@ export interface WorkspaceMirrorPushPayload {
   ts: number;
   entries: WorkspaceListEntry[];
   fleets: FleetSnapshot[];
+  /**
+   * ptyId → resolved role→model binding for every surface whose pane carries a
+   * bound role (D2). COMPLETE when present: a ptyId absent from the map has no
+   * binding, so main's resolver can answer "unbound" without a renderer
+   * round-trip. An OLD renderer (stale preload under a packaged update) omits
+   * the field entirely — main must treat `undefined` as "unknown, round-trip",
+   * never as "unbound". Values are renderer-normalized but re-normalized at the
+   * main read boundary (the store is hand-editable via session.json).
+   */
+  roleBindings?: Record<string, unknown>;
 }


### PR DESCRIPTION
Every external MCP call used to pay one to three main→renderer round-trips
through `input.findOwnerWorkspace`: the ownership assert, the caller-identity
resolution, and the D2 role→model lookup. The renderer answers those late
exactly when the app is busy — a large-buffer flush storm is precisely when
the latency is felt — so the hot path depended on the slowest thing in the
process.

Main already keeps a renderer-pushed `WorkspaceMirror` (structural changes push
immediately, status churn debounced 300ms, plus a 30s refresh). This makes it
the first answer and keeps the round-trip as the fallback.

## What changed

A shared resolver, `src/main/workspace/ptyOwnership.ts`, with two postures:

- **assert** (an expected workspace is known — `input.send`, `deck.resolvePaneRoute`):
  the mirror may only short-circuit an **allow**, and only when it agrees with
  the expectation. Any miss, staleness, or disagreement falls through to the
  round-trip, which stays the sole deny authority — a stale mirror can never
  produce a false reject.
- **resolve** (caller identity from a verified `senderPtyId` — `events.poll`,
  `fanout`, `meta`, `a2a`, `a2a.channel`): a fresh mirror hit answers; misses
  still round-trip and the fail-closed `''` contract at each call site is
  preserved.

Freshness is bounded by the existing `STALE_TRUST_MS` (10s). Worth stating
plainly for review: this trades "always ask the freshest source" for a
bounded-staleness allow. Structural changes push immediately, so the realistic
exposure is IPC delivery latency, and the `senderPtyId` anchor is advisory
attribution under the #113 same-user ceiling by design (see the note in
`events.rpc.ts` — the unforgeable fix is peer-PID, deferred). The mirror does
not change that ceiling.

Role bindings now ride the mirror push payload as a complete `ptyId → binding`
map built by the same resolution the round-trip performs, so a bound pane's
model enforcement no longer costs a second round-trip on
`terminal_send submit:true`. A renderer that predates the field pushes nothing,
which the resolver treats as *unknown* and round-trips — never as "unbound".

## Review findings folded in

Three-way review (Claude / Codex / GLM-5.2) caught a silent one: the IPC parser
rebuilt `{ts, entries, fleets}` and **dropped** the new `roleBindings` field, so
every production push looked like an old renderer and the fast path was dead on
arrival. The unit tests missed it because they called `setSnapshot` directly,
bypassing the parser. There is now an end-to-end test that walks
parse → setSnapshot → resolve, plus parser cases for present/absent/empty/junk.

Also from review: `MirrorSnapshotState` indexes its role maps off `StoreState`
so a store rename breaks the build instead of silently producing an empty map
main would trust as "nothing bound"; and `peekRoleBinding(ptyId)` replaced a
whole-map copy per lookup on the `input.send` path.

## Verification

Unit: 12 new resolver tests (driving the real `WorkspaceMirror` singleton, not a
mock) plus the parser suite; full suite green apart from two pre-existing local
failures unrelated to this branch.

Live dogfood on a dev instance:
- cross-workspace `input.send` still denied (`not owned by workspace …`), so the
  mirror short-circuit never weakened the gate
- under renderer load (20k lines streaming), `events.poll` (mirror-resolved)
  median 4ms / max 5ms vs `input.readScreen` (round-trip by design) median 8ms /
  max 12ms
