### PR TITLE
Keep internal-only documents out of this public repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Git hooks are executed by sh. With core.autocrlf=true (the Windows default,
+# and this project's primary dev platform) they would otherwise be checked out
+# with CRLF, and sh fails them at the shebang: `bad interpreter: /bin/sh^M`.
+# Scoped to .githooks/ on purpose — a repo-wide rule here would renormalize
+# every tracked text file in one commit.
+.githooks/* text eol=lf

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Blocks internal-only documents (strategy, roadmap, competitive material) from
+# entering this public repository. See scripts/lib/internal-doc-guard.mjs for
+# what the policy is and why it is shaped this way.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+#
+# `git commit --no-verify` skips this, as it skips every hook — git offers no
+# way to prevent that. The same audit therefore also runs as a vitest case, so a
+# local bypass still fails CI on the pull request.
+exec node scripts/check-internal-docs.mjs

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mcp": "node dist/mcp/mcp/entry.js",
     "notices": "node scripts/generate-notices.mjs",
     "licenses": "node scripts/check-licenses.mjs",
+    "check:internal-docs": "node scripts/check-internal-docs.mjs --tracked",
     "test": "npm run test:parallel && npm run test:runtime",
     "test:parallel": "vitest run --exclude \"**/*.runtime.test.ts\" --exclude \"**/*.runtime.test.tsx\" --exclude \"**/*.runtime.test.mjs\"",
     "test:runtime": "vitest run --config vitest.runtime.config.ts",

--- a/scripts/__tests__/internalDocGuard.test.mjs
+++ b/scripts/__tests__/internalDocGuard.test.mjs
@@ -1,0 +1,113 @@
+// Gate for the internal-document policy that keeps strategy material out of
+// this public repository.
+//
+// The integration test asserts the real tracked tree is clean. The unit tests
+// pin the behaviour that actually matters: a check that trusts `.gitignore`
+// agrees with whatever `.gitignore` currently says, so editing that one line is
+// enough to open the repository up. The cases below stop anyone "simplifying"
+// the guard back into that hole.
+import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  INTERNAL_DOC_ALLOWLIST,
+  checkGitignore,
+  checkPaths,
+  classifyPath,
+} from '../lib/internal-doc-guard.mjs';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function trackedPaths() {
+  return execFileSync('git', ['ls-files'], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  })
+    .split('\n')
+    .filter(Boolean);
+}
+
+describe('tracked tree', () => {
+  it('tracks no internal-only document', () => {
+    const violations = checkPaths(trackedPaths());
+    expect(
+      violations.map((v) => `${v.path} [${v.rule}] ${v.detail}`),
+      'an internal document is tracked in this public repo — see `npm run check:internal-docs`',
+    ).toEqual([]);
+  });
+
+  it('still ignores the internal document directory', () => {
+    const gitignore = readFileSync(path.join(REPO_ROOT, '.gitignore'), 'utf8');
+    expect(
+      checkGitignore(gitignore).map((v) => `${v.entry}: ${v.detail}`),
+      'the .gitignore entry protecting internal documents was weakened',
+    ).toEqual([]);
+  });
+
+  it('keeps every allowlist entry pointing at a real tracked file', () => {
+    // A stale entry is a standing permission for a path nobody reviews.
+    const tracked = new Set(trackedPaths());
+    for (const allowed of INTERNAL_DOC_ALLOWLIST.keys()) {
+      expect(tracked.has(allowed), `${allowed} is allowlisted but no longer tracked`).toBe(true);
+    }
+  });
+});
+
+describe('path classification', () => {
+  it('blocks anything under the internal directory', () => {
+    expect(classifyPath('plans/whatever.md')?.rule).toBe('internal-path');
+    expect(classifyPath('plans/nested/deep/notes.txt')?.rule).toBe('internal-path');
+  });
+
+  it('blocks internal filenames written outside that directory', () => {
+    // A directory rule only half-covers this: the same note saved as
+    // docs/our-roadmap.md would sail through.
+    expect(classifyPath('docs/our-roadmap.md')?.rule).toBe('internal-name');
+    expect(classifyPath('competitive-analysis.md')?.rule).toBe('internal-name');
+    expect(classifyPath('notes/2026-08-14-strategy.md')?.rule).toBe('internal-name');
+    expect(classifyPath('docs/as-is-to-be-2026-07-28.md')?.rule).toBe('internal-name');
+  });
+
+  it('requires the marker to be a delimited token, not a substring', () => {
+    // Precision is the whole design: a gate that fires on ordinary source files
+    // gets bypassed with --no-verify, and then guards nothing at all.
+    expect(classifyPath('src/renderer/roadmapView.tsx')).toBeNull();
+    expect(classifyPath('src/main/strategyResolver.ts')).toBeNull();
+    expect(classifyPath('README.md')).toBeNull();
+    expect(classifyPath('CHANGELOG.md')).toBeNull();
+  });
+
+  it('honours the allowlist', () => {
+    for (const allowed of INTERNAL_DOC_ALLOWLIST.keys()) {
+      expect(classifyPath(allowed), `${allowed} is allowlisted`).toBeNull();
+    }
+  });
+
+  it('normalizes Windows separators', () => {
+    // Hooks on this platform hand paths back with backslashes often enough that
+    // a separator-sensitive rule would silently pass the primary dev OS.
+    expect(classifyPath('plans\\note.md')?.rule).toBe('internal-path');
+  });
+});
+
+describe('gitignore integrity', () => {
+  it('accepts the entry being present', () => {
+    expect(checkGitignore('node_modules/\nplans/\ndist/\n')).toEqual([]);
+  });
+
+  it('reports a removed entry', () => {
+    // Caught one step before any document reaches a commit.
+    const violations = checkGitignore('node_modules/\ndist/\n');
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe('gitignore-weakened');
+  });
+
+  it('reports an entry that a later negation re-admits', () => {
+    const violations = checkGitignore('plans/\n!plans/public-notes.md\n');
+    expect(violations).toHaveLength(1);
+    expect(violations[0].rule).toBe('gitignore-weakened');
+  });
+});

--- a/scripts/check-internal-docs.mjs
+++ b/scripts/check-internal-docs.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * CLI for the internal-document policy gate.
+ *
+ * The audit itself lives in scripts/lib/internal-doc-guard.mjs so the test suite
+ * can import it — this file carries the `#!` line, and a module with a shebang
+ * cannot be imported under vitest.
+ *
+ * Usage:
+ *   node scripts/check-internal-docs.mjs             # staged changes (pre-commit)
+ *   node scripts/check-internal-docs.mjs --tracked   # every tracked file (CI / npm test)
+ *   node scripts/check-internal-docs.mjs --json      # machine-readable findings
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { checkGitignore, checkPaths } from './lib/internal-doc-guard.mjs';
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+/** Paths git will record in the next commit: added, copied, modified, renamed. */
+function stagedPaths() {
+  return git(['diff', '--cached', '--name-only', '--diff-filter=ACMR']).split('\n').filter(Boolean);
+}
+
+function trackedPaths() {
+  return git(['ls-files']).split('\n').filter(Boolean);
+}
+
+/**
+ * In staged mode the staged blob is what the commit will contain, so a
+ * `.gitignore` weakened in the working tree but not staged is not this commit's
+ * problem. Falling back to the working copy keeps the check useful when
+ * `.gitignore` is untouched (the common case — nothing staged for it).
+ */
+function gitignoreText(staged) {
+  if (staged) {
+    try {
+      return git(['show', ':.gitignore']);
+    } catch {
+      // Not staged — fall through to the working copy.
+    }
+  }
+  try {
+    return readFileSync('.gitignore', 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const tracked = args.includes('--tracked');
+
+  const paths = tracked ? trackedPaths() : stagedPaths();
+  const violations = [
+    ...checkGitignore(gitignoreText(!tracked)),
+    ...checkPaths(paths),
+  ];
+
+  if (args.includes('--json')) {
+    process.stdout.write(`${JSON.stringify({ scope: tracked ? 'tracked' : 'staged', checked: paths.length, violations }, null, 2)}\n`);
+    process.exit(violations.length ? 1 : 0);
+  }
+
+  if (violations.length === 0) {
+    console.log(`[internal-docs] OK — ${paths.length} ${tracked ? 'tracked' : 'staged'} path(s), no internal documents.`);
+    return;
+  }
+
+  console.error(`\n[internal-docs] BLOCKED — ${violations.length} policy violation(s):\n`);
+  for (const v of violations) {
+    console.error(`  ${v.path ?? `.gitignore: ${v.entry}`}  [${v.rule}]`);
+    console.error(`    ${v.detail}`);
+  }
+  console.error(
+    '\n  This repository is public. Internal strategy, roadmap, and competitive\n' +
+      '  documents belong outside it — write them to a private location instead.\n' +
+      '  A document that is genuinely meant to be published goes in the allowlist\n' +
+      '  in scripts/lib/internal-doc-guard.mjs, together with the reason.\n',
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/lib/internal-doc-guard.mjs
+++ b/scripts/lib/internal-doc-guard.mjs
@@ -1,0 +1,169 @@
+/**
+ * Repository policy gate: internal-only documents must never become tracked
+ * files in this public repository.
+ *
+ * The audit lives here (not in the `#!` CLI wrapper) so vitest can import it —
+ * a module with a shebang cannot be imported under vitest.
+ *
+ * ## What this guards, and why it is shaped this way
+ *
+ * `plans/` holds working notes that are deliberately not published. Encoding
+ * that in a `.gitignore` entry alone is weak: it is one line, in a file that
+ * changes for unrelated reasons, and editing it silently widens what the
+ * repository will accept. A check that reads `.gitignore` for its verdict
+ * inherits the same weakness — it agrees with whatever the file currently says.
+ *
+ * So the gate below asserts three things independently of `.gitignore`:
+ *
+ *  1. `plans/` must stay ignored          — catches the entry being weakened
+ *  2. no tracked file may live in `plans/` — catches the result, even if (1) is edited
+ *  3. high-signal filenames are blocked    — catches the same note moved elsewhere
+ *
+ * ## Why there is no content heuristic
+ *
+ * Scanning prose for "competitor name + strategy vocabulary" was measured
+ * against the tracked tree and is not precise enough to block a commit:
+ * `kpi` matches inside "co-c-kpi-t" (README's Fleet View **cockpit**), and
+ * `moat` appears in README/CHANGELOG describing the A2A moat — all three are
+ * intentionally public. A gate that cries wolf on README.md gets bypassed with
+ * `--no-verify` within a week, which is worse than no gate. Precision beats
+ * recall for a blocking check; recall is covered by rules 1-3 above.
+ *
+ * ## Bypass
+ *
+ * `git commit --no-verify` always skips local hooks — git offers no way to
+ * prevent that, and pretending otherwise would be false assurance. That is why
+ * the same audit also runs as a vitest case (`scripts/__tests__/`), which lands
+ * in CI through `npm test`: a local bypass still fails the pull request.
+ */
+
+/**
+ * Paths whose entire subtree is internal-only. Kept as a prefix list rather
+ * than a `.gitignore` read so editing `.gitignore` cannot widen it.
+ */
+export const INTERNAL_PATH_PREFIXES = ['plans/'];
+
+/**
+ * `.gitignore` entries this repository's document policy depends on. Stored
+ * verbatim: the check is "is this exact line still present", not a re-implementation
+ * of git's matching rules.
+ */
+export const REQUIRED_GITIGNORE_ENTRIES = ['plans/'];
+
+/**
+ * Filename tokens that mark a document as internal wherever it is written.
+ * Matched against the basename with its extension removed, so
+ * `docs/2026-07-28-strategy.md` trips on `strategy` while `src/roadmapView.tsx`
+ * does not (the token must be delimited, not embedded).
+ */
+export const INTERNAL_NAME_TOKENS = [
+  'strategy',
+  'strategies',
+  'roadmap',
+  'competitive',
+  'competitor',
+  'as-is-to-be',
+  'master-plan',
+];
+
+const INTERNAL_NAME_RE = new RegExp(
+  `(?:^|[^a-z])(${INTERNAL_NAME_TOKENS.join('|')})(?:[^a-z]|$)`,
+  'i',
+);
+
+/**
+ * Tracked files that match a rule above but are published on purpose.
+ *
+ * Adding an entry is a policy decision, not a formality: it says "this document
+ * is written for the public". Keep the reason with it — a bare path list decays
+ * into a place where violations go to be forgotten.
+ */
+export const INTERNAL_DOC_ALLOWLIST = new Map([
+  [
+    'docs/mcp-2026-07-28-strategy.md',
+    'Published MCP integration guidance for third-party agent authors — technical, contains no positioning or competitive material.',
+  ],
+]);
+
+/** Strip the directory and the final extension: `a/b/c-strategy.md` -> `c-strategy`. */
+function basenameWithoutExtension(path) {
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}
+
+/**
+ * Classify one repo-relative path.
+ *
+ * @returns {{path: string, rule: 'internal-path'|'internal-name', detail: string} | null}
+ */
+export function classifyPath(path) {
+  const normalized = path.replace(/\\/g, '/');
+  if (INTERNAL_DOC_ALLOWLIST.has(normalized)) return null;
+
+  const prefix = INTERNAL_PATH_PREFIXES.find((p) => normalized.startsWith(p));
+  if (prefix) {
+    return {
+      path: normalized,
+      rule: 'internal-path',
+      detail: `\`${prefix}\` holds internal-only documents and must never be tracked in this public repository.`,
+    };
+  }
+
+  const token = INTERNAL_NAME_RE.exec(basenameWithoutExtension(normalized));
+  if (token) {
+    return {
+      path: normalized,
+      rule: 'internal-name',
+      detail: `Filename carries the internal-document marker "${token[1]}". Write it under plans/ (ignored), or allowlist it in scripts/lib/internal-doc-guard.mjs with the reason it is public.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Classify a batch of repo-relative paths.
+ *
+ * @param {Iterable<string>} paths
+ * @returns {Array<{path: string, rule: string, detail: string}>}
+ */
+export function checkPaths(paths) {
+  const violations = [];
+  for (const path of paths) {
+    if (!path) continue;
+    const violation = classifyPath(path);
+    if (violation) violations.push(violation);
+  }
+  return violations;
+}
+
+/**
+ * Verify the `.gitignore` entries the policy leans on are still present.
+ *
+ * A removed entry is reported on its own, before any file has been committed
+ * through the hole — the same problem caught one step earlier.
+ *
+ * @param {string} gitignoreText
+ * @returns {Array<{rule: 'gitignore-weakened', entry: string, detail: string}>}
+ */
+export function checkGitignore(gitignoreText) {
+  const lines = gitignoreText.split(/\r?\n/).map((line) => line.trim());
+  const violations = [];
+  for (const entry of REQUIRED_GITIGNORE_ENTRIES) {
+    // A later `!plans/...` negation would re-admit the very files the entry
+    // exists to keep out, so an un-negated presence is what "still ignored" means.
+    const present = lines.includes(entry);
+    const negated = lines.some((line) => line.startsWith(`!${entry}`));
+    if (!present || negated) {
+      violations.push({
+        rule: 'gitignore-weakened',
+        entry,
+        detail: negated
+          ? `.gitignore negates \`${entry}\`, re-admitting internal documents.`
+          : `.gitignore no longer ignores \`${entry}\`, which is what this repository's document policy relies on — restore the entry rather than removing this check.`,
+      });
+    }
+  }
+  return violations;
+}


### PR DESCRIPTION
`plans/` holds working notes that are deliberately not published. Until now the
only thing standing between them and a commit was a `.gitignore` entry — one
line, in a file that changes for unrelated reasons, where an edit silently
widens what the repository will accept.

This adds a gate that does not read `.gitignore` for its verdict, because a
check that did would agree with whatever the file currently says. It asserts
three things independently:

| rule | catches |
|---|---|
| `plans/` is still ignored | the entry being weakened |
| no tracked file lives in `plans/` | the result, either way |
| high-signal filenames are blocked | the same note written elsewhere |

Filename markers: `strategy`, `roadmap`, `competitive`, `competitor`,
`as-is-to-be`, `master-plan` — matched as delimited tokens against the basename,
so `src/renderer/roadmapView.tsx` and `src/main/strategyResolver.ts` are not
affected. A document that is genuinely meant to be published goes in the
allowlist together with the reason it is public; `docs/mcp-2026-07-28-strategy.md`
is there now.

### No prose heuristic, on purpose

Scanning for "competitor name + strategy vocabulary" was measured against the
tracked tree and is not precise enough to block a commit: `kpi` matches inside
README's Fleet View **coc*kpi*t**, and `moat` appears in README and CHANGELOG
describing the A2A moat — all three intentionally public. A gate that cries wolf
on README.md gets bypassed within a week, which is worse than no gate. Precision
beats recall for a blocking check.

### Where it runs

- **Locally**: `.githooks/pre-commit`, enabled once per clone with
  `git config core.hooksPath .githooks`. Pinned to LF via `.gitattributes` —
  checked out with CRLF, `sh` rejects it at the shebang.
- **CI**: the same audit is a vitest case, so it lands through `npm test`.
  `git commit --no-verify` skips every hook and git offers no way to prevent
  that; the CI case is what makes a local bypass still fail the PR.
- **On demand**: `npm run check:internal-docs`.

### Verified

Three bypass routes were reproduced against the real repo and all three are
refused: staging a file under `plans/`, removing the `plans/` entry from
`.gitignore`, and writing the same content as `docs/our-roadmap.md`. The tracked
tree (1,863 paths) is clean, and the 11 unit cases pin the precision boundary so
nobody re-broadens it later.

No user-facing change, so no changelog fragment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks to prevent internal-only documents from being committed or tracked.
  * Added clear violation reporting with remediation guidance and optional JSON output.
  * Added protection for required ignore rules, with support for approved exceptions.

* **Tests**
  * Added comprehensive coverage for path detection, ignore rules, allowlists, and edge cases.

* **Chores**
  * Added a pre-commit check and command-line script for validating tracked files.
  * Standardized shell-hook line endings for compatibility across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->