### PR TITLE
perf: daemon log buffering, renderer hot-path fixes, pane.search tail bounding

### DIFF
--- a/changelog.d/871.md
+++ b/changelog.d/871.md
@@ -1,0 +1,22 @@
+### Changed
+
+- **Cross-pane search reads the newest output first.** `wmux_search_panes` used
+  to scan up to 20,000 lines per pane starting from the oldest, so on a long
+  scrollback the recent output you were actually looking for could be the part
+  that got cut. It now searches the newest 5,000 lines by default, says
+  `truncated: true` when older lines went unread, and takes a new optional
+  `searchTailLines` to go deeper. It also yields between panes instead of
+  freezing the window for the whole sweep. The in-app search bar is unaffected
+  and still covers your full configured scrollback. (#871)
+
+### Fixed
+
+- **The daemon no longer stalls on its own log file.** Each log line was written
+  and flushed to disk synchronously, which on Windows also meant a virus-scanner
+  hook per line. Routine lines are now batched; warnings and errors still write
+  through immediately, after the pending lines, so `daemon.log` stays in order
+  and a crash still records what happened. (#871)
+- **Terminal tab strips stopped re-rendering on unrelated panes.** Any pane's
+  status, label, or agent change re-rendered every tab strip in the app; each
+  strip now watches only its own pane. Terminal output also skips a
+  per-chunk regular-expression scan it did not need. (#871)

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 80000,
-      "wireResultSha256": "6b51db8f0b0b906e35903f48ed371ab1622b1297d0cad613106547d7baf59ee3",
+      "wireResultSha256": "43a8ff42f7d8c85aa201d30bbada14c3280888e4830afc60bd3b7ebfba4261c3",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",
@@ -97,7 +97,7 @@
     },
     "commander": {
       "maxListBytes": 47000,
-      "wireResultSha256": "68529d69c040a8b11d2da12b0ac82ecd4b560dd42a90a1acd5e7e15ca8ab7db3",
+      "wireResultSha256": "21d87db3c04f214f98c2bee54dda1a622970204c88233812df5a8c5634f8d13f",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",

--- a/src/daemon/__tests__/daemonLogging.test.ts
+++ b/src/daemon/__tests__/daemonLogging.test.ts
@@ -19,15 +19,17 @@ describe('daemon durable logging + recovery instrumentation', () => {
   const daemonIndexPath = path.join(__dirname, '..', 'index.ts');
   const src = fs.readFileSync(daemonIndexPath, 'utf-8');
 
-  it('log() mirrors every line to a rotating daemon.log file', () => {
+  it('log() mirrors every line to the durable daemon.log writer', () => {
     expect(src).toMatch(/const DAEMON_LOG_PATH = path\.join\(wmuxDir, 'daemon\.log'\)/);
-    // The console.log line stays, and the file append is added alongside it.
-    expect(src).toMatch(/fs\.appendFileSync\(DAEMON_LOG_PATH, line\)/);
+    // The console.log line stays; the file side now routes through the
+    // buffered writer (logWriter.ts — behavior covered by logWriter.test.ts,
+    // incl. sync write-through for warn/error and rotation at the byte cap).
+    expect(src).toMatch(/daemonLogWriter\.write\(level, line\)/);
   });
 
-  it('rotates the log at a byte cap so it cannot grow unbounded', () => {
+  it('rotates at a byte cap and drains the buffer on process exit', () => {
     expect(src).toMatch(/DAEMON_LOG_MAX_BYTES/);
-    expect(src).toMatch(/fs\.renameSync\(DAEMON_LOG_PATH, `\$\{DAEMON_LOG_PATH\}\.1`\)/);
+    expect(src).toMatch(/process\.once\('exit', \(\) => daemonLogWriter\.flush\(\)\)/);
   });
 
   it('recoverSessions logs a load summary and a completion summary', () => {

--- a/src/daemon/__tests__/logWriter.test.ts
+++ b/src/daemon/__tests__/logWriter.test.ts
@@ -1,0 +1,88 @@
+// DaemonLogWriter behavior (T7~T11): buffering, ordering, durability, rotation.
+// Real fs against a temp dir; fake timers drive the flush window.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDaemonLogWriter, type DaemonLogWriter } from '../logWriter';
+
+let dir: string;
+let logPath: string;
+
+function make(overrides: Partial<Parameters<typeof createDaemonLogWriter>[0]> = {}): DaemonLogWriter {
+  return createDaemonLogWriter({
+    path: logPath,
+    maxBytes: 5 * 1024 * 1024,
+    flushMs: 250,
+    bufferMaxBytes: 64 * 1024,
+    ...overrides,
+  });
+}
+
+function readLog(): string {
+  try { return fs.readFileSync(logPath, 'utf8'); } catch { return ''; }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-logwriter-'));
+  logPath = path.join(dir, 'daemon.log');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe('DaemonLogWriter', () => {
+  it('T8: info lines buffer and land after the flush window, in one chunk', () => {
+    const w = make();
+    w.write('info', 'a\n');
+    w.write('info', 'b\n');
+    expect(readLog()).toBe(''); // nothing on disk inside the window
+    vi.advanceTimersByTime(250);
+    expect(readLog()).toBe('a\nb\n');
+  });
+
+  it('T7: warn/error write through immediately AND drain earlier info first (order preserved)', () => {
+    const w = make();
+    w.write('info', 'earlier-info\n');
+    w.write('error', 'the-error\n');
+    // No timer advance: the error line forced everything out synchronously,
+    // with the earlier info line physically BEFORE it.
+    expect(readLog()).toBe('earlier-info\nthe-error\n');
+  });
+
+  it('T9: exceeding bufferMaxBytes force-flushes without waiting for the timer', () => {
+    const w = make({ bufferMaxBytes: 10 });
+    w.write('info', '0123456789ABC\n'); // 14 bytes ≥ 10 → immediate flush
+    expect(readLog()).toBe('0123456789ABC\n');
+  });
+
+  it('T10: flush() drains the tail synchronously (the exit-hook path)', () => {
+    const w = make();
+    w.write('info', 'tail\n');
+    expect(readLog()).toBe('');
+    w.flush(); // what process.on('exit') calls
+    expect(readLog()).toBe('tail\n');
+  });
+
+  it('T11: rotation happens on the flush path once the file exceeds maxBytes', () => {
+    fs.writeFileSync(logPath, 'x'.repeat(100)); // pre-existing oversized file
+    const w = make({ maxBytes: 50 });
+    w.write('info', 'after-rotate\n');
+    vi.advanceTimersByTime(250);
+    expect(readLog()).toBe('after-rotate\n'); // fresh file post-rotation
+    expect(fs.readFileSync(`${logPath}.1`, 'utf8')).toBe('x'.repeat(100));
+  });
+
+  it('write and flush never throw when the directory disappears (best-effort contract)', () => {
+    const w = make();
+    w.write('info', 'a\n');
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(() => w.write('error', 'boom\n')).not.toThrow();
+    expect(() => w.flush()).not.toThrow();
+    fs.mkdirSync(dir, { recursive: true }); // restore for afterEach
+  });
+});

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -8,6 +8,7 @@ import {
   readNotifySinks,
   readPushPresenceSuppression,
 } from './config';
+import { createDaemonLogWriter } from './logWriter';
 import { DaemonSessionManager } from './DaemonSessionManager';
 import { PaneSupervisor } from './PaneSupervisor';
 import { DaemonPipeServer } from './DaemonPipeServer';
@@ -594,9 +595,19 @@ const BOOT_MARKER_FILE = path.join(wmuxDir, 'daemon-booting');
 // failure must never crash the daemon.
 const DAEMON_LOG_PATH = path.join(wmuxDir, 'daemon.log');
 const DAEMON_LOG_MAX_BYTES = 5 * 1024 * 1024; // rotate at 5 MB, keep one .1 backup
-// In-memory byte counter so we don't statSync on every write. -1 = uninitialised
-// (seeded from the existing file size on the first line this process writes).
-let daemonLogBytes = -1;
+// Buffered file writer (logWriter.ts): info/debug lines coalesce for up to
+// 250ms / 64KB instead of paying one sync append (+ EDR scan on Windows) per
+// line; warn/error still write through synchronously after draining the
+// buffer, so ordering and crash durability are preserved. The 'exit' hook
+// below drains the tail on any clean exit; a hard kill can lose at most the
+// last 250ms of info lines (accepted — the error record is already durable).
+const daemonLogWriter = createDaemonLogWriter({
+  path: DAEMON_LOG_PATH,
+  maxBytes: DAEMON_LOG_MAX_BYTES,
+  flushMs: 250,
+  bufferMaxBytes: 64 * 1024,
+});
+process.once('exit', () => daemonLogWriter.flush());
 function log(level: string, msg: string, ...args: unknown[]): void {
   const ts = new Date().toISOString();
   console.log(`[${ts}] [daemon/${level}] ${msg}`, ...args);
@@ -613,15 +624,7 @@ function log(level: string, msg: string, ...args: unknown[]): void {
           .join(' ')
       : '';
     const line = `[${ts}] [daemon/${level}] ${msg}${extra}\n`;
-    if (daemonLogBytes < 0) {
-      try { daemonLogBytes = fs.statSync(DAEMON_LOG_PATH).size; } catch { daemonLogBytes = 0; }
-    }
-    if (daemonLogBytes > DAEMON_LOG_MAX_BYTES) {
-      try { fs.renameSync(DAEMON_LOG_PATH, `${DAEMON_LOG_PATH}.1`); } catch { /* ignore */ }
-      daemonLogBytes = 0;
-    }
-    fs.appendFileSync(DAEMON_LOG_PATH, line);
-    daemonLogBytes += Buffer.byteLength(line);
+    daemonLogWriter.write(level, line);
   } catch {
     // Logging must never crash the daemon.
   }

--- a/src/daemon/logWriter.ts
+++ b/src/daemon/logWriter.ts
@@ -1,0 +1,113 @@
+// Buffered writer for the daemon's durable log file (daemon.log).
+//
+// WHY: log() used to appendFileSync on EVERY line. Each sync append is a
+// write(2) + flush the calling thread waits on — and on Windows with EDR
+// filter drivers each one is also a scan hook, which is exactly the
+// environment where the daemon's hot paths (session churn, recovery, RPC
+// bursts) turned logging into measurable stall time. Buffering info/debug
+// lines and flushing every FLUSH_MS (or at the byte cap) collapses N syscalls
+// into one while keeping the file byte-identical in content and order.
+//
+// DURABILITY CONTRACT (deliberate, reviewed):
+//   - warn/error lines NEVER buffer. They first drain any pending info lines
+//     (so the file stays in true chronological order — the log exists for
+//     post-hoc causal reconstruction) and then append synchronously, so the
+//     last thing a dying daemon said is on disk before the crash propagates.
+//   - A clean exit flushes the tail via the process 'exit' hook (wired in
+//     index.ts). A hard kill (SIGKILL / supervisor force-respawn) can lose at
+//     most the last FLUSH_MS window of info lines — accepted: even the old
+//     per-line sync write lost the line that never got to execute, and the
+//     error-level record of whatever went wrong is already durable.
+//   - The existing postmortem sinks (src/daemon/util/logSink.ts,
+//     src/main/util/logSink.ts) are untouched: their all-sync behavior is
+//     their contract, not an accident.
+//
+// Best-effort throughout: a logging failure must never crash the daemon.
+
+import * as fs from 'fs';
+
+export interface DaemonLogWriterOptions {
+  /** Durable log file path (daemon.log). */
+  path: string;
+  /** Rotation cap: when the file would exceed this, rename to `<path>.1`. */
+  maxBytes: number;
+  /** Coalescing window for buffered (info/debug) lines. */
+  flushMs: number;
+  /** Force-flush threshold so a burst can never grow the buffer unbounded. */
+  bufferMaxBytes: number;
+}
+
+export interface DaemonLogWriter {
+  /** Queue (info/debug) or write-through (warn/error) one already-formatted line. */
+  write(level: string, line: string): void;
+  /** Drain any buffered lines synchronously. Safe to call from an 'exit' hook. */
+  flush(): void;
+}
+
+export function createDaemonLogWriter(opts: DaemonLogWriterOptions): DaemonLogWriter {
+  // In-memory byte counter so we don't statSync on every flush. -1 =
+  // uninitialised (seeded from the existing file size on first use).
+  let fileBytes = -1;
+  let pending: string[] = [];
+  let pendingBytes = 0;
+  let flushTimer: NodeJS.Timeout | null = null;
+
+  function rotateIfNeeded(): void {
+    if (fileBytes < 0) {
+      try { fileBytes = fs.statSync(opts.path).size; } catch { fileBytes = 0; }
+    }
+    if (fileBytes > opts.maxBytes) {
+      try { fs.renameSync(opts.path, `${opts.path}.1`); } catch { /* ignore */ }
+      fileBytes = 0;
+    }
+  }
+
+  function appendNow(chunk: string): void {
+    rotateIfNeeded();
+    fs.appendFileSync(opts.path, chunk);
+    fileBytes += Buffer.byteLength(chunk);
+  }
+
+  function flush(): void {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    if (pending.length === 0) return;
+    const chunk = pending.join('');
+    pending = [];
+    pendingBytes = 0;
+    try {
+      appendNow(chunk);
+    } catch {
+      // Logging must never crash the daemon.
+    }
+  }
+
+  function write(level: string, line: string): void {
+    try {
+      if (level === 'warn' || level === 'error') {
+        // Drain buffered lines FIRST so the file stays chronological, then
+        // write through synchronously — the error must be durable now.
+        flush();
+        appendNow(line);
+        return;
+      }
+      pending.push(line);
+      pendingBytes += Buffer.byteLength(line);
+      if (pendingBytes >= opts.bufferMaxBytes) {
+        flush();
+        return;
+      }
+      if (flushTimer === null) {
+        flushTimer = setTimeout(flush, opts.flushMs);
+        // Never let a pending log flush pin the process alive.
+        (flushTimer as unknown as { unref?: () => void }).unref?.();
+      }
+    } catch {
+      // Logging must never crash the daemon.
+    }
+  }
+
+  return { write, flush };
+}

--- a/src/main/pipe/handlers/pane.rpc.ts
+++ b/src/main/pipe/handlers/pane.rpc.ts
@@ -643,10 +643,20 @@ export function registerPaneRpc(
         new Error('pane.search: "workspaceId" must be a string if provided'),
       );
     }
+    const searchTailLines = params['searchTailLines'];
+    if (
+      searchTailLines !== undefined &&
+      (typeof searchTailLines !== 'number' || !Number.isFinite(searchTailLines) || searchTailLines < 1)
+    ) {
+      return Promise.reject(
+        new Error('pane.search: "searchTailLines" must be a number >= 1 if provided'),
+      );
+    }
     return sendToRenderer(getWindow, 'pane.search', {
       query: params['query'],
       ...(regex !== undefined && { regex }),
       ...(workspaceId !== undefined && { workspaceId }),
+      ...(searchTailLines !== undefined && { searchTailLines }),
     });
   });
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -166,6 +166,7 @@ const PANE_GET_METADATA_SHAPE = {
 const WMUX_SEARCH_PANES_SHAPE = {
   query: z.string().min(1).describe('The text to search for. Required, non-empty. Treated as a literal substring unless regex=true.'),
   regex: z.boolean().optional().describe('If true, treat query as a JavaScript regex pattern (e.g. "ERROR|WARN", "\\\\bTODO\\\\b"). Default flags only — case-sensitive, no inline `(?i)`. Invalid pattern returns an error. Default false.'),
+  searchTailLines: z.number().int().min(1).optional().describe('How many of the NEWEST scrollback lines to scan per pane. Default 5000; raise (capped at 20000) to search deeper history. A pane holding more lines than the window reports truncated=true.'),
 };
 
 const WMUX_EVENTS_POLL_SHAPE = {
@@ -1117,10 +1118,11 @@ server.tool(
   'wmux_search_panes',
   'Search across all live terminal panes in the caller\'s workspace. Returns up to 200 matches with paneId + matched line + 2-line context (truncated=true means more were found). Use to find which pane has the JWT error, failing test, or build warning instead of polling each pane individually. Live panes only (v1); regex uses JS RegExp with default flags (case-sensitive, no inline `(?i)` — use `[Ee]rror` for case-insensitive).',
   WMUX_SEARCH_PANES_SHAPE,
-  async ({ query, regex }) => {
+  async ({ query, regex, searchTailLines }) => {
     const workspaceId = await requireWorkspaceId();
     const params: Record<string, unknown> = { workspaceId, query };
     if (regex !== undefined) params.regex = regex;
+    if (searchTailLines !== undefined) params.searchTailLines = searchTailLines;
     return callRpc('pane.search', params);
   },
 );

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -48,6 +48,24 @@ function statusDotColor(status: AgentStatus): string {
   return status === 'complete' ? 'var(--accent-green)' : 'var(--accent-red)';
 }
 
+/** B8 blink dot for a BACKGROUND tab, extracted so each tab subscribes to its
+ *  OWN `surfaceAgentStatus[ptyId]` entry (a primitive). The parent used to
+ *  subscribe to the whole map, so any pane's status change re-rendered every
+ *  tab strip in the app. */
+function SurfaceTabStatusDot({ ptyId, active }: { ptyId?: string; active: boolean }) {
+  const t = useT();
+  const status = useStore((s) => (ptyId ? s.surfaceAgentStatus[ptyId] : undefined));
+  if (!status || active) return null;
+  return (
+    <span
+      className="tab-status-blink inline-block w-1.5 h-1.5 rounded-full shrink-0"
+      style={{ backgroundColor: statusDotColor(status) }}
+      title={t('surface.terminal')}
+      aria-hidden="true"
+    />
+  );
+}
+
 interface SurfaceTabsProps {
   surfaces: Surface[];
   activeSurfaceId: string;
@@ -87,11 +105,9 @@ export default function SurfaceTabs({
   // Same 200ms threshold pattern WorkspaceItem uses so a fast click never
   // gets eaten by a click-after-dragend race.
   const dragStartTimeRef = useRef<number>(0);
-  // B8: per-surface completed/awaiting status. A blinking dot marks a
-  // BACKGROUND tab (not the active surface) whose terminal finished, so a
-  // completed agent is discoverable even when its tab isn't on top. The
-  // active surface's completion is conveyed by the pane border blink instead.
-  const surfaceAgentStatus = useStore((s) => s.surfaceAgentStatus);
+  // B8 per-surface status dots live in SurfaceTabStatusDot (per-tab
+  // subscription) — subscribing to the whole map here re-rendered every tab
+  // strip on any pane's status change.
   const setTerminalTextDropDragActive = useStore((s) => s.setTerminalTextDropDragActive);
   // Right-aligned pane action cluster (new terminal / split / new browser).
   // Gated by a Settings toggle (default ON) for minimal-chrome setups.
@@ -102,9 +118,15 @@ export default function SurfaceTabs({
   const isZoomed = useStore((s) => s.zoomedPaneId === paneId);
   // P2: pane-level identity + rename (distinct from the per-surface tab rename
   // below). The pane's display name is its user label (paneLabel mirror) or the
-  // stable auto coordinate `w<ws>-<pane>(<agent>)`.
-  const paneLabelMap = useStore((s) => s.paneLabel);
-  const surfaceAgent = useStore((s) => s.surfaceAgent);
+  // stable auto coordinate `w<ws>-<pane>(<agent>)`. Narrowed to THIS pane's
+  // label / THIS pane's active-surface slug (primitives) so unrelated panes'
+  // label or agent changes don't re-render this strip.
+  const paneLabel = useStore((s) => s.paneLabel[paneId]);
+  const activeSurface = surfaces.find((s) => s.id === activeSurfaceId) ?? surfaces[0];
+  const activeSurfacePtyId = activeSurface?.ptyId;
+  const activeSlug = useStore((s) =>
+    activeSurfacePtyId ? s.surfaceAgent[activeSurfacePtyId]?.slug : undefined,
+  );
   const [paneEditing, setPaneEditing] = useState(false);
   const [paneEditName, setPaneEditName] = useState('');
   const paneInputRef = useRef<HTMLInputElement>(null);
@@ -153,10 +175,8 @@ export default function SurfaceTabs({
   // surface; the user label (if any) overrides the auto coordinate.
   const leaf = findPane(workspace.rootPane, paneId);
   const paneOrdinal = leaf && leaf.type === 'leaf' ? (leaf.ordinal ?? 0) : 0;
-  const activeSurface = surfaces.find((s) => s.id === activeSurfaceId) ?? surfaces[0];
-  const activeSlug = activeSurface?.ptyId ? surfaceAgent[activeSurface.ptyId]?.slug : undefined;
   const paneAutoName = computePaneAutoName(workspace.wsOrdinal ?? 0, paneOrdinal, activeSlug);
-  const paneDisplay = paneDisplayName(paneLabelMap[paneId], paneAutoName);
+  const paneDisplay = paneDisplayName(paneLabel, paneAutoName);
 
   const startPaneRename = () => {
     // Suppress the rename a double-click triggers right after a tab drag.
@@ -164,7 +184,7 @@ export default function SurfaceTabs({
     // Clear any stale cancel flag from a prior edit whose unmount-blur didn't
     // fire (e.g. parent unmounted) — else this rename would refuse to save (GLM).
     paneRenameCancelRef.current = false;
-    setPaneEditName(paneLabelMap[paneId] ?? '');
+    setPaneEditName(paneLabel ?? '');
     setPaneEditing(true);
   };
   const commitPaneRename = () => {
@@ -297,18 +317,7 @@ export default function SurfaceTabs({
           // once the shell renders its first prompt; before that, the name).
           title={editingId === s.id ? undefined : (displayPath(s.cwd) || s.title || t('surface.terminal'))}
         >
-          {(() => {
-            const status = s.ptyId ? surfaceAgentStatus[s.ptyId] : undefined;
-            if (!status || s.id === activeSurfaceId) return null;
-            return (
-              <span
-                className="tab-status-blink inline-block w-1.5 h-1.5 rounded-full shrink-0"
-                style={{ backgroundColor: statusDotColor(status) }}
-                title={t('surface.terminal')}
-                aria-hidden="true"
-              />
-            );
-          })()}
+          <SurfaceTabStatusDot ptyId={s.ptyId} active={s.id === activeSurfaceId} />
           {editingId === s.id ? (
             <input
               ref={inputRef}

--- a/src/renderer/hooks/__tests__/channelMentionPasteGate.test.ts
+++ b/src/renderer/hooks/__tests__/channelMentionPasteGate.test.ts
@@ -313,4 +313,12 @@ describe('notePtyOutput — remainder judging (adversarial review F11b)', () => 
     notePtyOutput(st, 'p', 1_000, '\x1b[24;80R\x1b[6n\x1b[1;1R');
     expect(st.lastOutputAt.has('p')).toBe(false);
   });
+
+  it('a plain chunk without ESC stamps via the fast path (no regex run)', () => {
+    // The ESC-free fast path must behave identically to the regex path for
+    // ordinary output: non-empty stamps, empty (covered above) does not.
+    const st = createPasteGateState();
+    notePtyOutput(st, 'p', 1_000, 'plain shell output\n');
+    expect(st.lastOutputAt.get('p')).toBe(1_000);
+  });
 });

--- a/src/renderer/hooks/channelMentionPasteGate.ts
+++ b/src/renderer/hooks/channelMentionPasteGate.ts
@@ -173,8 +173,16 @@ const CPR_SEQ_RE = /\x1b\[[0-9;?]*[Rn]/g;
 export function notePtyOutput(state: PasteGateState, ptyId: string, now: number, data?: string): void {
   if (!ptyId) return;
   if (data != null) {
-    const rest = data.replace(CPR_SEQ_RE, '');
-    if (rest.length === 0) return;
+    // Fast path: CPR/DSR sequences always contain ESC, so a chunk without one
+    // cannot reduce to empty — skip the regex on the (overwhelmingly common)
+    // plain-output chunk. The length guard keeps the F11b empty-chunk rule:
+    // an empty chunk is still not activity.
+    if (data.indexOf('\x1b') === -1) {
+      if (data.length === 0) return;
+    } else {
+      const rest = data.replace(CPR_SEQ_RE, '');
+      if (rest.length === 0) return;
+    }
   }
   state.lastOutputAt.set(ptyId, now);
 }

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -21,7 +21,7 @@ import {
 } from '../utils/browserTabs';
 import { terminalRegistry, hydrateTerminalForRead } from './useTerminal';
 import { readPtyBufferLines, readPtyBufferTail, DEFAULT_READ_TAIL_LINES } from '../utils/terminalTail';
-import { searchInBuffer, type SearchableBuffer } from '../utils/searchEngine';
+import { searchInBuffer, normalizeSearchTailLines, type SearchableBuffer } from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
 import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
@@ -170,7 +170,16 @@ export function useRpcBridge(): void {
     // IPC round trip.
     (window as unknown as { __wmuxRunPaneSearch: (q: string, r: boolean) => Promise<RpcResult> })
       .__wmuxRunPaneSearch = (query: string, regex: boolean) =>
-        handleRpcMethod('pane.search', { query, regex });
+        // The HUMAN search bar must cover the user's whole configured
+        // scrollback, not the agent-facing 5,000-line tail default — without
+        // this the UI silently skipped the older half of a default 10k
+        // scrollback (3-way review: Claude P1). normalizeSearchTailLines
+        // still clamps to the 20k scan cap downstream (pre-existing bound).
+        handleRpcMethod('pane.search', {
+          query,
+          regex,
+          searchTailLines: useStore.getState().scrollbackLines,
+        });
 
     // ── In-renderer entry point for useChannelsEventSubscription ─────────
     // The channel-message subscription hook (see
@@ -1136,14 +1145,12 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // ─── Tail bounding (perf root-fix P5) ────────────────────────────────
     // Default: scan only the NEWEST `searchTailLines` physical rows per
     // buffer (5,000) instead of up to 20k oldest-first. Callers that need
-    // deeper history raise the param (clamped to the 20k per-buffer cap by
-    // the engine). Any pane whose buffer holds more rows than the window
-    // reports `truncated: true` so agents know older output went unscanned.
-    const rawTail = params['searchTailLines'];
-    const searchTailLines =
-      typeof rawTail === 'number' && Number.isFinite(rawTail) && rawTail >= 1
-        ? Math.floor(rawTail)
-        : 5_000;
+    // deeper history raise the param. normalizeSearchTailLines CLAMPS to the
+    // 20k scan cap here, before every use — truncation checks against an
+    // unclamped request would report `truncated:false` on partially-scanned
+    // buffers (3-way review: Codex+GLM). Any pane whose buffer holds more
+    // rows than the effective window reports `truncated: true`.
+    const searchTailLines = normalizeSearchTailLines(params['searchTailLines']);
 
     // ─── Workspace scope (C1, decisions D9) ──────────────────────────────
     // External MCP callers pass `workspaceId` via T-D so the search is

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -1133,6 +1133,18 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const regex = params['regex'] === true;
     if (query.length === 0) return { error: 'pane.search: empty query' };
 
+    // ─── Tail bounding (perf root-fix P5) ────────────────────────────────
+    // Default: scan only the NEWEST `searchTailLines` physical rows per
+    // buffer (5,000) instead of up to 20k oldest-first. Callers that need
+    // deeper history raise the param (clamped to the 20k per-buffer cap by
+    // the engine). Any pane whose buffer holds more rows than the window
+    // reports `truncated: true` so agents know older output went unscanned.
+    const rawTail = params['searchTailLines'];
+    const searchTailLines =
+      typeof rawTail === 'number' && Number.isFinite(rawTail) && rawTail >= 1
+        ? Math.floor(rawTail)
+        : 5_000;
+
     // ─── Workspace scope (C1, decisions D9) ──────────────────────────────
     // External MCP callers pass `workspaceId` via T-D so the search is
     // scoped to the CALLING workspace, not whichever the user is currently
@@ -1199,6 +1211,21 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // return old output to agents. Hydration is a no-op for clean visible
     // panes and bounded for dirty ones (daemon resync ≤ scrollback lines).
     await Promise.all(scannablePtyIds.map((id) => hydrateTerminalForRead(id).catch(() => { /* per-pane best effort */ })));
+    // Yield to the event loop between panes so a many-pane search can't hold
+    // the renderer main thread for the whole sweep (one pane's ≤20k-row scan
+    // is the max contiguous slice). MessageChannel, NOT setTimeout(0): timers
+    // in a backgrounded window are throttled to ≥1s each, which would add
+    // ~N seconds and blow the MCP RPC deadline — message ports are not.
+    const yieldToEventLoop = (): Promise<void> =>
+      new Promise((resolve) => {
+        const ch = new MessageChannel();
+        ch.port1.onmessage = () => {
+          ch.port1.close();
+          ch.port2.close();
+          resolve();
+        };
+        ch.port2.postMessage(null);
+      });
     for (let pIdx = 0; pIdx < scannablePtyIds.length; pIdx++) {
       const ptyId = scannablePtyIds[pIdx];
       if (remainingBudget <= 0) {
@@ -1206,6 +1233,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
         truncated = true;
         break;
       }
+      if (pIdx > 0) await yieldToEventLoop();
       const paneId = ptyToPaneId.get(ptyId);
       if (!paneId) continue; // belt-and-braces; filtered above already
       const term = terminalRegistry.get(ptyId);
@@ -1213,10 +1241,13 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       try {
         // Adapt xterm Buffer to SearchableBuffer (it already conforms structurally)
         const requestedBudget = remainingBudget;
+        const liveBuffer = term.buffer.active as unknown as SearchableBuffer;
+        // Older rows exist beyond the tail window → partial coverage, say so.
+        if (liveBuffer.length > searchTailLines) truncated = true;
         const matches = searchInBuffer(
-          term.buffer.active as unknown as SearchableBuffer,
+          liveBuffer,
           query,
-          { regex, contextLines: 2, perBufferLineCap: 20_000, remainingBudget },
+          { regex, contextLines: 2, perBufferLineCap: 20_000, remainingBudget, tailRows: searchTailLines },
         );
         totalMatches += matches.length;
         for (const m of matches) {
@@ -1269,10 +1300,13 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       if (Date.now() - parkedStart > PARKED_DEADLINE_MS) { truncated = true; break; }
       const paneId = ptyToPaneId.get(ptyId);
       if (!paneId) continue;
-      // Request the renderer's configured scrollback depth (daemon clamps to
-      // MAX_SCROLLBACK) — a hard 5000 would miss the older half of a 10k buffer
-      // while still reporting truncated:false.
-      const read = await fetchParkedPaneRows(ptyId, store.scrollbackLines);
+      // Request the tail window (bounded by the configured scrollback depth;
+      // the daemon clamps to MAX_SCROLLBACK). A smaller-than-scrollback window
+      // does NOT silently under-report: the window-full check below flags
+      // `truncated: true` whenever older rows may exist beyond it — the exact
+      // failure mode the old comment here warned about for a hard 5000 cap.
+      const parkedTail = Math.min(store.scrollbackLines, searchTailLines);
+      const read = await fetchParkedPaneRows(ptyId, parkedTail);
       if (!read) {
         // Legacy daemon / local mode / gone session: this parked pane could not
         // be read, so coverage is incomplete — flag truncated so callers know
@@ -1282,6 +1316,10 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       }
       // The daemon dropped oldest rows to fit the RPC frame → partial coverage.
       if (read.truncated) truncated = true;
+      // Window came back full → older rows may exist beyond the tail request
+      // (we can't see the parked buffer's true length; a shorter history
+      // returns fewer rows and is NOT flagged).
+      if (read.rows.length >= parkedTail && parkedTail < store.scrollbackLines) truncated = true;
       try {
         const requestedBudget = remainingBudget;
         const matches = searchInBuffer(

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -21,7 +21,12 @@ import {
 } from '../utils/browserTabs';
 import { terminalRegistry, hydrateTerminalForRead } from './useTerminal';
 import { readPtyBufferLines, readPtyBufferTail, DEFAULT_READ_TAIL_LINES } from '../utils/terminalTail';
-import { searchInBuffer, normalizeSearchTailLines, type SearchableBuffer } from '../utils/searchEngine';
+import {
+  searchInBuffer,
+  normalizeSearchTailLines,
+  SEARCH_TAIL_MAX,
+  type SearchableBuffer,
+} from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
 import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
@@ -175,11 +180,13 @@ export function useRpcBridge(): void {
         // this the UI silently skipped the older half of a default 10k
         // scrollback (3-way review: Claude P1). normalizeSearchTailLines
         // still clamps to the 20k scan cap downstream (pre-existing bound).
-        handleRpcMethod('pane.search', {
-          query,
-          regex,
-          searchTailLines: useStore.getState().scrollbackLines,
-        });
+        // SEARCH_TAIL_MAX, not `scrollbackLines`: xterm's `buffer.length`
+        // counts the VIEWPORT on top of the scrollback, so a full buffer is
+        // `scrollbackLines + rows` and a window of exactly `scrollbackLines`
+        // would clip the oldest screenful (Codex re-review). The cap makes the
+        // window cover any buffer the engine will scan at all, which is the
+        // pre-tail-bounding behavior this entry point had.
+        handleRpcMethod('pane.search', { query, regex, searchTailLines: SEARCH_TAIL_MAX });
 
     // ── In-renderer entry point for useChannelsEventSubscription ─────────
     // The channel-message subscription hook (see
@@ -1329,10 +1336,16 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       if (read.rows.length >= parkedTail && parkedTail < store.scrollbackLines) truncated = true;
       try {
         const requestedBudget = remainingBudget;
+        // tailRows here too: the daemon answers a request for N rows with up
+        // to N + a viewport (readText's `scrollback` is history capacity, and
+        // generateTextSnapshot returns baseY + rows), so scanning everything
+        // it returned would let a parked pane match rows that the SAME pane
+        // mounted would exclude (Codex re-review). Bounding the scan to the
+        // requested window keeps live and parked panes consistent.
         const matches = searchInBuffer(
           rowsToSearchableBuffer(read.rows),
           query,
-          { regex, contextLines: 2, perBufferLineCap: 20_000, remainingBudget },
+          { regex, contextLines: 2, perBufferLineCap: 20_000, remainingBudget, tailRows: parkedTail },
         );
         totalMatches += matches.length;
         for (const m of matches) {

--- a/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/resumeSlice.test.ts
@@ -96,6 +96,16 @@ describe('resumeSlice', () => {
       // readiness map is independent — pty-z not marked ready
       expect(useStore.getState().ptyReadyByPtyId['pty-z']).toBeUndefined();
     });
+
+    it('a repeat call is a store no-op (hot-path early return, no subscriber fire)', () => {
+      useStore.getState().markPtyReady('pty-hot');
+      const fired: number[] = [];
+      const unsub = useStore.subscribe(() => fired.push(1));
+      useStore.getState().markPtyReady('pty-hot'); // already ready → bails before set()
+      unsub();
+      expect(fired).toHaveLength(0);
+      expect(useStore.getState().ptyReadyByPtyId['pty-hot']).toBe(true);
+    });
   });
 
   describe('dead-pane replacement hand-off (#650)', () => {

--- a/src/renderer/stores/slices/resumeSlice.ts
+++ b/src/renderer/stores/slices/resumeSlice.ts
@@ -106,7 +106,7 @@ export const createResumeSlice: StateCreator<
   [['zustand/immer', never]],
   [],
   ResumeSlice
-> = (set) => ({
+> = (set, get) => ({
   resumeHintByPtyId: {},
   resumeBindingByPtyId: {},
   commandRunningByPtyId: {},
@@ -142,9 +142,15 @@ export const createResumeSlice: StateCreator<
     }
   }),
 
-  markPtyReady: (ptyId) => set((draft: StoreState) => {
-    if (!draft.ptyReadyByPtyId[ptyId]) draft.ptyReadyByPtyId[ptyId] = true;
-  }),
+  markPtyReady: (ptyId) => {
+    // Hot path (fed per output-adjacent event from useTerminal): bail before
+    // set() when already ready so the immer/update machinery doesn't run at
+    // all for the steady-state repeat call.
+    if (get().ptyReadyByPtyId[ptyId]) return;
+    set((draft: StoreState) => {
+      draft.ptyReadyByPtyId[ptyId] = true;
+    });
+  },
 
   setResumeHint: (ptyId, agent) => set((draft: StoreState) => {
     draft.resumeHintByPtyId[ptyId] = agent;

--- a/src/renderer/utils/__tests__/searchEngine.test.ts
+++ b/src/renderer/utils/__tests__/searchEngine.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { searchInBuffer, type SearchableBuffer } from '../searchEngine';
+import { searchInBuffer, normalizeSearchTailLines, type SearchableBuffer } from '../searchEngine';
 import {
   makeBuffer,
   makeBufferWithGap,
@@ -313,5 +313,36 @@ describe('searchInBuffer — tail bounding (perf root-fix P5)', () => {
       perBufferLineCap: 2,
     });
     expect(matches.map((m) => m.physicalBaseY)).toEqual([0, 1]);
+  });
+});
+
+describe('normalizeSearchTailLines — clamp honesty (3-way review: Codex+GLM)', () => {
+  it('defaults to 5000 for absent/junk/sub-1 inputs and floors fractions', () => {
+    expect(normalizeSearchTailLines(undefined)).toBe(5_000);
+    expect(normalizeSearchTailLines('9000')).toBe(5_000);
+    expect(normalizeSearchTailLines(0)).toBe(5_000);
+    expect(normalizeSearchTailLines(NaN)).toBe(5_000);
+    expect(normalizeSearchTailLines(1234.9)).toBe(1_234);
+  });
+
+  it('clamps above-cap requests to 20000 so truncation checks stay honest', () => {
+    // The bug this pins: with an UNclamped 50000 vs a 30k buffer,
+    // `30000 > 50000` is false → truncated:false while the engine scanned
+    // only the newest 20k rows. Clamped, `30000 > 20000` is true.
+    expect(normalizeSearchTailLines(50_000)).toBe(20_000);
+    expect(30_000 > normalizeSearchTailLines(50_000)).toBe(true);
+  });
+});
+
+describe('searchInBuffer — lineIdx stays buffer-absolute under tailRows (Codex+Claude)', () => {
+  it('a match at row 9000 of a 10k unwrapped buffer reports lineIdx 9000, not 4000', () => {
+    const rows = Array.from({ length: 10_000 }, (_, i) => ({
+      text: i === 9_000 ? 'the MATCH line' : `row ${i}`,
+    }));
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'MATCH', { remainingBudget: 10, tailRows: 5_000 });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].physicalBaseY).toBe(9_000);
+    expect(matches[0].lineIdx).toBe(9_000);
   });
 });

--- a/src/renderer/utils/__tests__/searchEngine.test.ts
+++ b/src/renderer/utils/__tests__/searchEngine.test.ts
@@ -346,3 +346,20 @@ describe('searchInBuffer — lineIdx stays buffer-absolute under tailRows (Codex
     expect(matches[0].lineIdx).toBe(9_000);
   });
 });
+
+describe('searchInBuffer — tailRows never scans beyond its window (parked-path invariant)', () => {
+  // The parked-pane path asks the daemon for N rows and can get back N plus a
+  // viewport, so it bounds the scan with tailRows to stay consistent with the
+  // same pane when mounted (Codex re-review). This pins that guarantee.
+  it('rows older than the window are invisible even when handed to the engine', () => {
+    const rows = [
+      { text: 'MATCH oldest (outside the window)' },
+      { text: 'filler' },
+      { text: 'filler' },
+      { text: 'MATCH newest (inside the window)' },
+    ];
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'MATCH', { remainingBudget: 50, tailRows: 2 });
+    expect(matches.map((m) => m.physicalBaseY)).toEqual([3]);
+  });
+});

--- a/src/renderer/utils/__tests__/searchEngine.test.ts
+++ b/src/renderer/utils/__tests__/searchEngine.test.ts
@@ -252,3 +252,66 @@ describe('searchInBuffer — result ordering', () => {
     expect(matches.map((m) => m.physicalBaseY)).toEqual([1, 3, 5]);
   });
 });
+
+describe('searchInBuffer — tail bounding (perf root-fix P5)', () => {
+  it('T14: tailRows scans only the NEWEST rows — an older match is excluded', () => {
+    const rows = [
+      { text: 'old match' },
+      { text: 'filler-1' },
+      { text: 'filler-2' },
+      { text: 'new match' },
+    ];
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET, tailRows: 2 });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].physicalBaseY).toBe(3); // absolute buffer index survives windowing
+  });
+
+  it('T16: a tailRows window covering the whole buffer behaves like a full scan', () => {
+    const rows = [{ text: 'old match' }, { text: 'filler' }, { text: 'new match' }];
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'match', { remainingBudget: HUGE_BUDGET, tailRows: 1_000 });
+    expect(matches.map((m) => m.physicalBaseY)).toEqual([0, 2]);
+  });
+
+  it('tailRows is bounded by perBufferLineCap (window = newest min(tail, cap) rows)', () => {
+    const rows = [
+      { text: 'match-0' },
+      { text: 'match-1' },
+      { text: 'match-2' },
+      { text: 'match-3' },
+    ];
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'match', {
+      remainingBudget: HUGE_BUDGET,
+      tailRows: 3,
+      perBufferLineCap: 2,
+    });
+    // Window is the last min(3, 2) = 2 rows — the NEWEST two, not the oldest.
+    expect(matches.map((m) => m.physicalBaseY)).toEqual([2, 3]);
+  });
+
+  it('a window starting mid-wrap truncates that logical line at the boundary', () => {
+    const buf = makeBuffer(WRAPPED_3ROW_LINE); // one logical line over 3 physical rows
+    // Window starts at the 2nd physical row (mid-wrap): the continuation rows
+    // form their own (truncated) logical line rather than merging backwards.
+    const full = searchInBuffer(buf, '', { remainingBudget: HUGE_BUDGET });
+    expect(full).toHaveLength(0); // empty query guard unaffected
+    const matches = searchInBuffer(buf, WRAPPED_3ROW_LINE[1].text.slice(0, 3), {
+      remainingBudget: HUGE_BUDGET,
+      tailRows: 2,
+    });
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    expect(matches[0].physicalBaseY).toBe(1);
+  });
+
+  it('legacy behavior without tailRows is unchanged (head-first cap)', () => {
+    const rows = [{ text: 'first match' }, { text: 'second match' }, { text: 'third match' }];
+    const buf = makeBuffer(rows);
+    const matches = searchInBuffer(buf, 'match', {
+      remainingBudget: HUGE_BUDGET,
+      perBufferLineCap: 2,
+    });
+    expect(matches.map((m) => m.physicalBaseY)).toEqual([0, 1]);
+  });
+});

--- a/src/renderer/utils/searchEngine.ts
+++ b/src/renderer/utils/searchEngine.ts
@@ -32,6 +32,29 @@ const DEFAULT_CONTEXT_LINES = 2;
 /** Default ceiling on physical rows scanned per buffer. */
 const DEFAULT_BUFFER_LINE_CAP = 20_000;
 
+/** Default tail window for cross-pane search (pane.search). */
+export const SEARCH_TAIL_DEFAULT = 5_000;
+/** Hard ceiling on the tail window — mirrors the per-buffer scan cap. */
+export const SEARCH_TAIL_MAX = DEFAULT_BUFFER_LINE_CAP;
+
+/**
+ * Normalize a caller-supplied `searchTailLines` into the effective tail
+ * window: floor, default 5,000, CLAMPED to the 20k scan cap. The clamp is
+ * load-bearing for truncation honesty (3-way review: Codex+GLM): comparing a
+ * buffer's length against an UNclamped request (say 50,000) reports
+ * `truncated:false` while the engine actually scanned only the newest 20k
+ * rows — a false completeness signal in exactly the "search deeper" case the
+ * parameter exists for. Every consumer (live scan, parked fetch, truncation
+ * checks) must use THIS value, never the raw request.
+ */
+export function normalizeSearchTailLines(raw: unknown): number {
+  const n =
+    typeof raw === 'number' && Number.isFinite(raw) && raw >= 1
+      ? Math.floor(raw)
+      : SEARCH_TAIL_DEFAULT;
+  return Math.min(n, SEARCH_TAIL_MAX);
+}
+
 export interface SearchOpts {
   /**
    * Treat `query` as a JS RegExp pattern. Invalid patterns throw `SyntaxError`.
@@ -262,7 +285,15 @@ export function searchInBuffer(
     }
 
     results.push({
-      lineIdx: i,
+      // Buffer-absolute, not window-relative (3-way review: Codex+Claude —
+      // the search UI displays this as "matched line N" and a window-relative
+      // index showed ~line 4000 for a match at row 9000). Exact logical index
+      // in the legacy full scan (startRow 0). Under tailRows the rows BEFORE
+      // the window are counted physically (their wrap structure is unknowable
+      // without scanning them — the very work tail-bounding avoids), so the
+      // value is an upper-bound approximation that stays monotonic, unique
+      // per pane, and equal to the physical row anchor for unwrapped content.
+      lineIdx: startRow + i,
       physicalBaseY: line.physicalBaseY,
       text: capLine(line.text),
       contextBefore: before,

--- a/src/renderer/utils/searchEngine.ts
+++ b/src/renderer/utils/searchEngine.ts
@@ -51,6 +51,16 @@ export interface SearchOpts {
    * the global 200-result cap is enforced breadth-first across panes.
    */
   remainingBudget: number;
+  /**
+   * Scan only the LAST `tailRows` physical rows (the newest output) instead
+   * of the legacy head-first scan. Bounded by `perBufferLineCap` — when both
+   * are set the window is the last `min(tailRows, perBufferLineCap)` rows, so
+   * both bounds hold and the scan always keeps the NEWEST rows (the head-first
+   * cap kept the OLDEST 20k of a huge buffer, which is almost never what a
+   * cross-pane search wants). A window that starts mid-wrap truncates that
+   * logical line at the boundary — same explicit trade-off as the cap.
+   */
+  tailRows?: number;
 }
 
 export interface MatchInBuffer {
@@ -111,14 +121,15 @@ interface LogicalLine {
 function buildLogicalLines(
   buffer: SearchableBuffer,
   maxPhysicalRows: number,
+  startRow = 0,
 ): LogicalLine[] {
   const lines: LogicalLine[] = [];
-  const scanLimit = Math.min(buffer.length, maxPhysicalRows);
+  const scanLimit = Math.min(buffer.length, startRow + maxPhysicalRows);
 
   let currentText = '';
   let currentBaseY = -1;
 
-  for (let i = 0; i < scanLimit; i++) {
+  for (let i = startRow; i < scanLimit; i++) {
     const row = buffer.getLine(i);
     if (!row) {
       // Defensive: if a row is unexpectedly missing, flush any in-progress
@@ -134,9 +145,10 @@ function buildLogicalLines(
 
     const rowText = row.translateToString(true);
 
-    // Row 0 is by definition the start of a logical line; xterm should never
-    // mark it `isWrapped`, but we treat it as a fresh start defensively.
-    const isContinuation = i > 0 && row.isWrapped;
+    // The scan's first row is by definition the start of a logical line
+    // (row 0 is never wrapped; a tail window starting mid-wrap deliberately
+    // truncates that chain at the boundary).
+    const isContinuation = i > startRow && row.isWrapped;
 
     if (isContinuation && currentBaseY !== -1) {
       currentText += rowText;
@@ -213,7 +225,18 @@ export function searchInBuffer(
       })()
     : (text: string) => text.includes(query);
 
-  const logical = buildLogicalLines(buffer, perBufferLineCap);
+  const tailRows =
+    typeof opts.tailRows === 'number' && opts.tailRows > 0
+      ? Math.floor(opts.tailRows)
+      : undefined;
+  // Tail mode: scan the last min(tailRows, cap) rows. Legacy mode: head-first
+  // scan up to the cap (kept for callers that predate tail-bounding).
+  const startRow =
+    tailRows !== undefined
+      ? Math.max(0, buffer.length - Math.min(tailRows, perBufferLineCap))
+      : 0;
+
+  const logical = buildLogicalLines(buffer, perBufferLineCap, startRow);
   if (logical.length === 0) return [];
 
   const results: MatchInBuffer[] = [];


### PR DESCRIPTION
Four independent hot-path costs found in a renderer/main profiling pass. They
are unrelated to each other; the common thread is that each one taxes a path
that runs constantly, and on Windows every synchronous fs call also pays an
EDR scan hook.

## Daemon log buffering

`log()` did one `appendFileSync` per line — a write the calling thread waits
on, on a process whose hot paths are session churn, recovery, and RPC bursts.
Info/debug lines now coalesce for 250ms or 64KB in `src/daemon/logWriter.ts`.

`warn`/`error` deliberately do **not** buffer: they first drain any pending
info lines, so the file stays in true chronological order (it exists for
post-hoc causal reconstruction), then append synchronously so a dying daemon's
last words are already on disk. A clean exit flushes the tail; a hard kill can
lose at most the last 250ms of info lines, which is documented in the module.
The existing postmortem sinks (`daemon/util/logSink.ts`, `main/util/logSink.ts`)
are untouched — their all-sync behavior is their contract.

## Renderer one-liners

- `notePtyOutput` ran a regex replace on **every** output chunk to strip
  DSR/CPR cursor sequences. Chunks without ESC — the overwhelming majority —
  now take an `indexOf` fast path. The empty-chunk rule is preserved (an empty
  chunk is still not activity) and still tested.
- `markPtyReady` fired the whole store-update machinery on every repeat call;
  it now returns before `set()` once the pty is ready.
- `SurfaceTabs` subscribed to three whole store maps, so **any** pane's status,
  label, or agent change re-rendered **every** tab strip in the app. Narrowed
  to this pane's label and active-surface slug (primitives), with a per-tab
  status-dot child that subscribes to its own `surfaceAgentStatus` entry.

## pane.search

Two problems. It held the renderer main thread for the entire sweep, and it
scanned up to 20k rows **oldest-first** per buffer — so on a large scrollback
the newest output, which is what a cross-pane search almost always wants, was
the part that got cut.

It now yields between panes and scans the newest `searchTailLines` rows
(default 5000, clamped to the 20k cap), reporting `truncated: true` whenever
older rows went unscanned, on both the live and parked-pane paths.

The yield uses `MessageChannel`, not `setTimeout(0)`: timers in a backgrounded
window are throttled to ≥1s each, which on a 20-pane workspace would add ~20s
and blow the 10s MCP deadline the surrounding code already guards against.

`wmux_search_panes` gains an optional `searchTailLines` parameter. The
generated API reference is unchanged (it derives from `rpc.ts`/`events.ts`, not
the MCP zod schemas) — regenerated and confirmed byte-identical.

## Review findings folded in

Three-way review (Claude / Codex / GLM-5.2):

- **Truncation lied above the cap.** With `searchTailLines=50000` and a 30k-row
  buffer the engine scanned only the newest 20k while the check compared
  against the unclamped request and reported `truncated: false` — a false
  completeness signal in exactly the search-deeper case the parameter exists
  for. All consumers now go through `normalizeSearchTailLines` before any scan
  or truncation check.
- **`lineIdx` went window-relative** under a tail window, so a match at row
  9000 of a 10k buffer displayed as "matched line ~4000" in the search UI. It
  is buffer-absolute again.
- **The in-app search bar inherited the agent-facing default.** It rides the
  same handler, so a human searching their own scrollback silently skipped the
  older half of a default 10k buffer, with no way to widen it. The human entry
  point now passes the user's configured scrollback depth.

## Verification

Unit: new tests for the log writer (ordering, force-flush, rotation, exit
drain), the clamp, absolute `lineIdx`, and the ESC fast path. Full suite green
apart from two pre-existing local failures unrelated to this branch.

Live dogfood on a dev instance, with a marker buried under 7000 lines:
- agent search (default tail) misses it and reports `truncated: true`; the
  human search bar finds it — the regression fix, demonstrated as an A/B on the
  same marker
- newest marker reports `lineIdx: 7004` (it would have been ~2000 with the
  window-relative bug)
- `searchTailLines: 20000` finds the buried marker; `50000` is clamped and
  still reports honestly; `0` is rejected
- `daemon.log`: 1104 lines, zero out-of-order timestamps, including a `warn`
  line — the drain-then-write-through path holds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pane searches now prioritize recent output and support configurable search depth.
  * Search results indicate when older output may not have been included.
* **Improvements**
  * Searches remain responsive when scanning multiple panes.
  * Daemon logs are batched for efficiency while warnings and errors appear immediately and in order.
  * Log rotation and shutdown flushing are handled more reliably.
* **Bug Fixes**
  * Terminal tab updates are limited to the affected pane.
  * Reduced unnecessary processing during terminal output handling and readiness updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->