### PR TITLE
test(ci): serialize real-Git reboot demos

### DIFF
--- a/changelog.d/884.md
+++ b/changelog.d/884.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **Reboot-survival demos no longer contend with the parallel unit suite.**
+  The real-Git J1 and J3 checks now run in the serial runtime lane, preventing
+  load-sensitive Windows timeouts while preserving both standalone demo
+  commands without shell execution. (#884)

--- a/scripts/j1-reboot-survival-demo.mjs
+++ b/scripts/j1-reboot-survival-demo.mjs
@@ -21,13 +21,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const SPEC = 'src/daemon/worktask/__tests__/j1-reboot-survival.demo.test.ts';
+const VITEST_CLI = path.join(REPO_ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+const SPEC = 'src/daemon/worktask/__tests__/j1-reboot-survival.demo.runtime.test.ts';
 
 console.log('[j1-demo] 리부트 생존 왕복 시작 — 실 git worktree + 데몬 재시작 replay + fs 검사');
 
+// Invoke the installed CLI through Node so Windows never needs to spawn a
+// .cmd shim and a missing dependency cannot make npx download code.
 const res = spawnSync(
-  'npx',
-  ['vitest', 'run', SPEC],
+  process.execPath,
+  [VITEST_CLI, 'run', SPEC],
   { cwd: REPO_ROOT, stdio: 'inherit', env: process.env },
 );
 

--- a/scripts/j3-fleet-reboot-survival-demo.mjs
+++ b/scripts/j3-fleet-reboot-survival-demo.mjs
@@ -15,17 +15,17 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const SPEC = 'src/daemon/worktask/__tests__/j3-fleet-reboot-survival.demo.test.ts';
+const VITEST_CLI = path.join(REPO_ROOT, 'node_modules', 'vitest', 'vitest.mjs');
+const SPEC = 'src/daemon/worktask/__tests__/j3-fleet-reboot-survival.demo.runtime.test.ts';
 
 console.log('[j3-fleet-demo] 함대 리부트 생존 왕복 시작 — N=4 실 worktree + 산출물 시딩 + 재시작 replay');
 
-// Windows에서 `npx`는 `npx.cmd`라 shell 없이 직접 spawn하면 ENOENT/EINVAL(최신
-// Node의 .cmd 스폰 보안 완화). shell:true로 실행명을 해석시킨다 — 인자는 정적
-// 상수(SPEC)라 셸 인젝션 표면이 없다.
+// Invoke the installed CLI through Node so Windows never needs to spawn a
+// .cmd shim and a missing dependency cannot make npx download code.
 const res = spawnSync(
-  'npx',
-  ['vitest', 'run', SPEC],
-  { cwd: REPO_ROOT, stdio: 'inherit', env: process.env, shell: true },
+  process.execPath,
+  [VITEST_CLI, 'run', SPEC],
+  { cwd: REPO_ROOT, stdio: 'inherit', env: process.env },
 );
 
 if (res.status === 0) {

--- a/src/daemon/worktask/__tests__/j1-reboot-survival.demo.runtime.test.ts
+++ b/src/daemon/worktask/__tests__/j1-reboot-survival.demo.runtime.test.ts
@@ -7,6 +7,8 @@
 //
 // scripts/j1-reboot-survival-demo.mjs가 이 스펙을 구동한다. 여기 통과가 리부트
 // 생존 데모의 판정식이다.
+// This spec shells out to real Git and creates a worktree, so it belongs in
+// the serial runtime lane rather than the parallel unit-test lane.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
@@ -42,7 +44,7 @@ afterEach(() => {
 });
 
 function newLog(): AppendOnlyLog {
-  const log = new AppendOnlyLog({ dir: logDir, fsync: () => {} });
+  const log = new AppendOnlyLog({ dir: logDir, fsync: () => undefined });
   log.open();
   return log;
 }

--- a/src/daemon/worktask/__tests__/j3-fleet-reboot-survival.demo.runtime.test.ts
+++ b/src/daemon/worktask/__tests__/j3-fleet-reboot-survival.demo.runtime.test.ts
@@ -12,6 +12,8 @@
 // 이 테스트의 PASS를 근거로 "워크스페이스 생존"을 주장하지 않는다.
 //
 // scripts/j3-fleet-reboot-survival-demo.mjs가 이 스펙을 구동한다.
+// This spec shells out to real Git and creates four worktrees, so it belongs
+// in the serial runtime lane rather than the parallel unit-test lane.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
@@ -49,7 +51,7 @@ afterEach(() => {
 });
 
 function newLog(): AppendOnlyLog {
-  const log = new AppendOnlyLog({ dir: logDir, fsync: () => {} });
+  const log = new AppendOnlyLog({ dir: logDir, fsync: () => undefined });
   log.open();
   return log;
 }


### PR DESCRIPTION
## Root cause

The [latest `main` cross-platform baseline](https://github.com/openwong2kim/wmux/actions/runs/31704777962) failed only on Windows: `j3-fleet-reboot-survival.demo.test.ts` exceeded Vitest's 5-second timeout, then its cleanup hit `EBUSY` while removing the temporary repository.

The spec is not a unit test. It initializes a real Git repository and creates four real worktrees, but its ordinary `*.test.ts` suffix placed it in `test:parallel` with more than 700 other files. That made its deadline depend on Windows runner load. The J1 demo creates the same OS resources and had the same classification error, even though it did not happen to fail in that run.

The `EBUSY` is secondary: after the timeout, teardown can race worktree activity that Vitest stopped awaiting.

## What changed

- Rename the J1 and J3 specs to `*.demo.runtime.test.ts`. The existing runtime config discovers them and runs files serially; `test:parallel` excludes them. `npm test` still runs both.
- Keep every assertion and the original timeout. This removes cross-test contention instead of hiding it with a larger deadline.
- Update both standalone demo runners for the new paths.
- Launch the installed Vitest CLI through `process.execPath` instead of `npx`. J1 previously could not spawn the Windows `npx.cmd` shim; J3 used `shell: true`. The shared path now uses neither a shell nor an `npx` download fallback.

## Compatibility and security scope

This changes test scheduling and developer-only demo runners; production code and runtime behavior are untouched. The standalone commands are unchanged. They still require the repository's installed dependencies, and now fail locally rather than asking `npx` to fetch a missing package.

No timeout was raised, no assertion was removed, and no shell is involved.

## Verification

Passed locally:

- `npx tsc --noEmit`
- targeted ESLint on both moved specs
- `npm run build:mcp && npm run probe:mcp`
- `npx tsc --noEmit -p relay/tsconfig.json`
- `npm run test:parallel` — 731 files / 11,001 tests passed; J1/J3 absent from discovery
- focused runtime config — J1 + J3, 2/2 passed; both present in discovery
- `node scripts/j1-reboot-survival-demo.mjs`
- `node scripts/j3-fleet-reboot-survival-demo.mjs`
- `node scripts/collect-changelog.mjs --check`
- `git diff --check`

## Known local baseline limits

- The full runtime lane on this Node 24 Windows host has four unrelated existing failures: two ConPTY `AttachConsole failed` timeouts in `shellIntegration.runtime.test.ts` and two async ACL re-hardening mtime assertions in `webRestart.runtime.test.ts`. A control run that explicitly excluded both new J1/J3 specs reproduced the same four failures (166 other tests passed), so the new serial entries are not the cause. CI uses Node 22 and is the cross-platform result of record.
- Repository-wide ESLint remains its documented informational baseline (222 errors / 1,295 warnings across untouched and generated paths). The touched TypeScript files pass targeted ESLint.

No issue is closed by this test-only correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of real-Git reboot-survival checks, particularly on Windows, by running them serially.
  * Updated demo commands to invoke the installed test runner directly, avoiding shell and package-download issues.
  * Refined runtime test logging behavior for more consistent execution.

* **Documentation**
  * Added changelog details explaining the updated test execution and reliability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->