### PR TITLE
fix(daemon): preserve events across subscribe handshake

### DIFF
--- a/changelog.d/877.md
+++ b/changelog.d/877.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Daemon events no longer disappear during the subscription handshake.** The
+  daemon now preserves events emitted after accepting the app's control socket
+  but before its subscription request arrives, so one-shot session and channel
+  transitions reach the app instead of falling into that window. (#877)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -256,6 +256,8 @@ A control connection can carry **two kinds of frame in the same newline-delimite
 
 **Events are opt-in.** A connection receives replies and nothing else until it calls `daemon.events.subscribe`; `daemon.events.unsubscribe` turns them off again. The subscription is per-connection and dies with the socket, so a client that reconnects MUST subscribe again. A client that only makes requests — the CLI and the MCP server are both in this category — never needs to touch either method, and its stream is then a plain request/reply stream.
 
+The first-party app sends `daemon.events.subscribe` as its first authenticated RPC. The daemon retains a bounded per-connection backlog between accepting that socket and dispatching its first authenticated request. A first-request subscribe flushes those frames in order before the subscribe reply, closing the accept-to-subscribe loss window; any other first request discards the backlog and leaves the connection reply-only. If the bounded backlog overflows, the daemon closes the socket so the app reconnects and rehydrates rather than continuing after silent partial loss. A client that intends to receive pushed events SHOULD therefore subscribe first and MUST correlate replies by `id`, including while the subscribe request itself is pending.
+
 Once subscribed, the two frame kinds are told apart by `id`:
 
 - **Replies always echo the `id` of the request they answer**, and always carry `ok`. This holds on every path, including `unauthorized`, `rate limited`, and `Invalid RPC request`. A reply to a request that could not be parsed at all carries `"id": null`.

--- a/src/daemon/DaemonPipeServer.ts
+++ b/src/daemon/DaemonPipeServer.ts
@@ -8,6 +8,24 @@ import { getDaemonAuthTokenPath } from '../shared/constants';
 const MAX_LINE_BUFFER = 1024 * 1024; // 1 MB — prevent OOM from malicious clients
 
 /**
+ * Maximum pushed-event data retained while a fresh socket decides whether its
+ * first authenticated RPC is `daemon.events.subscribe`.
+ *
+ * The Electron main client deliberately sends subscribe first, but events can
+ * still be generated in the accept-to-subscribe round trip. Retaining that
+ * tiny window closes the loss gap without making ordinary RPC clients event
+ * subscribers. A client that cannot complete the handshake within this bound
+ * is disconnected so it reconnects and rehydrates instead of silently missing
+ * a partial backlog.
+ */
+export const PRE_SUBSCRIBE_BACKLOG_BYTES = 1024 * 1024;
+
+interface PreSubscribeBacklog {
+  frames: string[];
+  bytes: number;
+}
+
+/**
  * Unflushed bytes on one socket past which that client is treated as STALLED.
  *
  * `socket.write` returning false is advisory in Node: the data is queued anyway
@@ -70,13 +88,17 @@ export function classifyReclaimProbe(
  */
 export class DaemonPipeServer {
   private server: net.Server | null = null;
-  private authToken: string = '';
+  private authToken = '';
   private readonly handlers = new Map<string, RpcHandler>();
   private readonly connectedSockets = new Set<net.Socket>();
   // Clients that asked for pushed events via `daemon.events.subscribe`. Empty
   // by default — see `broadcast`. Dies with the socket, so a reconnecting
   // client must re-subscribe.
   private readonly eventSubscribers = new Set<net.Socket>();
+  // Fresh sockets get one bounded chance to subscribe without losing events
+  // generated between accept and their first authenticated RPC. A first RPC
+  // for any other method discards this queue and preserves the opt-in default.
+  private readonly preSubscribeBacklogs = new Map<net.Socket, PreSubscribeBacklog>();
   // Per-client identity for unicast delivery. Both directions are kept because
   // `sendTo` resolves an id → socket while the RPC path needs socket → id.
   private readonly clientIds = new Map<net.Socket, string>();
@@ -305,12 +327,14 @@ export class DaemonPipeServer {
           return;
         }
         this.connectedSockets.add(socket);
+        this.preSubscribeBacklogs.set(socket, { frames: [], bytes: 0 });
         const clientId = `c${this.nextClientId++}`;
         this.clientIds.set(socket, clientId);
         this.socketsByClientId.set(clientId, socket);
         socket.on('close', () => {
           this.connectedSockets.delete(socket);
           this.eventSubscribers.delete(socket);
+          this.preSubscribeBacklogs.delete(socket);
           this.rateLimits.delete(socket);
           this.clientIds.delete(socket);
           this.socketsByClientId.delete(clientId);
@@ -369,6 +393,7 @@ export class DaemonPipeServer {
     }
     this.connectedSockets.clear();
     this.eventSubscribers.clear();
+    this.preSubscribeBacklogs.clear();
     this.clientIds.clear();
     this.socketsByClientId.clear();
     this.firstPartyClients.clear();
@@ -421,6 +446,7 @@ export class DaemonPipeServer {
     }
     this.connectedSockets.clear();
     this.eventSubscribers.clear();
+    this.preSubscribeBacklogs.clear();
     this.clientIds.clear();
     this.socketsByClientId.clear();
     this.firstPartyClients.clear();
@@ -447,6 +473,29 @@ export class DaemonPipeServer {
    */
   broadcast(event: unknown): void {
     const msg = JSON.stringify(event) + '\n';
+
+    // A newly accepted app socket sends subscribe as its first authenticated
+    // RPC. Queue only until that first request declares the socket's intent;
+    // ordinary RPC clients remain untouched and never receive these frames.
+    if (this.preSubscribeBacklogs.size > 0) {
+      const msgBytes = Buffer.byteLength(msg);
+      this.preSubscribeBacklogs.forEach((backlog, socket) => {
+        if (socket.destroyed) return;
+        if (backlog.bytes + msgBytes > PRE_SUBSCRIBE_BACKLOG_BYTES) {
+          const clientId = this.clientIds.get(socket) ?? 'unknown';
+          this.preSubscribeBacklogs.delete(socket);
+          console.warn(
+            `[DaemonPipeServer] closing event subscriber handshake ${clientId}: `
+            + `pre-subscribe backlog exceeds ${PRE_SUBSCRIBE_BACKLOG_BYTES} bytes`,
+          );
+          socket.destroy();
+          return;
+        }
+        backlog.frames.push(msg);
+        backlog.bytes += msgBytes;
+      });
+    }
+
     this.eventSubscribers.forEach((socket) => {
       if (!socket.destroyed) {
         if (socket.writableLength > SUBSCRIBER_BACKPRESSURE_BYTES) {
@@ -538,6 +587,13 @@ export class DaemonPipeServer {
       // for every new token attempt instead of spamming a single long-lived socket.
       socket.destroy();
       return;
+    }
+
+    // The backlog exists only to close the app's accept-to-subscribe window.
+    // Once an authenticated client chooses any other first RPC, discard it and
+    // keep that socket reply-only exactly as the opt-in contract promises.
+    if (String(request.method) !== 'daemon.events.subscribe') {
+      this.preSubscribeBacklogs.delete(socket);
     }
 
     // Global rate limit
@@ -638,7 +694,24 @@ export class DaemonPipeServer {
   subscribeEvents(clientId: string): boolean {
     const socket = this.socketsByClientId.get(clientId);
     if (!socket || socket.destroyed) return false;
+    const backlog = this.preSubscribeBacklogs.get(socket);
+    this.preSubscribeBacklogs.delete(socket);
     this.eventSubscribers.add(socket);
+    // Flush before the subscribe reply is written by processLine. Subscribers
+    // already have to correlate RPC ids with interleaved id-less event frames;
+    // preserving this order makes every accepted-window event observable once.
+    for (const frame of backlog?.frames ?? []) {
+      if (socket.destroyed || socket.writableLength > SUBSCRIBER_BACKPRESSURE_BYTES) {
+        this.eventSubscribers.delete(socket);
+        return false;
+      }
+      try {
+        socket.write(frame);
+      } catch {
+        this.eventSubscribers.delete(socket);
+        return false;
+      }
+    }
     return true;
   }
 

--- a/src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts
@@ -16,7 +16,7 @@ import net from 'node:net';
 import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
-import { DaemonPipeServer } from '../DaemonPipeServer';
+import { DaemonPipeServer, PRE_SUBSCRIBE_BACKLOG_BYTES } from '../DaemonPipeServer';
 import { waitFor } from '../../test-utils/waitFor';
 
 function testPipeName(suffix: string): string {
@@ -101,6 +101,34 @@ describe('DaemonPipeServer — pushed events are opt-in (#659)', () => {
     // The frame shapes documented in PROTOCOL §2.9: events carry no `id`.
     expect(event['id']).toBeUndefined();
     expect(event['type']).toBe('title.changed');
+  });
+
+  it('replays events generated between accept and a first-RPC subscribe', async () => {
+    const { server, pipe, token } = await startServer('optin-accept-gap');
+    const { socket, lines } = await connectClient(pipe);
+    await waitFor(() => server.getConnectionCount() === 1);
+
+    server.broadcast({ type: 'session.died', sessionId: 's-gap', data: { exitCode: 1 } });
+    server.broadcast({ type: 'title.changed', sessionId: 's-gap', data: 'ready' });
+    expect(lines).toEqual([]);
+
+    socket.write(JSON.stringify({ id: 'sub', method: 'daemon.events.subscribe', token }) + '\n');
+    await waitFor(() => lines.some((l) => l.includes('"id":"sub"')));
+
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[0]!)).toMatchObject({ type: 'session.died', sessionId: 's-gap' });
+    expect(JSON.parse(lines[1]!)).toMatchObject({ type: 'title.changed', sessionId: 's-gap' });
+    expect(JSON.parse(lines[2]!)).toMatchObject({ id: 'sub', ok: true, result: { ok: true } });
+  });
+
+  it('disconnects instead of silently truncating an oversized pre-subscribe backlog', async () => {
+    const { server, pipe } = await startServer('optin-accept-overflow');
+    await connectClient(pipe);
+    await waitFor(() => server.getConnectionCount() === 1);
+
+    server.broadcast({ type: 'channel.message', data: 'x'.repeat(PRE_SUBSCRIBE_BACKLOG_BYTES) });
+
+    await waitFor(() => server.getConnectionCount() === 0);
   });
 
   it('stops pushing after unsubscribe', async () => {


### PR DESCRIPTION
## Summary

- retain daemon push events generated between socket accept and a first-RPC subscription
- flush the bounded backlog in order before the subscribe reply while keeping ordinary RPC clients reply-only
- disconnect on backlog overflow instead of continuing after silent partial loss
- document the first-RPC subscription contract and cover replay ordering plus overflow

Addresses gap 1 in #858. Gap 3 (the first-party subscription gate) remains deliberately out of scope.

## Verification

- `npm run build:daemon`
- `npx eslint src/daemon/DaemonPipeServer.ts src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts --quiet`
- `npx vitest run src/daemon/__tests__/DaemonPipeServer.eventOptIn.test.ts src/daemon/__tests__/DaemonPipeServer.subscriberGuards.test.ts` (15 passed)
- `npm run test:parallel` (10,947 passed, 24 skipped)
- `npm run test:runtime` (165 passed, 5 failed in unrelated Windows runtime fixtures)
  - `bootMarker.runtime.test.ts` passed on isolated retry
  - two `webRestart.runtime.test.ts` mtime assertions fail identically on clean `upstream/main`
  - two `shellIntegration.runtime.test.ts` cases fail because node-pty reports `AttachConsole failed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserves daemon events generated during the app’s subscription handshake and delivers them in order.
  * Supports one-time session and channel transition events without losing updates.
  * Reconnects clients when the pre-subscription event backlog exceeds its limit, allowing the app to rehydrate safely.

* **Documentation**
  * Documented first-request subscription behavior, event buffering, backlog handling, and reply correlation requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->