### PR TITLE
fix(browser): derive browser workspace scope from the caller

### DIFF
--- a/changelog.d/873.md
+++ b/changelog.d/873.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Browser automation now refuses a call whose workspace it cannot determine.**
+  A plugin or wire client that asked wmux to drive a browser page without saying
+  which workspace it was calling from used to get whichever page happened to be
+  registered first — possibly one in a workspace it had nothing to do with. It
+  now gets a clear, non-retryable refusal instead. Callers that already send
+  their workspace are unaffected, including the bundled MCP server, the `wmux`
+  CLI, and the app's own UI. Set `"mcp": { "mode": "shadow" }` in
+  `~/.wmux/config.json` to restore the previous behavior. (#810)

--- a/docs/api/mcp-plugin-spec.md
+++ b/docs/api/mcp-plugin-spec.md
@@ -330,12 +330,19 @@ Once a plugin has identified itself and declared its capability set, every subse
 - Users can override either way explicitly via the config key.
 
 The same bounded JSONL file also carries `entryKind: "browser-scope"` rows for
-`#810`'s caller-derived browser workspace decision. Those rows are observation
-only in every `mcp.mode`: current target selection still uses the request's
-optional `workspaceId`, and no browser call is refused by `callerScope` yet.
-They record the calls a later enforcement PR would reject (for example, an
-identified approved plugin that omitted its workspace), so the flip can be
-based on real compatibility evidence rather than assumption.
+`#810`'s caller-derived browser workspace decision, and `mcp.mode` governs that
+decision too — one switch, one rollback. Under `enforce`, a target-resolving
+`browser.*` call whose scope cannot be derived fails with
+`BROWSER_SCOPE_REFUSED` before any target lookup; the most common case is an
+identified client that omitted its `workspaceId`, which previously fell back to
+whichever surface happened to be registered first. **If your plugin calls any
+`browser.*` method, send the `workspaceId` of the workspace you are calling
+from.** Under `shadow` the row is still written and the call still runs on the
+request-derived workspace, so the old behavior remains available for rollback.
+
+The refusal is terminal — retrying the identical call will not succeed. Fix the
+request instead: add `workspaceId`, or use the workspace your commander token is
+bound to.
 
 **Wire shape.** The `RpcResponse` failure arm carries a `rejection?: RpcRejection` discriminated union (see `src/shared/rpc.ts`):
 

--- a/docs/internal/browser-tabs-workspace-contract.md
+++ b/docs/internal/browser-tabs-workspace-contract.md
@@ -446,16 +446,21 @@ What that closes, precisely:
 - A server-pinned caller can no longer name a workspace other than its token
   binding, and is scoped to that binding regardless of what it asked for.
 
-One lane was **added** during the flip: `internal-cli`. `wmux browser navigate`
-run outside a wmux pane has no pane above it, so `resolveSelfContext` correctly
-resolves nothing and the CLI omits the field to keep active-target behavior
-(#845) — while still sending `clientName`. Enforcing without this lane would
-have refused a shipped, tested command in every packaged build. The predicate
-mirrors `PermissionEnforcer`'s internal-CLI lane exactly
-(`isLocalExternalWireContext` + `isInternalCliClient`) and is deliberately
-narrower than the first-party predicate that gates `cdpPort`.
+**No lane is keyed on the caller's name.** Enforcing did surface one broken
+caller: `wmux browser navigate` run outside a wmux pane has no pane above it, so
+`resolveSelfContext` correctly resolves nothing and the CLI omitted the field to
+keep active-target behavior (#845) — while still sending `clientName`. It would
+have been refused in every packaged build.
 
-That lane is also the honest verdict on #846's shadow window: it recorded no
+A lane for the CLI's `clientName` was tried and rejected. `clientName` is
+self-asserted, so any wire caller could claim it and buy back exactly the
+unscoped access this change removes. The fix is on the CLI instead: when nothing
+resolves, it asks `workspace.current` and names that workspace — the same one
+the old server-side fallback would have picked, now chosen explicitly by the
+caller. If that lookup fails the CLI still sends nothing and lets the refusal
+explain itself, rather than inventing a workspace to get past the gate.
+
+That near-miss is the honest verdict on #846's shadow window: it recorded no
 `browser.*` traffic at all, so "the audit log is quiet" meant *unexercised*,
 not *exercised and clean*. The gap it hid was this CLI path.
 

--- a/docs/internal/browser-tabs-workspace-contract.md
+++ b/docs/internal/browser-tabs-workspace-contract.md
@@ -426,16 +426,43 @@ It originally composed with a sibling in `browser.close`, which resolved an expl
 
 This remains **confinement of approved plugins, not containment of hostile same-user code.** A same-user process holding the daemon token can impersonate a recognised wire client under the existing #113 trust ceiling. What #810 removes is the accidental implication that granting an honest plugin `browser.read` also grants direct attachment to every page in the Electron process.
 
-**Caller-derived target scope is shadow-only (#810).** The target-resolving
-`browser.*` handlers now compute a `callerScope` decision with explicit
-operator, server-pinned, legacy, declared, and rejected lanes. They still use
-the old request-derived `workspaceId` for every lookup, so this stage changes no
-target, response, or error. A future refusal is appended as an
-`entryKind: "browser-scope"` row in `~/.wmux/shadow-rejections.log`; logging is
-best-effort and cannot fail the call. Enforcement waits for those logs to be
-quiet and for a separate review. Envelope-less legacy traffic remains open and
-continues through its existing per-method milestone audit rather than starting
-a second deprecation clock here.
+**Caller-derived target scope is enforced under `mcp.mode: enforce` (#810).**
+The target-resolving `browser.*` handlers compute a `callerScope` decision with
+explicit operator, server-pinned, legacy, declared, and rejected lanes, and
+`scopeFor` is the single point where a handler learns which workspace to look a
+surface up in. A rejected decision is appended as an `entryKind: "browser-scope"`
+row in `~/.wmux/shadow-rejections.log` (best-effort, cannot fail the call) and
+then, under `enforce`, throws `BROWSER_SCOPE_REFUSED` before any lookup, wake,
+lease, or URL validation runs. Under `shadow` — the dev default, and available
+in production as `"mcp": {"mode": "shadow"}` — the same row is written and the
+call proceeds on the old request-derived workspace, which is the rollback path.
+
+What that closes, precisely:
+
+- A caller that **omits** `workspaceId` no longer falls through to the
+  workspace-blind "first registered surface" lookup.
+- A server-pinned caller can no longer name a workspace other than its token
+  binding, and is scoped to that binding regardless of what it asked for.
+
+What it does **not** close, and why it is written down rather than implied:
+
+- The `declared` lane checks that `workspaceId` is *present*, not that it is the
+  caller's own. Nothing in the main process binds a `clientName` to a workspace
+  (`mcp.claimWorkspace` forwards to the renderer and records no association), so
+  a caller naming a foreign workspace is accepted exactly as before.
+- The `legacy` lane (no `clientName`) stays allowed and unscoped, matching
+  `PermissionEnforcer`'s grandfather. Dropping the identity envelope bypasses
+  this layer. Envelope-less traffic continues through its existing per-method
+  milestone audit rather than starting a second deprecation clock here.
+- `browser.open` and `browser.close` route a create/close by the request's
+  `workspaceId` and fall back to the UI-active workspace when it is absent. They
+  are surface lifecycle rather than target resolution, were never shadowed, and
+  so are not flipped here — there is no traffic evidence to flip on.
+
+Both remaining lookup gaps need a caller-identity binding that does not exist
+yet; they stay tracked on #810. `browser.rpc.scopeCoverage.test.ts` reads this
+file's source and fails if a new handler resolves a target without going through
+`scopeFor`, or reads `workspaceId` outside the three handlers listed above.
 
 Both legs predated #565 and neither was introduced by it. `browser_tabs` never consulted `browser.cdp.info` and never left the caller's workspace, so its own contract was always unaffected. The exposure was already bounded: no URL, title, or page content, and a discarded surface is absent because it holds no registered target.
 

--- a/docs/internal/browser-tabs-workspace-contract.md
+++ b/docs/internal/browser-tabs-workspace-contract.md
@@ -439,10 +439,25 @@ call proceeds on the old request-derived workspace, which is the rollback path.
 
 What that closes, precisely:
 
-- A caller that **omits** `workspaceId` no longer falls through to the
-  workspace-blind "first registered surface" lookup.
+- An approved **third-party** caller that omits `workspaceId` no longer falls
+  through to the workspace-blind "first registered surface" lookup. This is the
+  caller #810 describes. A first-party MCP client that omits it is refused too —
+  they already send it on every call.
 - A server-pinned caller can no longer name a workspace other than its token
   binding, and is scoped to that binding regardless of what it asked for.
+
+One lane was **added** during the flip: `internal-cli`. `wmux browser navigate`
+run outside a wmux pane has no pane above it, so `resolveSelfContext` correctly
+resolves nothing and the CLI omits the field to keep active-target behavior
+(#845) — while still sending `clientName`. Enforcing without this lane would
+have refused a shipped, tested command in every packaged build. The predicate
+mirrors `PermissionEnforcer`'s internal-CLI lane exactly
+(`isLocalExternalWireContext` + `isInternalCliClient`) and is deliberately
+narrower than the first-party predicate that gates `cdpPort`.
+
+That lane is also the honest verdict on #846's shadow window: it recorded no
+`browser.*` traffic at all, so "the audit log is quiet" meant *unexercised*,
+not *exercised and clean*. The gap it hid was this CLI path.
 
 What it does **not** close, and why it is written down rather than implied:
 

--- a/src/cli/commands/__tests__/browser.test.ts
+++ b/src/cli/commands/__tests__/browser.test.ts
@@ -51,13 +51,48 @@ describe('wmux browser navigate caller scoping (#810)', () => {
     });
   });
 
-  it('preserves active-target fallback when no caller workspace resolves', async () => {
+  it('names the active workspace when no caller workspace resolves', async () => {
+    // Outside a wmux pane there is no pane identity to walk to. This used to
+    // send no workspace and let the main process fall back to whichever target
+    // registered first; #810 removed that fallback, so the CLI asks which
+    // workspace is active and says so. Same workspace the old fallback picked,
+    // now chosen explicitly by the caller.
     selfContext.mockResolvedValue({});
+    rpc.mockImplementation(async (method: string) =>
+      method === 'workspace.current'
+        ? { id: 'rpc-cur', ok: true, result: { id: 'ws-active', name: 'Active' } }
+        : { id: 'rpc-ok', ok: true, result: { ok: true } },
+    );
+
+    await handleBrowser(['navigate', 'https://example.com/outside'], false);
+
+    expect(rpc).toHaveBeenCalledWith('browser.navigate', {
+      url: 'https://example.com/outside',
+      workspaceId: 'ws-active',
+    });
+  });
+
+  it('omits the field when the active workspace cannot be read', async () => {
+    // Do not invent a workspace to get past the gate — send nothing and let the
+    // server's own refusal explain itself. Guessing here would reintroduce the
+    // "some workspace, who knows which" routing #810 is about.
+    selfContext.mockResolvedValue({});
+    rpc.mockImplementation(async (method: string) =>
+      method === 'workspace.current'
+        ? { id: 'rpc-cur', ok: false, error: 'renderer unavailable' }
+        : { id: 'rpc-ok', ok: true, result: { ok: true } },
+    );
 
     await handleBrowser(['navigate', 'https://example.com/outside'], false);
 
     expect(rpc).toHaveBeenCalledWith('browser.navigate', {
       url: 'https://example.com/outside',
     });
+  });
+
+  it('does not spend a round trip when the caller workspace already resolved', async () => {
+    await handleBrowser(['navigate', 'https://example.com'], false);
+
+    expect(rpc).not.toHaveBeenCalledWith('workspace.current', expect.anything());
   });
 });

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -88,16 +88,30 @@ export async function handleBrowser(
       // Resolve the caller exactly like `wmux open` / `wmux browser close`.
       // Inside a wmux pane this prevents a background workspace from
       // navigating whichever browser target happened to register first.
-      // Outside wmux, no workspace resolves and active-target compatibility is
-      // preserved by omitting the field.
       const ctx = await resolveSelfContext({
         sendRequest,
         env: process.env,
         ppid: process.ppid,
         getParentPid: getParentPidDefault,
       });
+      // Outside wmux nothing resolves, and this used to send no workspace at
+      // all — which let the main process fall back to "whichever target
+      // registered first". #810 removed that fallback, so ASK for the target
+      // instead of leaving the server to guess: `workspace.current` is the same
+      // active workspace the old renderer fallback would have picked, so the
+      // user-visible behavior is unchanged and the choice is now explicit and
+      // attributable. A failed lookup leaves the field absent and lets the
+      // server's own refusal explain itself, rather than inventing a workspace.
+      let workspaceId = ctx.workspaceId;
+      if (!workspaceId) {
+        const current = await sendRequest('workspace.current', {});
+        if (current.ok) {
+          const id = (current.result as { id?: unknown } | null)?.id;
+          if (typeof id === 'string' && id.length > 0) workspaceId = id;
+        }
+      }
       const params: Record<string, unknown> = { url };
-      if (ctx.workspaceId) params.workspaceId = ctx.workspaceId;
+      if (workspaceId) params.workspaceId = workspaceId;
 
       response = await sendRequest('browser.navigate', params);
       if (jsonMode) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -692,6 +692,19 @@ registerPerfRpc(rpcRouter);
 // arrive before the renderer has pushed anything, so renderer-push authority
 // would race and fail open to builtin).
 const browserBackendStore = new BrowserBackendStore(app.getPath('userData'));
+// Phase 2.2 enforcement mode. Production wmux defaults to `enforce`; dev
+// (electron-forge / npm start) defaults to `shadow` so a bad delta doesn't lock
+// the developer out. Override via `mcp.mode` in `~/.wmux/config.json`.
+//
+// Resolved HERE, above every handler that reads it, rather than next to
+// `rpcRouter.setEnforcementMode` further down. Nothing awaits between the two
+// points today, so a later read was safe — but only accidentally: adding one
+// `await` in between would turn a browser RPC's mode read into a TDZ
+// ReferenceError instead of a mode. Ordering the declaration first removes the
+// class rather than relying on the gap staying synchronous.
+const isDevEnvironment = !app.isPackaged || process.env.NODE_ENV === 'development';
+const enforcementMode = resolveEnforcementMode({ isDev: isDevEnvironment });
+
 // Shared bounded audit sink for permission rejections, legacy milestones, and
 // #810's browser caller-scope decisions.
 const shadowRejectionLogger = new ShadowRejectionLogger();
@@ -876,11 +889,8 @@ const legacyTrafficCounter = new LegacyTrafficCounter({
 rpcRouter.setLegacyTrafficCounter(legacyTrafficCounter);
 
 // Phase 2.2 pre-commit 6: enforcement mode + approval queue.
-// Production wmux defaults to `enforce`; dev (electron-forge / npm start)
-// defaults to `shadow` so a bad delta doesn't lock the developer out.
-// Override via `mcp.mode` in `~/.wmux/config.json`.
-const isDevEnvironment = !app.isPackaged || process.env.NODE_ENV === 'development';
-const enforcementMode = resolveEnforcementMode({ isDev: isDevEnvironment });
+// (`isDevEnvironment` / `enforcementMode` are resolved above, before the RPC
+// handlers that read them are registered.)
 rpcRouter.setEnforcementMode(enforcementMode);
 
 // Issue #636: operator-extensible first-party client names. Read once here —

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -693,7 +693,7 @@ registerPerfRpc(rpcRouter);
 // would race and fail open to builtin).
 const browserBackendStore = new BrowserBackendStore(app.getPath('userData'));
 // Shared bounded audit sink for permission rejections, legacy milestones, and
-// #810's shadow-only browser caller-scope decisions.
+// #810's browser caller-scope decisions.
 const shadowRejectionLogger = new ShadowRejectionLogger();
 registerBrowserRpc(
   rpcRouter,
@@ -701,6 +701,10 @@ registerBrowserRpc(
   webviewCdpManager,
   browserBackendStore,
   (entry) => shadowRejectionLogger.appendBrowserScope(entry),
+  // Same `mcp.mode` the permission enforcer runs on, so one switch rolls both
+  // back. Read lazily: `enforcementMode` is resolved further down this file,
+  // and the getter is only called once an RPC arrives.
+  () => enforcementMode,
 );
 registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker, { getDaemonClient: () => daemonClient });
 registerA2aChannelRpc(rpcRouter, () => daemonClient, () => mainWindow);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -715,8 +715,8 @@ registerBrowserRpc(
   browserBackendStore,
   (entry) => shadowRejectionLogger.appendBrowserScope(entry),
   // Same `mcp.mode` the permission enforcer runs on, so one switch rolls both
-  // back. Read lazily: `enforcementMode` is resolved further down this file,
-  // and the getter is only called once an RPC arrives.
+  // back. `enforcementMode` is resolved just above; the getter keeps the read
+  // lazy so registration does not depend on where the mode is resolved.
   () => enforcementMode,
 );
 registerA2aRpc(rpcRouter, () => mainWindow, claudeWorker, { getDaemonClient: () => daemonClient });

--- a/src/main/pipe/handlers/__tests__/browser.rpc.scopeCoverage.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.scopeCoverage.test.ts
@@ -1,0 +1,126 @@
+// #810 — structural invariant: no target-resolving browser handler may pick a
+// workspace on its own.
+//
+// The hole this guards is how #810 happened in the first place. Scoping was
+// added handler by handler, so "is this call scoped?" was answered by whoever
+// wrote the handler, and a later one that forgot simply kept the old
+// workspace-blind lookup. Nothing failed; the gap was invisible until someone
+// re-read the file.
+//
+// A behavioral test cannot catch that: it can only assert about handlers it
+// already knows to check, which is exactly the set that is not the problem.
+// So this reads the source instead and asserts the shape:
+//
+//   registerBrowserRpc
+//     │
+//     ├─ registerLeased('browser.X', (params, scope) => …)
+//     │     └─ scopeFor() runs in the wrapper, once, before any lookup
+//     │
+//     └─ router.register('browser.Y', (params, ctx) => …)
+//           └─ must call scopeFor() itself if it resolves a target
+//
+// Precedent for source-scan invariants in this repo: remoteInboxNoPaste.test.ts.
+
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const SOURCE_PATH = path.join(__dirname, '..', 'browser.rpc.ts');
+const source = readFileSync(SOURCE_PATH, 'utf8');
+
+/**
+ * Calls that pick or wake a browser surface. Any handler using one of these is
+ * making a workspace decision, whether or not it looks like it.
+ */
+const TARGET_RESOLVERS = [
+  'getTarget(',
+  'ensureAwake(',
+  'waitForTarget(',
+  'resolveWc(',
+  'resolveTargetSurface(',
+];
+
+interface HandlerBlock {
+  kind: 'leased' | 'plain';
+  method: string;
+  body: string;
+}
+
+/** Split the file into per-handler blocks, in registration order. */
+function handlerBlocks(): HandlerBlock[] {
+  const pattern = /(registerLeased|router\.register)\('(browser\.[A-Za-z.]+)'/g;
+  const starts: { kind: 'leased' | 'plain'; method: string; index: number }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(source)) !== null) {
+    starts.push({
+      kind: match[1] === 'registerLeased' ? 'leased' : 'plain',
+      method: match[2],
+      index: match.index,
+    });
+  }
+  return starts.map((start, i) => ({
+    kind: start.kind,
+    method: start.method,
+    // Up to the next registration, or end of file for the last one. Coarse but
+    // sufficient: the trailing slice only ever adds non-handler code, which
+    // cannot make a failing block pass.
+    body: source.slice(start.index, starts[i + 1]?.index ?? source.length),
+  }));
+}
+
+describe('browser RPC workspace-scope coverage (#810)', () => {
+  const blocks = handlerBlocks();
+
+  it('finds the handlers (guards against the scan silently matching nothing)', () => {
+    expect(blocks.length).toBeGreaterThan(20);
+    expect(blocks.some((b) => b.method === 'browser.evaluate')).toBe(true);
+  });
+
+  it('every leased handler takes the resolved scope instead of deriving one', () => {
+    const offenders = blocks
+      .filter((b) => b.kind === 'leased')
+      .filter((b) => !/registerLeased\('browser\.[A-Za-z.]+',\s*async \(params, scope\b/.test(b.body))
+      .map((b) => b.method);
+
+    // Failure means a leased handler was added with the old `(params)` shape.
+    // Give it the `scope` argument the wrapper already computed — do NOT read
+    // `params['workspaceId']` inside the handler.
+    expect(offenders).toEqual([]);
+  });
+
+  it('every non-leased handler that resolves a target computes the scope first', () => {
+    const offenders = blocks
+      .filter((b) => b.kind === 'plain')
+      .filter((b) => TARGET_RESOLVERS.some((call) => b.body.includes(call)))
+      .filter((b) => !b.body.includes('scopeFor('))
+      .map((b) => b.method);
+
+    // Failure means a handler resolves a browser surface without deciding which
+    // workspace may see it — the #810 defect. Call
+    // `scopeFor('<method>', params, ctx)` before the lookup and pass its result.
+    expect(offenders).toEqual([]);
+  });
+
+  it('only the documented handlers read workspaceId out of the request body', () => {
+    // Reading `params['workspaceId']` IS the opt-out #810 is about, so the set
+    // of handlers that still do it is an explicit, reviewed list rather than a
+    // habit. Adding to it should require changing this test.
+    //
+    //   browser.tabs   fails closed on its own with
+    //                  BROWSER_TABS_WORKSPACE_UNRESOLVED, and is a
+    //                  wmux.internal RPC whose id the bundled MCP resolves.
+    //   browser.open   surface LIFECYCLE, not target resolution: it routes a
+    //   browser.close  create/close through the renderer, which falls back to
+    //                  the UI-active workspace when the field is absent. Same
+    //                  class of gap as the lookup path this PR closes, but #846
+    //                  never shadowed them, so there is no traffic evidence to
+    //                  enforce on. Measure before flipping — tracked on #810.
+    const ALLOWED = ['browser.tabs', 'browser.open', 'browser.close'];
+
+    const readers = blocks
+      .filter((b) => /params\[['"]workspaceId['"]\]/.test(b.body))
+      .map((b) => b.method);
+
+    expect(readers.sort()).toEqual([...ALLOWED].sort());
+  });
+});

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -168,35 +168,25 @@ describe('callerScope shadow decision (#810)', () => {
       { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
     ],
     [
-      // `wmux browser navigate` outside a wmux pane: no pane above it, so
-      // resolveSelfContext returns nothing and the field is omitted (#845).
-      'bundled CLI that resolved to no workspace',
+      // No lane is keyed on the caller's NAME. `clientName` is self-asserted,
+      // so a lane for the bundled CLI would be a lane for anything willing to
+      // claim its name — the CLI resolves `workspace.current` instead.
+      'bundled CLI name buys nothing on its own',
       { origin: 'local', externalWire: true, clientName: 'wmux-cli' },
       {},
-      { kind: 'allowed', lane: 'internal-cli' },
+      { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
     ],
     [
-      // The lane is a fallback, not a bypass: a first-party client that DID
-      // resolve its workspace is scoped to it like anyone else.
-      'bundled CLI that did resolve one',
+      'bundled CLI that resolved its workspace',
       { origin: 'local', externalWire: true, clientName: 'wmux-cli' },
       { workspaceId: 'ws-cli' },
       { kind: 'scoped', lane: 'declared', workspaceId: 'ws-cli' },
     ],
     [
-      // The lane is narrower than the first-party predicate used for cdpPort:
-      // a bundled MCP server already sends its workspace, so it stays refused
-      // when it does not.
+      // Being first-party is not a scope either: the bundled MCP servers send
+      // their workspace on every call, so omitting it is a caller bug.
       'first-party MCP client omitting its scope',
       { origin: 'local', externalWire: true, clientName: 'claude-code' },
-      {},
-      { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
-    ],
-    [
-      // Name alone is not provenance: without PipeServer's external-wire
-      // marker, an iframe plugin sharing the manifest namespace stays refused.
-      'CLI name without external-wire provenance',
-      { origin: 'local', firstParty: true, clientName: 'wmux-cli' },
       {},
       { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
     ],

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -168,6 +168,39 @@ describe('callerScope shadow decision (#810)', () => {
       { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
     ],
     [
+      // `wmux browser navigate` outside a wmux pane: no pane above it, so
+      // resolveSelfContext returns nothing and the field is omitted (#845).
+      'bundled CLI that resolved to no workspace',
+      { origin: 'local', externalWire: true, clientName: 'wmux-cli' },
+      {},
+      { kind: 'allowed', lane: 'internal-cli' },
+    ],
+    [
+      // The lane is a fallback, not a bypass: a first-party client that DID
+      // resolve its workspace is scoped to it like anyone else.
+      'bundled CLI that did resolve one',
+      { origin: 'local', externalWire: true, clientName: 'wmux-cli' },
+      { workspaceId: 'ws-cli' },
+      { kind: 'scoped', lane: 'declared', workspaceId: 'ws-cli' },
+    ],
+    [
+      // The lane is narrower than the first-party predicate used for cdpPort:
+      // a bundled MCP server already sends its workspace, so it stays refused
+      // when it does not.
+      'first-party MCP client omitting its scope',
+      { origin: 'local', externalWire: true, clientName: 'claude-code' },
+      {},
+      { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
+    ],
+    [
+      // Name alone is not provenance: without PipeServer's external-wire
+      // marker, an iframe plugin sharing the manifest namespace stays refused.
+      'CLI name without external-wire provenance',
+      { origin: 'local', firstParty: true, clientName: 'wmux-cli' },
+      {},
+      { kind: 'rejected', lane: 'declared', reason: 'workspace-unresolved' },
+    ],
+    [
       'legacy caller remaining unscoped',
       { origin: 'local', externalWire: true },
       {},

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -753,6 +753,50 @@ describe('registerBrowserRpc', () => {
     expect(sendToRendererMock).not.toHaveBeenCalled();
   });
 
+  it('shadow mode looks targets up by the request field, not the decision', async () => {
+    // Shadow is the rollback, so it must be pre-#810 behavior exactly. The
+    // regression this guards: returning the decision's workspace here would
+    // re-scope callers (notably the pinned lane) in the mode whose promise is
+    // that it changes nothing.
+    const router = register(() => null, undefined, 'shadow');
+
+    await router.dispatch({
+      id: 'scope-shadow-passthrough-none',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+    expect(cdpOf(router).getTarget).toHaveBeenCalledWith(undefined, undefined);
+
+    await router.dispatch({
+      id: 'scope-shadow-passthrough-declared',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1', workspaceId: 'ws-declared' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+    expect(cdpOf(router).getTarget).toHaveBeenCalledWith(undefined, 'ws-declared');
+  });
+
+  it('treats an empty workspaceId as absent, the same as the pre-#810 inline check', async () => {
+    // `browser.cdp.info` used to inline `typeof x === 'string' && x.length > 0`
+    // and now shares `requestedWorkspaceId`. If those ever diverge, `""` would
+    // start filtering targets to a workspace that cannot exist — an empty list
+    // reported as `targetsScoped`, which reads as "you own nothing" rather than
+    // "your request was malformed".
+    const enforced = register(() => null, undefined, 'enforce');
+    const response = await enforced.dispatch({
+      id: 'scope-empty-ws',
+      method: 'browser.cdp.info',
+      params: { workspaceId: '' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    // Empty means unresolved, so an identified caller is refused rather than
+    // silently scoped to "".
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+  });
+
   it('shadow mode still answers every one of those calls', async () => {
     const router = register(() => null, undefined, 'shadow');
 

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -215,6 +215,7 @@ describe('registerBrowserRpc', () => {
   function register(
     getWindow: () => BrowserWindow | null = () => null,
     browserScopeShadowSink?: Parameters<typeof registerBrowserRpc>[4],
+    enforcementMode: 'shadow' | 'enforce' = 'shadow',
   ): RpcRouter {
     const router = new RpcRouter();
     const webviewCdpManager = {
@@ -237,8 +238,17 @@ describe('registerBrowserRpc', () => {
       webviewCdpManager as never,
       undefined,
       browserScopeShadowSink,
+      () => enforcementMode,
     );
+    // Handed back so enforcement tests can assert a refusal never reached the
+    // target lookup — "returned an error" is not the same as "did not look".
+    (router as unknown as { __cdp: typeof webviewCdpManager }).__cdp = webviewCdpManager;
     return router;
+  }
+
+  /** The lookup mock behind a router built by `register`. */
+  function cdpOf(router: RpcRouter) {
+    return (router as unknown as { __cdp: { getTarget: ReturnType<typeof vi.fn>; listTargets: ReturnType<typeof vi.fn>; waitForTarget: ReturnType<typeof vi.fn>; ensureAwake: ReturnType<typeof vi.fn> } }).__cdp;
   }
 
   /** Build a fake main window whose webContents.getURL() returns `url`. */
@@ -585,6 +595,180 @@ describe('registerBrowserRpc', () => {
       reason: 'workspace-unresolved',
     });
     expect(mockWebContents.debugger.sendCommand).toHaveBeenCalled();
+  });
+
+  // ── #810 step 4: the same decisions, now authoritative ────────────────────
+  //
+  // Every case below is paired: the shadow assertions above prove the response
+  // is unchanged, these prove the enforce mode refuses. A test that only checked
+  // enforce would not catch the rollback path silently breaking.
+
+  it('refuses an identified caller that omits workspaceId, and never looks a target up', async () => {
+    const shadowSink = vi.fn();
+    const router = register(() => null, shadowSink, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-evaluate',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+      expect(response.error).toContain('send the workspaceId');
+      expect(response.error).toContain('Do not retry unchanged');
+    }
+    // The refusal is the whole point: no lookup, no lease, no evaluation.
+    expect(cdpOf(router).getTarget).not.toHaveBeenCalled();
+    expect(cdpOf(router).ensureAwake).not.toHaveBeenCalled();
+    expect(mockWebContents.debugger.sendCommand).not.toHaveBeenCalled();
+    // Enforced refusals stay auditable — the log is written before the throw.
+    expect(shadowSink).toHaveBeenCalledWith({
+      clientName: 'approved-plugin',
+      method: 'browser.evaluate',
+      reason: 'workspace-unresolved',
+    });
+  });
+
+  // The pinned lane cannot be reached from here: `commanderWorkspace` is set
+  // only by RpcRouter after validating a commander token, never from dispatch
+  // options or a request field. Its decisions are covered pure-functionally in
+  // the `callerScope` describe above; `scopeFor` funnels every rejected lane
+  // through one branch, exercised by the unresolved cases here.
+
+  it('hands the decided workspace to the lookup, not the raw request field', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-declared',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1', workspaceId: 'ws-declared' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    expect(response.ok).toBe(true);
+    expect(cdpOf(router).getTarget).toHaveBeenCalledWith(undefined, 'ws-declared');
+  });
+
+  it('refuses a caller with no context at all', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    // No dispatch options: RpcRouter still builds a ctx, so this exercises the
+    // realistic shape rather than a hand-made `undefined` ctx. An identified
+    // caller that never proved a source lands on the unresolved lane.
+    const response = await router.dispatch({
+      id: 'scope-enforce-nosource',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1' },
+      clientName: 'approved-plugin',
+    });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+  });
+
+  it('keeps the operator and legacy lanes working under enforce', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    // Human operator crossing workspaces on purpose.
+    const operator = await router.dispatch({
+      id: 'scope-enforce-operator',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1' },
+    }, { operator: true });
+    expect(operator.ok).toBe(true);
+
+    // Envelope-less caller: still grandfathered, matching PermissionEnforcer.
+    // This lane is the documented remaining hole on #810, asserted so that
+    // closing it later is a deliberate, visible change rather than a drift.
+    const legacy = await router.dispatch({
+      id: 'scope-enforce-legacy',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1' },
+    });
+    expect(legacy.ok).toBe(true);
+  });
+
+  it('refuses cdp.info before disclosing anything, including targets', async () => {
+    const router = register(windowWithUrl('http://localhost:5173/'), undefined, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-info',
+      method: 'browser.cdp.info',
+      params: {},
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+    expect(cdpOf(router).listTargets).not.toHaveBeenCalled();
+  });
+
+  it('refuses cdp.target before the discovery wait', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-cdp-target',
+      method: 'browser.cdp.target',
+      params: { surfaceId: 'surface-1' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+    expect(cdpOf(router).waitForTarget).not.toHaveBeenCalled();
+  });
+
+  it('refuses lease.acquire rather than handing back a null token', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-lease',
+      method: 'browser.lease.acquire',
+      params: {},
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    // `{ token: null }` would read as "no surface open" and send the caller
+    // into a retry loop; a refusal is terminal and says why.
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+  });
+
+  it('refuses navigate before URL validation or the external delegate', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-navigate',
+      method: 'browser.navigate',
+      params: { url: 'https://example.com/' },
+      clientName: 'approved-plugin',
+    }, { externalWire: true });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+    expect(validateResolvedNavigationUrlMock).not.toHaveBeenCalled();
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('shadow mode still answers every one of those calls', async () => {
+    const router = register(() => null, undefined, 'shadow');
+
+    for (const [id, method, params] of [
+      ['s1', 'browser.evaluate', { expression: '1 + 1' }],
+      ['s2', 'browser.cdp.info', {}],
+      ['s3', 'browser.lease.acquire', {}],
+    ] as const) {
+      const response = await router.dispatch({
+        id,
+        method,
+        params: params as Record<string, unknown>,
+        clientName: 'approved-plugin',
+      }, { externalWire: true });
+      expect(response.ok).toBe(true);
+    }
   });
 
   it('browser.navigate rejects URLs whose resolved targets are blocked', async () => {

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -300,22 +300,30 @@ export function registerBrowserRpc(
    * The single place a target-resolving browser handler learns which workspace
    * to look a surface up in.
    *
-   * Both modes audit the same decision; they differ only in what happens to a
-   * refusal:
+   * Both modes audit the same decision. They differ in what the caller gets:
    *
    *        callerScope(ctx, params)
    *                 │
-   *      ┌──────────┴───────────┐
-   *   rejected                allowed / scoped
-   *      │                       │
-   *   audit-log               return decision workspace
-   *      │                    (undefined for the operator and legacy
-   *      │                     lanes that may stay unscoped)
-   *      ├── enforce ─► throw scopeRefusalError  (terminal, no target lookup)
-   *      └── shadow  ─► return requestedWorkspaceId(params)
-   *                     (byte-identical to pre-#810 behavior, which is the
-   *                      point: a dev build or an explicit
-   *                      `"mcp": {"mode": "shadow"}` is the rollback.)
+   *      ┌──────────┴────────────┐
+   *   rejected                 allowed / scoped
+   *      │                        │
+   *   audit-log                   │
+   *      │                        │
+   *      ├─ enforce ─► throw      ├─ enforce ─► decision.workspaceId
+   *      │   (terminal: no        │              (the pinned lane returns the
+   *      │    lookup, wake,       │               TOKEN binding, which is the
+   *      │    lease, or URL       │               point — it may differ from
+   *      │    validation runs)    │               what the caller asked for)
+   *      │                        │
+   *      └─ shadow ──────────────►┴─ shadow ──► requestedWorkspaceId(params)
+   *
+   * Shadow returns the request-derived workspace on EVERY lane, refused or not.
+   * That is deliberate and load-bearing: shadow is the rollback, so it has to
+   * be pre-#810 behavior exactly, not "pre-#810 except where the new decision
+   * happens to be better". Returning `decision.workspaceId` here would already
+   * re-scope a pinned caller — changing which targets `browser.cdp.info` lists
+   * and whether it sets `targetsScoped` — in the mode whose whole promise is
+   * that it changes nothing.
    *
    * The mode is `mcp.mode`, shared with the permission enforcer rather than a
    * second knob — both answer "is substrate enforcement live on this install?",
@@ -331,28 +339,31 @@ export function registerBrowserRpc(
     ctx: RpcContext | undefined,
   ): string | undefined => {
     const decision = callerScope(ctx, params);
-    if (decision.kind !== 'rejected') return decision.workspaceId;
+    const enforcing = getEnforcementMode() === 'enforce';
 
-    if (browserScopeShadowSink) {
-      try {
-        browserScopeShadowSink({
-          clientName: ctx?.clientName,
-          method,
-          reason: decision.reason,
-          ...(decision.requestedWorkspaceId && {
-            requestedWorkspaceId: decision.requestedWorkspaceId,
-          }),
-          ...(decision.pinnedWorkspaceId && {
-            pinnedWorkspaceId: decision.pinnedWorkspaceId,
-          }),
-        });
-      } catch {
-        /* browser scope audit logging must never affect dispatch */
+    if (decision.kind === 'rejected') {
+      if (browserScopeShadowSink) {
+        try {
+          browserScopeShadowSink({
+            clientName: ctx?.clientName,
+            method,
+            reason: decision.reason,
+            ...(decision.requestedWorkspaceId && {
+              requestedWorkspaceId: decision.requestedWorkspaceId,
+            }),
+            ...(decision.pinnedWorkspaceId && {
+              pinnedWorkspaceId: decision.pinnedWorkspaceId,
+            }),
+          });
+        } catch {
+          /* browser scope audit logging must never affect dispatch */
+        }
       }
+      if (enforcing) throw scopeRefusalError(method, decision.reason);
+      return requestedWorkspaceId(params);
     }
 
-    if (getEnforcementMode() === 'enforce') throw scopeRefusalError(method, decision.reason);
-    return requestedWorkspaceId(params);
+    return enforcing ? decision.workspaceId : requestedWorkspaceId(params);
   };
 
   // Resolve the guest webview's WebContents for a CDP-backed handler, throwing a

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -28,6 +28,7 @@ import type {
   BrowserScopeShadowReason,
 } from '../../audit/shadowRejectionLog';
 import type { BrowserBackendStore } from '../../browser-session/BrowserBackendStore';
+import type { EnforcementMode } from '../../mcp/enforcementMode';
 import { isFirstPartyClient } from '../../mcp/firstParty';
 import { isLocalExternalWireContext } from '../../mcp/rpcProvenance';
 
@@ -87,11 +88,31 @@ function requestedWorkspaceId(params: Record<string, unknown>): string | undefin
 }
 
 /**
- * Compute the future caller-derived browser scope without enforcing it.
+ * Compute the caller-derived browser scope.
  *
- * PR #810 lands this decision table in shadow first: handlers continue using
- * the request-derived scope below, while rejected decisions are audit-logged.
- * A later, separately reviewed change can switch target lookup to this result.
+ * #846 landed this table in shadow; it is now what target lookup actually uses
+ * under `mcp.mode: enforce` (see `scopeFor` below). The table is deliberately
+ * unchanged by the enforcement step so the behavior that ships is the behavior
+ * the shadow window observed.
+ *
+ * What this closes and what it does NOT (#810, be precise — the tool layer has
+ * been mistaken for a boundary before):
+ *
+ *   closes  a caller that OMITS `workspaceId` no longer falls through to the
+ *           workspace-blind "first registered surface" lookup; it is refused.
+ *   closes  a pinned commander can no longer name a workspace other than the
+ *           one its validated token is bound to.
+ *   OPEN    the `declared` lane checks that `workspaceId` is PRESENT, not that
+ *           it is the caller's own. Nothing in the main process binds a
+ *           clientName to a workspace — `mcp.claimWorkspace` forwards to the
+ *           renderer and records no server-side association — so a caller that
+ *           names a foreign workspace is still accepted here, exactly as before.
+ *   OPEN    the `legacy` lane (no `clientName`) stays allowed and unscoped, and
+ *           `PermissionEnforcer` grandfathers the same callers. Dropping the
+ *           identity envelope therefore still bypasses this.
+ *
+ * Both OPEN items need a caller-identity binding that does not exist yet; they
+ * are tracked on #810 rather than papered over here.
  */
 export function callerScope(
   ctx: RpcContext | undefined,
@@ -187,12 +208,49 @@ const CDP_SCREENSHOT_TIMEOUT_MS = 2_500;
 // Bound for the capturePage fallback — it can hang on exactly the same guests.
 const CAPTURE_PAGE_TIMEOUT_MS = 1_500;
 
+/**
+ * Caller-facing text for a refused scope decision.
+ *
+ * Same contract as `noTargetError`: name the refusal, say it is terminal, and
+ * say what the caller can do instead. Never name another workspace or its URL —
+ * a refusal must not become the enumeration primitive it exists to prevent.
+ * `pinnedWorkspaceId` is the caller's own binding, but it is still left out so
+ * every branch has one disclosure rule instead of two.
+ */
+const SCOPE_REFUSAL_REMEDY: Record<BrowserScopeShadowReason, string> = {
+  'caller-context-unavailable':
+    'this call arrived without a caller context, so no workspace can be resolved for it',
+  'caller-origin-unsupported':
+    'browser surfaces are reachable only from this machine',
+  'pinned-source-unqualified':
+    'a workspace-pinned caller must arrive on the local wmux wire',
+  'pinned-workspace-mismatch':
+    'address a surface in the workspace your token is bound to',
+  'workspace-unresolved':
+    'send the workspaceId of the workspace you are calling from',
+};
+
+export function scopeRefusalError(
+  method: string,
+  reason: BrowserScopeShadowReason,
+): Error {
+  return new Error(
+    `${method}: BROWSER_SCOPE_REFUSED: ${SCOPE_REFUSAL_REMEDY[reason]}. ` +
+      `Do not retry unchanged.`,
+  );
+}
+
 export function registerBrowserRpc(
   router: RpcRouter,
   getWindow: GetWindow,
   webviewCdpManager: WebviewCdpManager,
   backendStore?: BrowserBackendStore,
   browserScopeShadowSink?: (input: BrowserScopeShadowInput) => void,
+  // Read per call, not captured at registration: main/index.ts resolves the
+  // mode after this runs, and a getter keeps that ordering from mattering.
+  // Defaults to shadow so any caller that forgets to wire it keeps observing
+  // rather than silently starting to refuse traffic.
+  getEnforcementMode: () => EnforcementMode = () => 'shadow',
 ): void {
   const getActivePartition = (): string => profileManager.getActiveProfile().partition;
 
@@ -239,46 +297,62 @@ export function registerBrowserRpc(
   };
 
   /**
-   * The request-derived workspace used by the current lookup behavior (#695).
+   * The single place a target-resolving browser handler learns which workspace
+   * to look a surface up in.
    *
-   * This intentionally remains authoritative while callerScope is shadow-only:
-   * passing it to getTarget/ensureAwake preserves every pre-#810 response,
-   * including the unscoped fallback when the field is absent. Do not extend
-   * this into a caller-identity decision; the pure callerScope table above is
-   * the reviewed replacement that a later enforcement PR will switch to after
-   * the audit log is quiet.
+   * Both modes audit the same decision; they differ only in what happens to a
+   * refusal:
+   *
+   *        callerScope(ctx, params)
+   *                 │
+   *      ┌──────────┴───────────┐
+   *   rejected                allowed / scoped
+   *      │                       │
+   *   audit-log               return decision workspace
+   *      │                    (undefined for the operator and legacy
+   *      │                     lanes that may stay unscoped)
+   *      ├── enforce ─► throw scopeRefusalError  (terminal, no target lookup)
+   *      └── shadow  ─► return requestedWorkspaceId(params)
+   *                     (byte-identical to pre-#810 behavior, which is the
+   *                      point: a dev build or an explicit
+   *                      `"mcp": {"mode": "shadow"}` is the rollback.)
+   *
+   * The mode is `mcp.mode`, shared with the permission enforcer rather than a
+   * second knob — both answer "is substrate enforcement live on this install?",
+   * and one switch means one rollback.
+   *
+   * The audit write is best-effort for the same reason as the permission shadow
+   * logger: telemetry must never break a browser call. Note the ordering — the
+   * log happens BEFORE the throw, so an enforced refusal is still evidence.
    */
-  const scopeOf = requestedWorkspaceId;
-
-  /**
-   * Observe future caller-scope refusals without changing target selection.
-   * The old request-derived `scopeOf` remains authoritative in this PR. The
-   * sink is best-effort for the same reason as the permission shadow logger:
-   * telemetry must never break a browser call.
-   */
-  const observeCallerScope = (
+  const scopeFor = (
     method: RpcMethod,
     params: Record<string, unknown>,
     ctx: RpcContext | undefined,
-  ): void => {
-    if (!browserScopeShadowSink) return;
+  ): string | undefined => {
     const decision = callerScope(ctx, params);
-    if (decision.kind !== 'rejected') return;
-    try {
-      browserScopeShadowSink({
-        clientName: ctx?.clientName,
-        method,
-        reason: decision.reason,
-        ...(decision.requestedWorkspaceId && {
-          requestedWorkspaceId: decision.requestedWorkspaceId,
-        }),
-        ...(decision.pinnedWorkspaceId && {
-          pinnedWorkspaceId: decision.pinnedWorkspaceId,
-        }),
-      });
-    } catch {
-      /* browser scope shadow logging must never affect dispatch */
+    if (decision.kind !== 'rejected') return decision.workspaceId;
+
+    if (browserScopeShadowSink) {
+      try {
+        browserScopeShadowSink({
+          clientName: ctx?.clientName,
+          method,
+          reason: decision.reason,
+          ...(decision.requestedWorkspaceId && {
+            requestedWorkspaceId: decision.requestedWorkspaceId,
+          }),
+          ...(decision.pinnedWorkspaceId && {
+            pinnedWorkspaceId: decision.pinnedWorkspaceId,
+          }),
+        });
+      } catch {
+        /* browser scope audit logging must never affect dispatch */
+      }
     }
+
+    if (getEnforcementMode() === 'enforce') throw scopeRefusalError(method, decision.reason);
+    return requestedWorkspaceId(params);
   };
 
   // Resolve the guest webview's WebContents for a CDP-backed handler, throwing a
@@ -345,16 +419,27 @@ export function registerBrowserRpc(
   // a per-op lease on the RESOLVED target surface. When no target is
   // registered yet, the handler runs unleased and fails with its own
   // "no webview target" error as before.
+  // The leased handlers take the resolved workspace as an argument rather than
+  // re-deriving it: `scopeFor` is the enforcement point, so a handler that
+  // forgot to call it used to silently keep the old workspace-blind lookup
+  // (#810). Threading it in makes that a type error instead of a quiet hole,
+  // and guarantees one decision — and at most one audit entry — per RPC.
   const registerLeased = (
     method: Parameters<RpcRouter['register']>[0],
-    handler: (params: Record<string, unknown>, ctx?: RpcContext) => Promise<unknown>,
+    handler: (
+      params: Record<string, unknown>,
+      scope: string | undefined,
+      ctx?: RpcContext,
+    ) => Promise<unknown>,
     // #517 backend fork: what to do when no builtin target resolves while the
     // backend is 'external'. Default is the fail-closed contract error; the
     // open-shaped handlers (navigate) pass a delegate instead.
     externalFallback?: (params: Record<string, unknown>) => Promise<unknown>,
   ): void => {
     router.register(method, async (params, ctx) => {
-      observeCallerScope(method, params, ctx);
+      // Before any work: a refused caller must not reach URL validation, the
+      // external-backend delegate, or a wake. Throwing here is the whole point.
+      const scope = scopeFor(method, params, ctx);
       const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
       // Memory relief (#517 slice C): automation targeting a discarded guest
       // wakes it (renderer remounts + page reloads) before taking the lease,
@@ -364,15 +449,15 @@ export function registerBrowserRpc(
       // (codex P1 — otherwise the default MCP path fails once the only pane is
       // discarded). In EXTERNAL mode the default lookup is blocked entirely —
       // see resolveTargetSurface.
-      const resolved = await resolveTargetSurface(surfaceId, scopeOf(params));
+      const resolved = await resolveTargetSurface(surfaceId, scope);
       if (!resolved) {
         if (backend() === 'external') {
           if (externalFallback) return externalFallback(params);
           throw new Error(EXTERNAL_BACKEND_UNSUPPORTED_MESSAGE);
         }
-        return handler(params, ctx);
+        return handler(params, scope, ctx);
       }
-      return webviewCdpManager.withAutomationLease(resolved, () => handler(params, ctx));
+      return webviewCdpManager.withAutomationLease(resolved, () => handler(params, scope, ctx));
     });
   };
 
@@ -382,13 +467,13 @@ export function registerBrowserRpc(
   // TTL-bounded lease around each tool invocation instead, renewing during
   // long waits.
   router.register('browser.lease.acquire', async (params, ctx) => {
-    observeCallerScope('browser.lease.acquire', params, ctx);
+    const scope = scopeFor('browser.lease.acquire', params, ctx);
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     // Wake a discarded guest so out-of-process (Playwright) automation gets a
     // live target under its lease (#517 slice C). Without surfaceId this
     // defaults to any discarded surface in builtin mode; external mode blocks
     // the default lookup (see resolveTargetSurface).
-    const resolved = await resolveTargetSurface(surfaceId, scopeOf(params));
+    const resolved = await resolveTargetSurface(surfaceId, scope);
     if (!resolved) return { token: null };
     return { token: webviewCdpManager.acquireRpcLease(resolved) };
   });
@@ -635,13 +720,13 @@ export function registerBrowserRpc(
     }
     return params['url'];
   };
-  registerLeased('browser.navigate', async (params) => {
+  registerLeased('browser.navigate', async (params, scope) => {
     const navUrl = requireNavigateUrl(params);
     await validateUrl(navUrl, 'browser.navigate');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
     // Try CDP direct navigation first
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
     if (target) {
       try {
         const wc = webContents.fromId(target.webContentsId);
@@ -661,11 +746,11 @@ export function registerBrowserRpc(
     // workspace check of its own — it picks the caller-supplied id, or its own
     // default when there is none. Neither choice is safe to hand a scoped
     // caller unless this side has already proven ownership (#695).
-    if (scopeOf(params)) {
+    if (scope) {
       // No target means the scoped lookup refused one, or there is none to
       // own. Routing that to the bridge would reinstate exactly the
       // workspace-blind selection this change removes, so refuse instead.
-      if (!target) throw noTargetError('browser.navigate', surfaceId, scopeOf(params));
+      if (!target) throw noTargetError('browser.navigate', surfaceId, scope);
       // A target did resolve and CDP merely failed on it. Ownership is already
       // established, so the bridge is fine — but pin it to that exact surface.
       // Leaving the id absent would let the bridge choose its own default,
@@ -690,11 +775,11 @@ export function registerBrowserRpc(
    * Navigate the active browser Surface back by one history entry.
    * params: { surfaceId?: string }
    */
-  registerLeased('browser.goBack', async (params) => {
+  registerLeased('browser.goBack', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.goBack', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.goBack', surfaceId, scope);
 
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.goBack: WebContents unavailable');
@@ -843,7 +928,8 @@ export function registerBrowserRpc(
    * not the primitive that bypasses the tool-layer capability and lease checks.
    */
   router.register('browser.cdp.info', async (params, ctx) => {
-    observeCallerScope('browser.cdp.info', params, ctx);
+    // Refuse before disclosing anything, including whether CDP is enabled.
+    const callerWorkspaceId = scopeFor('browser.cdp.info', params, ctx);
     const cdpPort = webviewCdpManager.getCdpPort();
     if (cdpPort <= 0) {
       throw new Error(
@@ -853,10 +939,6 @@ export function registerBrowserRpc(
       );
     }
     const discloseAttachInfo = canDiscloseBrowserAttachInfo(ctx);
-    const callerWorkspaceId =
-      typeof params['workspaceId'] === 'string' && params['workspaceId'].length > 0
-        ? params['workspaceId']
-        : undefined;
 
     const listRelevantTargets = () => {
       const targets = webviewCdpManager.listTargets();
@@ -927,12 +1009,12 @@ export function registerBrowserRpc(
    * Capture a screenshot of the webview.
    * params: { surfaceId?: string, fullPage?: boolean }
    */
-  registerLeased('browser.screenshot', async (params) => {
+  registerLeased('browser.screenshot', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const fullPage = params['fullPage'] === true;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.screenshot', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.screenshot', surfaceId, scope);
 
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.screenshot: WebContents unavailable');
@@ -994,13 +1076,13 @@ export function registerBrowserRpc(
    * Execute JavaScript in the webview and return the result.
    * params: { expression: string, surfaceId?: string }
    */
-  registerLeased('browser.evaluate', async (params) => {
+  registerLeased('browser.evaluate', async (params, scope) => {
     const expression = typeof params['expression'] === 'string' ? params['expression'] : '';
     if (!expression) throw new Error('browser.evaluate: missing "expression"');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.evaluate', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.evaluate', surfaceId, scope);
 
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.evaluate: WebContents unavailable');
@@ -1039,12 +1121,12 @@ export function registerBrowserRpc(
    * the MCP browser_console tool, #106). Capture is enabled lazily on first call.
    * params: { surfaceId?: string, clear?: boolean }
    */
-  registerLeased('browser.console.get', async (params) => {
+  registerLeased('browser.console.get', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const clear = params['clear'] === true;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.console.get', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.console.get', surfaceId, scope);
 
     const state = await captureManager.ensure(target.webContentsId);
     if (!state) throw new Error('browser.console.get: capture unavailable (webContents gone)');
@@ -1060,12 +1142,12 @@ export function registerBrowserRpc(
    * fetched separately via browser.responseBody.get to keep this payload small.
    * params: { surfaceId?: string, clear?: boolean }
    */
-  registerLeased('browser.network.get', async (params) => {
+  registerLeased('browser.network.get', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const clear = params['clear'] === true;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.network.get', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.network.get', surfaceId, scope);
 
     const state = await captureManager.ensure(target.webContentsId);
     if (!state) throw new Error('browser.network.get: capture unavailable (webContents gone)');
@@ -1080,13 +1162,13 @@ export function registerBrowserRpc(
    * Return the last captured response body whose URL matches the glob (#106).
    * params: { surfaceId?: string, urlPattern: string }
    */
-  registerLeased('browser.responseBody.get', async (params) => {
+  registerLeased('browser.responseBody.get', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const urlPattern = typeof params['urlPattern'] === 'string' ? params['urlPattern'] : '';
     if (!urlPattern) throw new Error('browser.responseBody.get: missing "urlPattern"');
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.responseBody.get', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.responseBody.get', surfaceId, scope);
 
     const state = await captureManager.ensure(target.webContentsId);
     if (!state) throw new Error('browser.responseBody.get: capture unavailable (webContents gone)');
@@ -1101,13 +1183,13 @@ export function registerBrowserRpc(
    * This simulates real keyboard input, which works with React/controlled inputs.
    * params: { text: string, surfaceId?: string }
    */
-  registerLeased('browser.type.cdp', async (params) => {
+  registerLeased('browser.type.cdp', async (params, scope) => {
     const text = typeof params['text'] === 'string' ? params['text'] : '';
     if (!text) throw new Error('browser.type.cdp: missing "text"');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.type.cdp', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.type.cdp', surfaceId, scope);
 
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.type.cdp: WebContents unavailable');
@@ -1122,12 +1204,12 @@ export function registerBrowserRpc(
    * Click at coordinates or on the focused element via CDP Input events.
    * params: { x?: number, y?: number, selector?: string, surfaceId?: string }
    */
-  registerLeased('browser.click.cdp', async (params) => {
+  registerLeased('browser.click.cdp', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const selector = typeof params['selector'] === 'string' ? params['selector'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.click.cdp', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.click.cdp', surfaceId, scope);
 
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.click.cdp: WebContents unavailable');
@@ -1177,13 +1259,13 @@ export function registerBrowserRpc(
    * Press a keyboard key via CDP Input events.
    * params: { key: string, surfaceId?: string }
    */
-  registerLeased('browser.press.cdp', async (params) => {
+  registerLeased('browser.press.cdp', async (params, scope) => {
     const key = typeof params['key'] === 'string' ? params['key'] : '';
     if (!key) throw new Error('browser.press.cdp: missing "key"');
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
-    const target = webviewCdpManager.getTarget(surfaceId, scopeOf(params));
-    if (!target) throw noTargetError('browser.press.cdp', surfaceId, scopeOf(params));
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.press.cdp', surfaceId, scope);
 
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.press.cdp: WebContents unavailable');
@@ -1205,7 +1287,7 @@ export function registerBrowserRpc(
    * params: { surfaceId?: string }
    */
   router.register('browser.cdp.target', async (params, ctx) => {
-    observeCallerScope('browser.cdp.target', params, ctx);
+    const scope = scopeFor('browser.cdp.target', params, ctx);
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
 
     if (surfaceId) {
@@ -1215,7 +1297,7 @@ export function registerBrowserRpc(
         // latency. Post-checking an unscoped wait would not achieve that: the
         // foreign case answers instantly and the missing case costs the full
         // timeout, and that difference is itself the disclosure.
-        const target = await webviewCdpManager.waitForTarget(surfaceId, 5000, scopeOf(params));
+        const target = await webviewCdpManager.waitForTarget(surfaceId, 5000, scope);
         return {
           targetId: target.targetId,
           surfaceId: target.surfaceId,
@@ -1225,7 +1307,7 @@ export function registerBrowserRpc(
       }
     }
 
-    const target = webviewCdpManager.getTarget(undefined, scopeOf(params));
+    const target = webviewCdpManager.getTarget(undefined, scope);
     if (!target) return { error: 'no active browser webview' };
 
     return {
@@ -1250,10 +1332,10 @@ export function registerBrowserRpc(
    * params: { action, urls?, cookies?, surfaceId? }
    * Sensitive-domain redaction stays in the MCP tool (state.ts), not here.
    */
-  registerLeased('browser.cookies', async (params) => {
+  registerLeased('browser.cookies', async (params, scope) => {
     const action = params['action'];
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
-    const wc = resolveWc(surfaceId, 'browser.cookies', scopeOf(params));
+    const wc = resolveWc(surfaceId, 'browser.cookies', scope);
 
     if (action === 'get') {
       const urls = Array.isArray(params['urls'])
@@ -1303,14 +1385,14 @@ export function registerBrowserRpc(
    * Override the viewport size via CDP Emulation.setDeviceMetricsOverride.
    * params: { width: number, height: number, surfaceId? }
    */
-  registerLeased('browser.resize', async (params) => {
+  registerLeased('browser.resize', async (params, scope) => {
     const width = typeof params['width'] === 'number' ? params['width'] : NaN;
     const height = typeof params['height'] === 'number' ? params['height'] : NaN;
     if (!Number.isFinite(width) || !Number.isFinite(height)) {
       throw new Error('browser.resize: width and height must be numbers');
     }
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
-    const wc = resolveWc(surfaceId, 'browser.resize', scopeOf(params));
+    const wc = resolveWc(surfaceId, 'browser.resize', scope);
     await wc.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
       width, height, deviceScaleFactor: 0, mobile: false,
     });
@@ -1330,9 +1412,9 @@ export function registerBrowserRpc(
    *   surfaceId?
    * }
    */
-  registerLeased('browser.emulate', async (params) => {
+  registerLeased('browser.emulate', async (params, scope) => {
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
-    const wc = resolveWc(surfaceId, 'browser.emulate', scopeOf(params));
+    const wc = resolveWc(surfaceId, 'browser.emulate', scope);
     const send = (method: string, p?: Record<string, unknown>): Promise<unknown> =>
       wc.debugger.sendCommand(method, p);
     const applied: string[] = [];

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -30,6 +30,7 @@ import type {
 import type { BrowserBackendStore } from '../../browser-session/BrowserBackendStore';
 import type { EnforcementMode } from '../../mcp/enforcementMode';
 import { isFirstPartyClient } from '../../mcp/firstParty';
+import { isInternalCliClient } from '../../mcp/internalCli';
 import { isLocalExternalWireContext } from '../../mcp/rpcProvenance';
 
 type GetWindow = () => BrowserWindow | null;
@@ -65,7 +66,7 @@ export function canDiscloseBrowserAttachInfo(ctx: RpcContext | undefined): boole
 export type BrowserCallerScopeDecision =
   | {
       kind: 'allowed';
-      lane: 'operator' | 'legacy';
+      lane: 'operator' | 'legacy' | 'internal-cli';
       workspaceId?: string;
     }
   | {
@@ -91,15 +92,23 @@ function requestedWorkspaceId(params: Record<string, unknown>): string | undefin
  * Compute the caller-derived browser scope.
  *
  * #846 landed this table in shadow; it is now what target lookup actually uses
- * under `mcp.mode: enforce` (see `scopeFor` below). The table is deliberately
- * unchanged by the enforcement step so the behavior that ships is the behavior
- * the shadow window observed.
+ * under `mcp.mode: enforce` (see `scopeFor` below).
+ *
+ * One lane was ADDED when enforcement was tried: `first-party`. #846 intended
+ * the table to ship unchanged, on the theory that the shadow window had
+ * validated it — but that window recorded no `browser.*` traffic at all, so it
+ * validated nothing about these callers. The gap it hid is `wmux browser
+ * navigate` run outside a wmux pane, which deliberately omits `workspaceId`
+ * while still sending its `clientName`, and would have been refused in every
+ * packaged build. Read that as the shadow evidence being weaker than it looked,
+ * not as the lane being an afterthought.
  *
  * What this closes and what it does NOT (#810, be precise — the tool layer has
  * been mistaken for a boundary before):
  *
- *   closes  a caller that OMITS `workspaceId` no longer falls through to the
- *           workspace-blind "first registered surface" lookup; it is refused.
+ *   closes  an approved THIRD-party caller that OMITS `workspaceId` no longer
+ *           falls through to the workspace-blind "first registered surface"
+ *           lookup; it is refused. This is the caller #810 describes.
  *   closes  a pinned commander can no longer name a workspace other than the
  *           one its validated token is bound to.
  *   OPEN    the `declared` lane checks that `workspaceId` is PRESENT, not that
@@ -179,6 +188,31 @@ export function callerScope(
   if (requested) {
     return { kind: 'scoped', lane: 'declared', workspaceId: requested };
   }
+
+  // The bundled CLI can legitimately resolve to no workspace at all, and that
+  // is a real state rather than a caller cutting a corner: `wmux browser
+  // navigate` typed into an ordinary terminal has no wmux pane above it, so
+  // `resolveSelfContext` correctly returns nothing and the CLI omits the field
+  // to keep active-target behavior (#845). Refusing it would break a shipped,
+  // tested command in every packaged build, where the default mode is
+  // `enforce`.
+  //
+  // This mirrors `PermissionEnforcer`'s internal-CLI lane exactly — same
+  // `isLocalExternalWireContext` + `isInternalCliClient` pair — rather than
+  // inventing a parallel notion of "trusted enough". Deliberately NARROWER
+  // than the first-party predicate used for `cdpPort` above: the bundled MCP
+  // servers are first-party too, but they already send their workspace on
+  // every call, so widening this to them would give up refusals for callers
+  // that do not need the lane.
+  //
+  // A self-asserted `clientName` is not identity. That ceiling is #113's and
+  // already carries the CLI's permission bypass, so this adds no reach a caller
+  // willing to claim the name did not already have. The approved THIRD-party
+  // plugin that #810 is actually about fails this predicate and stays refused.
+  if (isLocalExternalWireContext(ctx) && isInternalCliClient(ctx.clientName)) {
+    return { kind: 'allowed', lane: 'internal-cli' };
+  }
+
   return {
     kind: 'rejected',
     lane: 'declared',

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -30,7 +30,6 @@ import type {
 import type { BrowserBackendStore } from '../../browser-session/BrowserBackendStore';
 import type { EnforcementMode } from '../../mcp/enforcementMode';
 import { isFirstPartyClient } from '../../mcp/firstParty';
-import { isInternalCliClient } from '../../mcp/internalCli';
 import { isLocalExternalWireContext } from '../../mcp/rpcProvenance';
 
 type GetWindow = () => BrowserWindow | null;
@@ -66,7 +65,7 @@ export function canDiscloseBrowserAttachInfo(ctx: RpcContext | undefined): boole
 export type BrowserCallerScopeDecision =
   | {
       kind: 'allowed';
-      lane: 'operator' | 'legacy' | 'internal-cli';
+      lane: 'operator' | 'legacy';
       workspaceId?: string;
     }
   | {
@@ -94,14 +93,18 @@ function requestedWorkspaceId(params: Record<string, unknown>): string | undefin
  * #846 landed this table in shadow; it is now what target lookup actually uses
  * under `mcp.mode: enforce` (see `scopeFor` below).
  *
- * One lane was ADDED when enforcement was tried: `first-party`. #846 intended
- * the table to ship unchanged, on the theory that the shadow window had
- * validated it — but that window recorded no `browser.*` traffic at all, so it
- * validated nothing about these callers. The gap it hid is `wmux browser
- * navigate` run outside a wmux pane, which deliberately omits `workspaceId`
- * while still sending its `clientName`, and would have been refused in every
- * packaged build. Read that as the shadow evidence being weaker than it looked,
- * not as the lane being an afterthought.
+ * The table itself is unchanged by the enforcement step. Enforcing it did
+ * surface one broken caller — `wmux browser navigate` outside a wmux pane omits
+ * `workspaceId` on purpose while still sending its `clientName`, so it would
+ * have been refused in every packaged build — but the fix belongs on the CLI,
+ * which now asks `workspace.current` instead of leaving the server to guess.
+ * A lane keyed on the CLI's `clientName` was tried and rejected: `clientName`
+ * is self-asserted, so any wire caller could claim it and buy back exactly the
+ * unscoped access this closes.
+ *
+ * Read that near-miss as the shadow evidence being weaker than it looked: #846's
+ * window recorded no `browser.*` traffic at all, so it validated nothing about
+ * these callers.
  *
  * What this closes and what it does NOT (#810, be precise — the tool layer has
  * been mistaken for a boundary before):
@@ -189,30 +192,6 @@ export function callerScope(
     return { kind: 'scoped', lane: 'declared', workspaceId: requested };
   }
 
-  // The bundled CLI can legitimately resolve to no workspace at all, and that
-  // is a real state rather than a caller cutting a corner: `wmux browser
-  // navigate` typed into an ordinary terminal has no wmux pane above it, so
-  // `resolveSelfContext` correctly returns nothing and the CLI omits the field
-  // to keep active-target behavior (#845). Refusing it would break a shipped,
-  // tested command in every packaged build, where the default mode is
-  // `enforce`.
-  //
-  // This mirrors `PermissionEnforcer`'s internal-CLI lane exactly — same
-  // `isLocalExternalWireContext` + `isInternalCliClient` pair — rather than
-  // inventing a parallel notion of "trusted enough". Deliberately NARROWER
-  // than the first-party predicate used for `cdpPort` above: the bundled MCP
-  // servers are first-party too, but they already send their workspace on
-  // every call, so widening this to them would give up refusals for callers
-  // that do not need the lane.
-  //
-  // A self-asserted `clientName` is not identity. That ceiling is #113's and
-  // already carries the CLI's permission bypass, so this adds no reach a caller
-  // willing to claim the name did not already have. The approved THIRD-party
-  // plugin that #810 is actually about fails this predicate and stays refused.
-  if (isLocalExternalWireContext(ctx) && isInternalCliClient(ctx.clientName)) {
-    return { kind: 'allowed', lane: 'internal-cli' };
-  }
-
   return {
     kind: 'rejected',
     lane: 'declared',
@@ -280,10 +259,10 @@ export function registerBrowserRpc(
   webviewCdpManager: WebviewCdpManager,
   backendStore?: BrowserBackendStore,
   browserScopeShadowSink?: (input: BrowserScopeShadowInput) => void,
-  // Read per call, not captured at registration: main/index.ts resolves the
-  // mode after this runs, and a getter keeps that ordering from mattering.
-  // Defaults to shadow so any caller that forgets to wire it keeps observing
-  // rather than silently starting to refuse traffic.
+  // `mcp.mode` is resolved above this registration in main/index.ts; the getter
+  // reads it lazily per call so the two never have to stay adjacent. Defaults
+  // to shadow, so a caller that forgets to wire it keeps observing rather than
+  // silently starting to refuse traffic.
   getEnforcementMode: () => EnforcementMode = () => 'shadow',
 ): void {
   const getActivePartition = (): string => profileManager.getActiveProfile().partition;


### PR DESCRIPTION
## Summary

Fourth and final step of the #810 series. #844 narrowed what a browser caller may be told, #845 taught the CLI to say which workspace it is calling from, and #846 landed the `callerScope` decision table in shadow while deliberately leaving `scopeOf = requestedWorkspaceId` authoritative. This makes the decision authoritative under `mcp.mode: enforce`.

A caller whose scope cannot be derived is now refused with `BROWSER_SCOPE_REFUSED` before any target lookup, wake, lease, or URL validation runs. `shadow` — the dev default, and available in production as `"mcp": {"mode": "shadow"}` — still writes the same audit row and still serves the call on the request-derived workspace. That is the rollback, and it is exact: shadow returns `requestedWorkspaceId(params)` on every lane, refused or not.

## What this closes, and what it does not

The tool layer here has been read as a boundary before, so the limits are in the code comments and `docs/internal/browser-tabs-workspace-contract.md`, not just in this description.

**Closes**

- An approved **third-party** caller that omits `workspaceId` no longer falls through to the workspace-blind "first registered surface" lookup. This is the caller #810 describes.
- A server-pinned caller can no longer name a workspace other than its token binding, and is scoped to that binding regardless of what it asked for.

Read "closes" as **closing the accidental path, not the deliberate one**. Live evidence below: the same approved plugin that gets refused for omitting `workspaceId` reaches the surface anyway if it simply stops sending `clientName`. This change is worth making — it stops an honest caller from silently driving someone else's page, and it turns a silent misroute into an explicit refusal — but it is not a boundary against a plugin that wants around it, and nothing here should be read as one.

**Still open — tracked on #810, not fixed here**

- The `declared` lane checks that `workspaceId` is *present*, not that it is the caller's own. Nothing in the main process binds a `clientName` to a workspace (`mcp.claimWorkspace` forwards to the renderer and records no association), so a caller naming a foreign workspace is accepted exactly as before.
- The `legacy` lane (no `clientName`) stays allowed and unscoped, matching `PermissionEnforcer`'s grandfather. Dropping the identity envelope bypasses this layer — **verified live**, with the approved plugin from the dogfood below. The bypass is not silent (it lands in the audit log as a `legacy-traffic` milestone for `browser.evaluate`) but it is only counted at 1/10/100 thresholds, not per call, and it produces no `browser-scope` row because the lane is an allow.
- `browser.open` / `browser.close` route a create/close by the request's `workspaceId` and fall back to the UI-active workspace when it is absent. Same class of gap, but they are surface lifecycle rather than target resolution and #846 never shadowed them, so there is no traffic evidence to flip them on.

Both lookup gaps need a caller-identity binding that does not exist yet.

## No lane is keyed on the caller's name

#846 intended the table to ship unchanged, on the theory that the shadow window had validated it. It had not: **the window recorded no `browser.*` traffic at all**, so "the audit log is quiet" meant *unexercised*, not *exercised and clean*.

What it hid: `wmux browser navigate` run outside a wmux pane has no pane above it, so `resolveSelfContext` correctly resolves nothing and the CLI omitted `workspaceId` to preserve active-target behavior (#845) — while still sending its `clientName`. Enforcing would have refused a shipped, tested command in **every packaged build**.

A lane for the CLI's `clientName` was tried first and rejected on re-review. `clientName` is self-asserted, so any caller already holding the daemon token could send `wmux-cli`, omit `workspaceId`, and buy back exactly the unscoped lookup this change removes. Mirroring `PermissionEnforcer`'s own internal-CLI guard made it consistent, not safe.

The fix is on the caller instead: when nothing resolves, the CLI asks `workspace.current` and names that workspace. Same workspace the old server-side fallback would have picked, so user-visible behavior is unchanged, but the choice is explicit and attributable rather than the server guessing. If that lookup fails the CLI still sends nothing and lets the refusal explain itself, rather than inventing a workspace to get past the gate. `callerScope` is therefore exactly the table #846 reviewed.

## Structural change

Scope is computed once per RPC in `scopeFor` and handed to the leased handlers as an argument instead of each one re-deriving it. That is the actual defect this issue records — scoping was added handler by handler, so a handler that forgot simply kept the old lookup and nothing failed. `browser.rpc.scopeCoverage.test.ts` reads the source and fails if a new handler resolves a target without going through `scopeFor`, or reads `workspaceId` outside the three handlers documented as still doing so.

## CHANGELOG entry

### Changed

- **Browser automation now refuses a call whose workspace it cannot determine.** A plugin or wire client that asks wmux to drive a browser page without saying which workspace it is calling from used to get whichever page happened to be registered first, possibly in a workspace it had nothing to do with. It now gets a clear refusal instead. Callers that already send their workspace — including the bundled MCP server, the wmux CLI, and the app itself — are unaffected. (#810)

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [x] Change to an `experimental` surface (note in release notes).
- [ ] Change to an `internal` surface (no contract impact).

A previously-served call shape (`browser.*` from an identified non-CLI client with no `workspaceId`) now fails. It is gated by `mcp.mode` and reversible without a rebuild, and `docs/api/mcp-plugin-spec.md` tells plugin authors what to send.

## Substrate contract impact (Substrate 3.0)

`browser.*` target resolution moves from request-derived to caller-derived under `enforce`. No RPC, parameter, response, or event shape changes; the new failure is an error string plus the existing audit row. `mcp.mode` gains a second consumer rather than a second switch.

## Test plan

- `browser.rpc.test.ts` — 84 tests. Enforcement per lane, shadow pass-through (asserting the lookup receives the request field, not the decision), refusal-before-lookup for `evaluate` / `cdp.info` / `cdp.target` / `lease.acquire` / `navigate`, refusal text naming no workspace, empty-string `workspaceId`, the operator and legacy lanes staying open, and the CLI's name buying nothing on its own.
- `browser.rpc.scopeCoverage.test.ts` — new source-scan invariant, 4 tests.
- `src/cli/commands/__tests__/browser.test.ts` — the CLI's outside-a-pane path: names the active workspace, omits the field when that lookup fails, and spends no extra round trip when the caller workspace already resolved.
- CLI + pipe + mcp + audit suites (66 files): 1221 passed.
- Focused browser suite (4 files): 117 passed. Handlers + audit suites (27 files): 635 passed.
- Root typecheck clean. ESLint on touched files reports the same 9 pre-existing problems as `origin/main` — none from this diff.

### Live verification

Dev instance forced into the packaged default (`WMUX_DATA_SUFFIX=-dg810`, `mcp.mode: enforce`), driven over the real pipe with real PipeServer provenance — which is what the unit tests cannot cover, since they inject `externalWire` / `clientName` directly.

**enforce — 12/12**: unscoped identified callers refused across `evaluate` / `cdp.info` / `lease.acquire` / `screenshot` / `navigate`; the same caller with its `workspaceId` served; refusals naming no workspace id; refusals written to the bounded audit log and attributed to their caller; the envelope-less legacy lane still served; **claiming `wmux-cli` with no workspace still refused** (and logged under that name), while the path the CLI actually takes now — `workspace.current`, then that id — is served; an unapproved third-party name still stopped by the permission layer first.

**rollback to `shadow` — 7/7**: every refused call served again, the unscoped call resolving the pre-#810 default target, and the audit trail still recording what enforce would have refused.

Three harness bugs were fixed along the way rather than reported as findings — `example.com` fails this box's DNS guard, `about:` is a blocked scheme, and `BROWSER_NO_TARGET` is evidence a call *passed* the scope layer, not that it failed.

### Known unrelated failures

The full non-runtime suite is flaky under parallel load on this machine and fails on `origin/main` too (4-7 files, varying per run; every named file passes in isolation). `scripts/__tests__/generateNotices.test.mjs` fails identically on `origin/main` — a local `node_modules` state (`mime-db` nested under `express`), not this diff.

## Related issues / PRs

Tracks #810. Fourth step after merged #844, #845, #846. The issue stays open for the `declared`-lane and `legacy`-lane bindings named above.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs updated if the surface changed.
- [x] Tests cover the new behavior and the regression case.
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
