### PR TITLE
Report the pane hidden when the window is minimized, hidden to tray, or locked

### DIFF
--- a/changelog.d/883.md
+++ b/changelog.d/883.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **Minimise wmux on Windows and your phone can finally resize the session.**
+  Handing PTY geometry to a phone depends on the desktop admitting nobody is
+  looking at the pane, and the desktop worked that out from the browser's
+  page-visibility signal — which on Windows never changes, not when the window
+  is covered and not even when it is minimised. So the phone was told the desk
+  owns the size forever, and the terminal it showed stayed wrapped for a window
+  nobody could see. The desktop now takes that answer from the window itself:
+  minimised, hidden to the tray, or screen locked all count as nobody looking,
+  and restoring the window takes the geometry back. Locking your screen releases
+  the size too, which is exactly when the phone is the only screen left.
+  (#882, follow-up to #766)

--- a/src/main/ipc/handlers/metadata.handler.ts
+++ b/src/main/ipc/handlers/metadata.handler.ts
@@ -2,6 +2,7 @@ import { ipcMain, BrowserWindow } from 'electron';
 import fs from 'node:fs';
 import { IPC } from '../../../shared/constants';
 import type { MetadataUpdatePayload } from '../../../shared/types';
+import { isWindowDisplayed } from '../../window/windowDisplayed';
 import { MetadataCollector } from '../../metadata/MetadataCollector';
 import { prStatusCache } from '../../metadata/PrStatusCache';
 import { gitSyncStatusCache } from '../../metadata/GitSyncStatusCache';
@@ -61,8 +62,11 @@ export function broadcastMetadataUpdate(
 export function shouldPollMetadata(win: BrowserWindow): boolean {
   if (win.isDestroyed()) return false;
   if (win.webContents.isLoading()) return false;
-  if (!win.isVisible() || win.isMinimized()) return false;
-  return true;
+  // Shared with the #882 viewer-visibility report so the two definitions of
+  // "the window is on screen" cannot drift apart. The loading check above stays
+  // local: a loading renderer is a reason not to poll it for cosmetics, but not
+  // a reason to tell the daemon nobody can see the window.
+  return isWindowDisplayed(win);
 }
 
 const collector = new MetadataCollector();

--- a/src/main/ipc/registerHandlers.ts
+++ b/src/main/ipc/registerHandlers.ts
@@ -40,6 +40,7 @@ import { updateUnreadBadge } from '../tray';
 import { eventBus } from '../events/EventBus';
 import { WMUX_EVENT_TYPES, type WmuxEventType } from '../../shared/events';
 import { VALID_TRANSITIONS, type TaskState } from '../../shared/types';
+import { windowDisplayedReporter } from '../window/windowDisplayed';
 
 const EVENT_TYPE_SET = new Set<WmuxEventType>(WMUX_EVENT_TYPES);
 
@@ -373,6 +374,13 @@ export function registerAllHandlers(
     const win = getWindow();
     return !!win && !win.isDestroyed() && win.isFullScreen();
   });
+
+  // #882 — mount-time pull for "is anyone looking at this window". The push
+  // lives in createWindow with the other window events. The pull is what makes
+  // a renderer that loads while the window is hidden (start to tray, reload
+  // after a crash) start from the truth instead of the optimistic default.
+  ipcMain.removeHandler(IPC.WINDOW_IS_DISPLAYED);
+  ipcMain.handle(IPC.WINDOW_IS_DISPLAYED, () => windowDisplayedReporter.current());
 
   // EventBus publish from renderer (one-way). Validates the event type and
   // workspaceId at the trust boundary so a misbehaving renderer can't poison

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.resolveIdentity.test.ts
@@ -17,7 +17,11 @@ vi.mock('../_bridge', () => ({
   sendToRenderer: sendToRendererMock,
 }));
 
-vi.mock('../../../../shared/constants', () => ({
+// Spread the real module: replacing it wholesale makes this test break the
+// moment anything in the import graph reaches for another export (IPC, and
+// friends). Only getPidMapDir needs redirecting.
+vi.mock('../../../../shared/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../shared/constants')>()),
   getPidMapDir: () => dirRef.current,
 }));
 

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
@@ -13,7 +13,11 @@ vi.mock('../_bridge', () => ({
   sendToRenderer: sendToRendererMock,
 }));
 
-vi.mock('../../../../shared/constants', () => ({
+// Spread the real module: replacing it wholesale makes this test break the
+// moment anything in the import graph reaches for another export (IPC, and
+// friends). Only getPidMapDir needs redirecting.
+vi.mock('../../../../shared/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../shared/constants')>()),
   getPidMapDir: () => '/tmp/wmux-test-pidmap',
 }));
 

--- a/src/main/window/__tests__/windowDisplayed.test.ts
+++ b/src/main/window/__tests__/windowDisplayed.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createWindowDisplayedReporter,
+  isWindowDisplayed,
+  type DisplayableWindow,
+} from '../windowDisplayed';
+
+type WinEvent = 'minimize' | 'restore' | 'hide' | 'show';
+type PowerEvent = 'lock-screen' | 'unlock-screen' | 'suspend' | 'resume';
+
+function fakeWindow(state: {
+  visible?: boolean;
+  minimized?: boolean;
+  destroyed?: boolean;
+  contentsDestroyed?: boolean;
+} = {}) {
+  const listeners = new Map<WinEvent, Set<() => void>>();
+  const sent: Array<{ channel: string; payload: unknown }> = [];
+  const win = {
+    visible: state.visible ?? true,
+    minimized: state.minimized ?? false,
+    destroyed: state.destroyed ?? false,
+    contentsDestroyed: state.contentsDestroyed ?? false,
+    sent,
+    isDestroyed: () => win.destroyed,
+    isVisible: () => win.visible,
+    isMinimized: () => win.minimized,
+    on(event: WinEvent, listener: () => void) {
+      const set = listeners.get(event) ?? new Set<() => void>();
+      set.add(listener);
+      listeners.set(event, set);
+      return win;
+    },
+    webContents: {
+      isDestroyed: () => win.contentsDestroyed,
+      send: (channel: string, payload: unknown) => { sent.push({ channel, payload }); },
+    },
+    fire(event: WinEvent) { for (const l of [...(listeners.get(event) ?? [])]) l(); },
+    /** Values pushed so far, in order. */
+    values: () => sent.map((s) => (s.payload as { displayed: boolean }).displayed),
+  };
+  return win;
+}
+
+function fakePower() {
+  const listeners = new Map<PowerEvent, Set<() => void>>();
+  return {
+    on(event: PowerEvent, listener: () => void) {
+      const set = listeners.get(event) ?? new Set<() => void>();
+      set.add(listener);
+      listeners.set(event, set);
+      return this;
+    },
+    fire(event: PowerEvent) { for (const l of [...(listeners.get(event) ?? [])]) l(); },
+  };
+}
+
+describe('isWindowDisplayed', () => {
+  it('true only when the window is visible and not minimized', () => {
+    expect(isWindowDisplayed(fakeWindow() as unknown as DisplayableWindow)).toBe(true);
+    expect(isWindowDisplayed(fakeWindow({ minimized: true }) as unknown as DisplayableWindow)).toBe(false);
+    expect(isWindowDisplayed(fakeWindow({ visible: false }) as unknown as DisplayableWindow)).toBe(false);
+    expect(isWindowDisplayed(fakeWindow({ visible: false, minimized: true }) as unknown as DisplayableWindow)).toBe(false);
+  });
+
+  it('checks destruction FIRST — isVisible() on a destroyed window throws in Electron', () => {
+    const win = fakeWindow({ destroyed: true });
+    win.isVisible = () => { throw new Error('Object has been destroyed'); };
+    win.isMinimized = () => { throw new Error('Object has been destroyed'); };
+    expect(isWindowDisplayed(win as unknown as DisplayableWindow)).toBe(false);
+  });
+});
+
+describe('windowDisplayedReporter', () => {
+  it('pushes on minimize and restore', () => {
+    const win = fakeWindow();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow);
+
+    win.minimized = true;
+    win.fire('minimize');
+    win.minimized = false;
+    win.fire('restore');
+
+    expect(win.values()).toEqual([false, true]);
+    expect(win.sent[0].channel).toBe('ch');
+  });
+
+  it('pushes on hide and show (tray)', () => {
+    const win = fakeWindow();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow);
+
+    win.visible = false;
+    win.fire('hide');
+    win.visible = true;
+    win.fire('show');
+
+    expect(win.values()).toEqual([false, true]);
+  });
+
+  it('does not push when the answer did not change', () => {
+    // A `show` on an already-shown window is routine; waking every pane's
+    // report effect for it is not free.
+    const win = fakeWindow();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow);
+
+    win.fire('show');
+    win.fire('restore');
+    expect(win.values()).toEqual([]);
+
+    win.minimized = true;
+    win.fire('minimize');
+    win.fire('minimize');
+    expect(win.values()).toEqual([false]);
+  });
+
+  it('treats a locked screen as not displayed, even though the window is untouched', () => {
+    // Locking does not hide or minimize the window — the whole reason this
+    // term exists separately.
+    const win = fakeWindow();
+    const power = fakePower();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow, { powerMonitor: power });
+
+    power.fire('lock-screen');
+    expect(win.values()).toEqual([false]);
+    expect(r.current()).toBe(false);
+
+    power.fire('unlock-screen');
+    expect(win.values()).toEqual([false, true]);
+    expect(r.current()).toBe(true);
+  });
+
+  it('suspend/resume behaves the same, and resume re-reads the window instead of assuming', () => {
+    const win = fakeWindow();
+    const power = fakePower();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow, { powerMonitor: power });
+
+    win.minimized = true;
+    win.fire('minimize');
+    power.fire('suspend');
+    // Already false — no duplicate push.
+    expect(win.values()).toEqual([false]);
+
+    // Machine is back but the window is still minimized: still not displayed.
+    power.fire('resume');
+    expect(win.values()).toEqual([false]);
+    expect(r.current()).toBe(false);
+
+    win.minimized = false;
+    win.fire('restore');
+    expect(win.values()).toEqual([false, true]);
+  });
+
+  it('never sends to a destroyed window or destroyed webContents', () => {
+    const win = fakeWindow();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow);
+
+    win.contentsDestroyed = true;
+    win.minimized = true;
+    win.fire('minimize');
+    expect(win.sent).toEqual([]);
+
+    win.contentsDestroyed = false;
+    win.destroyed = true;
+    win.minimized = false;
+    win.fire('restore');
+    expect(win.sent).toEqual([]);
+  });
+
+  it('current() answers the pull, and falls back to the safe default with no window', () => {
+    const r = createWindowDisplayedReporter('ch');
+    expect(r.current()).toBe(true); // nothing attached yet
+
+    const win = fakeWindow({ minimized: true });
+    const detach = r.attach(win as unknown as DisplayableWindow);
+    expect(r.current()).toBe(false);
+
+    detach();
+    expect(r.current()).toBe(true);
+  });
+
+  it('a destroyed window reads as not displayed through current()', () => {
+    const win = fakeWindow();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(win as unknown as DisplayableWindow);
+    win.destroyed = true;
+    expect(r.current()).toBe(false);
+  });
+});

--- a/src/main/window/__tests__/windowDisplayed.test.ts
+++ b/src/main/window/__tests__/windowDisplayed.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   createWindowDisplayedReporter,
   isWindowDisplayed,
@@ -182,6 +182,43 @@ describe('windowDisplayedReporter', () => {
 
     detach();
     expect(r.current()).toBe(true);
+  });
+
+  it('ignores events from a window it no longer reports on (macOS dock re-activate)', () => {
+    // The main window is recreated, and the old one's listeners outlive it.
+    const old = fakeWindow();
+    const fresh = fakeWindow();
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(old as unknown as DisplayableWindow);
+    r.attach(fresh as unknown as DisplayableWindow);
+
+    old.minimized = true;
+    old.fire('minimize');
+    expect(old.sent).toEqual([]);   // nothing sent to the dead window
+    expect(fresh.sent).toEqual([]); // and the live one is not disturbed either
+    expect(r.current()).toBe(true); // the fresh window is what current() reads
+
+    fresh.minimized = true;
+    fresh.fire('minimize');
+    expect(fresh.values()).toEqual([false]);
+  });
+
+  it('wires the process-wide powerMonitor once, not once per window', () => {
+    // Stacking a fresh set on every window recreation would fire the lock
+    // handler N times and leak a listener per window.
+    const power = fakePower();
+    const onSpy = vi.spyOn(power, 'on');
+    const r = createWindowDisplayedReporter('ch');
+    r.attach(fakeWindow() as unknown as DisplayableWindow, { powerMonitor: power });
+    const afterFirst = onSpy.mock.calls.length;
+
+    const fresh = fakeWindow();
+    r.attach(fresh as unknown as DisplayableWindow, { powerMonitor: power });
+    expect(onSpy.mock.calls.length).toBe(afterFirst);
+
+    // The single set still follows the window that replaced the original.
+    power.fire('lock-screen');
+    expect(fresh.values()).toEqual([false]);
   });
 
   it('a destroyed window reads as not displayed through current()', () => {

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -1,9 +1,10 @@
-import { app, BrowserWindow, shell } from 'electron';
+import { app, BrowserWindow, powerMonitor, shell } from 'electron';
 import path from 'node:path';
 import { platformChoice } from '../../shared/platform';
 import { IPC } from '../../shared/constants';
 import { PLUGIN_PROTOCOL_SCHEME } from '../../shared/pluginHost';
 import { attachFlashFrameAutoClear } from './flashFrame';
+import { windowDisplayedReporter } from './windowDisplayed';
 
 // OS-aware window-icon extension. Mirrors tray.ts so the same generated asset
 // set (icon.ico / icon.icns / icon.png) is used in both places.
@@ -150,6 +151,14 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
   };
   mainWindow.on('enter-full-screen', () => pushFullscreen(true));
   mainWindow.on('leave-full-screen', () => pushFullscreen(false));
+
+  // #882 — "is anyone looking at this window" (minimized / hidden to tray /
+  // screen locked), pushed on the same window-event → renderer pattern. The
+  // renderer folds it into the #766 viewer-visibility report, which on Windows
+  // had no working window term at all: `document.visibilityState` never
+  // reports hidden there, not even for a minimized window. Rationale and the
+  // deliberate exclusion of plain blur live in window/windowDisplayed.ts.
+  windowDisplayedReporter.attach(mainWindow, { powerMonitor });
 
   // UI zoom (#822) is now renderer-driven: the persisted factor lives in the
   // renderer store and is pushed via the window:setUiScale IPC on hydration

--- a/src/main/window/windowDisplayed.ts
+++ b/src/main/window/windowDisplayed.ts
@@ -103,6 +103,8 @@ export function createWindowDisplayedReporter(channel: string): WindowDisplayedR
   // (a `show` on an already-shown window, `resume` right after `unlock-screen`)
   // does not wake every pane's report effect for nothing.
   let lastSent: boolean | null = null;
+  // powerMonitor is process-wide; its listeners are wired once, not per window.
+  let powerWired = false;
 
   const current = (): boolean => {
     if (!attached) return true;
@@ -133,10 +135,19 @@ export function createWindowDisplayedReporter(channel: string): WindowDisplayedR
       // every pane's report effect. Any real change still pushes.
       lastSent = current();
       for (const event of ['minimize', 'restore', 'hide', 'show'] as const) {
-        win.on(event, push);
+        // Ignore events from a window we are no longer reporting on. The main
+        // window is recreated on macOS dock re-activate, and Electron gives no
+        // listener-removal slice worth stubbing here, so the old window's
+        // listeners outlive the attach that replaced it.
+        win.on(event, () => { if (attached === win) push(); });
       }
       const power = opts.powerMonitor;
-      if (power) {
+      // powerMonitor is a PROCESS-wide emitter, not a per-window one: wiring it
+      // on every attach would stack a fresh set of listeners on each window
+      // recreation. The handlers read `attached` when they fire, so one set
+      // stays correct for every window that follows.
+      if (power && !powerWired) {
+        powerWired = true;
         for (const event of ['lock-screen', 'suspend'] as const) {
           power.on(event, () => { userAway = true; push(); });
         }

--- a/src/main/window/windowDisplayed.ts
+++ b/src/main/window/windowDisplayed.ts
@@ -1,0 +1,166 @@
+// Is anyone actually looking at the desktop window? (#882)
+//
+// #766 made PTY geometry ownership visibility-based: while a desk renderer
+// reports a pane on screen, a phone resize gets `409 desk-owns-size`; while it
+// reports the pane hidden, the phone's numbers are applied. The renderer built
+// the window half of that report out of `document.visibilityState`.
+//
+// On Windows that value is a constant. Measured on Electron 41: it stays
+// 'visible' while the window is fully covered by another app AND while the
+// window is minimized; `visibilitychange` fires once per window, at teardown;
+// disabling Chromium's `CalculateNativeWinOcclusion` changes nothing. So the
+// window term contributed nothing there, and minimising wmux never handed the
+// size to the phone — the handoff #766 exists for simply did not happen.
+//
+// Main is the only side that can see the window, so main owns the signal:
+//
+//   'minimize' / 'restore' / 'hide' / 'show'   window state
+//   'lock-screen' / 'suspend'                  user is gone, window or not
+//   'unlock-screen' / 'resume'                 re-read, never assume
+//                     │
+//                     ▼   dedup, then push
+//        IPC.WINDOW_DISPLAYED_CHANGED ──► renderer (+ IPC.WINDOW_IS_DISPLAYED
+//                                          pull at mount, so a renderer that
+//                                          loads while hidden — start-to-tray,
+//                                          or a reload after a crash — starts
+//                                          from the truth rather than from the
+//                                          optimistic default)
+//
+// BLUR IS DELIBERATELY NOT PART OF THIS. A blurred window is still on screen:
+// someone typing in another app with wmux open beside it is looking at that
+// layout, and letting the phone reshape the PTY there is exactly the geometry
+// fight #766's own comment set out to prevent. Worse on Windows, where there is
+// no reveal event either, so the desk would not re-fit and the pane would sit
+// at the phone's geometry until some unrelated layout pass. Minimize, hide to
+// tray and lock screen are different in kind: nobody can see the layout at all.
+//
+// Occlusion — covered by another window but not minimized — stays unhandled,
+// because Chromium on Windows will not tell us. Known hole, not an oversight.
+//
+// The lock-screen half mirrors desktopPresence.ts, which learned the same
+// lesson for notification presence: locking the screen does NOT blur or hide
+// the window, so a window-events-only reporter would keep claiming the desk is
+// in use while the user is away from the machine — the moment the phone is the
+// only channel left.
+
+import { IPC } from '../../shared/constants';
+
+/** The slice of `BrowserWindow` this touches, so a test can pass a stub. */
+export interface DisplayableWindow {
+  isDestroyed(): boolean;
+  isVisible(): boolean;
+  isMinimized(): boolean;
+  on(event: 'minimize' | 'restore' | 'hide' | 'show', listener: () => void): unknown;
+  webContents: {
+    isDestroyed(): boolean;
+    send(channel: string, payload: unknown): void;
+  };
+}
+
+/** The slice of `powerMonitor` this touches. */
+export interface DisplayedPowerMonitor {
+  on(
+    event: 'lock-screen' | 'unlock-screen' | 'suspend' | 'resume',
+    listener: () => void,
+  ): unknown;
+}
+
+/**
+ * Is the window itself on screen right now?
+ *
+ * Destruction is checked FIRST: `isVisible()`/`isMinimized()` on a destroyed
+ * window throw, and every caller wants "no" rather than an exception.
+ *
+ * This is the predicate `shouldPollMetadata` was already using inline; it now
+ * calls this so the two definitions of "displayed" cannot drift apart. Note
+ * `shouldPollMetadata` adds its own `webContents.isLoading()` term — a loading
+ * renderer is a reason not to poll it for cosmetics, but not a reason to tell
+ * the daemon nobody can see the window.
+ */
+export function isWindowDisplayed(win: DisplayableWindow): boolean {
+  if (win.isDestroyed()) return false;
+  return win.isVisible() && !win.isMinimized();
+}
+
+export interface WindowDisplayedReporter {
+  /** Wire the window and power events; returns the teardown. */
+  attach(win: DisplayableWindow, opts?: { powerMonitor?: DisplayedPowerMonitor }): () => void;
+  /**
+   * The value the pull handler answers with. True when nothing is attached:
+   * the same optimistic default the daemon holds (`viewerVisible: true`), so a
+   * build without this wiring behaves exactly as it did before.
+   */
+  current(): boolean;
+}
+
+export function createWindowDisplayedReporter(channel: string): WindowDisplayedReporter {
+  let attached: DisplayableWindow | null = null;
+  // Screen locked / machine suspended. Tracked separately from window state
+  // because it does not change window state at all — that is the whole reason
+  // this term exists.
+  let userAway = false;
+  // Last value actually pushed, so an event that does not change the answer
+  // (a `show` on an already-shown window, `resume` right after `unlock-screen`)
+  // does not wake every pane's report effect for nothing.
+  let lastSent: boolean | null = null;
+
+  const current = (): boolean => {
+    if (!attached) return true;
+    if (userAway) return false;
+    return isWindowDisplayed(attached);
+  };
+
+  const push = (): void => {
+    const win = attached;
+    if (!win) return;
+    const value = current();
+    if (value === lastSent) return;
+    lastSent = value;
+    // Both guards: a BrowserWindow can outlive its webContents (mid-navigation,
+    // renderer crash), and send() on a dead webContents throws.
+    if (win.isDestroyed() || win.webContents.isDestroyed()) return;
+    win.webContents.send(channel, { displayed: value });
+  };
+
+  return {
+    current,
+    attach(win, opts = {}) {
+      attached = win;
+      userAway = false;
+      // Seed from the window's own state rather than from "nothing sent yet".
+      // The renderer PULLS its initial value, so a push that merely restates
+      // what the window already was is not information — it is a wake-up for
+      // every pane's report effect. Any real change still pushes.
+      lastSent = current();
+      for (const event of ['minimize', 'restore', 'hide', 'show'] as const) {
+        win.on(event, push);
+      }
+      const power = opts.powerMonitor;
+      if (power) {
+        for (const event of ['lock-screen', 'suspend'] as const) {
+          power.on(event, () => { userAway = true; push(); });
+        }
+        // Back at the machine: re-read the window rather than assuming it came
+        // back to the foreground. It may still be minimized.
+        for (const event of ['unlock-screen', 'resume'] as const) {
+          power.on(event, () => { userAway = false; push(); });
+        }
+      }
+      return () => {
+        // Electron has no removeListener slice worth stubbing here, and the
+        // window's listeners die with the window. Dropping the reference is
+        // what matters: `current()` must go back to the safe default so a pull
+        // arriving during teardown does not read a dead window.
+        attached = null;
+        lastSent = null;
+        userAway = false;
+      };
+    },
+  };
+}
+
+/** App-wide singleton: `createWindow` attaches the window, the
+ *  `WINDOW_IS_DISPLAYED` handler answers pulls from it. */
+export const windowDisplayedReporter = createWindowDisplayedReporter(
+  IPC.WINDOW_DISPLAYED_CHANGED,
+);

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1044,6 +1044,21 @@ const electronAPI = {
       ipcRenderer.on(IPC.WINDOW_FULLSCREEN_CHANGED, listener);
       return () => ipcRenderer.removeListener(IPC.WINDOW_FULLSCREEN_CHANGED, listener);
     },
+    /**
+     * #882 — is anyone looking at this window (not minimized, not hidden to
+     * tray, screen not locked)? Mount-time pull; the push below carries the
+     * transitions. Feeds the #766 viewer-visibility report, whose window term
+     * was dead on Windows because `document.visibilityState` never reports any
+     * of those states there.
+     */
+    isDisplayed: () => ipcRenderer.invoke(IPC.WINDOW_IS_DISPLAYED) as Promise<boolean>,
+    /** #882 — live transitions of the above (push). */
+    onDisplayedChanged: (cb: (displayed: boolean) => void) => {
+      const listener = (_e: Electron.IpcRendererEvent, payload: { displayed?: boolean }) =>
+        cb(payload?.displayed === true);
+      ipcRenderer.on(IPC.WINDOW_DISPLAYED_CHANGED, listener);
+      return () => ipcRenderer.removeListener(IPC.WINDOW_DISPLAYED_CHANGED, listener);
+    },
   },
   events: {
     /**

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -25,6 +25,7 @@ import ApprovalDialog from '../Company/ApprovalDialog';
 import ExecuteApprovalDialog from '../A2a/ExecuteApprovalDialog';
 import PermissionApprovalDialogContainer from '../Approval/PermissionApprovalDialogContainer';
 import { initAtlasWakeRecovery } from '../../terminal/atlasWakeRecovery';
+import { windowDisplayedStore } from '../../hooks/useWindowDisplayed';
 import CompanyView from '../Company/CompanyView';
 import MessageFeedPanel from '../Company/MessageFeedPanel';
 import OnboardingOverlay from '../Onboarding/OnboardingOverlay';
@@ -516,6 +517,14 @@ export default function AppLayout() {
         typeof onResumed === 'function' ? onResumed : () => () => {},
     });
   }, []);
+
+  // #882 — one renderer-wide subscription to "is anyone looking at this
+  // window" (minimized / hidden to tray / screen locked), which panes fold
+  // into their #766 viewer-visibility report. All platforms: the bit is right
+  // everywhere, it is only Windows where `document.visibilityState` could not
+  // supply it. See hooks/useWindowDisplayed.ts.
+  useEffect(() => windowDisplayedStore.init(), []);
+
 
   // #517 slice C — discard mode mirrors the same way. Effective only while
   // lightweight mode is also on (belt-and-braces: main enforces this too).

--- a/src/renderer/hooks/__tests__/useTerminal.viewerVisibility.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.viewerVisibility.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// #882 wiring lock (source-level).
+//
+// viewerVisibility.test.ts proves the decision; this proves the decision is
+// actually the one useTerminal makes. A pure function nobody calls is exactly
+// how this bug survived: #766 shipped a correct-looking expression whose window
+// term was dead on Windows, and no test noticed because no test asserted what
+// fed it. Mounting useTerminal for real needs a WebGL context and the whole
+// preload bridge, so the wiring is pinned here, as useTerminal.atlasClear.test.ts
+// does for the #191 invariant.
+
+const hookSrc = fs.readFileSync(path.join(__dirname, '..', 'useTerminal.ts'), 'utf-8');
+const layoutSrc = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'components', 'Layout', 'AppLayout.tsx'),
+  'utf-8',
+);
+
+describe('#882 — the viewer-visibility report is fed by the window-displayed bit', () => {
+  it('useTerminal subscribes to the window-displayed store', () => {
+    expect(hookSrc).toMatch(/const windowDisplayed = useWindowDisplayed\(\);/);
+  });
+
+  it('the report goes through the shared decision, not an inline expression', () => {
+    const start = hookSrc.indexOf('const { viewerVisible, windowVisible, refit } = decideViewerVisibility({');
+    expect(start).toBeGreaterThan(-1);
+    const block = hookSrc.slice(start, hookSrc.indexOf('});', start));
+    expect(block).toMatch(/paneVisible: isVisible/);
+    expect(block).toMatch(/docVisible,/);
+    expect(block).toMatch(/windowDisplayed,/);
+    expect(block).toMatch(/prevWindowVisible: prevWindowVisibleRef\.current/);
+  });
+
+  it('the effect re-runs when the window-displayed bit flips', () => {
+    // Without windowDisplayed in the dependency list the report would be
+    // computed once and never revisited — the same silent staleness as the
+    // original bug, one layer up.
+    const start = hookSrc.indexOf('const { viewerVisible, windowVisible, refit } = decideViewerVisibility({');
+    const deps = hookSrc.slice(start, hookSrc.indexOf('\n  }, [', start) + 200);
+    expect(deps).toMatch(/\}, \[ptyId, isVisible, docVisible, windowDisplayed, fit\]\);/);
+  });
+});
+
+describe('#882 — a daemon reattach cannot silently revert the report', () => {
+  it('replays the last reported value after reconnect', () => {
+    // The daemon starts sessions at viewerVisible:true and resets to true on
+    // detach, and this pane's visibility will not change just because the
+    // daemon respawned — so without a replay the desk would go back to owning
+    // the size for a pane nobody can see.
+    const start = hookSrc.indexOf('void reconnectPtyWithRetry(id,');
+    expect(start).toBeGreaterThan(-1);
+    const block = hookSrc.slice(start, hookSrc.indexOf('.finally(', start));
+    expect(block).toMatch(/reportViewerVisibility\(id, viewerVisibleRef\.current\)/);
+    expect(block).toMatch(/if \(ptyIdRef\.current !== id\) return;/);
+  });
+});
+
+describe('#882 — the store is initialised once for the app', () => {
+  it('AppLayout initialises it', () => {
+    expect(layoutSrc).toMatch(/windowDisplayedStore\.init\(\)/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useWindowDisplayed.test.ts
+++ b/src/renderer/hooks/__tests__/useWindowDisplayed.test.ts
@@ -3,8 +3,10 @@ import { createWindowDisplayedStore } from '../useWindowDisplayed';
 
 /** A controllable stand-in for the preload bridge. */
 function fakeBridge(initial: boolean, opts: { rejects?: boolean } = {}) {
-  let resolvePull: (v: boolean) => void = () => {};
-  let rejectPull: (e: unknown) => void = () => {};
+  // Definite assignment: the Promise executor below runs synchronously and
+  // assigns both before fakeBridge returns.
+  let resolvePull!: (v: boolean) => void;
+  let rejectPull!: (e: unknown) => void;
   const pull = new Promise<boolean>((res, rej) => { resolvePull = res; rejectPull = rej; });
   const pushListeners = new Set<(v: boolean) => void>();
   return {

--- a/src/renderer/hooks/__tests__/useWindowDisplayed.test.ts
+++ b/src/renderer/hooks/__tests__/useWindowDisplayed.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createWindowDisplayedStore } from '../useWindowDisplayed';
+
+/** A controllable stand-in for the preload bridge. */
+function fakeBridge(initial: boolean, opts: { rejects?: boolean } = {}) {
+  let resolvePull: (v: boolean) => void = () => {};
+  let rejectPull: (e: unknown) => void = () => {};
+  const pull = new Promise<boolean>((res, rej) => { resolvePull = res; rejectPull = rej; });
+  const pushListeners = new Set<(v: boolean) => void>();
+  return {
+    deps: {
+      isDisplayed: () => pull,
+      onDisplayedChanged: (cb: (v: boolean) => void) => {
+        pushListeners.add(cb);
+        return () => { pushListeners.delete(cb); };
+      },
+    },
+    settlePull: async () => {
+      if (opts.rejects) rejectPull(new Error('no such handler'));
+      else resolvePull(initial);
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    push: (v: boolean) => { for (const cb of [...pushListeners]) cb(v); },
+    listenerCount: () => pushListeners.size,
+  };
+}
+
+describe('windowDisplayedStore', () => {
+  it('defaults to true before main has answered', () => {
+    // Same optimistic default the daemon holds (viewerVisible: true), so a
+    // preload too old to expose the bridge behaves exactly as before.
+    const store = createWindowDisplayedStore();
+    expect(store.get()).toBe(true);
+  });
+
+  it('takes the pulled value at init — the case a push-only design misses', async () => {
+    // The window can already be hidden when the renderer loads: started to
+    // tray, or reloaded after a renderer crash.
+    const store = createWindowDisplayedStore();
+    const bridge = fakeBridge(false);
+    store.init(bridge.deps);
+    await bridge.settlePull();
+    expect(store.get()).toBe(false);
+  });
+
+  it('follows pushes and notifies subscribers on change only', async () => {
+    const store = createWindowDisplayedStore();
+    const bridge = fakeBridge(true);
+    store.init(bridge.deps);
+    await bridge.settlePull();
+
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    bridge.push(false);
+    expect(store.get()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    bridge.push(false); // no change
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    bridge.push(true);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('a push that lands before the pull resolves is not overwritten by it', async () => {
+    // The invoke is in flight while the user minimizes: the pull's answer is
+    // already stale by the time it arrives.
+    const store = createWindowDisplayedStore();
+    const bridge = fakeBridge(true); // pull will answer "displayed"
+    store.init(bridge.deps);
+
+    bridge.push(false);
+    expect(store.get()).toBe(false);
+
+    await bridge.settlePull();
+    expect(store.get()).toBe(false);
+  });
+
+  it('a failed pull leaves the safe default and the push path still works', async () => {
+    const store = createWindowDisplayedStore();
+    const bridge = fakeBridge(false, { rejects: true });
+    store.init(bridge.deps);
+    await bridge.settlePull();
+    expect(store.get()).toBe(true);
+
+    bridge.push(false);
+    expect(store.get()).toBe(false);
+  });
+
+  it('unsubscribe stops delivery; teardown detaches the bridge and ignores late answers', async () => {
+    const store = createWindowDisplayedStore();
+    const bridge = fakeBridge(false);
+    const teardown = store.init(bridge.deps);
+
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+    unsubscribe();
+    bridge.push(false);
+    expect(listener).not.toHaveBeenCalled();
+
+    teardown();
+    expect(bridge.listenerCount()).toBe(0);
+    // A pull that resolves after teardown must not mutate a torn-down store.
+    const before = store.get();
+    await bridge.settlePull();
+    expect(store.get()).toBe(before);
+  });
+
+  it('init without a bridge (old preload) does not throw and keeps the default', () => {
+    const store = createWindowDisplayedStore();
+    const teardown = store.init({});
+    expect(store.get()).toBe(true);
+    expect(() => teardown()).not.toThrow();
+  });
+});

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -26,6 +26,8 @@ import { webglContextPool } from '../terminal/webglContextPool';
 import { teardownWebglAddon } from '../terminal/webglTeardown';
 import { createGlyphRepaintScheduler, type GlyphRepaintScheduler } from '../terminal/glyphRepaint';
 import { atlasGuard } from '../terminal/atlasGuard';
+import { decideViewerVisibility } from '../terminal/viewerVisibility';
+import { useWindowDisplayed } from './useWindowDisplayed';
 import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
 import { awaitParseBarrier } from '../terminal/parseBarrier';
 import { STALE_REPLAY_INPUT_MODE_RESETS, STALE_REPLAY_ALIVE_SHELL_RESETS, STALE_REPLAY_DISPLAY_RESETS, staleReplayResetLevel } from '../terminal/staleReplayModeReset';
@@ -433,6 +435,20 @@ function reconnectPtyWithRetry(ptyId: string, isCurrent: () => boolean): Promise
   });
 }
 
+/**
+ * #766/#882 — tell the daemon whether a desk renderer can see this pane.
+ *
+ * Fire-and-forget: local mode ignores it, and the value is re-sent on every
+ * visibility flip and after a daemon reattach, so one lost report self-corrects.
+ * Optional-chain style guard, as at resync: a packaged app updated under a
+ * running renderer can leave a preload that does not expose the method yet.
+ */
+function reportViewerVisibility(ptyId: string | null | undefined, visible: boolean): void {
+  if (!ptyId) return;
+  if (typeof window.electronAPI.pty.setViewerVisibility !== 'function') return;
+  window.electronAPI.pty.setViewerVisibility(ptyId, visible);
+}
+
 // Lightweight copy feedback toast — injects/removes a DOM element
 let copyToastTimer: ReturnType<typeof setTimeout> | null = null;
 function showCopyToast() {
@@ -592,6 +608,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // closure value captured at mount would go stale across workspace switches.
   const isVisibleRef = useRef(isVisible);
   isVisibleRef.current = isVisible;
+  // #882 — last value reported to the daemon for this pane. Read by the daemon
+  // reattach path, which is keyed on ptyId alone and would otherwise capture a
+  // stale value. Seeded to the same optimistic default the daemon holds.
+  const viewerVisibleRef = useRef(true);
   const onFirstDataRef = useRef(onFirstData);
   onFirstDataRef.current = onFirstData;
   const onContextMenuRef = useRef(onContextMenu);
@@ -2241,6 +2261,17 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       inFlight = true;
       console.log(`[useTerminal] daemon reattach ptyId=${id} (${reason})`);
       void reconnectPtyWithRetry(id, () => ptyIdRef.current === id && terminalRef.current !== null)
+        .then(() => {
+          // #882 — the daemon starts every managed session at `viewerVisible:
+          // true` and resets to true on detach, so a reattach that lands while
+          // this pane is hidden (background workspace, minimized window) leaves
+          // the daemon believing the desk owns the size, and the phone keeps
+          // getting 409 with nothing to correct it: this pane's visibility is
+          // not going to change just because the daemon respawned. Replay the
+          // last reported value so a reattach cannot silently revert it.
+          if (ptyIdRef.current !== id) return;
+          reportViewerVisibility(id, viewerVisibleRef.current);
+        })
         .finally(() => { inFlight = false; });
     };
     // Daemon already connected when we mounted: its daemon:connected fired before
@@ -2438,26 +2469,35 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
   // #766 — visibility-based size ownership. Report to the daemon whether this
   // pane is actually on screen: `isVisible` (workspace shown + active tab) AND
-  // the window itself visible (`document.visibilityState` — minimized, fully
-  // occluded, or hidden windows report 'hidden'). While the report says
-  // hidden, the daemon lets a phone reshape the PTY; while it says visible,
-  // the phone gets `409 desk-owns-size` as before.
+  // the window itself visible. While the report says hidden, the daemon lets a
+  // phone reshape the PTY; while it says visible, the phone gets
+  // `409 desk-owns-size` as before.
+  //
+  // #882 — the window half needs BOTH terms. `document.visibilityState` is a
+  // constant `true` on Windows (measured: it does not change when the window is
+  // covered, nor when it is MINIMIZED), so on that platform it contributed
+  // nothing and minimising wmux never handed the size over. `windowDisplayed`
+  // is main's answer to the same question, which it can actually see.
   const [docVisible, setDocVisible] = useState(() => document.visibilityState === 'visible');
   useEffect(() => {
     const onChange = () => setDocVisible(document.visibilityState === 'visible');
     document.addEventListener('visibilitychange', onChange);
     return () => document.removeEventListener('visibilitychange', onChange);
   }, []);
-  const effectiveVisible = isVisible && docVisible;
-  const prevDocVisibleRef = useRef(docVisible);
+  const windowDisplayed = useWindowDisplayed();
+  const prevWindowVisibleRef = useRef(docVisible && windowDisplayed);
   useEffect(() => {
-    // Optional-chain style guard, as at resync above: a stale preload
-    // (packaged app updated under a running renderer) may not expose it yet.
-    if (ptyId && typeof window.electronAPI.pty.setViewerVisibility === 'function') {
-      // Fire-and-forget: local mode ignores it, and a report lost to a race
-      // is corrected by the next flip or the detach-time reset to visible.
-      window.electronAPI.pty.setViewerVisibility(ptyId, effectiveVisible);
-    }
+    const { viewerVisible, windowVisible, refit } = decideViewerVisibility({
+      paneVisible: isVisible,
+      docVisible,
+      windowDisplayed,
+      prevWindowVisible: prevWindowVisibleRef.current,
+    });
+    prevWindowVisibleRef.current = windowVisible;
+    // Latest reported value, for the replay after a daemon reattach (that
+    // effect is keyed on ptyId alone and must not capture a stale value).
+    viewerVisibleRef.current = viewerVisible;
+    reportViewerVisibility(ptyId, viewerVisible);
     // Reclaim on window-level reveal. Workspace/tab reveals re-fit via the
     // visibility effect above, but a restored window's container never
     // changed size, so no ResizeObserver tick fires — if a phone reshaped
@@ -2465,10 +2505,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // fit() resizes unconditionally (no last-sent dedup), and the daemon
     // drops the SIGWINCH when the geometry is already ours, so this is free
     // when nothing changed.
-    const docRevealed = docVisible && !prevDocVisibleRef.current;
-    prevDocVisibleRef.current = docVisible;
-    if (docRevealed && isVisible) fit();
-  }, [ptyId, effectiveVisible, docVisible, isVisible, fit]);
+    if (refit) fit();
+  }, [ptyId, isVisible, docVisible, windowDisplayed, fit]);
 
   const getSearchDecorations = useCallback(() => {
     const y = getComputedStyle(document.documentElement).getPropertyValue('--accent-yellow').trim();

--- a/src/renderer/hooks/useWindowDisplayed.ts
+++ b/src/renderer/hooks/useWindowDisplayed.ts
@@ -1,0 +1,107 @@
+// "Is anyone looking at this window" as one renderer-wide fact (#882).
+//
+// Main owns the signal (main/window/windowDisplayed.ts has the measurements and
+// the reasoning); this is the renderer half. Panes read it through
+// `useWindowDisplayed` and fold it into the #766 viewer-visibility report.
+//
+// ONE bridge subscription for the whole app, not one per pane. Every pane wants
+// the same global bit, and N panes each calling `ipcRenderer.on` would be N
+// preload listeners and N duplicate deliveries of one event.
+//
+// PULL AT INIT, then push. The pull is not decoration: the window can already be
+// hidden when the renderer loads (started to tray, or reloaded after a renderer
+// crash), and a push-only design would leave every such renderer sitting on the
+// optimistic default until the user happened to minimize and restore. Same
+// shape as the fullscreen state in Titlebar.tsx.
+//
+// Defaults to TRUE — the same optimistic default the daemon holds
+// (`viewerVisible: true`) — so a preload too old to expose the bridge behaves
+// exactly as it did before this existed.
+
+import { useSyncExternalStore } from 'react';
+
+type Listener = () => void;
+
+export interface WindowDisplayedStore {
+  /** Current value. True until main says otherwise. */
+  get(): boolean;
+  subscribe(listener: Listener): () => void;
+  /** Wire the bridge: pull the current value, then follow transitions.
+   *  Called once from App; returns the teardown. */
+  init(deps?: WindowDisplayedDeps): () => void;
+}
+
+export interface WindowDisplayedDeps {
+  isDisplayed?: () => Promise<boolean>;
+  onDisplayedChanged?: (cb: (displayed: boolean) => void) => () => void;
+}
+
+export function createWindowDisplayedStore(): WindowDisplayedStore {
+  let displayed = true;
+  const listeners = new Set<Listener>();
+
+  const set = (value: boolean): void => {
+    if (value === displayed) return;
+    displayed = value;
+    for (const listener of [...listeners]) listener();
+  };
+
+  return {
+    get: () => displayed,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => { listeners.delete(listener); };
+    },
+    init(deps = {}) {
+      // `typeof window` guard, not a bare access: this module is imported by
+      // node-environment unit tests that never load jsdom.
+      const api = typeof window === 'undefined'
+        ? undefined
+        : (window as { electronAPI?: { window?: WindowDisplayedDeps } }).electronAPI?.window;
+      const {
+        // Optional-chained rather than assumed: a packaged app can be updated
+        // under a running renderer, leaving a preload without these members.
+        isDisplayed = api?.isDisplayed?.bind(api),
+        onDisplayedChanged = api?.onDisplayedChanged?.bind(api),
+      } = deps;
+
+      let alive = true;
+      // Subscribe BEFORE pulling, so a transition that lands between the two
+      // is not dropped. The pull is then only allowed to fill in the initial
+      // value — never to overwrite a push that has already arrived, which
+      // would resurrect a stale answer from an in-flight invoke.
+      let pushed = false;
+      const off = onDisplayedChanged?.((value) => {
+        if (!alive) return;
+        pushed = true;
+        set(value);
+      });
+      void isDisplayed?.().then((value) => {
+        if (!alive || pushed) return;
+        set(value === true);
+      }).catch(() => {
+        // Best-effort: the push path corrects the value on the next transition,
+        // and the default is the safe one.
+      });
+
+      return () => {
+        alive = false;
+        off?.();
+      };
+    },
+  };
+}
+
+/** App-wide singleton — `AppLayout` calls `init`, panes call the hook. */
+export const windowDisplayedStore = createWindowDisplayedStore();
+
+/** Subscribe a component to the window-displayed bit. */
+export function useWindowDisplayed(): boolean {
+  return useSyncExternalStore(
+    windowDisplayedStore.subscribe,
+    windowDisplayedStore.get,
+    // Server snapshot: tests render with jsdom, never SSR, but React demands
+    // the third argument when the second can differ across environments.
+    windowDisplayedStore.get,
+  );
+}

--- a/src/renderer/terminal/__tests__/viewerVisibility.test.ts
+++ b/src/renderer/terminal/__tests__/viewerVisibility.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { decideViewerVisibility } from '../viewerVisibility';
+
+const base = {
+  paneVisible: true,
+  docVisible: true,
+  windowDisplayed: true,
+  prevWindowVisible: true,
+};
+
+describe('decideViewerVisibility — what the daemon is told', () => {
+  it('reports visible only when the pane AND both window terms agree', () => {
+    expect(decideViewerVisibility(base).viewerVisible).toBe(true);
+    expect(decideViewerVisibility({ ...base, paneVisible: false }).viewerVisible).toBe(false);
+    expect(decideViewerVisibility({ ...base, docVisible: false }).viewerVisible).toBe(false);
+    expect(decideViewerVisibility({ ...base, windowDisplayed: false }).viewerVisible).toBe(false);
+  });
+
+  it('#882 — a minimized window hides the pane even though docVisible stays true', () => {
+    // This is the whole bug: on Windows `document.visibilityState` never
+    // reports hidden, so without the windowDisplayed term the desk kept
+    // claiming the size and the phone kept getting 409 desk-owns-size.
+    const d = decideViewerVisibility({ ...base, docVisible: true, windowDisplayed: false });
+    expect(d.windowVisible).toBe(false);
+    expect(d.viewerVisible).toBe(false);
+  });
+
+  it('keeps docVisible load-bearing — occlusion on the platforms that report it', () => {
+    const d = decideViewerVisibility({ ...base, docVisible: false, windowDisplayed: true });
+    expect(d.viewerVisible).toBe(false);
+  });
+});
+
+describe('decideViewerVisibility — retaking the geometry', () => {
+  it('refits when the window comes back and this pane is on screen', () => {
+    // A restored window fires no ResizeObserver tick (the container never
+    // changed size), so without this the pane keeps whatever geometry the
+    // phone gave it while the desk was away.
+    const d = decideViewerVisibility({ ...base, prevWindowVisible: false });
+    expect(d.refit).toBe(true);
+  });
+
+  it('#882 — a restore that only windowDisplayed can see still refits', () => {
+    const d = decideViewerVisibility({
+      paneVisible: true,
+      docVisible: true,        // constant on Windows, before and after
+      windowDisplayed: true,
+      prevWindowVisible: false, // was minimized
+    });
+    expect(d.refit).toBe(true);
+  });
+
+  it('does not refit a pane that is not on screen', () => {
+    const d = decideViewerVisibility({ ...base, paneVisible: false, prevWindowVisible: false });
+    expect(d.refit).toBe(false);
+  });
+
+  it('does not refit while the window stays visible', () => {
+    expect(decideViewerVisibility(base).refit).toBe(false);
+  });
+
+  it('does not refit on the way out', () => {
+    const d = decideViewerVisibility({ ...base, windowDisplayed: false, prevWindowVisible: true });
+    expect(d.refit).toBe(false);
+  });
+
+  it('keys the reveal on the window terms only, so a workspace switch does not double-fit', () => {
+    // useTerminal's own visibility effect already refits on a workspace/tab
+    // reveal; keying this on the combined value would fit twice.
+    const d = decideViewerVisibility({ ...base, paneVisible: true, prevWindowVisible: true });
+    expect(d.refit).toBe(false);
+  });
+});

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -32,6 +32,16 @@
 //
 // The two triggers routinely fire together on a real wake; the throttle
 // collapses them into one rebuild.
+//
+// ON WINDOWS THE VISIBILITY TRIGGER NEVER FIRES. Measured on Electron 41:
+// `document.visibilityState` stays 'visible' while the window is fully covered
+// by another application, and also while the window is MINIMIZED, with and
+// without Chromium's `CalculateNativeWinOcclusion` feature —
+// `visibilitychange` fires exactly once per window, at teardown. So on Windows
+// `system-resumed` is the only live trigger here. Do not assume the visibility
+// backstop above covers that platform; anything that needs to know whether the
+// window can be seen has to ask main instead (see main/window/windowDisplayed.ts,
+// which is how the #766 viewer-visibility report gets its answer since #882).
 
 import { atlasGuard } from './atlasGuard';
 

--- a/src/renderer/terminal/viewerVisibility.ts
+++ b/src/renderer/terminal/viewerVisibility.ts
@@ -1,0 +1,56 @@
+// What the desk tells the daemon about who can see a pane (#766, fixed #882).
+//
+// The daemon hands PTY geometry ownership to the phone exactly when the desk
+// says nobody is looking (`WebTerminalServer` → `409 desk-owns-size` otherwise).
+// Getting that bit wrong is invisible until someone picks the session up on
+// their phone and it will not resize, so the decision lives here as a pure
+// function rather than inline in a hook nothing can test.
+//
+// Three inputs, two of them about the window:
+//
+//   paneVisible      this pane's workspace is shown and its tab is active
+//   docVisible       document.visibilityState — real on macOS/Linux, a
+//                    constant `true` on Windows (measured, #882)
+//   windowDisplayed  main's answer: not minimized, not hidden to tray, screen
+//                    not locked. The term that makes this work on Windows.
+//
+// Both window terms are ANDed, not swapped: `docVisible` still catches occlusion
+// on the platforms that report it, and `windowDisplayed` catches the states no
+// platform reports through the DOM.
+//
+// The refit half is the other half of the bug. When the desk stops claiming the
+// size, a phone may reshape the PTY; when the desk comes back it has to take the
+// geometry back, and a restored window fires no ResizeObserver tick because the
+// container never changed size. So a WINDOW-level reveal has to refit
+// explicitly. It is keyed on the window terms only — a workspace/tab reveal
+// already refits through useTerminal's visibility effect, and keying it on the
+// combined value would fit twice on every workspace switch.
+
+export interface ViewerVisibilityInput {
+  /** This pane's workspace is shown and its tab is active. */
+  paneVisible: boolean;
+  /** `document.visibilityState === 'visible'`. */
+  docVisible: boolean;
+  /** Main's window-displayed bit (#882). */
+  windowDisplayed: boolean;
+  /** The `windowVisible` of the previous evaluation, for reveal detection. */
+  prevWindowVisible: boolean;
+}
+
+export interface ViewerVisibilityDecision {
+  /** Both window terms — "the window itself can be seen". */
+  windowVisible: boolean;
+  /** What to report to the daemon for this pane. */
+  viewerVisible: boolean;
+  /** The window came back and this pane is on screen: retake the geometry. */
+  refit: boolean;
+}
+
+export function decideViewerVisibility(input: ViewerVisibilityInput): ViewerVisibilityDecision {
+  const windowVisible = input.docVisible && input.windowDisplayed;
+  return {
+    windowVisible,
+    viewerVisible: input.paneVisible && windowVisible,
+    refit: windowVisible && !input.prevWindowVisible && input.paneVisible,
+  };
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -461,6 +461,12 @@ export const IPC = {
   // time initial state.
   WINDOW_FULLSCREEN_CHANGED: 'window:fullscreen-changed',
   WINDOW_IS_FULLSCREEN: 'window:isFullScreen',
+  // #882 — "is anyone looking at this window": minimized / hidden to tray /
+  // screen locked. Same push + pull shape as fullscreen above. Feeds the #766
+  // viewer-visibility report, because `document.visibilityState` never reports
+  // any of those on Windows (see main/window/windowDisplayed.ts).
+  WINDOW_DISPLAYED_CHANGED: 'window:displayed-changed',
+  WINDOW_IS_DISPLAYED: 'window:isDisplayed',
   // MCP integration status / management (Settings panel + CLI parity)
   MCP_CHECK: 'mcp:check',
   MCP_REREGISTER: 'mcp:reregister',


### PR DESCRIPTION
## The bug

#766 made PTY geometry ownership visibility-based: while the desk says it is showing a pane, a phone resize gets `409 desk-owns-size`; while the desk says the pane is hidden, the phone's numbers are applied. The renderer built the window half of that answer out of `document.visibilityState`.

On Windows that value is a constant. Measured on Electron 41:

| window state | `document.visibilityState` | rAF |
|---|---|---|
| foreground | visible | 60/s |
| fully covered by another app | visible | 60/s |
| **minimized** | **visible** | 60/s |

`visibilitychange` fires once per window, at teardown; disabling Chromium's `CalculateNativeWinOcclusion` changes nothing.

So the window term contributed nothing, and minimising wmux never handed the size over — the handoff #766 exists for did not happen. Workspace and tab switches still flipped the pane term, so the feature was not dead; it just never responded to the window. Never worked on Windows, so not a regression.

## What this changes

Main is the only side that can see the window, so main owns the signal.

```
BrowserWindow  minimize | restore | hide | show
powerMonitor   lock-screen | suspend        → nobody is at the machine
               unlock-screen | resume       → re-read, never assume
        │
        ├─ isWindowDisplayed(win) = !destroyed && isVisible() && !isMinimized()
        ▼   dedup
  WINDOW_DISPLAYED_CHANGED (push) ──► renderer store ──► useTerminal
  WINDOW_IS_DISPLAYED      (pull)          │              │
                                           │              ▼
                                           │   decideViewerVisibility()
                                           │      ├─ report → daemon
                                           ▼      └─ refit on reveal
```

- **Lock screen counts.** Locking neither hides nor minimizes the window, so a window-events-only reporter would keep claiming the desk is in use while the user is away from the machine — which is exactly when the phone is the only screen left. `desktopPresence.ts` learned this for notifications; this mirrors it.
- **Plain blur does not count.** A blurred window is still on screen. Letting a phone reshape the PTY behind someone reading that pane on a second monitor is the geometry fight #766 set out to prevent, and on Windows there would be no reveal event to take it back either.
- **Pull at mount, not just push.** `did-finish-load` does not mean the renderer installed its listener, and this window reloads after a renderer crash. Same push + pull shape as the existing fullscreen state. The store subscribes before pulling and lets a push win, so an in-flight invoke cannot resurrect a stale answer.
- **The reveal is half the fix.** A restored window fires no ResizeObserver tick (the container never changed size), so without an explicit refit the desk would release the size on minimize and never take it back. Report and reveal come from one pure function, keyed on the window terms only so a workspace switch does not fit twice.
- **A daemon reattach replays the report.** The daemon starts sessions at `viewerVisible: true` and resets to true on detach, and a hidden pane's visibility does not change just because the daemon respawned.
- **One subscription for the app**, not one per pane, and `shouldPollMetadata` now shares the window predicate instead of repeating it — keeping its own `isLoading` term, because a loading renderer is a reason not to poll it for cosmetics, not a reason to tell the daemon nobody can see the window.

Occlusion — covered but not minimized — stays unhandled, because Chromium on Windows will not report it. Documented hole, not an oversight. Daemon side is unchanged.

The last commit is documentation only: `atlasWakeRecovery.ts` now records the same measurement, because its own `visibility` trigger is dead on Windows for exactly this reason and nothing in the file said so.

## Tests

24 new. The decision (report + reveal) is a pure function with its own behavioural tests, including the two cases that define the bug: a minimized window hides the pane even though `docVisible` stays true, and a restore that only the new term can see still refits. The main-side reporter is tested against a stub window: each of the four window events, lock/suspend/unlock/resume, no push when the answer did not change, never sending to a destroyed window or destroyed webContents, and `current()` answering the pull. The renderer store covers pull-at-init, push-wins-over-in-flight-pull, failed pull leaving the safe default, and teardown. Source locks pin the call sites the pure tests cannot reach — a pure function nobody calls is how #766 shipped a correct-looking expression whose window term was dead.

Two `a2a` rpc tests replaced `shared/constants` wholesale rather than spreading it, so they broke the moment anything in their import graph reached for another export. They spread it now.

`tsc --noEmit` clean. Full suite: no new failures.

Closes #882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session resizing when the desktop is minimized, hidden in the system tray, screen-locked, or restored.
  * Corrected terminal visibility tracking across window, document, and pane states.
  * Automatically refits active terminals when the application window becomes visible again.
* **Reliability**
  * Improved recovery after reconnecting to terminal sessions and system resume events.
* **Tests**
  * Added comprehensive coverage for window visibility, terminal refitting, event handling, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->