### PR TITLE
fix(terminal): anchor IME compositions to the cursor's resting cell

### DIFF
--- a/changelog.d/888.md
+++ b/changelog.d/888.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **The IME candidate window now anchors to where you are typing, not where the
+  agent's redraw parked the cursor.** The v3.42.0 fix pinned the candidate list
+  in place for a whole composition, but it pinned it to wherever the terminal
+  cursor happened to sit at the instant the composition started — and while a
+  TUI like Claude Code repaints, the cursor transiently rides along with the
+  redraw. Start typing Chinese, Japanese, or Korean in that instant and the
+  candidate list landed on the status line or the agent's streaming row instead
+  of the input box. wmux now tracks the cell the cursor actually rests on
+  between repaints and anchors compositions there, so the candidate list stays
+  on your caret even when a composition starts mid-redraw. (#874)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1061,14 +1061,20 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Remove the whole diagnostic once #874 is confirmed fixed in the field.
     let imeAnchorLogsLeft = 20;
     const imeAnchor = attachImeAnchor(terminal, {
-      onCompositionDiagnostic: ({ baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy }) => {
+      onCompositionDiagnostic: ({ baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, src, held, restAge, selY, selX }) => {
         if (imeAnchorLogsLeft <= 0) return;
         imeAnchorLogsLeft -= 1;
         // Mirrored into the main-side log file by src/main/index.ts's
-        // console-message listener, so the user can share it.
+        // console-message listener, so the user can share it. The "2" in the
+        // tag marks the resting-cell build so a shared log is unambiguous
+        // about which release produced it. src/held/restAge/sel are the
+        // cause-3 discriminator: src=resting means the composition started
+        // mid-repaint and the anchor used the last resting cell instead of
+        // the instantaneous cursor.
         console.info(
-          `[wmux:ime-anchor] pty=${ptyIdRef.current} compositionstart ybase=${baseY} ydisp=${viewportY} ` +
-          `cursor=(${cursorX},${cursorY}) cellHeight=${cellHeight.toFixed(2)} correction=(${dx.toFixed(1)},${dy.toFixed(1)})` +
+          `[wmux:ime-anchor2] pty=${ptyIdRef.current} compositionstart ybase=${baseY} ydisp=${viewportY} ` +
+          `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src} held=${held.toFixed(0)}ms ` +
+          `restAge=${restAge.toFixed(0)}ms cellHeight=${cellHeight.toFixed(2)} correction=(${dx.toFixed(1)},${dy.toFixed(1)})` +
           (imeAnchorLogsLeft === 0 ? ' (last one, diagnostic capped)' : ''),
         );
       },

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -482,6 +482,33 @@ describe('#874 resting-cell tracker (cause 3, pure)', () => {
     // Mid-burst right after the reset: no resting cell -> instantaneous.
     expect(selectFreezeCell(t, 12, 0, 1106).src).toBe('instant');
   });
+
+  it('rejects a resting cell that has scrolled off the viewport', () => {
+    // Scrolling output (a build log, not an in-place TUI repaint) leaves the
+    // resting cell above ydisp within a frame or two. pointFromCell would clamp
+    // it to row 0 and park the candidate window at the top of the terminal —
+    // worse than the live cursor, which is always on screen.
+    const t = createRestingTracker(1000, 8, 1000);
+    noteCursorMove(t, 3000, 0, 1100); // 1000,8 promoted; buffer has scrolled on
+    const viewport = { top: 2960, rows: 40 }; // rows 2960..2999 are visible
+    const sel = selectFreezeCell(t, 3000, 0, 1105, viewport);
+    expect(sel).toMatchObject({ absRow: 3000, col: 0, src: 'scrolled_out' });
+  });
+
+  it('keeps a resting cell that is still inside the viewport', () => {
+    // The in-place repaint case (ybase unchanged): both cells are on screen, so
+    // the resting cell is still the caret and must win.
+    const t = createRestingTracker(2990, 18, 1000);
+    noteCursorMove(t, 2984, 6, 1100);
+    const sel = selectFreezeCell(t, 2984, 6, 1105, { top: 2960, rows: 40 });
+    expect(sel).toMatchObject({ absRow: 2990, col: 18, src: 'resting' });
+  });
+
+  it('without a viewport the off-screen guard does not fire (arg stays optional)', () => {
+    const t = createRestingTracker(1000, 8, 1000);
+    noteCursorMove(t, 3000, 0, 1100);
+    expect(selectFreezeCell(t, 3000, 0, 1105).src).toBe('resting');
+  });
 });
 
 describe('#874 resting-cell wiring (cause 3)', () => {
@@ -567,6 +594,20 @@ describe('#874 resting-cell wiring (cause 3)', () => {
     setClock(1105);
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     expect(diag.mock.calls[0][0].src).toBe('instant');
+    handle.dispose();
+  });
+
+  it('scrolling output past the resting cell falls back to the live cursor', () => {
+    // The wiring passes the live viewport to the selection, so a resting cell
+    // the output has scrolled away from is rejected instead of being clamped to
+    // the top edge (dogfooded on the dev build with 20k lines of output).
+    const { dom, t, handle, diag, setClock, parkCursorAt } = scenario();
+    setClock(1100);
+    parkCursorAt(49, 113);          // caret cell (30,8) promoted to resting
+    Object.assign(t.state, { viewportY: 45 }); // …and then scrolled out of view
+    setClock(1105);
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'scrolled_out', selY: 49, selX: 113 });
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -17,9 +17,15 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   attachImeAnchor,
   computeImeAnchorCorrection,
+  createRestingTracker,
   isUsableGeometry,
+  noteCursorMove,
   paintedCursorPosition,
   parsePxOrNull,
+  pointFromCell,
+  resetRestingTracker,
+  RESTING_MS,
+  selectFreezeCell,
   type ImeAnchorBufferState,
   type ImeAnchorGeometry,
   type ImeAnchorTerminal,
@@ -159,22 +165,27 @@ function makeTerminal(dom: ReturnType<typeof buildTerminalDom>, rows = 39, cols 
   onRender: FakeEmitter<unknown>;
   onScroll: FakeEmitter<unknown>;
   onResize: FakeEmitter<unknown>;
+  onCursorMove: FakeEmitter<unknown>;
+  onBufferChange: FakeEmitter<unknown>;
   state: ImeAnchorBufferState;
 } {
   const onRender = new FakeEmitter<unknown>();
   const onScroll = new FakeEmitter<unknown>();
   const onResize = new FakeEmitter<unknown>();
+  const onCursorMove = new FakeEmitter<unknown>();
+  const onBufferChange = new FakeEmitter<unknown>();
   const state = buf();
   const terminal: ImeAnchorTerminal = {
     rows, cols,
     textarea: dom.textarea,
     element: dom.root,
-    buffer: { active: state },
+    buffer: { active: state, onBufferChange: onBufferChange.event },
     onRender: onRender.event,
     onScroll: onScroll.event,
     onResize: onResize.event,
+    onCursorMove: onCursorMove.event,
   };
-  return { terminal, onRender, onScroll, onResize, state };
+  return { terminal, onRender, onScroll, onResize, onCursorMove, onBufferChange, state };
 }
 
 describe('#874 attachImeAnchor', () => {
@@ -367,7 +378,7 @@ describe('#874 attachImeAnchor', () => {
 
   it('dispose unsubscribes everything and clears the transform', () => {
     const dom = buildTerminalDom();
-    const { terminal, onRender, onScroll, onResize, state } = makeTerminal(dom);
+    const { terminal, onRender, onScroll, onResize, onCursorMove, onBufferChange, state } = makeTerminal(dom);
     const handle = attachImeAnchor(terminal);
     Object.assign(state, { baseY: 10, viewportY: 5, cursorY: 4, cursorX: 0 });
     dom.textarea.style.top = `${4 * 17.6}px`;
@@ -380,6 +391,8 @@ describe('#874 attachImeAnchor', () => {
     expect(onRender.size).toBe(0);
     expect(onScroll.size).toBe(0);
     expect(onResize.size).toBe(0);
+    expect(onCursorMove.size).toBe(0);
+    expect(onBufferChange.size).toBe(0);
     // A composition after dispose must not resurrect the transform.
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     onRender.fire(undefined);
@@ -391,12 +404,170 @@ describe('#874 attachImeAnchor', () => {
     const textarea = document.createElement('textarea');
     const terminal = {
       rows: 39, cols: 142, textarea, element: root,
-      buffer: { active: buf() },
+      buffer: { active: buf(), onBufferChange: new FakeEmitter<unknown>().event },
       onRender: new FakeEmitter<unknown>().event,
       onScroll: new FakeEmitter<unknown>().event,
       onResize: new FakeEmitter<unknown>().event,
+      onCursorMove: new FakeEmitter<unknown>().event,
     } as ImeAnchorTerminal;
     expect(() => attachImeAnchor(terminal).dispose()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('#874 resting-cell tracker (cause 3, pure)', () => {
+  it('pointFromCell and paintedCursorPosition agree (delegation)', () => {
+    const b = buf({ baseY: 22, viewportY: 14, cursorY: 38, cursorX: 12 });
+    const geom = { ...GEOM, rows: 47 };
+    expect(paintedCursorPosition(b, geom)).toEqual(
+      pointFromCell(b.baseY + b.cursorY, b.cursorX, b, geom),
+    );
+  });
+
+  it('pointFromCell clamps rows into the viewport and a wrap-pending col', () => {
+    const b = buf({ viewportY: 30 });
+    // Above the viewport -> row 0; below -> last row; col === cols -> cols - 1.
+    expect(pointFromCell(2, 0, b, GEOM).top).toBe(0);
+    expect(pointFromCell(200, 0, b, GEOM).top).toBe((GEOM.rows - 1) * GEOM.cellHeight);
+    expect(pointFromCell(30, GEOM.cols, b, GEOM).left).toBe((GEOM.cols - 1) * GEOM.cellWidth);
+  });
+
+  it('a bootstrap-seeded tracker reads as at-rest (no null hole before the first move)', () => {
+    const t = createRestingTracker(30, 8, 1000);
+    const sel = selectFreezeCell(t, 30, 8, 1005);
+    // held < RESTING_MS but there is no resting cell yet — instantaneous wins.
+    expect(sel).toMatchObject({ absRow: 30, col: 8, src: 'instant', restAge: -1 });
+  });
+
+  it('a burst of sub-threshold moves never promotes a resting cell', () => {
+    const t = createRestingTracker(30, 8, 1000);
+    noteCursorMove(t, 49, 113, 1000 + RESTING_MS); // 30,8 held exactly RESTING_MS -> promoted
+    expect(t.hasResting).toBe(true);
+    noteCursorMove(t, 49, 0, 1000 + RESTING_MS + 2);   // 49,113 held 2ms -> not promoted
+    noteCursorMove(t, 50, 0, 1000 + RESTING_MS + 5);   // 49,0 held 3ms -> not promoted
+    expect(t.lastRestingAbsRow).toBe(30);
+    expect(t.lastRestingCol).toBe(8);
+  });
+
+  it('same-cell events are no-ops (the dwell clock keeps running)', () => {
+    const t = createRestingTracker(30, 8, 1000);
+    noteCursorMove(t, 30, 8, 1010);
+    expect(t.currentSince).toBe(1000);
+    // Leaving after a long same-cell run still promotes from the ORIGINAL entry time.
+    noteCursorMove(t, 49, 113, 1100);
+    expect(t.hasResting).toBe(true);
+    expect(t.lastRestingAbsRow).toBe(30);
+  });
+
+  it('selectFreezeCell: at-rest cursor is trusted, mid-burst falls back to the resting cell', () => {
+    const t = createRestingTracker(30, 8, 1000);
+    noteCursorMove(t, 49, 113, 1100); // caret promoted, cursor parked at 49,113
+    // 5ms after the park: mid-burst -> resting cell.
+    const midBurst = selectFreezeCell(t, 49, 113, 1105);
+    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5 });
+    // 100ms after the park: the parked cell is now at rest -> trusted as-is
+    // (the documented cause-3 residual: dwell cannot tell a caret from a parked
+    // cell — the diagnostic fields are the field-log discriminator).
+    const atRest = selectFreezeCell(t, 49, 113, 1200);
+    expect(atRest).toMatchObject({ absRow: 49, col: 113, src: 'instant', held: 100 });
+  });
+
+  it('resetRestingTracker drops the resting cell across a reflow boundary', () => {
+    const t = createRestingTracker(30, 8, 1000);
+    noteCursorMove(t, 49, 113, 1100);
+    expect(t.hasResting).toBe(true);
+    resetRestingTracker(t, 12, 0, 1105);
+    expect(t.hasResting).toBe(false);
+    // Mid-burst right after the reset: no resting cell -> instantaneous.
+    expect(selectFreezeCell(t, 12, 0, 1106).src).toBe('instant');
+  });
+});
+
+describe('#874 resting-cell wiring (cause 3)', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  /** Attach with a controllable clock; park the caret, then burst the cursor away. */
+  function scenario(): {
+    dom: ReturnType<typeof buildTerminalDom>;
+    t: ReturnType<typeof makeTerminal>;
+    handle: { dispose(): void };
+    diag: ReturnType<typeof vi.fn>;
+    setClock: (ms: number) => void;
+    parkCursorAt: (absRow: number, col: number) => void;
+  } {
+    const dom = buildTerminalDom(10, 17.6, 60);
+    const t = makeTerminal(dom, 60);
+    let clock = 1000;
+    const diag = vi.fn();
+    // Caret rests at row 30, col 8 from attach time.
+    Object.assign(t.state, { baseY: 0, viewportY: 0, cursorY: 30, cursorX: 8 });
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      onCompositionDiagnostic: diag,
+    });
+    return {
+      dom, t, handle, diag,
+      setClock: (ms) => { clock = ms; },
+      parkCursorAt: (absRow, col) => {
+        Object.assign(t.state, { cursorY: absRow, cursorX: col });
+        t.onCursorMove.fire(undefined);
+        // Stand in for xterm's own (instantaneous) anchoring of the textarea.
+        dom.textarea.style.top = `${absRow * 17.6}px`;
+        dom.textarea.style.left = `${col * 10}px`;
+      },
+    };
+  }
+
+  it('a composition starting mid-burst anchors to the resting caret, not the parked cursor', () => {
+    const { dom, handle, diag, setClock, parkCursorAt } = scenario();
+    setClock(1100);
+    parkCursorAt(49, 113); // TUI repaint parks the cursor bottom-right
+    setClock(1105);        // 5ms later — inside the burst window
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    // Anchor must land on the caret cell (30, 8): correction = desired - actual.
+    expect(translateOf(dom.helpers)?.dy).toBeCloseTo((30 - 49) * 17.6, 6);
+    expect(translateOf(dom.helpers)?.dx).toBeCloseTo((8 - 113) * 10, 6);
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'resting', held: 5, restAge: 5, selY: 30, selX: 8, cursorY: 49, cursorX: 113,
+    });
+    handle.dispose();
+  });
+
+  it('a composition starting at rest keeps the #875 instantaneous behavior (regression lock)', () => {
+    const { dom, handle, diag, setClock, parkCursorAt } = scenario();
+    setClock(1100);
+    parkCursorAt(30, 8); // no-op move: cursor is already the caret
+    dom.textarea.style.top = `${30 * 17.6}px`;
+    dom.textarea.style.left = '80px';
+    setClock(1200); // held 200ms >= RESTING_MS
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    // Pinned at bottom, cursor at rest: nothing to correct, no transform.
+    expect(dom.helpers.style.transform).toBe('');
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'instant', selY: 30, selX: 8 });
+    handle.dispose();
+  });
+
+  it('resize resets the tracker — no stale resting cell crosses a reflow', () => {
+    const { dom, t, handle, diag, setClock, parkCursorAt } = scenario();
+    setClock(1100);
+    parkCursorAt(49, 113);
+    t.onResize.fire(undefined); // reflow boundary between park and composition
+    setClock(1105);
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0].src).toBe('instant'); // resting cell was dropped
+    handle.dispose();
+  });
+
+  it('an alt-screen switch resets the tracker', () => {
+    const { dom, t, handle, diag, setClock, parkCursorAt } = scenario();
+    setClock(1100);
+    parkCursorAt(49, 113);
+    t.onBufferChange.fire(undefined);
+    setClock(1105);
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0].src).toBe('instant');
+    handle.dispose();
   });
 });
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -26,11 +26,42 @@
  *      the TUI last parked the cursor mid-redraw. Latin input shows no
  *      candidate window, which is why only CJK users see it.
  *
- * Both live in upstream xterm and this repo does not patch node_modules, so the
- * correction is applied downstream: one `transform` on the `.xterm-helpers`
- * container, which holds the textarea and the visible preedit box. xterm keeps
- * writing `style.top` / `style.left` on those children; a transform on their
- * parent composes with that instead of fighting it.
+ * And a third cause lives in the anchor's input rather than its math
+ * (field-verified on v3.42.0 after the first two were fixed): the buffer
+ * cursor sampled at `compositionstart` is not always the input caret. A TUI
+ * like Claude Code repaints its lower region every frame, and while a frame's
+ * escape stream is being parsed the cursor rides along with the writes — it is
+ * only parked back on the caret by the cursor-positioning sequence at the end
+ * of the frame. Frames arrive from the PTY split across chunks, so there are
+ * real JS turns where the cursor sits mid-frame, and a composition starting in
+ * one of them freezes a wrong-but-stable anchor:
+ *
+ *   PTY frame (one TUI repaint, split across N chunks):
+ *
+ *    chunk1        chunk2        chunk3(final: CUP to caret)
+ *    ├─parse─┤gap├─parse─┤gap├─parse─┤───────── rest ─────────┤ next frame
+ *    cursor:  mid-frame    mid-frame  caret     caret (holds)
+ *             (transient)  (transient)
+ *    gap  = inter-chunk, sub-ms to a few ms
+ *    rest = inter-frame, >= ~50 ms streaming, seconds when idle
+ *
+ *    compositionstart in a "gap"  -> samples a transient   <- the bug
+ *    compositionstart in "rest"   -> samples the caret
+ *
+ * The countermeasure is a resting-cell tracker: the anchor freezes to the last
+ * cell the cursor held for at least RESTING_MS when the instantaneous cursor
+ * is inside a move burst. Known limit, accepted deliberately: dwell time
+ * cannot distinguish the caret from any cell the cursor parks on for
+ * >= RESTING_MS, so the compositionstart diagnostic reports which source was
+ * selected and why — the field log is the discriminator before any further
+ * complexity is added.
+ *
+ * All of this lives in upstream xterm and this repo does not patch
+ * node_modules, so the correction is applied downstream: one `transform` on
+ * the `.xterm-helpers` container, which holds the textarea and the visible
+ * preedit box. xterm keeps writing `style.top` / `style.left` on those
+ * children; a transform on their parent composes with that instead of
+ * fighting it.
  *
  *   .xterm-screen  (position: relative, origin for everything below)
  *     +-- .xterm-helpers                 <- transform: translate(dx, dy)  [ours]
@@ -91,7 +122,8 @@ export function isUsableGeometry(geometry: ImeAnchorGeometry): boolean {
 }
 
 /**
- * Where the renderer actually paints the cursor, in screen-local CSS pixels.
+ * Where the renderer would paint a given buffer cell, in screen-local CSS
+ * pixels.
  *
  * The row is clamped into the viewport: once the cursor scrolls out of view
  * xterm stops moving the textarea at all, and an unclamped anchor would send
@@ -99,16 +131,26 @@ export function isUsableGeometry(geometry: ImeAnchorGeometry): boolean {
  * keeps it attached to the terminal, which is the least surprising thing an IME
  * can do when the caret itself is off-screen. The column is clamped to
  * `cols - 1` to match what xterm does (CompositionHelper.ts:221) so a
- * wrap-pending cursor at `cursorX === cols` does not land a cell too far right.
+ * wrap-pending cursor at `col === cols` does not land a cell too far right.
  */
+export function pointFromCell(
+  absRow: number,
+  col: number,
+  buffer: ImeAnchorBufferState,
+  geometry: ImeAnchorGeometry,
+): ImeAnchorPoint {
+  const viewportRow = absRow - buffer.viewportY;
+  const row = Math.min(Math.max(viewportRow, 0), geometry.rows - 1);
+  const clampedCol = Math.min(Math.max(col, 0), geometry.cols - 1);
+  return { left: clampedCol * geometry.cellWidth, top: row * geometry.cellHeight };
+}
+
+/** Where the renderer actually paints the live cursor. */
 export function paintedCursorPosition(
   buffer: ImeAnchorBufferState,
   geometry: ImeAnchorGeometry,
 ): ImeAnchorPoint {
-  const viewportRow = (buffer.baseY + buffer.cursorY) - buffer.viewportY;
-  const row = Math.min(Math.max(viewportRow, 0), geometry.rows - 1);
-  const col = Math.min(Math.max(buffer.cursorX, 0), geometry.cols - 1);
-  return { left: col * geometry.cellWidth, top: row * geometry.cellHeight };
+  return pointFromCell(buffer.baseY + buffer.cursorY, buffer.cursorX, buffer, geometry);
 }
 
 /**
@@ -140,6 +182,111 @@ export function parsePxOrNull(value: string | undefined | null): number | null {
 }
 
 // ---------------------------------------------------------------------------
+// Resting-cell tracker (cause 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * A cell counts as "at rest" once the cursor has held it this long. Inter-chunk
+ * gaps inside one TUI repaint are sub-ms to a few ms; the inter-frame rest is
+ * >= ~50 ms while streaming and seconds when idle — 32 ms sits between the two
+ * populations with roughly 10x margin on both sides.
+ */
+export const RESTING_MS = 32;
+
+/**
+ * Mutable tracker record. The transition functions below mutate it in place —
+ * that is how "pure-function testability" and an allocation-free hot path
+ * coexist: each function is deterministic in (state, args), returns scalars,
+ * and tests simply construct a fresh record per case.
+ */
+export interface RestingTrackerState {
+  /** Cell the cursor is in right now (absolute row = ybase + buffer.y). */
+  currentAbsRow: number;
+  currentCol: number;
+  /** Clock reading when the current cell was entered. */
+  currentSince: number;
+  /** Last cell that was held for >= RESTING_MS before the cursor left it. */
+  lastRestingAbsRow: number;
+  lastRestingCol: number;
+  /** Clock reading when the resting cell was promoted. */
+  lastRestingAt: number;
+  hasResting: boolean;
+}
+
+/**
+ * Seed the tracker from the live cursor. Seeding (rather than starting empty)
+ * means an idle caret that never moves still reads as "at rest", so the
+ * pre-first-move window has no hole where the selection could do nothing.
+ */
+export function createRestingTracker(absRow: number, col: number, now: number): RestingTrackerState {
+  return {
+    currentAbsRow: absRow,
+    currentCol: col,
+    currentSince: now,
+    lastRestingAbsRow: 0,
+    lastRestingCol: 0,
+    lastRestingAt: 0,
+    hasResting: false,
+  };
+}
+
+/** Record a cursor movement. Promotes the cell being left if it had rested. */
+export function noteCursorMove(state: RestingTrackerState, absRow: number, col: number, now: number): void {
+  if (absRow === state.currentAbsRow && col === state.currentCol) return;
+  if (now - state.currentSince >= RESTING_MS) {
+    state.lastRestingAbsRow = state.currentAbsRow;
+    state.lastRestingCol = state.currentCol;
+    state.lastRestingAt = now;
+    state.hasResting = true;
+  }
+  state.currentAbsRow = absRow;
+  state.currentCol = col;
+  state.currentSince = now;
+}
+
+/**
+ * Invalidate everything and re-seed. Resize reflow and buffer switches
+ * (alt-screen) change what an absolute row means, so a resting cell recorded
+ * before either event must never be selected after it.
+ */
+export function resetRestingTracker(state: RestingTrackerState, absRow: number, col: number, now: number): void {
+  state.currentAbsRow = absRow;
+  state.currentCol = col;
+  state.currentSince = now;
+  state.hasResting = false;
+}
+
+export interface FreezeCellSelection {
+  absRow: number;
+  col: number;
+  src: 'instant' | 'resting';
+  /** How long the instantaneous cell had been held when selection ran. */
+  held: number;
+  /** Age of the resting cell at selection time; -1 when none exists. */
+  restAge: number;
+}
+
+/**
+ * Pick the cell the composition should anchor to. A cursor that has held its
+ * cell for RESTING_MS is at rest — trust it. A cursor that moved more recently
+ * is mid-repaint, so fall back to the last cell that did rest. With no resting
+ * cell recorded (fresh tracker), the instantaneous cursor is all there is.
+ */
+export function selectFreezeCell(
+  state: RestingTrackerState,
+  instAbsRow: number,
+  instCol: number,
+  now: number,
+): FreezeCellSelection {
+  const held = now - state.currentSince;
+  const restAge = state.hasResting ? now - state.lastRestingAt : -1;
+  if (held >= RESTING_MS || !state.hasResting) {
+    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge };
+  }
+  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge };
+}
+
+// ---------------------------------------------------------------------------
 // Runtime wiring
 // ---------------------------------------------------------------------------
 
@@ -157,10 +304,15 @@ export interface ImeAnchorTerminal {
   readonly cols: number;
   readonly textarea: HTMLTextAreaElement | undefined;
   readonly element: HTMLElement | undefined;
-  readonly buffer: { active: ImeAnchorBufferState };
+  readonly buffer: {
+    active: ImeAnchorBufferState;
+    /** Fires on normal <-> alt buffer switches. */
+    onBufferChange: EventEmitterLike<unknown>;
+  };
   onRender: EventEmitterLike<unknown>;
   onScroll: EventEmitterLike<unknown>;
   onResize: EventEmitterLike<unknown>;
+  onCursorMove: EventEmitterLike<unknown>;
 }
 
 export interface ImeAnchorOptions {
@@ -177,7 +329,16 @@ export interface ImeAnchorOptions {
     cellHeight: number;
     dx: number;
     dy: number;
+    /** Which cell the anchor froze to (cause 3 discriminator). */
+    src: 'instant' | 'resting';
+    held: number;
+    restAge: number;
+    /** Selected cell, ybase-relative like cursorY/cursorX. */
+    selY: number;
+    selX: number;
   }) => void;
+  /** Clock override for tests. Defaults to performance.now. */
+  now?: () => number;
 }
 
 const NO_OP: Disposable = { dispose: () => undefined };
@@ -192,6 +353,8 @@ export function attachImeAnchor(
   if (!textarea || !screen || !helpers) {
     return NO_OP;
   }
+
+  const now = options.now ?? ((): number => performance.now());
 
   // xterm's own cell height, learned from the `style.height` it writes onto the
   // textarea in _syncTextArea. Deriving it from clientHeight instead leaves a
@@ -236,6 +399,13 @@ export function attachImeAnchor(
   // with the rest of the geometry.
   let helpersOrigin: ImeAnchorPoint = readHelpersOrigin();
 
+  const bufferState = (): ImeAnchorBufferState => terminal.buffer.active;
+  const tracker = createRestingTracker(
+    bufferState().baseY + bufferState().cursorY,
+    bufferState().cursorX,
+    now(),
+  );
+
   let frozen: ImeAnchorPoint | null = null;
   let lastDx = 0;
   let lastDy = 0;
@@ -277,28 +447,40 @@ export function attachImeAnchor(
     // `left: -9999em`). Nothing to correct against, and forcing a transform
     // now would only move the off-screen parking spot around.
     if (!actual) return null;
-    const desired = frozen ?? paintedCursorPosition(terminal.buffer.active, geometry);
+    const desired = frozen ?? paintedCursorPosition(bufferState(), geometry);
     const correction = computeImeAnchorCorrection(desired, actual);
     apply(correction.dx, correction.dy);
     return correction;
   };
 
+  const resetTracker = (): void => {
+    const b = bufferState();
+    resetRestingTracker(tracker, b.baseY + b.cursorY, b.cursorX, now());
+  };
+
   const onRefreshGeometry = (): void => {
     geometry = readGeometry();
     helpersOrigin = readHelpersOrigin();
+    // Resize reflow re-wraps the buffer — absolute rows recorded before it no
+    // longer name the same content, so the resting cell must not survive.
+    resetTracker();
     sync();
   };
 
   const onCompositionStart = (): void => {
     // Pin the anchor for the whole composition. The buffer cursor keeps moving
     // while the agent streams, but the candidate window belongs where the user
-    // started typing, not wherever the TUI's redraw last left the cursor.
+    // started typing, not wherever the TUI's redraw last left the cursor. The
+    // cell it pins to is the resting-tracker selection: the instantaneous
+    // cursor when it is at rest, the last resting cell when the composition
+    // starts inside a repaint burst (cause 3).
+    const b = bufferState();
+    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now());
     frozen = isUsableGeometry(geometry)
-      ? paintedCursorPosition(terminal.buffer.active, geometry)
+      ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;
     const correction = sync();
     if (options.onCompositionDiagnostic) {
-      const b = terminal.buffer.active;
       options.onCompositionDiagnostic({
         baseY: b.baseY,
         viewportY: b.viewportY,
@@ -307,6 +489,11 @@ export function attachImeAnchor(
         cellHeight: geometry.cellHeight,
         dx: correction?.dx ?? 0,
         dy: correction?.dy ?? 0,
+        src: sel.src,
+        held: sel.held,
+        restAge: sel.restAge,
+        selY: sel.absRow - b.baseY,
+        selX: sel.col,
       });
     }
   };
@@ -335,6 +522,14 @@ export function attachImeAnchor(
   // #874 — so this is where the scrolled-viewport correction actually lands.
   const scrollSub = terminal.onScroll(() => sync());
   const resizeSub = terminal.onResize(onRefreshGeometry);
+  // Coalesced per parse batch by xterm; the handler is a compare plus a few
+  // number writes, so the streaming hot path stays cold.
+  const cursorSub = terminal.onCursorMove(() => {
+    const b = bufferState();
+    noteCursorMove(tracker, b.baseY + b.cursorY, b.cursorX, now());
+  });
+  // Normal <-> alt buffer switches change what an absolute row means.
+  const bufferSub = terminal.buffer.onBufferChange(resetTracker);
 
   textarea.addEventListener('compositionstart', onCompositionStart);
   textarea.addEventListener('compositionupdate', onCompositionUpdate);
@@ -347,6 +542,8 @@ export function attachImeAnchor(
       renderSub.dispose();
       scrollSub.dispose();
       resizeSub.dispose();
+      cursorSub.dispose();
+      bufferSub.dispose();
       textarea.removeEventListener('compositionstart', onCompositionStart);
       textarea.removeEventListener('compositionupdate', onCompositionUpdate);
       textarea.removeEventListener('compositionend', onCompositionEnd);

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -256,10 +256,15 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
   state.hasResting = false;
 }
 
+/** Where the freeze cell came from. `scrolled_out` is `instant` chosen because
+ *  the resting cell had left the viewport — kept distinct so a field log can
+ *  tell that rejection apart from a cursor that was simply at rest. */
+export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out';
+
 export interface FreezeCellSelection {
   absRow: number;
   col: number;
-  src: 'instant' | 'resting';
+  src: FreezeCellSource;
   /** How long the instantaneous cell had been held when selection ran. */
   held: number;
   /** Age of the resting cell at selection time; -1 when none exists. */
@@ -271,17 +276,33 @@ export interface FreezeCellSelection {
  * cell for RESTING_MS is at rest — trust it. A cursor that moved more recently
  * is mid-repaint, so fall back to the last cell that did rest. With no resting
  * cell recorded (fresh tracker), the instantaneous cursor is all there is.
+ *
+ * `viewport` guards the one case where the resting cell is the WORSE of the
+ * two. A resting cell is by definition a past cell, so output that scrolls the
+ * buffer (a build log, not an in-place TUI repaint) pushes it off the top of
+ * the screen within a frame or two. `pointFromCell` then clamps that row into
+ * view and parks the candidate window at the very top of the terminal — a
+ * bigger miss than the live cursor, and one #875 could not produce because it
+ * only ever read the live cursor, which is always on screen. Verified on the
+ * dev build: 20k lines of scrolling output selected resting cells 1000+ rows
+ * above `ydisp`, every one correcting to the top edge. Off-screen resting
+ * cells are therefore rejected rather than trusted.
  */
 export function selectFreezeCell(
   state: RestingTrackerState,
   instAbsRow: number,
   instCol: number,
   now: number,
+  viewport?: { top: number; rows: number },
 ): FreezeCellSelection {
   const held = now - state.currentSince;
   const restAge = state.hasResting ? now - state.lastRestingAt : -1;
   if (held >= RESTING_MS || !state.hasResting) {
     return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge };
+  }
+  if (viewport && (state.lastRestingAbsRow < viewport.top
+    || state.lastRestingAbsRow >= viewport.top + viewport.rows)) {
+    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge };
   }
   return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge };
 }
@@ -330,7 +351,7 @@ export interface ImeAnchorOptions {
     dx: number;
     dy: number;
     /** Which cell the anchor froze to (cause 3 discriminator). */
-    src: 'instant' | 'resting';
+    src: FreezeCellSource;
     held: number;
     restAge: number;
     /** Selected cell, ybase-relative like cursorY/cursorX. */
@@ -475,7 +496,10 @@ export function attachImeAnchor(
     // cursor when it is at rest, the last resting cell when the composition
     // starts inside a repaint burst (cause 3).
     const b = bufferState();
-    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now());
+    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now(), {
+      top: b.viewportY,
+      rows: geometry.rows,
+    });
     frozen = isUsableGeometry(geometry)
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;


### PR DESCRIPTION
Follow-up to #875 for #874, driven by cnxiekun's v3.42.0 field verification (https://github.com/openwong2kim/wmux/pull/875#issuecomment — log with 20 `[wmux:ime-anchor]` records + 6 screenshots).

## The third cause

The buffer cursor sampled at `compositionstart` is not always the input caret. Claude Code (Ink) repaints its lower region every frame; while a frame's escape stream is parsed, the cursor rides along with the writes and is only parked back on the caret at the end of the frame. Frames arrive split across PTY chunks, so a composition can start in a JS turn where the cursor sits mid-frame — and the #875 freeze then holds that transient stable for the whole composition.

The reporter's records show it plainly, with `ybase == ydisp` and `correction=(0,0)` in every one:

| Records | Reading |
|---|---|
| `(6,42) … (32,42)` | x advancing along row 42 — the real caret; these anchored correctly |
| `(53,49) (113,49) (113,44)` | cursor parked where the last write ended: status-line bottom-right when idle, the streaming row while working — matching the three misplacement screenshots one-to-one |

`correction=(0,0)` is consistent: the #875 correction fixes *where a cell is painted*, not *which cell is the caret*.

## The fix

Freeze the anchor to the cursor's **resting cell**. A tracker fed by `onCursorMove` records the last cell the cursor held for ≥ 32 ms (inter-chunk gaps inside one repaint are sub-ms to a few ms; inter-frame rest is ≥ ~50 ms — ~10x margin both ways). A composition starting mid-burst anchors to that resting cell; a cursor at rest is trusted as-is, keeping the #875 behavior identical in the common case.

- Tracker is seeded from the live cursor at attach (no pre-first-move hole) and resets on resize and alt-screen switches, where reflow changes what an absolute row means.
- The frozen anchor stays a pixel point exactly as in #875 — only the source-cell selection changed.
- The viewport/col clamp now lives in one place (`pointFromCell`; `paintedCursorPosition` delegates).

**Known limit, accepted deliberately:** dwell time cannot distinguish the caret from any cell the cursor parks on for ≥ 32 ms. The compositionstart diagnostic (retagged `[wmux:ime-anchor2]`) now reports `src=instant|resting` plus `held`/`restAge`/`sel`, so a field log discriminates that residual case before any further complexity is added. If misplacement persists with `src=instant` and a large `held`, the next iteration is revisit-frequency tracking — gated on that evidence, not shipped speculatively.

## Tests

36 in the module suite (all green; terminal + hooks suites 858/858, typecheck clean):

- Pure tracker state machine: burst never promotes, ≥ 32 ms promotes on leave, same-cell no-ops keep the dwell clock, reset drops the resting cell, selection semantics incl. exact `held`/`restAge`.
- Wiring with an injected clock: mid-burst composition anchors to the resting caret, not the parked cursor; at-rest composition is a byte-identical #875 regression lock (no transform pinned-at-bottom); resize and alt-screen resets; dispose unsubscribes the two new listeners.
- Existing #875 suite and the upstream tripwire untouched.

Not `Closes #874` — that stays open until the reporter confirms on a release build, same as the #875 round.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CJK IME candidate-window placement by anchoring it to the cursor’s stable cell, preventing misplacement on status or streaming rows.
  - Improved behavior during cursor movement, screen resizing, buffer changes, alternate-screen transitions, and off-screen cursor positions.

- **Tests**
  - Added comprehensive coverage for IME anchoring, viewport scrolling, reset behavior, event handling, and resource cleanup.

- **Documentation**
  - Added a changelog entry describing the IME placement fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->