### PR TITLE
Read the Windows build number instead of hardcoding xterm's ConPTY boundary

### DIFF
--- a/changelog.d/900.md
+++ b/changelog.d/900.md
@@ -6,3 +6,10 @@
   build the machine is actually on. That turns on reflow and turns off the
   compensation for older ConPTY at the same time, which is the wrong half of
   both on Windows 10. wmux now reads the real build number.
+
+  Windows 10 therefore moves onto xterm's older-ConPTY path, which is what that
+  build actually needs, and reflow is off there instead of on. Reflow being on
+  was also suppressing the spurious row-change events ConPTY emits on resize,
+  which helped keep a drag-selection alive while the pane was being resized, so
+  on Windows 10 that selection is now held by the resize guard alone. Windows 11
+  is unaffected — it was already on the branch it is on now. (#897)

--- a/changelog.d/900.md
+++ b/changelog.d/900.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Lines no longer misalign when you resize a pane on Windows 10.** The
+  terminal told xterm that every Windows machine was running a recent ConPTY,
+  by passing the exact build number xterm uses as its cut-off rather than the
+  build the machine is actually on. That turns on reflow and turns off the
+  compensation for older ConPTY at the same time, which is the wrong half of
+  both on Windows 10. wmux now reads the real build number.

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -6,6 +6,7 @@ import type {
   SampleTaskStartPayload,
 } from '../shared/firstRun';
 import { isFileDrag } from '../shared/dragDrop';
+import { parseWindowsBuildNumber } from '../shared/platform';
 import type { NotificationCategory } from '../shared/types';
 import type { ResumeBinding } from '../shared/agentResume';
 import type { DeadPaneRecovery } from '../shared/ptyRecovery';
@@ -51,6 +52,20 @@ const electronAPI = {
   // directly under sandbox + contextIsolation, so expose it here.
   // 'win32' | 'darwin' | 'linux' | 'aix' | 'freebsd' | 'openbsd' | 'sunos' | 'cygwin' | 'netbsd'
   platform: process.platform as NodeJS.Platform,
+  // The Windows build number (eg. 19045), or null off Windows / when it cannot
+  // be read. xterm needs this SYNCHRONOUSLY at Terminal construction to pick
+  // its ConPTY behaviour, so it is a static value here rather than an IPC call.
+  //
+  // `process.getSystemVersion()` and not `os.release()`: this preload IS
+  // sandboxed (measured — `process.sandboxed === true`, and `require('node:os')`
+  // throws "module not found"), and getSystemVersion is one of the process
+  // methods Electron keeps in the sandboxed subset. Measured on Win11 26200:
+  // both return the identical '10.0.26200'.
+  windowsBuildNumber: process.platform === 'win32'
+    ? parseWindowsBuildNumber(
+      typeof process.getSystemVersion === 'function' ? process.getSystemVersion() : null,
+    )
+    : null,
   pty: {
     // `exec`/`supervision` (X8): set by the AppLayout funnel for a supervised
     // wmux.json leaf — `exec` runs the command as the pane's ROOT process and

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -900,8 +900,29 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // unconditionally clearing the user's selection mid-drag.
       // macOS/Linux PTY는 ConPTY가 아니므로 이 reflow 경로를 켜면 오히려
       // focus/resize 시 줄바꿈이 어긋나 글자가 깨진다(좌측 팬 garble). win32 한정.
+      //
+      // The build number is READ, not assumed. xterm switches on 21376 twice —
+      // reflow is enabled only at `>= 21376` (Buffer `_isReflowEnabled`) and the
+      // legacy ConPTY wrapping heuristics only at `< 21376` (CoreTerminal
+      // `_handleWindowsPtyOptionChange`) — so a hardcoded 21376 declared every
+      // Windows install to be modern ConPTY. On Windows 10 (19045 is still in
+      // the field; #897's reporter is on it) that turns reflow on and the
+      // compensation off, and lines misalign on resize.
+      //
+      // Null means "could not read it" — off Windows, or a version string that
+      // did not parse. Leaving the field out then is deliberate: xterm falls
+      // back to reflow-enabled, which is exactly the behaviour this code had
+      // before, so an unreadable version changes nothing rather than flipping
+      // every install to the opposite branch.
       ...(window.electronAPI.platform === 'win32'
-        ? { windowsPty: { backend: 'conpty' as const, buildNumber: 21376 } }
+        ? {
+          windowsPty: {
+            backend: 'conpty' as const,
+            ...(window.electronAPI.windowsBuildNumber != null
+              ? { buildNumber: window.electronAPI.windowsBuildNumber }
+              : {}),
+          },
+        }
         : {}),
     });
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -894,10 +894,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       theme: xtermTheme,
       minimumContrastRatio,
       allowProposedApi: true,
-      // Enable xterm 6's Windows-aware ConPTY reflow path. ConPTY emits
-      // spurious row-change events on resize; the dedicated reflow logic
-      // suppresses them, which in turn keeps SelectionService from
-      // unconditionally clearing the user's selection mid-drag.
+      // Enable xterm 6's Windows-aware ConPTY handling. ConPTY emits spurious
+      // row-change events on resize; on a build where the reflow path is taken
+      // that logic suppresses them, which in turn keeps SelectionService from
+      // unconditionally clearing the user's selection mid-drag. Which path a
+      // machine takes now depends on its build number (below), so on Windows 10
+      // that suppression is NOT in play and the deferred-fit guard behind
+      // `claimFit` is what holds the selection through a resize.
       // macOS/Linux PTY는 ConPTY가 아니므로 이 reflow 경로를 켜면 오히려
       // focus/resize 시 줄바꿈이 어긋나 글자가 깨진다(좌측 팬 garble). win32 한정.
       //

--- a/src/shared/__tests__/platform.test.ts
+++ b/src/shared/__tests__/platform.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { currentPlatform, isLinux, isMac, isUnix, isWindows, platformChoice } from '../platform';
+import os from 'node:os';
+import {
+  currentPlatform,
+  isLinux,
+  isMac,
+  isUnix,
+  isWindows,
+  parseWindowsBuildNumber,
+  platformChoice,
+} from '../platform';
 
 describe('platform constants', () => {
   it('exactly one of isWindows / isMac / isLinux is true on supported OS', () => {
@@ -57,5 +66,52 @@ describe('platformChoice', () => {
       default: { key: 'd' },
     });
     expect(typeof obj.key).toBe('string');
+  });
+});
+
+/**
+ * xterm switches on build 21376 in two opposite directions — reflow is on only
+ * at `>= 21376`, the legacy ConPTY wrapping heuristics only at `< 21376` — so
+ * the boundary is asserted from both sides here. The terminal used to hardcode
+ * 21376, which declared every Windows install modern.
+ */
+describe('parseWindowsBuildNumber', () => {
+  it('takes the build out of the third field, not the frozen 10.0 prefix', () => {
+    // Windows 11 still reports major.minor 10.0, so only the third field
+    // separates it from Windows 10.
+    expect(parseWindowsBuildNumber('10.0.19045')).toBe(19045);
+    expect(parseWindowsBuildNumber('10.0.26200')).toBe(26200);
+  });
+
+  it('lands each side of xterm\'s 21376 boundary', () => {
+    // Windows 10 stays on the legacy side; Windows 11 and the build that
+    // introduced the modern behaviour stay on the reflow side.
+    expect(parseWindowsBuildNumber('10.0.19045')).toBeLessThan(21376);
+    expect(parseWindowsBuildNumber('10.0.22000')).toBeGreaterThanOrEqual(21376);
+    expect(parseWindowsBuildNumber('10.0.21376')).toBeGreaterThanOrEqual(21376);
+  });
+
+  it('agrees with what this machine actually reports', () => {
+    // The parser is only useful if it handles the real string. os.release() and
+    // Electron's process.getSystemVersion() were measured to return the same
+    // value on Windows.
+    if (process.platform !== 'win32') return;
+    const release = os.release();
+    const parsed = parseWindowsBuildNumber(release);
+    expect(parsed).not.toBeNull();
+    expect(String(parsed)).toBe(release.split('.')[2]);
+  });
+
+  it('returns null rather than guessing when there is no readable build', () => {
+    // The caller keeps its no-information default on null. A wrong number would
+    // silently flip every install to the opposite ConPTY branch.
+    for (const bad of [null, undefined, '', '10.0', '10', 'unknown', '10.0.x', '10.0.-1', 'a.b.c']) {
+      expect(parseWindowsBuildNumber(bad)).toBeNull();
+    }
+  });
+
+  it('tolerates the trailing forms a version string can arrive in', () => {
+    expect(parseWindowsBuildNumber(' 10.0.19045 ')).toBe(19045);
+    expect(parseWindowsBuildNumber('10.0.19045.3803')).toBe(19045);
   });
 });

--- a/src/shared/platform.ts
+++ b/src/shared/platform.ts
@@ -42,3 +42,23 @@ export function platformChoice<T>(choices: PlatformChoice<T>): T {
   if (isLinux && choices.linux !== undefined) return choices.linux;
   return choices.default;
 }
+
+/**
+ * Windows build number out of an OS version string — `10.0.19045` -> `19045`.
+ *
+ * Accepts what `os.release()` and Electron's `process.getSystemVersion()` both
+ * return on Windows (measured: identical, `10.0.26200` on Win11 26200). The
+ * build is the THIRD field; the first two are the marketing-frozen `10.0` that
+ * Windows 11 still reports, so neither one distinguishes 10 from 11.
+ *
+ * Returns null for anything that is not a version string with a numeric third
+ * field, so a caller can keep whatever its no-information default is instead of
+ * acting on a number that was never really read.
+ */
+export function parseWindowsBuildNumber(systemVersion: string | null | undefined): number | null {
+  if (typeof systemVersion !== 'string') return null;
+  const build = systemVersion.trim().split('.')[2];
+  if (build === undefined || !/^\d+$/.test(build)) return null;
+  const parsed = Number(build);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}


### PR DESCRIPTION
The terminal handed xterm a hardcoded `buildNumber: 21376` on every Windows install.

That number is not a constant to pass through — it is the exact boundary xterm switches on, and it switches on it in two opposite directions:

| | condition |
|---|---|
| `Buffer._isReflowEnabled` | reflow only when `>= 21376` |
| `CoreTerminal._handleWindowsPtyOptionChange` | legacy ConPTY wrapping heuristics only when `< 21376` |

So hardcoding the boundary declared every machine to be modern ConPTY: reflow on, compensation off. On Windows 10 that is the wrong half of both switches, and lines misalign on resize. 19045 is still in the field — the reporter on #897 is on it.

Nothing anywhere read the real value. There was no `os.release()` or `getSystemVersion()` call in `src/` at all.

## Where the number comes from

It has to be available synchronously when the `Terminal` is constructed, so it is exposed as a static value on the preload bridge next to `platform` rather than fetched over IPC.

`process.getSystemVersion()`, not `os.release()`, because this preload is sandboxed. Measured with a real Electron window using the same `webPreferences` as ours: `process.sandboxed === true` and `require('node:os')` throws "module not found", while `getSystemVersion` is in the subset Electron keeps available. Both return the identical string on Windows — `10.0.26200` on the machine this was measured on.

The build is the third dotted field. The first two are the marketing-frozen `10.0` that Windows 11 still reports, so neither one separates 10 from 11.

## When it cannot be read

The field is left out entirely, which is what xterm already treats as reflow-enabled — the behaviour this code had before. An unreadable version therefore changes nothing, rather than flipping every install to the opposite branch.

## Note on scope

This is one of two Windows regressions that came out of reviewing the UI-scale work. The other one — a hypothesis that a hidden pane's canvas backing store goes stale across a DPR change — did not reproduce when measured, so nothing is changed for it here. Details in the review notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pane resizing on Windows 10, including improved drag-selection behavior.
  * Windows 10 terminals now use the appropriate compatibility settings based on the installed Windows build.
  * Windows 11 behavior remains unchanged.
* **Tests**
  * Added coverage for Windows version detection and compatibility handling across supported and invalid version formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->