### PR TITLE
fix: persist Anthropic usage meter opt-in

### DIFF
--- a/changelog.d/906.md
+++ b/changelog.d/906.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **The Anthropic 5h / 7d utilization setting now survives app restarts.**
+  The toggle used to update only the running app, so every new launch silently
+  turned the status-bar meter off again. wmux now remembers the explicit opt-in
+  and resumes usage polling after restoring the session. Older or malformed
+  session files still default safely to off. (#906)

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -266,6 +266,7 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     notificationSoundEnabled: state.notificationSoundEnabled,
     toastEnabled: state.toastEnabled,
     notificationRingEnabled: state.notificationRingEnabled,
+    anthropicUsageEnabled: state.anthropicUsageEnabled,
     mutedNotificationCategories: state.mutedNotificationCategories,
     customKeybindings: state.customKeybindings,
     autoUpdateEnabled: state.autoUpdateEnabled,

--- a/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
+++ b/src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts
@@ -80,6 +80,10 @@ describe('AppLayout — axis A session-save invariants', () => {
     expect(source).not.toMatch(/addEventListener\('beforeunload', saveSession\)/);
   });
 
+  it('persists the Anthropic usage opt-in explicitly, including false', () => {
+    expect(source).toMatch(/anthropicUsageEnabled:\s*state\.anthropicUsageEnabled/);
+  });
+
   // Fix B — cap-skipped suspended promote. Boot recovery honours a session cap,
   // so a workspace beyond the cap came back with its ptyId absent and reconcile
   // destructively cleared it (losing the pane's scrollback and identity). The

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -868,12 +868,9 @@ export function useNotificationListener() {
     const unsubUsage = window.electronAPI.usage.onUpdate((state) => {
       useStore.getState().setAnthropicUsage(state);
     });
-    // Hydrate main from persisted opt-in. Main boots with the poller
-    // stopped; if the user had it enabled before app restart, the
-    // SessionData restore in workspaceSlice.loadSession sets
-    // `anthropicUsageEnabled` back to true, and we mirror that to
-    // main here so the poller starts again. Calling setEnabled on a
-    // poller already in the requested state is a no-op (idempotent).
+    // loadSession normally restores this opt-in and starts main's poller.
+    // Mirror it again after subscribing as a safe fallback if this listener
+    // mounts after hydration; UsagePoller.setEnabled is idempotent.
     if (useStore.getState().anthropicUsageEnabled) {
       window.electronAPI.usage.setEnabled(true);
     }

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
@@ -27,6 +27,7 @@ type TestState = WorkspaceSlice & {
   notificationSoundEnabled: boolean;
   toastEnabled: boolean;
   notificationRingEnabled: boolean;
+  anthropicUsageEnabled: boolean;
   customKeybindings: unknown[];
   autoUpdateEnabled: boolean;
   sidebarMode: 'workspaces' | 'company';
@@ -77,6 +78,7 @@ function createTestStore() {
       notificationSoundEnabled: true,
       toastEnabled: true,
       notificationRingEnabled: true,
+      anthropicUsageEnabled: false,
       customKeybindings: [],
       autoUpdateEnabled: true,
       sidebarMode: 'workspaces',
@@ -106,6 +108,8 @@ function createTestStore() {
   );
 }
 
+const setUsageEnabled = vi.fn();
+
 // Stub Electron settings/i18n bridges so loadSession's optional side-effects
 // don't throw. Tests don't assert on these — they just need them to no-op.
 beforeAll(() => {
@@ -119,8 +123,15 @@ beforeAll(() => {
       setToastEnabled: () => undefined,
       setAutoUpdateEnabled: () => undefined,
     },
+    usage: {
+      setEnabled: setUsageEnabled,
+    },
   };
   // document is provided by jsdom in vitest; safe to call setAttribute.
+});
+
+beforeEach(() => {
+  setUsageEnabled.mockReset();
 });
 
 // Pane tree builder helper: nested split with two leaves at depth 2.
@@ -569,6 +580,63 @@ describe('loadSession — multiview arrangement (#746)', () => {
     const store = createTestStore();
     store.getState().loadSession(sessionWith('masonry'));
     expect(store.getState().multiviewArrangement).toBe('auto');
+  });
+});
+
+describe('loadSession — Anthropic usage meter (#896)', () => {
+  function sessionWith(enabled: unknown = undefined): SessionData {
+    const ws: Workspace = {
+      id: 'ws-usage',
+      name: 'Usage',
+      rootPane: makeBrowserSurfaceTree('https://example.com'),
+      activePaneId: 'pane-root',
+    };
+    const session = {
+      workspaces: [ws],
+      activeWorkspaceId: ws.id,
+      sidebarVisible: true,
+    } as Record<string, unknown>;
+    if (enabled !== undefined) session.anthropicUsageEnabled = enabled;
+    return session as unknown as SessionData;
+  }
+
+  it('restores an enabled opt-in and starts main-process polling', () => {
+    const store = createTestStore();
+
+    store.getState().loadSession(sessionWith(true));
+
+    expect(store.getState().anthropicUsageEnabled).toBe(true);
+    expect(setUsageEnabled).toHaveBeenCalledOnce();
+    expect(setUsageEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('restores an explicit disabled value and stops main-process polling', () => {
+    const store = createTestStore();
+    store.setState({ anthropicUsageEnabled: true });
+
+    store.getState().loadSession(sessionWith(false));
+
+    expect(store.getState().anthropicUsageEnabled).toBe(false);
+    expect(setUsageEnabled).toHaveBeenCalledOnce();
+    expect(setUsageEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the safe default and does not touch main for an older session', () => {
+    const store = createTestStore();
+
+    store.getState().loadSession(sessionWith());
+
+    expect(store.getState().anthropicUsageEnabled).toBe(false);
+    expect(setUsageEnabled).not.toHaveBeenCalled();
+  });
+
+  it.each(['true', 1, null, {}])('ignores malformed persisted value %j', (enabled) => {
+    const store = createTestStore();
+
+    store.getState().loadSession(sessionWith(enabled));
+
+    expect(store.getState().anthropicUsageEnabled).toBe(false);
+    expect(setUsageEnabled).not.toHaveBeenCalled();
   });
 });
 

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -939,6 +939,10 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         window.electronAPI.settings.setToastEnabled(data.toastEnabled);
       }
       if (data.notificationRingEnabled != null) state.notificationRingEnabled = data.notificationRingEnabled;
+      if (typeof data.anthropicUsageEnabled === 'boolean') {
+        state.anthropicUsageEnabled = data.anthropicUsageEnabled;
+        window.electronAPI.usage.setEnabled(data.anthropicUsageEnabled);
+      }
       if (data.customKeybindings) {
         // Merge saved keybindings with current built-in defaults (mirrors the
         // layoutTemplates merge below). Built-in defaults (id 'kb-default-*')

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -723,6 +723,8 @@ export interface SessionData {
   notificationSoundEnabled?: boolean;
   toastEnabled?: boolean;
   notificationRingEnabled?: boolean;
+  /** Whether the user opted in to Anthropic usage polling (#896). No credentials are persisted. */
+  anthropicUsageEnabled?: boolean;
   /** Categories whose surface actions are suppressed (#516). */
   mutedNotificationCategories?: NotificationCategory[];
   customKeybindings?: CustomKeybinding[];


### PR DESCRIPTION
## Summary

Persist the Anthropic 5h / 7d usage-meter opt-in so enabling it survives an app restart and resumes main-process polling.

## Changes

- Add the optional `anthropicUsageEnabled` preference to `SessionData` and save explicit `false` values.
- Restore only valid boolean values and synchronize the main-process usage poller during session hydration.
- Add regression coverage for enabled, disabled, missing, malformed, and save-side behavior.

## CHANGELOG entry

### Fixed

- Persist the "Show 5h / 7d utilization in status bar" setting across app restarts.

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — no protocol, RPC, event, permission, or named-pipe surface changes.

## Test plan

- `npx vitest run src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts src/renderer/components/Layout/__tests__/appLayout.sessionSaveInvariants.test.ts` — 50 passed.
- `npx tsc --noEmit` — passed.
- `npm run test:parallel` — 11,235 passed, 24 skipped.
- `npm run test:runtime` — 168 passed, 1 skipped, 4 unrelated Windows/Node 24 runtime failures: two `node-pty` AttachConsole timeouts in shell integration and two existing web-restart mtime assertions.

## Related issues / PRs

Closes #896

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anthropic utilization preferences now persist across app restarts.
  * Usage polling resumes automatically when a session is restored.
  * Older or malformed session data safely defaults utilization tracking to disabled.

* **Bug Fixes**
  * Restored settings now correctly synchronize with utilization tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->