### PR TITLE
fix(a2a): report reply delivery outcome instead of silently suppressing nudges

### DIFF
--- a/changelog.d/887.md
+++ b/changelog.d/887.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- A2A replies no longer fail silently: `a2a_task_send` now returns a `delivery`
+  field (`stored` / `notified` / `reason` / `hint`) that says whether the other
+  party was actually nudged and, if not, why and what to do about it. A reply
+  whose nudge is withheld also emits the task pointer event, so a polling
+  receiver still learns the thread moved.
+
+### Added
+
+- A2A thread round cap: replies past 5 completed round trips are refused with a
+  `cap_reached` error so two agents cannot ping-pong unattended forever.
+- `a2a_discover` responses include `elapsedMs` (measured at the MCP tool entry)
+  to separate server latency from client-side stalls.

--- a/changelog.d/887.md
+++ b/changelog.d/887.md
@@ -8,7 +8,8 @@
 
 ### Added
 
-- A2A thread round cap: replies past 5 completed round trips are refused with a
+- A2A thread round cap: replies past 5 completed round trips — or past a per-side
+  message ceiling that catches one-sided monologues — are refused with a
   `cap_reached` error so two agents cannot ping-pong unattended forever.
 - `a2a_discover` responses include `elapsedMs` (measured at the MCP tool entry)
   to separate server latency from client-side stalls.

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1180,7 +1180,35 @@ server.tool(
   'a2a_discover',
   'List all available workspaces/agents and their names. ALWAYS call this first when the user references a workspace by number or name (e.g. "3번", "Workspace 1") so you know valid targets.',
   {},
-  async () => callRpc('a2a.discover'),
+  async () => {
+    // elapsedMs: measured at the MCP tool entry, i.e. the caller-visible round
+    // trip through pipe + main + renderer. A dogfood report blamed a ~2865s
+    // stall on this call; the server side is bounded by a 5s bridge timeout
+    // (_bridge.ts) and the handler is a pure in-memory map, so any large number
+    // a client observes accrues OUTSIDE this span (its own queueing/harness).
+    // Stamping the span here lets the next report tell those apart.
+    const t0 = Date.now();
+    const res = await callRpc('a2a.discover');
+    const elapsedMs = Date.now() - t0;
+    // callRpc returns the MCP content envelope; the RPC payload is JSON text
+    // inside it. Re-stringify with elapsedMs appended; a non-JSON payload
+    // (error string) passes through untouched.
+    const text = res.content[0]?.text;
+    if (typeof text === 'string') {
+      try {
+        const parsed: unknown = JSON.parse(text);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({ ...(parsed as Record<string, unknown>), elapsedMs }, null, 2),
+            }],
+          };
+        }
+      } catch { /* non-JSON payload — return unmodified */ }
+    }
+    return res;
+  },
 );
 
 // 3. send_message — Primary tool for inter-workspace communication

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1197,7 +1197,9 @@ server.tool(
     if (typeof text === 'string') {
       try {
         const parsed: unknown = JSON.parse(text);
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        // Leave error payloads untouched — appending elapsedMs would mutate the
+        // error object shape callers match on.
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed) && !('error' in parsed)) {
           return {
             content: [{
               type: 'text' as const,

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { PaneLeaf, Surface } from '../../../shared/types';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, type PaneAddress } from '../a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, countRoundTrips, REPLY_ROUND_CAP, REPLY_SUPPRESS_HINTS, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, type PaneAddress } from '../a2aAddressing';
 
 function surface(id: string, ptyId: string, surfaceType: Surface['surfaceType'] = 'terminal'): Surface {
   return { id, ptyId, title: id, shell: '', cwd: '', surfaceType } as Surface;
@@ -209,5 +209,89 @@ describe('resolvePaneRole (S-C2 per-pane history role)', () => {
     const wsOnlyFrom = { from: {}, to: { paneId: 'pane-B' } };
     expect(resolvePaneRole(wsOnlyFrom, addrA)).toBeNull(); // from has no anchor
     expect(resolvePaneRole(wsOnlyFrom, addrB1)).toBe('agent'); // to still matches
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideReplyDelivery — the four reply suppression guards as values
+// ---------------------------------------------------------------------------
+describe('decideReplyDelivery', () => {
+  it('pin_lost wins over everything (a dead pinned pane fails closed)', () => {
+    const d = decideReplyDelivery(true, true, true, undefined, '');
+    expect(d).toEqual({ kind: 'suppress', reason: 'pin_lost' });
+  });
+
+  it('same-ws task without an anchor on the target side → same_ws_no_anchor', () => {
+    const d = decideReplyDelivery(true, false, false, undefined, 'pty-caller');
+    expect(d).toEqual({ kind: 'suppress', reason: 'same_ws_no_anchor' });
+  });
+
+  it('pinned target resolving to the caller own pty → self_loop', () => {
+    const d = decideReplyDelivery(false, true, false, 'pty-A', 'pty-A');
+    expect(d).toEqual({ kind: 'suppress', reason: 'self_loop' });
+  });
+
+  it('same-ws with an unverified caller (no callerPtyId) → unverified_sender', () => {
+    const d = decideReplyDelivery(true, true, false, 'pty-B', '');
+    expect(d).toEqual({ kind: 'suppress', reason: 'unverified_sender' });
+  });
+
+  it('same-ws verified sibling delivers with the explicit pty', () => {
+    const d = decideReplyDelivery(true, true, false, 'pty-B', 'pty-A');
+    expect(d).toEqual({ kind: 'deliver', sameWs: true, explicitPtyId: 'pty-B' });
+  });
+
+  it('cross-ws without an anchor delivers (active-pane fallback preserved — no explicitPtyId)', () => {
+    const d = decideReplyDelivery(false, false, false, undefined, '');
+    expect(d).toEqual({ kind: 'deliver', sameWs: false });
+  });
+
+  it('cross-ws unverified caller still delivers (unverified guard is same-ws only)', () => {
+    const d = decideReplyDelivery(false, true, false, 'pty-B', '');
+    expect(d).toEqual({ kind: 'deliver', sameWs: false, explicitPtyId: 'pty-B' });
+  });
+
+  it('every suppress reason has a hint that names a next action', () => {
+    for (const hint of Object.values(REPLY_SUPPRESS_HINTS)) {
+      expect(hint).toMatch(/a2a_task_query|pane_id/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countRoundTrips — cap arithmetic (1 round trip = one message from EACH side)
+// ---------------------------------------------------------------------------
+describe('countRoundTrips', () => {
+  const msg = (role: 'user' | 'agent') => ({ kind: 'message', role });
+
+  it('empty history → 0', () => {
+    expect(countRoundTrips([])).toBe(0);
+  });
+
+  it('one-sided thread is 0 round trips regardless of length', () => {
+    expect(countRoundTrips([msg('user'), msg('user'), msg('user')])).toBe(0);
+  });
+
+  it('alternating exchange counts min(user, agent)', () => {
+    expect(countRoundTrips([msg('user'), msg('agent'), msg('user'), msg('agent')])).toBe(2);
+  });
+
+  it('double-posts do not inflate the count', () => {
+    expect(countRoundTrips([msg('user'), msg('user'), msg('agent'), msg('agent')])).toBe(2);
+    // min(2,2)=2 — but a single reply to a burst stays 1:
+    expect(countRoundTrips([msg('user'), msg('user'), msg('user'), msg('agent')])).toBe(1);
+  });
+
+  it('non-message history entries are ignored', () => {
+    expect(countRoundTrips([{ kind: 'status-update' }, msg('user'), msg('agent')])).toBe(1);
+  });
+
+  it('cap boundary: 4 round trips pass, 5 hit REPLY_ROUND_CAP', () => {
+    const four = Array.from({ length: 4 }, () => [msg('user'), msg('agent')]).flat();
+    expect(countRoundTrips(four)).toBe(4);
+    expect(countRoundTrips(four) >= REPLY_ROUND_CAP).toBe(false);
+    const five = [...four, msg('user'), msg('agent')];
+    expect(countRoundTrips(five)).toBe(5);
+    expect(countRoundTrips(five) >= REPLY_ROUND_CAP).toBe(true);
   });
 });

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { PaneLeaf, Surface } from '../../../shared/types';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, countRoundTrips, REPLY_ROUND_CAP, REPLY_SUPPRESS_HINTS, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, type PaneAddress } from '../a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, countRoundTrips, maxSideMessages, REPLY_ROUND_CAP, REPLY_SUPPRESS_HINTS, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, type PaneAddress } from '../a2aAddressing';
 
 function surface(id: string, ptyId: string, surfaceType: Surface['surfaceType'] = 'terminal'): Surface {
   return { id, ptyId, title: id, shell: '', cwd: '', surfaceType } as Surface;
@@ -293,5 +293,32 @@ describe('countRoundTrips', () => {
     const five = [...four, msg('user'), msg('agent')];
     expect(countRoundTrips(five)).toBe(5);
     expect(countRoundTrips(five) >= REPLY_ROUND_CAP).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maxSideMessages — the monologue ceiling companion to countRoundTrips
+// ---------------------------------------------------------------------------
+describe('maxSideMessages', () => {
+  const msg = (role: 'user' | 'agent') => ({ kind: 'message', role });
+
+  it('empty history → 0', () => {
+    expect(maxSideMessages([])).toBe(0);
+  });
+
+  it('returns the LARGER side count (a monologue registers where min() stays 0)', () => {
+    const monologue = Array.from({ length: 11 }, () => msg('user'));
+    expect(countRoundTrips(monologue)).toBe(0);      // ping-pong cap never trips...
+    expect(maxSideMessages(monologue)).toBe(11);     // ...but the monologue ceiling does
+  });
+
+  it('ceiling boundary: 2*CAP messages pass, 2*CAP+1 exceed', () => {
+    const atCap = Array.from({ length: REPLY_ROUND_CAP * 2 }, () => msg('agent'));
+    expect(maxSideMessages(atCap) > REPLY_ROUND_CAP * 2).toBe(false);
+    expect(maxSideMessages([...atCap, msg('agent')]) > REPLY_ROUND_CAP * 2).toBe(true);
+  });
+
+  it('non-message entries are ignored', () => {
+    expect(maxSideMessages([{ kind: 'status-update' }, msg('user'), msg('user')])).toBe(2);
   });
 });

--- a/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
@@ -68,15 +68,21 @@ describe('useRpcBridge — pane-level A2A identity wiring', () => {
     expect(block).toMatch(/const suppressPaste = silent \|\| sameWsDecision\.suppressPaste/);
     expect(block).toMatch(/if \(!suppressPaste\)/);
     // S-C2: the same-ws reply is no longer blanket-suppressed — it pins to the
-    // SYMMETRIC from/to anchor and suppresses ONLY on no-anchor or self-loop,
-    // delivering a one-line nudge to a proven sibling (never a full-body paste).
+    // SYMMETRIC from/to anchor and suppresses ONLY per the four guards, which
+    // now live in decideReplyDelivery (a2aAddressing.ts, unit-tested there):
+    // pin_lost / same_ws_no_anchor / self_loop / unverified_sender. The reply
+    // branch must route through that single decision point AND surface its
+    // outcome in the response (delivery.reason + hint) instead of skipping
+    // silently — the silent skip is what the 2026-08-13 dogfood hit.
     expect(block).toMatch(/const sameWsTask = task\.metadata\.from\.workspaceId === task\.metadata\.to\.workspaceId/);
     expect(block).toMatch(/const pinAnchor = replyingToReceiver \? task\.metadata\.to : task\.metadata\.from/);
-    expect(block).toMatch(/const sameWsNoAnchor = sameWsTask && !hasAnchor/);
-    expect(block).toMatch(/const selfLoop = !!explicitPty && !!callerPtyId && explicitPty === callerPtyId/);
-    // an unverified same-ws caller (no senderPtyId) is suppressed: ws-level role
-    // defaults to 'user' and would self-route the nudge to the caller's own pane
-    expect(block).toMatch(/const sameWsUnverified = sameWsTask && !callerPtyId/);
+    expect(block).toMatch(/decideReplyDelivery\(sameWsTask, hasAnchor, pinnedAddressLost, explicitPty, callerPtyId\)/);
+    expect(block).toMatch(/REPLY_SUPPRESS_HINTS\[decision\.reason\]/);
+    // a suppressed reply still emits the task pointer onto the bus (the ONLY
+    // remaining signal to the receiver when the nudge is withheld)
+    expect(block).toMatch(/if \(updatedTask\) emitA2aTaskEvent\(updatedTask, 'updated'\)/);
+    // the round cap refuses further replies BEFORE the store write
+    expect(block).toMatch(/countRoundTrips\(task\.history\) >= REPLY_ROUND_CAP/);
   });
 
   it('a2a.task.send computes the reply role per-pane (S-C2) with a ws-level fallback', () => {

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -292,6 +292,25 @@ export function countRoundTrips(history: ReadonlyArray<{ kind: string; role?: st
   return Math.min(user, agent);
 }
 
+/**
+ * The larger of the two per-side message counts. Companion ceiling to
+ * `countRoundTrips`: min() alone never trips on a MONOLOGUE — an agent
+ * re-replying to a thread the other side ignores stays at 0 round trips
+ * forever while nudging the receiver on every message (review finding). The
+ * reply path refuses once one side exceeds `REPLY_ROUND_CAP * 2` messages,
+ * so a one-sided runaway is bounded even though it never completes a round.
+ */
+export function maxSideMessages(history: ReadonlyArray<{ kind: string; role?: string }>): number {
+  let user = 0;
+  let agent = 0;
+  for (const h of history) {
+    if (h.kind !== 'message') continue;
+    if (h.role === 'user') user++;
+    else if (h.role === 'agent') agent++;
+  }
+  return Math.max(user, agent);
+}
+
 /** Reply round-trip ceiling per thread. When `countRoundTrips` reaches this,
  *  further replies are REFUSED (a2a.task.send returns an error) instead of
  *  silently looping — two agents left alone will politely ping-pong without

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -207,3 +207,96 @@ export function resolvePaneRole(
   if (task.to.paneId && task.to.paneId === callerAddr.paneId) return 'agent';
   return null;
 }
+
+// ---------------------------------------------------------------------------
+// Reply delivery decision (dogfood 2026-08-13 follow-up)
+// ---------------------------------------------------------------------------
+
+/** Why a reply's PTY nudge was withheld. Surfaced verbatim in the
+ *  `delivery.reason` field of the a2a.task.send response so the SENDING agent
+ *  can act on it instead of believing the send reached the other party. */
+export type ReplySuppressReason =
+  | 'pin_lost'            // pinned target pane no longer exists (fail closed, no active-pane fallback)
+  | 'same_ws_no_anchor'   // same-ws task side has no pane anchor → active-pane fallback would risk the #239 self-paste loop
+  | 'self_loop'           // pinned target resolves to the caller's own pty
+  | 'unverified_sender';  // same-ws + no verified senderPtyId → cannot prove the route is not self
+
+export type ReplyDeliveryDecision =
+  | { kind: 'deliver'; sameWs: boolean; explicitPtyId?: string }
+  | { kind: 'suppress'; reason: ReplySuppressReason };
+
+/**
+ * Decide whether a reply's nudge may be delivered, or why it must be withheld.
+ * Extracted verbatim from the reply branch of useRpcBridge (same four guards,
+ * same precedence) so the decision is unit-testable and the suppression reason
+ * is a value, not a silent skip. The 2026-08-13 dogfood sessions hit these
+ * guards blind: the send reported success, the receiver got nothing, and a
+ * human ended up relaying every message by hand. The guards are CORRECT
+ * (they exist so a same-ws route that can't be proven non-self never pastes
+ * into the caller's own prompt) — what was broken was their silence.
+ *
+ * Precedence (first match wins) only affects the REPORTED reason; any single
+ * true guard suppresses, exactly as the original conjunction did.
+ */
+export function decideReplyDelivery(
+  sameWsTask: boolean,
+  hasAnchor: boolean,
+  pinnedAddressLost: boolean,
+  explicitPtyId: string | undefined,
+  callerPtyId: string,
+): ReplyDeliveryDecision {
+  if (pinnedAddressLost) return { kind: 'suppress', reason: 'pin_lost' };
+  if (sameWsTask && !hasAnchor) return { kind: 'suppress', reason: 'same_ws_no_anchor' };
+  if (!!explicitPtyId && !!callerPtyId && explicitPtyId === callerPtyId) {
+    return { kind: 'suppress', reason: 'self_loop' };
+  }
+  if (sameWsTask && !callerPtyId) return { kind: 'suppress', reason: 'unverified_sender' };
+  return { kind: 'deliver', sameWs: sameWsTask, ...(explicitPtyId ? { explicitPtyId } : {}) };
+}
+
+/** Per-reason guidance for the SENDING agent, shipped as `delivery.hint`.
+ *  Every branch names a concrete next action — an honest failure that offers
+ *  no recovery path is just a better-documented dead end. */
+export const REPLY_SUPPRESS_HINTS: Record<ReplySuppressReason, string> = {
+  pin_lost:
+    'The pinned target pane is gone. The reply is stored; the receiver can still poll ' +
+    'a2a_task_query. To nudge a live pane, start a new task addressed with pane_id.',
+  same_ws_no_anchor:
+    'This same-workspace task has no pane anchor on the target side, so a nudge cannot be ' +
+    'routed safely. The reply is stored; the receiver must poll a2a_task_query.',
+  self_loop:
+    'The pinned target resolves to your own pane — no nudge was sent to avoid pasting into ' +
+    'your own prompt. The reply is stored for the other party to poll via a2a_task_query.',
+  unverified_sender:
+    'Your pane identity could not be verified (no senderPtyId reached the server), so a ' +
+    'same-workspace nudge cannot be proven non-self and was withheld. The reply is stored; ' +
+    'the receiver must poll a2a_task_query.',
+};
+
+/**
+ * Count completed round trips in a task thread. Definition (fixed here so the
+ * cap fires identically everywhere): 1 round trip = one message from EACH side,
+ * i.e. `min(#user-role messages, #agent-role messages)`. Consecutive messages
+ * from the same side count once toward that side's total, so a double-post
+ * cannot inflate the round count, and a thread where only one side has ever
+ * spoken is 0 round trips regardless of length.
+ */
+export function countRoundTrips(history: ReadonlyArray<{ kind: string; role?: string }>): number {
+  let user = 0;
+  let agent = 0;
+  for (const h of history) {
+    if (h.kind !== 'message') continue;
+    if (h.role === 'user') user++;
+    else if (h.role === 'agent') agent++;
+  }
+  return Math.min(user, agent);
+}
+
+/** Reply round-trip ceiling per thread. When `countRoundTrips` reaches this,
+ *  further replies are REFUSED (a2a.task.send returns an error) instead of
+ *  silently looping — two agents left alone will politely ping-pong without
+ *  converging, and no state-machine transition can stop them (the reply path
+ *  never consults task status). A refusal is visible to the sending agent AND
+ *  costs nothing to honor: continue by having the human open a fresh task
+ *  that references this one. */
+export const REPLY_ROUND_CAP = 5;

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -29,7 +29,7 @@ import {
 } from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, REPLY_SUPPRESS_HINTS, countRoundTrips, REPLY_ROUND_CAP, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
 import { resolveWorkspaceTarget } from './workspaceTargeting';
 import { findActivePtyId, collectAllPtyIds, buildWorkspaceListEntries } from './workspaceMirrorSnapshot';
 
@@ -1860,6 +1860,22 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
           && task.metadata.from.paneId && callerAddr && paneRole === null) {
         return { error: 'a2a.task.send: caller pane is not a participant of this task' };
       }
+      // Round cap (dogfood 2026-08-13): refuse the reply BEFORE storing it once
+      // the thread has completed REPLY_ROUND_CAP round trips. A status-based cap
+      // was rejected in review — the reply path never consults task.status, and
+      // input-required→working is agent-reachable, so a transition would neither
+      // stop the loop nor stay stopped. A hard refusal in the send response is
+      // visible to the agent that must act on it.
+      if (countRoundTrips(task.history) >= REPLY_ROUND_CAP) {
+        return {
+          error:
+            `a2a.task.send: round cap reached — this thread has completed ${REPLY_ROUND_CAP} ` +
+            'round trips. Escalate to the human: summarize the thread state and, if the ' +
+            'conversation must continue, have a NEW task opened that references this task id.',
+          reason: 'cap_reached',
+          roundTrips: countRoundTrips(task.history),
+        };
+      }
       const role = paneRole ?? (task.metadata.from.workspaceId === workspaceId ? 'user' : 'agent');
       const msg: Message = { kind: 'message', messageId: generateId('msg'), role, parts };
       store.addTaskMessage(taskId, msg);
@@ -1876,11 +1892,25 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       // re-enter "paste into your own prompt". The reply is still persisted +
       // teed onto the bus (pollable via a2a_task_query). Same-ws delivery is a
       // one-line NUDGE only, never a full-body paste into a sibling agent's prompt.
+      // Delivery outcome, reported honestly in the response. `stored` is always
+      // true past this point (addTaskMessage above); `notified` says whether the
+      // OTHER party got any push signal. Before this field existed the response
+      // was a bare success either way — the 2026-08-13 dogfood sessions showed
+      // both agents believing their replies were delivered while every nudge was
+      // being suppressed, leaving a human to relay the whole debate by hand.
+      let delivery: Record<string, unknown> = { stored: true, notified: false, reason: 'silent' };
       if (!silent) {
         const replyingToReceiver = role === 'user';
         const targetWsId = replyingToReceiver ? task.metadata.to.workspaceId : task.metadata.from.workspaceId;
         const targetWs = store.workspaces.find((w) => w.id === targetWsId);
-        if (targetWs) {
+        if (!targetWs) {
+          delivery = {
+            stored: true,
+            notified: false,
+            reason: 'target_workspace_gone',
+            hint: 'The other party\'s workspace no longer exists. The reply is stored on the task.',
+          };
+        } else {
           const senderWs = store.workspaces.find((w) => w.id === workspaceId);
           const senderName = senderWs?.name ?? 'unknown';
           const sameWsTask = task.metadata.from.workspaceId === task.metadata.to.workspaceId;
@@ -1893,32 +1923,44 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
             if ('error' in addr) pinnedAddressLost = true;
             else explicitPty = addr.ptyId;
           }
-          const selfLoop = !!explicitPty && !!callerPtyId && explicitPty === callerPtyId;
-          const sameWsNoAnchor = sameWsTask && !hasAnchor;
-          // Same-ws with an UNVERIFIED caller (no senderPtyId): we cannot tell the
-          // sender pane from the receiver pane, so the ws-level role defaults to
-          // 'user' and would route the nudge to `to` — which is the caller ITSELF
-          // when the receiver is the one replying (self-route), and the selfLoop
-          // guard can't catch it because callerPtyId is empty. Suppress, mirroring
-          // decideSameWsSend's absent-senderPtyId rule. The reply is still
-          // persisted + teed onto the bus (pollable via a2a_task_query).
-          const sameWsUnverified = sameWsTask && !callerPtyId;
-          if (!pinnedAddressLost && !sameWsNoAnchor && !selfLoop && !sameWsUnverified) {
-            if (sameWsTask) {
+          // Four suppression guards, extracted to decideReplyDelivery (pure,
+          // unit-tested) — semantics unchanged, but the reason is now a VALUE
+          // that reaches the sender instead of a silent skip. See the extracted
+          // function for why each guard exists (same-ws self-paste safety).
+          const decision = decideReplyDelivery(sameWsTask, hasAnchor, pinnedAddressLost, explicitPty, callerPtyId);
+          if (decision.kind === 'suppress') {
+            delivery = {
+              stored: true,
+              notified: false,
+              reason: decision.reason,
+              hint: REPLY_SUPPRESS_HINTS[decision.reason],
+            };
+            // Suppressed replies previously emitted NOTHING — no nudge, no bus
+            // event (the "teed onto the bus" comment described the create path,
+            // not this one). Emit the task pointer so a receiver polling
+            // wmux_events_poll still learns the thread moved. Flood-safe: this
+            // fires only on the suppressed branch, which is paced by LLM turns.
+            const updatedTask = store.getTask(taskId);
+            if (updatedTask) emitA2aTaskEvent(updatedTask, 'updated');
+          } else {
+            if (decision.sameWs) {
               // Same-ws sibling: pointer-only nudge (no full-body injection).
               deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
+              delivery = { stored: true, notified: true, mode: 'nudge' };
             } else {
               const liveMeta = deliveryLiveMeta(store.surfaceAgent, explicitPty, targetWs.metadata);
               if (!silentExplicit && isLiveTuiAgent(liveMeta)) {
                 deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
+                delivery = { stored: true, notified: true, mode: 'nudge' };
               } else {
                 deliverPtyNotification(targetWs, senderName, message, explicitPty);
+                delivery = { stored: true, notified: true, mode: 'notification' };
               }
             }
           }
         }
       }
-      return { ok: true, taskId, silent };
+      return { ok: true, taskId, silent, delivery };
     }
 
     // ── New task branch ──
@@ -2041,6 +2083,11 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // still created + teed onto the EventBus below, so a sibling can poll it via
     // a2a_task_query — only the loud prompt injection is withheld.
     const suppressPaste = silent || sameWsDecision.suppressPaste;
+    // Honest delivery outcome for the response (mirrors the reply branch). The
+    // suppressPaste=true-without-silent case is the one that used to lie: a
+    // same-ws send whose caller identity could not be verified was created
+    // silently while the response looked identical to a delivered one.
+    let delivery: Record<string, unknown>;
     if (!suppressPaste) {
       const explicitPty = resolvedAddr?.ptyId;
       // Liveness for the nudge-vs-paste choice must reflect the ADDRESSED pane's
@@ -2048,9 +2095,20 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       const liveMeta = deliveryLiveMeta(store.surfaceAgent, explicitPty, target.metadata);
       if (!silentExplicit && isLiveTuiAgent(liveMeta)) {
         deliverPtyNudge(target, buildA2aNudge(newTaskId, fromName), explicitPty);
+        delivery = { stored: true, notified: true, mode: 'nudge' };
       } else {
         deliverPtyNotification(target, fromName, message, explicitPty);
+        delivery = { stored: true, notified: true, mode: 'notification' };
       }
+    } else if (silent) {
+      delivery = { stored: true, notified: false, reason: 'silent' };
+    } else {
+      delivery = {
+        stored: true,
+        notified: false,
+        reason: 'unverified_sender',
+        hint: REPLY_SUPPRESS_HINTS.unverified_sender,
+      };
     }
 
     // Tee the new task onto the EventBus (created). Read it BACK from the
@@ -2066,7 +2124,7 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // `task`: 확정된 태스크 스냅샷(주소 해석 반영) — main이 데몬 A2aTaskService에
     // 정본 미러-생성(envelope PR4)할 때 쓰고, 파이프 호출자에게 반환하기 전에
     // main이 제거한다(응답 계약 불변).
-    return { ok: true, taskId: newTaskId, silent, toWorkspaceId: target.id, executeApproved: executeRequested, task: createdTask };
+    return { ok: true, taskId: newTaskId, silent, delivery, toWorkspaceId: target.id, executeApproved: executeRequested, task: createdTask };
   }
 
   if (method === 'a2a.task.query') {

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -29,7 +29,7 @@ import {
 } from '../utils/searchEngine';
 import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, REPLY_SUPPRESS_HINTS, countRoundTrips, REPLY_ROUND_CAP, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, REPLY_SUPPRESS_HINTS, countRoundTrips, maxSideMessages, REPLY_ROUND_CAP, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
 import { resolveWorkspaceTarget } from './workspaceTargeting';
 import { findActivePtyId, collectAllPtyIds, buildWorkspaceListEntries } from './workspaceMirrorSnapshot';
 
@@ -319,16 +319,23 @@ export function useRpcBridge(): void {
 // active terminal. Extracted to avoid duplication across send/reply/update.
 // ---------------------------------------------------------------------------
 
+// Returns whether a pty was actually written to. A workspace whose active pane
+// has no terminal (browser surface, empty) resolves no pty and this is a no-op
+// — callers that report a `delivery` outcome MUST use the return value instead
+// of assuming success (review 2-MODEL finding: the unconditional
+// `notified:true` was the same false receipt this PR set out to remove).
 function deliverPtyNotification(
   targetWs: { rootPane: Pane; activePaneId: string; name: string },
   senderName: string,
   message: string,
   explicitPtyId?: string,
-): void {
+): boolean {
   const ptyId = explicitPtyId ?? activePaneTerminalPty(findLeafPanes(targetWs.rootPane), targetWs.activePaneId);
   if (ptyId) {
     submitToPty(ptyId, formatA2aMessage(senderName, targetWs.name, message));
+    return true;
   }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -340,15 +347,18 @@ function deliverPtyNotification(
 // it cannot corrupt a multi-line readline state.
 // ---------------------------------------------------------------------------
 
+// Returns whether a pty was actually written to — see deliverPtyNotification.
 function deliverPtyNudge(
   targetWs: { rootPane: Pane; activePaneId: string },
   nudge: string,
   explicitPtyId?: string,
-): void {
+): boolean {
   const ptyId = explicitPtyId ?? activePaneTerminalPty(findLeafPanes(targetWs.rootPane), targetWs.activePaneId);
   if (ptyId) {
     submitToPty(ptyId, nudge);
+    return true;
   }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -1866,12 +1876,19 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       // input-required→working is agent-reachable, so a transition would neither
       // stop the loop nor stay stopped. A hard refusal in the send response is
       // visible to the agent that must act on it.
-      if (countRoundTrips(task.history) >= REPLY_ROUND_CAP) {
+      // Two ceilings: completed round trips (ping-pong), and per-side message
+      // count (monologue — min() never trips when the other side stays silent,
+      // but every one-sided reply still nudges the receiver).
+      if (
+        countRoundTrips(task.history) >= REPLY_ROUND_CAP ||
+        maxSideMessages(task.history) > REPLY_ROUND_CAP * 2
+      ) {
         return {
           error:
             `a2a.task.send: round cap reached — this thread has completed ${REPLY_ROUND_CAP} ` +
-            'round trips. Escalate to the human: summarize the thread state and, if the ' +
-            'conversation must continue, have a NEW task opened that references this task id.',
+            'round trips (or one side exceeded its message ceiling). Escalate to the human: ' +
+            'summarize the thread state and, if the conversation must continue, have a NEW ' +
+            'task opened that references this task id.',
           reason: 'cap_reached',
           roundTrips: countRoundTrips(task.history),
         };
@@ -1935,30 +1952,47 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
               reason: decision.reason,
               hint: REPLY_SUPPRESS_HINTS[decision.reason],
             };
-            // Suppressed replies previously emitted NOTHING — no nudge, no bus
-            // event (the "teed onto the bus" comment described the create path,
-            // not this one). Emit the task pointer so a receiver polling
-            // wmux_events_poll still learns the thread moved. Flood-safe: this
-            // fires only on the suppressed branch, which is paced by LLM turns.
-            const updatedTask = store.getTask(taskId);
-            if (updatedTask) emitA2aTaskEvent(updatedTask, 'updated');
           } else {
+            // `notified` comes from the delivery helpers' actual outcome — they
+            // resolve a pty at write time and are a no-op when none exists (e.g.
+            // the cross-ws active pane is a browser surface). Assuming success
+            // here would recreate the exact false receipt this change removes.
+            let wrote: boolean;
+            let mode: 'nudge' | 'notification' = 'nudge';
             if (decision.sameWs) {
               // Same-ws sibling: pointer-only nudge (no full-body injection).
-              deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
-              delivery = { stored: true, notified: true, mode: 'nudge' };
+              wrote = deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
             } else {
               const liveMeta = deliveryLiveMeta(store.surfaceAgent, explicitPty, targetWs.metadata);
               if (!silentExplicit && isLiveTuiAgent(liveMeta)) {
-                deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
-                delivery = { stored: true, notified: true, mode: 'nudge' };
+                wrote = deliverPtyNudge(targetWs, buildA2aNudge(taskId, senderName), explicitPty);
               } else {
-                deliverPtyNotification(targetWs, senderName, message, explicitPty);
-                delivery = { stored: true, notified: true, mode: 'notification' };
+                wrote = deliverPtyNotification(targetWs, senderName, message, explicitPty);
+                mode = 'notification';
               }
             }
+            delivery = wrote
+              ? { stored: true, notified: true, mode }
+              : {
+                  stored: true,
+                  notified: false,
+                  reason: 'no_target_pty',
+                  hint:
+                    'The target workspace has no terminal pane to write to (its active pane may ' +
+                    'be a browser surface). The reply is stored; the receiver must poll a2a_task_query.',
+                };
           }
         }
+      }
+      // Any reply that produced NO push signal still tees the task pointer onto
+      // the EventBus, so a receiver polling wmux_events_poll learns the thread
+      // moved. This covers every not-notified outcome — guard suppression,
+      // silent, target workspace gone, and a failed pty write. Delivered
+      // replies deliberately do NOT emit (the nudge already signals; emitting
+      // per delivered message is the flood the create-path comment forbids).
+      if (delivery.notified !== true) {
+        const updatedTask = store.getTask(taskId);
+        if (updatedTask) emitA2aTaskEvent(updatedTask, 'updated');
       }
       return { ok: true, taskId, silent, delivery };
     }
@@ -2093,13 +2127,24 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       // Liveness for the nudge-vs-paste choice must reflect the ADDRESSED pane's
       // agent (a workspace can host >1 agent), not ws-level metadata.
       const liveMeta = deliveryLiveMeta(store.surfaceAgent, explicitPty, target.metadata);
+      let wrote: boolean;
+      let mode: 'nudge' | 'notification' = 'nudge';
       if (!silentExplicit && isLiveTuiAgent(liveMeta)) {
-        deliverPtyNudge(target, buildA2aNudge(newTaskId, fromName), explicitPty);
-        delivery = { stored: true, notified: true, mode: 'nudge' };
+        wrote = deliverPtyNudge(target, buildA2aNudge(newTaskId, fromName), explicitPty);
       } else {
-        deliverPtyNotification(target, fromName, message, explicitPty);
-        delivery = { stored: true, notified: true, mode: 'notification' };
+        wrote = deliverPtyNotification(target, fromName, message, explicitPty);
+        mode = 'notification';
       }
+      delivery = wrote
+        ? { stored: true, notified: true, mode }
+        : {
+            stored: true,
+            notified: false,
+            reason: 'no_target_pty',
+            hint:
+              'The target workspace has no terminal pane to write to (its active pane may ' +
+              'be a browser surface). The task is stored; the receiver must poll a2a_task_query.',
+          };
     } else if (silent) {
       delivery = { stored: true, notified: false, reason: 'silent' };
     } else {


### PR DESCRIPTION
## Problem

The reply path of `a2a.task.send` withholds its PTY nudge behind four safety guards (`pin_lost` / `same_ws_no_anchor` / `self_loop` / `unverified_sender`) but still returned a bare success. A sending agent could not tell a delivered reply from a suppressed one, and the receiver got no signal of any kind (the bus tee only ever covered the create path).

Two 2026-08-13 dogfood sessions (3 agents in one workspace) hit exactly this: every nudge was withheld invisibly and a human ended up hand-relaying an agent-to-agent debate, message by message.

## Changes

- **`decideReplyDelivery`** (new, `a2aAddressing.ts`): the four reply suppression guards extracted verbatim into a pure, unit-tested function — same semantics, same precedence, but the reason is a value instead of a silent skip.
- **`delivery` response field** on both branches of `a2a.task.send`: `{stored, notified, mode? | reason?, hint?}`. Every suppressed path now reports why and what the sender can do about it (per-reason recovery hints).
- **Bus pointer on suppressed replies**: emits the `a2a.task` `'updated'` event so a receiver polling `wmux_events_poll` still learns the thread moved. Fires only on the suppressed branch (LLM-turn paced — no ring flood).
- **Round cap**: replies past 5 completed round trips (`countRoundTrips` = min of per-side message counts) are refused with a `cap_reached` error. Deliberately NOT a status transition: the reply path never consults task status, and `input-required→working` is agent-reachable, so a transition would neither stop a runaway two-agent loop nor stay stopped.
- **`a2a_discover` `elapsedMs`**: stamped at the MCP tool entry. A dogfood report attributed a ~2865s stall to this call; the server span is bounded by the 5s bridge timeout and the handler is a pure in-memory map, so the stall accrued client-side — now the numbers can prove that.

## Explicitly not in this PR

- Loosening any of the four guards (they are correct — the pull-model nudge is the prompt-injection defense line; what was broken was their silence).
- Anchor stamping at delivery time — review showed the reply path has no daemon mirror-update RPC (create-only), and stamping would trade active-pane fallback for fail-closed on pane death in cross-ws. Revisit with observability data.
- Per-message EventBus emission on the happy path (flood-guard decision stands).

## Tests

- `a2aAddressing.test.ts`: +14 cases — all four suppress reasons, deliver shapes (same-ws/cross-ws), hint actionability, round-trip arithmetic incl. the 4→5 cap boundary and double-post non-inflation.
- `useRpcBridge.a2aPaneIdentity.test.ts`: source invariant updated to pin the single decision point, the surfaced `delivery.reason`/hint, the suppressed-reply bus emit, and the pre-store cap check.
- Full A2A suites green (79 tests), `tsc --noEmit` clean, `gen-api-reference` no drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Successful JSON discovery responses now include elapsed time.
  - A2A messages report delivery outcomes, including stored, notified, suppressed, and missing-target states.
  - Added recovery hints when delivery is suppressed.
  - Added protection against self-replies, unverified senders, and missing workspace targets.
  - Limited A2A conversations to five completed reply round trips and per-side message limits.
  - Task-pointer updates are emitted when nudging is withheld.

- **Bug Fixes**
  - Improved cross-workspace reply routing and duplicate-message handling.
  - Task sends now report when notifications are nudged, suppressed, or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->