### PR TITLE
Pin the atlas invariants the guard actually leans on

### DIFF
--- a/src/renderer/terminal/__tests__/atlasCoherence.test.ts
+++ b/src/renderer/terminal/__tests__/atlasCoherence.test.ts
@@ -35,14 +35,88 @@ describe('atlas coherence model', () => {
     expect(atlas.pageCount).toBeLessThanOrEqual(max);
   });
 
-  it('I3: two observers both see a wipe', () => {
+  it('I1: a merged page counts as occupied even with its cursor at the origin', () => {
+    // The page a merge produces holds every glyph it absorbed while its
+    // packing cursor is untouched. Upstream probed the cursor alone, so it
+    // read exactly this page as empty and skipped the clear. Occupancy has to
+    // be multi-axis or the clear silently does nothing.
+    const atlas = createAtlasModel(8);
+    for (let i = 0; i < 5; i++) atlas.rasterize(`g${i}`, 64, 64);
+    expect(atlas.pageCount).toBeGreaterThan(4);
+
+    expect(atlas.mergePages(4)).toBe(true);
+    const afterMerge = atlas.pageCount;
+
+    atlas.clearTexture();
+    expect(atlas.pageCount).toBeLessThan(afterMerge);
+    expect(atlas.pageCount).toBe(1);
+    expect(atlas.cacheSize).toBe(0);
+  });
+
+  it('I1: the no-op branch still empties the caches, and does not bump', () => {
+    // A sentinel (empty-glyph) entry occupies no page, so a shape probe cannot
+    // see it — it would otherwise survive a clear. Nothing an observer holds
+    // has moved though, so this must NOT invalidate anyone.
     const atlas = createAtlasModel(4);
-    const a = atlas.generation;
-    const b = atlas.generation;
     atlas.rasterize('x', 8, 8);
     atlas.clearTexture();
-    expect(atlas.generation).not.toBe(a);
-    expect(atlas.generation).not.toBe(b);
+    const generationAfterWipe = atlas.generation;
+    expect(atlas.cacheSize).toBe(0);
+
+    // Constructor shape now. Put a cache entry back without occupying a page.
+    const sentinel = atlas.rasterize('sentinel', 0, 0);
+    expect(sentinel.page).toBe(0);
+
+    atlas.clearTexture();
+    expect(atlas.cacheSize).toBe(0);
+    expect(atlas.generation).toBe(generationAfterWipe);
+  });
+
+  it('I3: a merge invalidates every observer, not just a wipe', () => {
+    // A merge rewrites page indices, so it has to advance the generation for
+    // the same reason a wipe does. atlasGuard leans on this: it treats an
+    // advance as "the atlas already rebuilt its owners" and skips its own
+    // repair, which is only sound if a merge really does advance it.
+    const atlas = createAtlasModel(8);
+    for (let i = 0; i < 5; i++) atlas.rasterize(`g${i}`, 64, 64);
+    const before = atlas.generation;
+    expect(atlas.mergePages(4)).toBe(true);
+    expect(atlas.generation).toBeGreaterThan(before);
+  });
+
+  it('I3: two independent observers each see the invalidation exactly once', () => {
+    // Mirrors GlyphRenderer.beginFrame: every renderer keeps its OWN last-seen
+    // generation, so no renderer can consume another's signal — the failure
+    // mode of the shared one-shot boolean this replaced. Reading one counter
+    // into two variables, as this test used to, asserts nothing of the sort.
+    const atlas = createAtlasModel(8);
+    const observer = () => {
+      let lastSeen = -1;
+      return () => {
+        const needsRebuild = lastSeen !== atlas.generation;
+        lastSeen = atlas.generation;
+        return needsRebuild;
+      };
+    };
+    const a = observer();
+    const b = observer();
+
+    // First frame: neither has synced yet.
+    expect(a()).toBe(true);
+    expect(b()).toBe(true);
+    // Steady state: no invalidation, no rebuilds.
+    expect(a()).toBe(false);
+    expect(b()).toBe(false);
+
+    atlas.rasterize('x', 8, 8);
+    atlas.clearTexture();
+
+    // A sees it. B must STILL see it — A did not consume the signal.
+    expect(a()).toBe(true);
+    expect(b()).toBe(true);
+    // And exactly once each.
+    expect(a()).toBe(false);
+    expect(b()).toBe(false);
   });
 
   it('installed addon-webgl 0.19.0 still has the I1/I3 patch', () => {

--- a/src/renderer/terminal/__tests__/atlasGuard.test.ts
+++ b/src/renderer/terminal/__tests__/atlasGuard.test.ts
@@ -175,6 +175,31 @@ class CoherentFakeAtlas {
   occupyAll(): void {
     for (const p of this.pages) p.currentRow = { x: 12, y: 340 };
   }
+  /**
+   * The patched atlas fires upstream's removal event too — `_deletePage` is
+   * still what a reducing merge calls. Without this the coherent fake never
+   * arms the guard's latch, so the STRONGEST cure signal was the one the
+   * coherent cases never exercised.
+   */
+  private removalListeners: Array<(canvas: unknown) => void> = [];
+  onRemoveTextureAtlasCanvas(listener: (canvas: unknown) => void): { dispose(): void } {
+    this.removalListeners.push(listener);
+    return { dispose: () => { this.removalListeners = []; } };
+  }
+  /**
+   * A reducing same-size merge (`_tryMergeSameSizePages`): four pages go, one
+   * merged page arrives, the removal event fires once per deleted page, and
+   * the generation advances — that last part is what the guard leans on, and
+   * nothing pinned it before.
+   */
+  mergePages(count = 4): void {
+    this.pages.splice(0, count);
+    this.pages.push({ currentRow: { x: 0, y: 1 } });
+    for (let i = 0; i < count; i++) {
+      for (const l of this.removalListeners) l({});
+    }
+    this.clearModelGeneration++;
+  }
 }
 
 type GuardAtlas = FakeAtlas | CoherentFakeAtlas;
@@ -804,6 +829,66 @@ describe('atlasGuard', () => {
       expect(prevents).toHaveLength(0);
       expect(atlas.clearCalls).toBe(0);
       expect(pane.refreshes()).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not CURE a coherent atlas that merges pages itself', () => {
+    // The evict case above only covers count-drop + page-identity. A reducing
+    // merge also fires the REMOVAL EVENT, which is the guard's strongest cure
+    // signal and outranks both — `removed` short-circuits detectMerge. The
+    // generation check has to consume that one too, and until now no test
+    // asked it to: the coherent fake had no removal event at all, so the
+    // latch was never even armed on this path.
+    const atlas = new CoherentFakeAtlas(12);
+    atlas.occupyAll();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const guard = createAtlasGuard();
+      const pane = makePane(atlas);
+      guard.register(pane.entry);
+      vi.advanceTimersByTime(GUARD_POLL_MS); // baseline tick arms the latch
+
+      atlas.mergePages(4);
+      vi.advanceTimersByTime(GUARD_POLL_MS);
+
+      const lines = warn.mock.calls.map((c) => String(c[0]));
+      expect(lines.filter((l) => /\[wmux:atlas-guard] cure/.test(l))).toHaveLength(0);
+      expect(lines.filter((l) => /\[wmux:atlas-guard] prevent/.test(l))).toHaveLength(0);
+      expect(atlas.clearCalls).toBe(0);
+      expect(pane.refreshes()).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('still CUREs a coherent atlas when pages vanish WITHOUT a generation bump', () => {
+    // The skip is not "coherent atlases are exempt" — it is "the atlas told us
+    // it already rebuilt its owners". A collapse with no generation advance
+    // means nobody rebuilt anything, and the backstop must still fire. This is
+    // what keeps the check honest if a future patch ever drops a bump.
+    const atlas = new CoherentFakeAtlas(12);
+    atlas.occupyAll();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const guard = createAtlasGuard();
+      const pane = makePane(atlas);
+      guard.register(pane.entry);
+      vi.advanceTimersByTime(GUARD_POLL_MS);
+
+      const generationBefore = atlas.clearModelGeneration;
+      atlas.mergePages(4);
+      atlas.clearModelGeneration = generationBefore; // the bump never happened
+      vi.advanceTimersByTime(GUARD_POLL_MS);
+
+      const cures = warn.mock.calls
+        .map((c) => String(c[0]))
+        .filter((l) => /\[wmux:atlas-guard] cure/.test(l));
+      expect(cures).toHaveLength(1);
+      expect(pane.refreshes()).toBe(1);
     } finally {
       warn.mockRestore();
     }

--- a/src/renderer/terminal/atlasCoherenceModel.ts
+++ b/src/renderer/terminal/atlasCoherenceModel.ts
@@ -1,7 +1,7 @@
 /**
  * Local shared-atlas model used only by atlasCoherence tests.
- * States the I1–I3 algorithm in wmux-owned code before patching
- * @xterm/addon-webgl. Not used at runtime.
+ * States the I1–I3 algorithm in wmux-owned code alongside the
+ * @xterm/addon-webgl patch. Not used at runtime.
  *
  * Packing is deliberately tiny: fixed PAGE_AREA pages, tail-active
  * placement (page 0 can sit idle while the tail fills). That shape is
@@ -9,8 +9,22 @@
  *
  * I1 — clearTexture is total: empty both caches, collapse to one fresh page.
  * I2 — never grow past maxPages; on overflow, evict-all (same end state as I1).
- * I3 — bump generation on every wipe (and on merge, if a later model adds one)
- *      so N observers can each notice invalidation independently.
+ * I3 — bump generation on every wipe AND on every merge, so N observers can
+ *      each notice invalidation independently.
+ *
+ * The model only earns its keep where it MATCHES the patch, so the two places
+ * it used to diverge are gone:
+ *
+ *   - Occupancy is multi-axis. The patch probes `glyphs.length`, both
+ *     `currentRow` axes and `fixedRows`; a single "pixels used" counter cannot
+ *     express a page that HOLDS GLYPHS while its packing cursor sits at the
+ *     origin, which is precisely what a merged page looks like — and precisely
+ *     the state a cursor-only probe calls empty.
+ *   - `clearTexture`'s no-op branch keys on SHAPE alone and still empties the
+ *     caches. The patch has to: a sentinel (empty-glyph) entry occupies no
+ *     page, so a shape probe cannot see it, and leaving it behind would let it
+ *     survive a clear. Requiring an empty cache to take the no-op branch — as
+ *     this model used to — describes the opposite algorithm.
  */
 
 /** Fixed packing capacity per page (pixels). One 64×64 glyph fills a page. */
@@ -19,14 +33,30 @@ const PAGE_AREA = 64 * 64;
 export interface AtlasModel {
   rasterize(id: string, width: number, height: number): { page: number };
   clearTexture(): void;
+  /** A reducing same-size merge: `count` pages out, one merged page in. */
+  mergePages(count?: number): boolean;
   readonly generation: number;
   readonly pageCount: number;
   readonly cacheSize: number;
 }
 
 interface Page {
-  /** Pixels already packed into this page. */
+  /** Pixels already packed into this page (drives placement, not occupancy). */
   used: number;
+  /** Glyphs resident on this page. A merged page has these with no cursor. */
+  glyphs: number;
+  /** Packing cursor. Both axes, because the upstream probe read both. */
+  cursorX: number;
+  cursorY: number;
+}
+
+function emptyPage(): Page {
+  return { used: 0, glyphs: 0, cursorX: 0, cursorY: 0 };
+}
+
+/** Mirrors the patch's `_pageIsOccupied` — any axis, not just the cursor. */
+function pageIsOccupied(page: Page): boolean {
+  return page.glyphs > 0 || page.cursorX !== 0 || page.cursorY !== 0;
 }
 
 export function createAtlasModel(maxPages: number): AtlasModel {
@@ -34,7 +64,7 @@ export function createAtlasModel(maxPages: number): AtlasModel {
     throw new Error('maxPages must be >= 1');
   }
 
-  let pages: Page[] = [{ used: 0 }];
+  let pages: Page[] = [emptyPage()];
   let generation = 0;
   // Two caches mirror the real atlas's single-char / combined-char maps.
   const singleCache = new Map<string, number>();
@@ -44,16 +74,14 @@ export function createAtlasModel(maxPages: number): AtlasModel {
     return singleCache.size + combinedCache.size;
   }
 
-  function anyPageInUse(): boolean {
-    for (let i = 0; i < pages.length; i++) {
-      if (pages[i].used > 0) return true;
-    }
-    return false;
+  /** Mirrors the patch's `_isConstructorShape`: one page, and it is idle. */
+  function isConstructorShape(): boolean {
+    return pages.length === 1 && !pageIsOccupied(pages[0]);
   }
 
   /** Full wipe → constructor shape. Always bumps generation. */
   function wipe(): void {
-    pages = [{ used: 0 }];
+    pages = [emptyPage()];
     singleCache.clear();
     combinedCache.clear();
     generation++;
@@ -63,10 +91,17 @@ export function createAtlasModel(maxPages: number): AtlasModel {
     if (pages.length >= maxPages) {
       // Evict-all on overflow: same end state as clearTexture (I2).
       wipe();
-      pages[0].used = Math.min(cost, PAGE_AREA);
+      const page = pages[0];
+      page.used = Math.min(cost, PAGE_AREA);
+      page.glyphs++;
+      page.cursorX = page.used;
       return 0;
     }
-    pages.push({ used: Math.min(cost, PAGE_AREA) });
+    const page = emptyPage();
+    page.used = Math.min(cost, PAGE_AREA);
+    page.glyphs++;
+    page.cursorX = page.used;
+    pages.push(page);
     return pages.length - 1;
   }
 
@@ -87,13 +122,24 @@ export function createAtlasModel(maxPages: number): AtlasModel {
         return { page: cached };
       }
 
-      const cost = Math.max(1, width * height);
+      // An empty glyph (a sentinel) is cached but occupies no page — which is
+      // why `clearTexture`'s shape probe cannot see it, and why the no-op
+      // branch has to empty the caches anyway.
+      if (width * height === 0) {
+        singleCache.set(id, pages.length - 1);
+        return { page: pages.length - 1 };
+      }
+
+      const cost = width * height;
       // Pack onto the active (tail) page — same shape as 0.19 after a clear.
       let page = pages.length - 1;
       if (pages[page].used + cost > PAGE_AREA) {
         page = placeOnNewPage(cost);
       } else {
-        pages[page].used += cost;
+        const target = pages[page];
+        target.used += cost;
+        target.glyphs++;
+        target.cursorX = target.used;
       }
 
       // Split entries across both maps so clearTexture must empty both.
@@ -105,9 +151,33 @@ export function createAtlasModel(maxPages: number): AtlasModel {
       return { page };
     },
 
+    mergePages(count = 4): boolean {
+      // Only a REDUCING merge, matching the patch: fewer than `count` pages to
+      // give up means there is nothing to win, and the caller falls back to a
+      // wipe rather than growing past the budget.
+      if (pages.length < count + 1) {
+        return false;
+      }
+      const merged = emptyPage();
+      // The merged page carries every glyph it absorbed, and its packing
+      // cursor is untouched — occupied on the glyph axis ALONE. A cursor-only
+      // probe reads this page as empty, which is the whole point of I1.
+      for (const page of pages.splice(0, count)) {
+        merged.glyphs += page.glyphs;
+        merged.used = Math.min(PAGE_AREA, merged.used + page.used);
+      }
+      pages.push(merged);
+      generation++;
+      return true;
+    },
+
     clearTexture(): void {
-      // Probe ALL pages' occupancy — never page 0 alone (that is the 0.19 bug).
-      if (!anyPageInUse() && pages.length === 1 && cacheSize() === 0) {
+      if (isConstructorShape()) {
+        // Sentinel (empty-glyph) entries hold no page, so the shape probe
+        // cannot see them — empty the caches even on the no-op path, and do
+        // NOT bump: nothing that any observer can be holding has moved.
+        singleCache.clear();
+        combinedCache.clear();
         return;
       }
       wipe();


### PR DESCRIPTION
## Summary

Follow-up to #902. Three gaps between what the tests check and what the patched addon does. None is a runtime defect — the patch and the guard are both correct as merged, verified against the installed 0.19.0 sources. All three mean a regression in them would ship green.

## What was unpinned

**A merge never reached the guard's coherence check.** The guard skips its repair when `clearModelGeneration` advanced, on the grounds that the atlas already rebuilt its owners. A reducing merge is the case that matters: it fires the removal event, which outranks both polled signals (`removed` short-circuits `detectMerge`). Nothing exercised it — `CoherentFakeAtlas` had no removal event at all, so the latch was never even armed on that path. The only coherent case was an evict, which produces count-drop and page-identity but no event.

**The model diverged from the patch in two places**, so its green said nothing about either:

| | model, before | the patch |
|---|---|---|
| page occupancy | one `used` pixel counter | `glyphs.length`, both `currentRow` axes, `fixedRows` |
| `clearTexture` no-op | required an empty cache; left caches alone | keys on SHAPE alone; empties caches regardless |

The occupancy one matters most: a single counter cannot express a page that holds glyphs while its packing cursor sits at the origin. That is what a merged page looks like, and it is exactly the state upstream's cursor-only probe called empty — the bug I1 exists to fix. The model could not have caught it.

The cache one describes the opposite algorithm. The patch empties the caches on the no-op path because a sentinel (empty-glyph) entry occupies no page, so a shape probe cannot see it and it would otherwise outlive a clear.

**The I3 test asserted the same thing twice.** `const a = atlas.generation; const b = atlas.generation;` reads one counter into two variables — there are no two observers in it.

## Changes

- `CoherentFakeAtlas` gains the removal event and a reducing `mergePages()` that bumps the generation, matching `_tryMergeSameSizePages`.
- Two guard cases: a merge that bumps must not cure; a collapse **without** a bump still must. The second is what keeps the skip honest — it is conditioned on the generation, not on the atlas merely looking coherent, and this fails if that ever inverts.
- Model: multi-axis occupancy, a `mergePages()` that produces the glyphs-without-cursor page, and a `clearTexture` no-op branch that matches the patch. Sentinel glyphs are modelled, since they are the reason that branch clears caches.
- I3 becomes two independent observers, each holding its own last-seen generation — the property that replaced the shared one-shot boolean. A seeing the invalidation must not stop B from seeing it.

## CHANGELOG entry

n/a — tests and test-only model. No user-facing change.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- `src/renderer/terminal` — 18 files, 280 passing in this worktree, including the 42 across `atlasGuard` and `atlasCoherence`.
- Both new guard cases were confirmed to be real assertions rather than tautologies: the no-bump case fails if the generation check is widened to skip on `coherent` alone.
- `tsc --noEmit` and `eslint` clean on the touched files.

## Related issues / PRs

Follows #902.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved texture-atlas maintenance during page merging and clearing.
  * Preserved cached zero-area glyphs without consuming unnecessary space.
  * Improved invalidation handling to prevent redundant updates while ensuring stale data is refreshed.

* **Tests**
  * Added comprehensive coverage for page occupancy, cache clearing, merging, and independent observer invalidation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->