### PR TITLE
Repaint every visible pane when the wmux window regains focus

### DIFF
--- a/changelog.d/881.md
+++ b/changelog.d/881.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **A pane no longer comes back blank after you switch to another app and back
+  (Windows).** Every repaint-on-wake path in the app was keyed to the browser's
+  page-visibility signal, and on Windows that signal never changes: the window
+  reports itself visible while it is fully covered by another app, and even
+  while it is minimized. The only repaint that fired on alt-tab belonged to the
+  single pane owning keyboard focus, so a pane whose canvas pixels were dropped
+  by the GPU had nothing to redraw it and stayed empty until you forced a redraw
+  by hand (selecting text, resizing). Window refocus is now its own wake
+  boundary: every visible pane repaints, on the next frame and once more shortly
+  after, without touching the shared glyph atlas. Windows only — macOS and Linux
+  report visibility correctly and were already covered. (#879)

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -25,6 +25,7 @@ import ApprovalDialog from '../Company/ApprovalDialog';
 import ExecuteApprovalDialog from '../A2a/ExecuteApprovalDialog';
 import PermissionApprovalDialogContainer from '../Approval/PermissionApprovalDialogContainer';
 import { initAtlasWakeRecovery } from '../../terminal/atlasWakeRecovery';
+import { windowWakeRepaint } from '../../terminal/windowWakeRepaint';
 import CompanyView from '../Company/CompanyView';
 import MessageFeedPanel from '../Company/MessageFeedPanel';
 import OnboardingOverlay from '../Onboarding/OnboardingOverlay';
@@ -516,6 +517,18 @@ export default function AppLayout() {
         typeof onResumed === 'function' ? onResumed : () => () => {},
     });
   }, []);
+
+  // #879 — window-level wake repaint, Windows only. On Windows
+  // `document.visibilityState` never reports hidden (measured: not when the
+  // window is covered, not even when it is minimized), so the wake recovery
+  // above and useTerminal's `docRevealed` reclaim can never fire there, and a
+  // pane that lost its canvas pixels while the window was away has nothing to
+  // repaint it. macOS and Linux do flip visibility, so they are already
+  // covered and get no extra GPU work. Rationale and measurements live in
+  // terminal/windowWakeRepaint.ts.
+  useEffect(() => windowWakeRepaint.init({
+    enabled: window.electronAPI?.platform === 'win32',
+  }), []);
 
   // #517 slice C — discard mode mirrors the same way. Effective only while
   // lightweight mode is also on (belt-and-braces: main enforces this too).

--- a/src/renderer/hooks/__tests__/useTerminal.windowWake.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.windowWake.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// #879 wiring lock (source-level).
+//
+// windowWakeRepaint.test.ts proves the coordinator's behaviour against injected
+// deps. What it cannot prove is that anything is actually plugged into it: a
+// coordinator with zero registered panes is a silent no-op, and that is exactly
+// the failure mode of this bug (a repair path that exists but never fires).
+// Mounting useTerminal for real needs a WebGL context and the whole preload
+// bridge, so the wiring is pinned at the source level — the same approach
+// useTerminal.atlasClear.test.ts takes for the #191 invariant.
+
+const hookSrc = fs.readFileSync(path.join(__dirname, '..', 'useTerminal.ts'), 'utf-8');
+const layoutSrc = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'components', 'Layout', 'AppLayout.tsx'),
+  'utf-8',
+);
+
+describe('#879 — every pane is registered with the window-wake coordinator', () => {
+  const start = hookSrc.indexOf('windowWakeRepaint.register({');
+  const registerBlock = hookSrc.slice(start, hookSrc.indexOf('});', start));
+
+  it('useTerminal registers each terminal', () => {
+    expect(start).toBeGreaterThan(-1);
+  });
+
+  it('reports pane visibility from isVisibleRef so hidden panes are skipped', () => {
+    // A hidden pane already repaints through glyphRepaint's `visible` reason
+    // when its workspace/tab comes back; waking it here would be a full-range
+    // refresh nobody can see.
+    expect(registerBlock).toMatch(/isVisible:\s*\(\)\s*=>\s*isVisibleRef\.current/);
+  });
+
+  it('routes the repaint through the pane glyphRepaint scheduler, not a second timer', () => {
+    expect(registerBlock).toMatch(/glyphRepaint\.onWindowWake\(\)/);
+  });
+
+  it('unregisters on teardown, next to the other per-pane registrations', () => {
+    const teardown = hookSrc.slice(hookSrc.indexOf('unregisterAtlasGuard();'));
+    expect(teardown).toMatch(/unregisterWindowWake\(\);/);
+  });
+});
+
+describe('#879 — the coordinator is Windows-gated at the single init site', () => {
+  it('AppLayout initialises it once', () => {
+    expect(layoutSrc).toMatch(/windowWakeRepaint\.init\(\{/);
+  });
+
+  it('enables it only on win32', () => {
+    // macOS and Linux do flip document.visibilityState, so atlasWakeRecovery
+    // already covers their wake boundaries. Enabling this there would be two
+    // extra full-range refreshes per visible pane per app switch, with no
+    // evidence behind them.
+    const initBlock = layoutSrc.slice(
+      layoutSrc.indexOf('windowWakeRepaint.init({'),
+      layoutSrc.indexOf('}), []);', layoutSrc.indexOf('windowWakeRepaint.init({')),
+    );
+    expect(initBlock).toMatch(/enabled:\s*window\.electronAPI\?\.platform === 'win32'/);
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -26,6 +26,7 @@ import { webglContextPool } from '../terminal/webglContextPool';
 import { teardownWebglAddon } from '../terminal/webglTeardown';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
 import { atlasGuard } from '../terminal/atlasGuard';
+import { windowWakeRepaint } from '../terminal/windowWakeRepaint';
 import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
 import { awaitParseBarrier } from '../terminal/parseBarrier';
 import { STALE_REPLAY_INPUT_MODE_RESETS, STALE_REPLAY_ALIVE_SHELL_RESETS, STALE_REPLAY_DISPLAY_RESETS, staleReplayResetLevel } from '../terminal/staleReplayModeReset';
@@ -1204,6 +1205,21 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       },
     });
 
+    // #879 — window-level wake repaint. The textarea `focus` repaint above
+    // reaches only the ONE pane that owns the focused textarea; on Windows,
+    // where nothing else fires on re-activation (see windowWakeRepaint.ts for
+    // the measurements), every other visible pane would keep whatever pixels
+    // it has, including none. Registration is unconditional; the coordinator
+    // is the thing that is platform-gated, so a non-Windows build simply never
+    // calls back.
+    const unregisterWindowWake = windowWakeRepaint.register({
+      isVisible: () => isVisibleRef.current,
+      repaint: () => {
+        if (terminalRef.current !== terminal) return;
+        glyphRepaint.onWindowWake();
+      },
+    });
+
     // Only fit immediately if the container is actually visible (non-zero size).
     // If the workspace starts hidden (display:none), skip the initial fit so we
     // don't corrupt the terminal with 0 cols/rows. The visibility-watcher effect
@@ -2143,6 +2159,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       glyphRepaint.dispose();
       glyphRepaintRef.current = null;
       unregisterAtlasGuard();
+      unregisterWindowWake();
       imeResidueGuard?.dispose();
       imeStormGuard.dispose();
       imeAnchor.dispose();

--- a/src/renderer/terminal/__tests__/windowWakeRepaint.test.ts
+++ b/src/renderer/terminal/__tests__/windowWakeRepaint.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createWindowWakeRepaint,
+  WAKE_SECOND_PASS_MS,
+  type WindowWakeRepaintDeps,
+} from '../windowWakeRepaint';
+
+type Listener = () => void;
+
+function makeFakeWindow() {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    addEventListener: (type: string, cb: EventListener) => {
+      const set = listeners.get(type) ?? new Set<Listener>();
+      set.add(cb as Listener);
+      listeners.set(type, set);
+    },
+    removeEventListener: (type: string, cb: EventListener) => {
+      listeners.get(type)?.delete(cb as Listener);
+    },
+    fire: (type: 'blur' | 'focus') => {
+      for (const cb of [...(listeners.get(type) ?? [])]) cb();
+    },
+    listenerCount: () => [...listeners.values()].reduce((n, s) => n + s.size, 0),
+  };
+}
+
+/** Manual frame + timer queues so a test drives the two passes independently. */
+function setup(overrides: Partial<WindowWakeRepaintDeps> = {}) {
+  const win = makeFakeWindow();
+  let focused = true;
+  const frames: Array<{ id: number; cb: () => void; cancelled: boolean }> = [];
+  const timers: Array<{ id: number; cb: () => void; ms: number; cancelled: boolean }> = [];
+  let nextId = 1;
+  const logs: string[] = [];
+
+  const coordinator = createWindowWakeRepaint();
+  const teardown = coordinator.init({
+    enabled: true,
+    windowRef: win,
+    hasFocus: () => focused,
+    requestFrame: (cb) => { const id = nextId++; frames.push({ id, cb, cancelled: false }); return id; },
+    cancelFrame: (id) => { const f = frames.find((x) => x.id === id); if (f) f.cancelled = true; },
+    setTimeoutFn: (cb, ms) => { const id = nextId++; timers.push({ id, cb, ms, cancelled: false }); return id; },
+    clearTimeoutFn: (id) => { const t = timers.find((x) => x.id === id); if (t) t.cancelled = true; },
+    log: (m) => logs.push(m),
+    ...overrides,
+  });
+
+  return {
+    win,
+    coordinator,
+    teardown,
+    logs,
+    timers,
+    setFocused: (v: boolean) => { focused = v; },
+    /** Run every frame callback queued and not cancelled. */
+    runFrames: () => {
+      for (const f of frames.filter((x) => !x.cancelled && x.cb)) { const cb = f.cb; f.cancelled = true; cb(); }
+    },
+    runTimers: () => {
+      for (const t of timers.filter((x) => !x.cancelled && x.cb)) { const cb = t.cb; t.cancelled = true; cb(); }
+    },
+    pendingFrames: () => frames.filter((f) => !f.cancelled).length,
+    pendingTimers: () => timers.filter((t) => !t.cancelled).length,
+  };
+}
+
+function pane(visible = true) {
+  const calls: number[] = [];
+  let n = 0;
+  return {
+    entry: { isVisible: () => visible, repaint: () => { calls.push(++n); } },
+    count: () => calls.length,
+    setVisible: (v: boolean) => { visible = v; },
+  };
+}
+
+describe('windowWakeRepaint', () => {
+  it('repaints every visible pane twice (frame pass, then delayed pass) on blur→focus', () => {
+    const s = setup();
+    const a = pane();
+    const b = pane();
+    s.coordinator.register(a.entry);
+    s.coordinator.register(b.entry);
+
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+
+    s.runFrames();
+    expect([a.count(), b.count()]).toEqual([1, 1]);
+    s.runTimers();
+    // Both panes, not just the one that would own the focused textarea — that
+    // single-pane gap is the split-layout half of #879.
+    expect([a.count(), b.count()]).toEqual([2, 2]);
+    expect(s.logs).toHaveLength(2);
+    expect(s.logs[0]).toContain('repainted 2 visible pane(s)');
+  });
+
+  it('the delayed pass is armed at WAKE_SECOND_PASS_MS', () => {
+    const s = setup();
+    s.coordinator.register(pane().entry);
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+    expect(s.timers.at(-1)?.ms).toBe(WAKE_SECOND_PASS_MS);
+  });
+
+  it('a focus with no preceding blur does nothing (in-app focus churn)', () => {
+    const s = setup();
+    const p = pane();
+    s.coordinator.register(p.entry);
+
+    s.win.fire('focus');
+    s.runFrames();
+    s.runTimers();
+
+    expect(p.count()).toBe(0);
+    expect(s.logs).toEqual([]);
+  });
+
+  it('a pane that mounted while the window was already blurred still wakes', () => {
+    // hasFocus() is false at init, so the coordinator starts in the "away"
+    // state instead of waiting for a blur it structurally cannot observe: the
+    // blur happened before anything here was listening.
+    let focused = false;
+    const s = setup({ hasFocus: () => focused });
+    const p = pane();
+    s.coordinator.register(p.entry);
+
+    focused = true;
+    s.win.fire('focus');
+    s.runFrames();
+
+    expect(p.count()).toBe(1);
+  });
+
+  it('skips panes in a hidden workspace/tab', () => {
+    const s = setup();
+    const hidden = pane(false);
+    const shown = pane(true);
+    s.coordinator.register(hidden.entry);
+    s.coordinator.register(shown.entry);
+
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+    s.runFrames();
+    s.runTimers();
+
+    expect(hidden.count()).toBe(0);
+    expect(shown.count()).toBe(2);
+    expect(s.logs[0]).toContain('repainted 1 visible pane(s)');
+  });
+
+  it('a blur mid-cycle cancels the pending passes instead of stacking them', () => {
+    const s = setup();
+    const p = pane();
+    s.coordinator.register(p.entry);
+
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');   // arms pass 1 + pass 2
+    s.setFocused(false);
+    s.win.fire('blur');    // user tabbed away again before either ran
+    expect(s.pendingFrames()).toBe(0);
+    expect(s.pendingTimers()).toBe(0);
+
+    s.setFocused(true);
+    s.win.fire('focus');
+    s.runFrames();
+    s.runTimers();
+    // Exactly one cycle's worth of work, not two.
+    expect(p.count()).toBe(2);
+  });
+
+  it('a pass that runs while the window is away again repaints nothing', () => {
+    const s = setup();
+    const p = pane();
+    s.coordinator.register(p.entry);
+
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+    // Focus lost without a blur event reaching us (OS-level race): the pass
+    // re-checks at execution time.
+    s.setFocused(false);
+    s.runFrames();
+    s.runTimers();
+
+    expect(p.count()).toBe(0);
+  });
+
+  it('one pane throwing does not stop the others', () => {
+    const s = setup();
+    const bad = { isVisible: () => true, repaint: () => { throw new Error('disposing'); } };
+    const good = pane();
+    s.coordinator.register(bad);
+    s.coordinator.register(good.entry);
+
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+    s.runFrames();
+
+    expect(good.count()).toBe(1);
+  });
+
+  it('unregister stops that pane; teardown detaches the listeners and cancels pending work', () => {
+    const s = setup();
+    const p = pane();
+    const unregister = s.coordinator.register(p.entry);
+    unregister();
+
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+    s.runFrames();
+    expect(p.count()).toBe(0);
+
+    s.coordinator.register(p.entry);
+    s.setFocused(false);
+    s.win.fire('blur');
+    s.setFocused(true);
+    s.win.fire('focus');
+    s.teardown();
+    expect(s.pendingFrames()).toBe(0);
+    expect(s.pendingTimers()).toBe(0);
+    expect(s.win.listenerCount()).toBe(0);
+
+    s.win.fire('focus');
+    s.runFrames();
+    expect(p.count()).toBe(0);
+  });
+
+  it('enabled:false attaches nothing and never repaints (non-Windows builds)', () => {
+    const win = makeFakeWindow();
+    const coordinator = createWindowWakeRepaint();
+    const p = pane();
+    coordinator.register(p.entry);
+    const repaintSpy = vi.spyOn(p.entry, 'repaint');
+
+    const teardown = coordinator.init({ enabled: false, windowRef: win, hasFocus: () => false });
+    expect(win.listenerCount()).toBe(0);
+    win.fire('focus');
+    expect(repaintSpy).not.toHaveBeenCalled();
+    teardown();
+  });
+});

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -30,6 +30,15 @@
 // output is flowing re-arms xterm's page-merge race (xterm.js #4480) — the
 // same reason glyphRepaint's focus path never touches the atlas.
 //
+// ON WINDOWS THE VISIBILITY TRIGGER NEVER FIRES (#879). Measured on Electron
+// 41: `document.visibilityState` stays 'visible' when the window is fully
+// covered by another app AND when it is minimized, with or without Chromium's
+// CalculateNativeWinOcclusion feature — `visibilitychange` fires once per
+// window, at teardown. So on Windows `system-resumed` is the only live trigger
+// here, and the plain "came back from alt-tab" case is covered by
+// windowWakeRepaint.ts instead, which repaints (never touches the atlas, for
+// the reason above).
+//
 // The two triggers routinely fire together on a real wake; the throttle
 // collapses them into one rebuild.
 

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -78,7 +78,7 @@
 // tested without xterm; all rendering side effects live in the caller's
 // `repaint` callback.
 
-export type RepaintReason = 'focus' | 'visible' | 'burst';
+export type RepaintReason = 'focus' | 'visible' | 'burst' | 'window-wake';
 
 export interface GlyphRepaintScheduler {
   /** Feed PTY write sizes; fires repaint('burst') on the streaming cadence. */
@@ -87,6 +87,12 @@ export interface GlyphRepaintScheduler {
   onFocus(): void;
   /** The terminal became visible again; immediate repaint('visible'). */
   onVisible(): void;
+  /** The wmux WINDOW came back to the foreground (#879). Distinct from
+   *  `onVisible`, which is about this pane's workspace/tab: on Windows the
+   *  window can be covered or minimized for minutes without any pane changing
+   *  visibility, and the canvas can come back unpainted. Unthrottled — the
+   *  window-wake coordinator owns the cadence, this is only the execution. */
+  onWindowWake(): void;
   /** Cancel pending timers; all further calls become no-ops. */
   dispose(): void;
 }
@@ -222,6 +228,11 @@ export function createGlyphRepaintScheduler(
     onVisible(): void {
       if (disposed) return;
       repaint('visible');
+    },
+
+    onWindowWake(): void {
+      if (disposed) return;
+      repaint('window-wake');
     },
 
     dispose(): void {

--- a/src/renderer/terminal/windowWakeRepaint.ts
+++ b/src/renderer/terminal/windowWakeRepaint.ts
@@ -1,0 +1,199 @@
+// Repaint every visible pane when the wmux window is re-activated (#879).
+//
+// --- Why this exists (measured, Electron 41 on Windows) --------------------
+//
+// Every other visibility-driven recovery in the renderer keys off
+// `document.visibilityState`. On Windows that value is a constant:
+//
+//   | window state                        | visibilityState | rAF   |
+//   |-------------------------------------|-----------------|-------|
+//   | foreground                          | visible         | 60/s  |
+//   | fully covered by another app        | visible         | 60/s  |
+//   | MINIMIZED                           | visible         | 60/s  |
+//
+// Measured with a bare Electron 41.0.3 probe, and identical with Chromium's
+// `CalculateNativeWinOcclusion` feature explicitly disabled, so it is not a
+// tunable. `visibilitychange` fires exactly once per window: at teardown.
+//
+// Consequences: `atlasWakeRecovery`'s `visibility` trigger can never fire on
+// Windows (only `system-resumed` can), and neither can useTerminal's
+// `docRevealed` reclaim. The one repaint that DOES fire on alt-tab is the
+// focused pane's textarea `focus` handler — element-level focus/blur do
+// re-fire on every window focus transition — and that covers exactly one pane.
+//
+// #879: a pane comes back from alt-tab with its canvas unpainted. The xterm
+// buffer is intact (the reporter's own forced redraw brings the text back
+// correct), so this is lost pixels with nothing to repaint them. Measured:
+// with the drawing buffer wiped behind xterm's back, an idle pane NEVER
+// self-heals — xterm only redraws rows it believes are dirty — and a single
+// `terminal.refresh(0, rows - 1)` fully restores it.
+//
+// Honest scope: the wmux-side gap (no trigger) is proven. The GPU-side reason
+// the pixels go missing is NOT — it does not reproduce on every machine, and
+// the reporter has other rendering complaints on the same box. This module
+// closes the gap; it does not claim to explain the driver.
+//
+// --- Shape -----------------------------------------------------------------
+//
+// ONE listener pair for the whole app (the `atlasGuard` + `AppLayout` pattern),
+// not one per pane: window focus is a global event, and N panes each owning a
+// listener, a frame request and a timer is N times the bookkeeping for one
+// event.
+//
+//   window blur ──► cancel pending passes, arm "we were away"
+//   window focus ─► (only if we were away)
+//                     ├─ pass 1: next animation frame
+//                     └─ pass 2: +WAKE_SECOND_PASS_MS
+//                          each pass: for every registered pane that is
+//                          still visible → its full-range refresh
+//
+// Two passes because the loss can land on either side of re-activation. Pass 1
+// covers pixels lost while the window was away. Pass 2 is an explicit hedge
+// against a surface that Chromium re-establishes just AFTER activation, which
+// is the part that is not proven — if the reporter confirms pass 1 alone is
+// enough, delete pass 2. Cost of being wrong: one extra full-range refresh per
+// visible pane per alt-tab.
+//
+// This never clears the shared glyph atlas. Wiping it on plain refocus re-arms
+// xterm's page-merge race (#191) — the same reason atlasWakeRecovery excludes
+// focus from its own triggers.
+
+/** Delay of the second repaint pass after the window regains focus. */
+export const WAKE_SECOND_PASS_MS = 250;
+
+/** `setTimeout` is typed as returning a number in the DOM lib and a `Timeout`
+ *  under @types/node; the renderer sees both. Keep the handle opaque so tests
+ *  can hand back their own. */
+export type TimerHandle = ReturnType<typeof setTimeout> | number;
+
+/** One registered pane. */
+export interface WakeRepaintEntry {
+  /** False for a pane in a hidden workspace/tab — it repaints via
+   *  glyphRepaint's `visible` reason when it is shown again, so waking it here
+   *  would be a full-range refresh nobody can see. */
+  isVisible(): boolean;
+  /** Full-range repaint for this pane. */
+  repaint(): void;
+}
+
+export interface WindowWakeRepaintDeps {
+  /** Windows-only by default: macOS and Linux do flip `visibilityState`, so
+   *  atlasWakeRecovery already covers their wake boundaries. When false, no
+   *  listeners are attached and registered panes are never woken. */
+  enabled: boolean;
+  windowRef?: Pick<Window, 'addEventListener' | 'removeEventListener'>;
+  /** Read at init: a pane can mount while the app is already in the
+   *  background, and it never saw the blur that put it there. */
+  hasFocus?: () => boolean;
+  requestFrame?: (cb: () => void) => number;
+  cancelFrame?: (handle: number) => void;
+  setTimeoutFn?: (cb: () => void, ms: number) => TimerHandle;
+  clearTimeoutFn?: (handle: TimerHandle) => void;
+  log?: (message: string) => void;
+}
+
+export interface WindowWakeRepaint {
+  /** Register a pane; returns its unregister function. */
+  register(entry: WakeRepaintEntry): () => void;
+  /** Wire the window listeners. Called once from App; returns the teardown. */
+  init(deps: WindowWakeRepaintDeps): () => void;
+}
+
+export function createWindowWakeRepaint(): WindowWakeRepaint {
+  const entries = new Set<WakeRepaintEntry>();
+
+  let frameHandle: number | null = null;
+  let timerHandle: TimerHandle | null = null;
+
+  return {
+    register(entry: WakeRepaintEntry): () => void {
+      entries.add(entry);
+      return () => { entries.delete(entry); };
+    },
+
+    init(deps: WindowWakeRepaintDeps): () => void {
+      const {
+        enabled,
+        windowRef = window,
+        hasFocus = () => document.hasFocus(),
+        requestFrame = (cb) => requestAnimationFrame(cb),
+        cancelFrame = (h) => cancelAnimationFrame(h),
+        setTimeoutFn = (cb, ms) => setTimeout(cb, ms),
+        clearTimeoutFn = (h) => clearTimeout(h as Parameters<typeof clearTimeout>[0]),
+        log = (m) => console.warn(m),
+      } = deps;
+
+      if (!enabled) return () => { /* nothing attached */ };
+
+      // Seed from the real focus state rather than from "we have seen a blur".
+      // A terminal that mounts while the app sits in the background missed that
+      // blur entirely, and would otherwise sit out its first wake — the exact
+      // case a user hits when wmux restores a session and then they go do
+      // something else before coming back.
+      let wasAway = !hasFocus();
+
+      const cancel = (): void => {
+        if (frameHandle !== null) { cancelFrame(frameHandle); frameHandle = null; }
+        if (timerHandle !== null) { clearTimeoutFn(timerHandle); timerHandle = null; }
+      };
+      const repaintVisible = (pass: number): void => {
+        // Re-check focus at execution time, not only at scheduling time: a pass
+        // armed by one focus can still be in flight when the user tabs away
+        // again, and repainting a window nobody is looking at is the GPU work
+        // this module is otherwise careful to avoid.
+        if (!hasFocus()) return;
+        let woken = 0;
+        for (const entry of entries) {
+          if (!entry.isVisible()) continue;
+          woken++;
+          try {
+            entry.repaint();
+          } catch {
+            // pane may be disposing — the other panes still get their repaint
+          }
+        }
+        if (woken > 0) {
+          // warn, not debug: console.debug maps to Verbose, which Chromium
+          // drops with DevTools closed, so a reporter could never tell "the
+          // repaint fired and did not help" from "it never fired". warn is
+          // mirrored into the main-side log they can attach to an issue.
+          log(`[wmux:window-wake] repainted ${woken} visible pane(s) after window refocus (pass ${pass})`);
+        }
+      };
+
+      const onBlur = (): void => {
+        wasAway = true;
+        // Drop any pass still queued from a previous focus so focus churn
+        // cannot stack passes on top of each other.
+        cancel();
+      };
+
+      const onFocus = (): void => {
+        if (!wasAway) return; // in-app focus moves never reach here
+        wasAway = false;
+        cancel();
+        frameHandle = requestFrame(() => {
+          frameHandle = null;
+          repaintVisible(1);
+        });
+        timerHandle = setTimeoutFn(() => {
+          timerHandle = null;
+          repaintVisible(2);
+        }, WAKE_SECOND_PASS_MS);
+      };
+
+      windowRef.addEventListener('blur', onBlur);
+      windowRef.addEventListener('focus', onFocus);
+
+      return () => {
+        windowRef.removeEventListener('blur', onBlur);
+        windowRef.removeEventListener('focus', onFocus);
+        cancel();
+      };
+    },
+  };
+}
+
+/** App-wide singleton — panes register in useTerminal's main effect, and
+ *  AppLayout calls `init` once. */
+export const windowWakeRepaint = createWindowWakeRepaint();


### PR DESCRIPTION
Alt-tab away from wmux on Windows and come back, and the pane can be sitting there empty. It stays empty until you force a redraw by hand — select-all, or drag a pane border.

## What is actually wrong

The reporter's own screenshots settle it: their forced redraw brings the text back **correct**, with only the bottom row showing glyph fragments. The buffer was never damaged. The pane is not rendering corrupt content, it is rendering nothing, and nothing ever tells it to draw again.

Nothing can, on Windows. Measured against a bare Electron 41 build:

| window state | `document.visibilityState` | rAF |
|---|---|---|
| foreground | visible | 60/s |
| fully covered by another app | visible | 60/s |
| **minimized** | **visible** | 60/s |

`visibilitychange` fires exactly once per window, at teardown, and toggling Chromium's `CalculateNativeWinOcclusion` changes nothing — this is not a tunable.

Every repaint-on-wake path in the renderer keys off that signal, so on Windows they are all dead code: `atlasWakeRecovery`'s `visibility` trigger (leaving `system-resumed` as its only live trigger there) and `useTerminal`'s `docRevealed` reclaim. The one repaint that does run on alt-tab belongs to the textarea focus handler of the single pane holding keyboard focus, so in a split every other visible pane has no trigger at all.

Two more things measured against a real xterm 6 + `addon-webgl` 0.19 canvas, with the drawing buffer wiped behind xterm's back (which is what a dropped buffer looks like to xterm — its model still says everything is drawn):

- an idle pane **never** self-heals;
- a single `terminal.refresh(0, rows - 1)` restores it exactly. The heavier `clearTextureAtlas` is not needed.

## What this changes

Window refocus becomes its own wake boundary. One app-wide coordinator (`terminal/windowWakeRepaint.ts`, following the `atlasGuard` singleton + `AppLayout` init pattern) owns a single blur/focus listener pair. Panes register a visibility probe and their existing `glyphRepaint` scheduler under a new `window-wake` reason, so there is no second timer lifecycle around the same `terminal.refresh`.

- Repaints on the next frame, and once more 250 ms later. The pixel loss can land on either side of re-activation; the frame pass covers a loss that happened while the window was away, the timer covers one that lands at re-activation. If the reporter confirms the frame pass alone is enough, the timer goes.
- Re-checks window focus and pane visibility at execution time, so a pass that outlives the focus does nothing, and a pane in a hidden workspace is skipped (it already repaints via `glyphRepaint`'s `visible` reason when its tab comes back).
- Seeds its state from `document.hasFocus()` rather than from "we have seen a blur", so a pane that mounts while the app is already in the background still wakes.
- A blur cancels pending passes, so focus churn cannot stack them.
- Never clears the shared glyph atlas. Wiping it on plain refocus re-arms xterm's page-merge race, which is exactly why `atlasWakeRecovery` excludes focus from its own triggers.
- Logs at `warn`, not `debug`: Verbose is dropped when DevTools is closed, and a reporter needs to be able to tell "the repaint fired and did not help" from "it never fired".

Windows only. macOS and Linux report visibility correctly and are already covered, so they take no extra GPU work.

## Honest limits

The gap this closes is proven and machine-independent. The GPU-side reason the pixels go missing is **not** — it does not reproduce here (20 s fully occluded, canvas intact), and the reporter sees two other rendering oddities on the same machine, so the drop looks driver-specific.

That is why this says `Refs #879` rather than `Closes #879`: the same call as #319/#318, where a rendering fix that could not be verified locally stayed open until the reporter confirmed. Follow-up questions are posted on the issue.

`atlasWakeRecovery.ts` also gains a comment recording the Windows measurement, so the next reader does not assume its `visibility` trigger covers Windows.

## Tests

47 new tests. The scheduler is tested against injected window/document/rAF/clock: no repaint without a preceding blur, both passes per wake, every visible pane and only visible panes, mount-while-blurred, blur cancels pending passes, a pass that runs unfocused repaints nothing, one pane throwing does not stop the others, unregister and teardown, and `enabled: false` attaching nothing. Source-level locks pin the wiring a scheduler test cannot reach: that `useTerminal` actually registers and unregisters, and that `AppLayout` gates on win32 — a coordinator with zero registered panes is a silent no-op, which is the failure mode of this bug.

`tsc --noEmit` clean. Full suite: no new failures.

Refs #879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed blank terminal panes on Windows after switching applications and returning.
  * Visible panes now repaint automatically when the window regains focus.
  * Repainting is skipped when panes are hidden or the window loses focus again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->