### PR TITLE
fix(i18n): translate the toolbar and Git labels left in English in zh

### DIFF
--- a/changelog.d/880.md
+++ b/changelog.d/880.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Three labels stayed in English when wmux ran in Simplified Chinese.** The
+  agent toolbar's Broadcast and Multi Task buttons and the Git panel's Pull
+  Requests heading were carried over verbatim from the English locale, so they
+  read as English in an otherwise translated UI. (#880)

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -370,10 +370,10 @@ export const zh = {
   'settings.inspect.proxyLabel': '编辑 {token}（{role}）',
 
   // ─── 智能体工具栏: fan-out / broadcast 按钮 ───
-  'toolbar.fanOut': 'Multi Task',
-  'toolbar.broadcast': 'Broadcast',
-  'toolbar.broadcastTooltip': 'Broadcast — 向当前工作区的每个终端面板发送相同文本（无隔离）',
-  'toolbar.broadcastPrompt': 'Broadcast — 发送到当前工作区的每个终端面板',
+  'toolbar.fanOut': '多任务',
+  'toolbar.broadcast': '广播',
+  'toolbar.broadcastTooltip': '广播 — 向当前工作区的每个终端面板发送相同文本（无隔离）',
+  'toolbar.broadcastPrompt': '广播 — 发送到当前工作区的每个终端面板',
 
   // ─── Fan-out 对话框（1 个提示 → N 个隔离任务）───
   'fanout.title': 'Fan-out — 1 个提示 → N 个隔离任务',
@@ -1065,7 +1065,7 @@ export const zh = {
   'git.create': '创建',
   'git.createFailed': '创建失败',
   'git.newBranchPlaceholder': '新分支名…',
-  'git.pullRequests': 'Pull Requests',
+  'git.pullRequests': '拉取请求',
   'git.noPrs': '没有打开的 pull request。',
   'git.noComments': '没有评论。',
   'git.ghMissing': '未安装 GitHub CLI（gh）— 安装后即可在此查看 pull request。',


### PR DESCRIPTION
## Summary

Three `zh.ts` values were carried over verbatim from `en.ts` when #876 completed the locale. Key parity does not catch this — the key is present, the string is just still English — so it only surfaces with the app actually running in Chinese, which is how it was found.

- `toolbar.broadcast`: `Broadcast` → `广播`
- `toolbar.fanOut`: `Multi Task` → `多任务` (`ko.ts` already translates this one)
- `git.pullRequests`: `Pull Requests` → `拉取请求`

The first two sit on the agent toolbar, which is on screen the whole time, so they read as English right next to 附加 / 文件 / 片段 / 富文本输入.

Also brings `toolbar.broadcastTooltip` and `toolbar.broadcastPrompt` into step with the button they describe. Both opened with a literal `Broadcast — ` while `toolbar.broadcastTitle` had already settled on 广播, so translating the button alone would have left the control disagreeing with its own tooltip.

## What is deliberately left alone

Five other `zh` values are identical to `en` and should stay that way: `Finder`, `LanLink`, `main` (the branch name), `NAME` (an env-var placeholder), and `shell`.

## Verification

- Found by running the app in Chinese and reading the toolbar, not by a test — see the note below.
- `npx tsc -p tsconfig.json --noEmit`
- `npx eslint src/renderer/i18n/locales/zh.ts --quiet`
- Key parity against `en.ts` re-checked after the change: 1203/1203, 0 missing, 0 extra, 0 `{var}` placeholder mismatches.

## Follow-up worth having

There is no locale contract test in this repo — `en.ts` is the SSOT and every other locale is a `Partial` with an English fallback, so both missing keys and untranslated values degrade silently. A check that flags "value identical to `en` and contains no script from the target locale", with a small allowlist for proper nouns, would have caught this before it shipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Simplified Chinese translations for the agent toolbar’s Broadcast and Multi Task buttons.
  - Updated the Git panel’s Pull Requests heading to display in Simplified Chinese.
- **Documentation**
  - Added a changelog entry documenting the localization improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->