### PR TITLE
A subagent returning is not the pane finishing

### DIFF
--- a/changelog.d/914.md
+++ b/changelog.d/914.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A pane no longer looks finished when one of its subagents returns.** When an
+  agent spawned a nested subagent, that subagent finishing marked the whole pane
+  as done — while its main turn was still running. The pane dropped out of the
+  count of busy work, the fleet read it as free, and the orchestrator was told
+  that pane had finished, so its next instruction could land on an agent that
+  never stopped. A subagent returning now leaves the pane reported as running,
+  which is what it actually is. (#914)

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -433,12 +433,26 @@ function isMetadataKind(kind: AgentSignalKind): kind is
  */
 function eventShapeFor(
   kind: 'agent.stop' | 'agent.subagent_stop' | 'agent.awaiting_input',
-): { status: 'complete' | 'awaiting_input'; message: string } {
+): { status: 'complete' | 'awaiting_input' | 'running'; message: string } {
   switch (kind) {
     case 'agent.stop':
       return { status: 'complete', message: 'Task finished' };
     case 'agent.subagent_stop':
-      return { status: 'complete', message: 'Subagent finished' };
+      // A nested subagent returning is NOT this pane finishing. It said
+      // 'complete', which flows straight through to the pane's agentStatus
+      // (DaemonNotificationRouter: `agentStatus: ev.status`), so every
+      // subagent return marked the whole pane done while its main turn was
+      // still running — the pane drops out of "who is busy", the fleet reads
+      // it as free, and the orchestrator's next wake lands on an agent that
+      // never stopped. Same family as #733's stuck status, in the opposite
+      // direction: there a deleted guard blocked the only clear, here a
+      // nested event clears too eagerly.
+      //
+      // It reports 'running' rather than being dropped, because the pane IS
+      // still working and saying so is more accurate than saying nothing —
+      // and the event itself still reaches the bus, so a poller that wants
+      // subagent boundaries can still see them.
+      return { status: 'running', message: 'Subagent finished' };
     case 'agent.awaiting_input':
       return { status: 'awaiting_input', message: 'Awaiting input' };
   }

--- a/src/daemon/hooks/__tests__/HookIngest.test.ts
+++ b/src/daemon/hooks/__tests__/HookIngest.test.ts
@@ -148,6 +148,38 @@ describe('HookIngest', () => {
       expect(data.signal.kind).toBe('agent.stop');
     });
 
+    /**
+     * A nested subagent returning is NOT this pane finishing.
+     *
+     * This mapped to 'complete', and that status flows straight through to the
+     * pane's agentStatus (DaemonNotificationRouter: `agentStatus: ev.status`),
+     * so every subagent return marked the whole pane done while its main turn
+     * was still running: the pane drops out of "who is busy", the fleet reads
+     * it as free, and an orchestrator's next wake lands on an agent that never
+     * stopped. Same family as #733, in the opposite direction — there a
+     * deleted guard blocked the only clear, here a nested event cleared too
+     * eagerly.
+     *
+     * It reports 'running' rather than nothing: the pane IS still working.
+     * The event itself still reaches the bus either way, so a consumer that
+     * genuinely wants subagent boundaries can still see them.
+     */
+    it('never lets a subagent return mark the pane finished', () => {
+      // The regression guard, stated as the property rather than the value:
+      // whatever shape subagent_stop takes, it must not be the same "this pane
+      // is done" status that agent.stop produces. Someone restoring symmetry
+      // between the two ("both are stops, right?") is exactly how this comes
+      // back, and every other test stays green when it does.
+      ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.stop' }));
+      ingest.handle(makeSignal({ ptyId: 'pty-b', kind: 'agent.subagent_stop' }));
+      const [mainStop, subStop] = fixture.emitted;
+      expect(mainStop.data.status).toBe('complete');
+      expect(subStop.data.status).not.toBe('complete');
+      // and it must still be reported, not silently dropped — the pane is
+      // working, and saying so beats saying nothing.
+      expect(subStop.data.hookKind).toBe('agent.subagent_stop');
+    });
+
     it('maps subagent_stop and awaiting_input to their own shapes', () => {
       ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.subagent_stop' }));
       // A subagent stop is never a lead-turn end: status-only, immediate, and
@@ -158,12 +190,17 @@ describe('HookIngest', () => {
         decision: 'internal',
       });
       ingest.handle(makeSignal({ ptyId: 'pty-a', kind: 'agent.awaiting_input' }));
+      // The attention cue opens its own provisional window, so the
+      // awaiting_input broadcast lands only once that confirms.
       vi.advanceTimersByTime(DEFAULT_ALARM_WINDOW_MS);
-      expect(fixture.emitted[1].data).toMatchObject({
-        status: 'awaiting_input',
-        message: 'Awaiting input',
-        decision: 'emit',
-      });
+      // The whole sequence, not just one entry: the subagent emit must stay
+      // `running` AND stay ahead of the attention one. Asserting them
+      // separately let a regression swap either without failing.
+      expect(fixture.emitted.map((e) => [e.data.status, e.data.message])).toEqual([
+        ['running', 'Subagent finished'],
+        ['awaiting_input', 'Awaiting input'],
+      ]);
+      expect(fixture.emitted[1].data.decision).toBe('emit');
     });
 
     it('reports a broadcast failure as internal-error rather than throwing at the bridge', () => {


### PR DESCRIPTION
`agent.subagent_stop` mapped to status `complete`, and that status flows straight through to the pane's `agentStatus` — `DaemonNotificationRouter` does `agentStatus: ev.status`. So every time a nested subagent returned, the whole pane was marked done while its main turn was still running.

## What that reaches

The pane's status is not cosmetic here; it is what the orchestration layer reasons over:

| | reads it as |
|---|---|
| `deck.rpc.ts:139` | outstanding work = `running \|\| awaiting_input` — a pane flipped to `complete` stops counting as outstanding, so a fan-out can finalize while an agent is mid-turn |
| `deckBriefing.ts:283` | `complete` after not-complete is reported to the brain as **finished** |
| `deck.handler.ts:195` | counted as `stopped` |
| `CommanderEventCoalescer` | drives wake/surface decisions off `complete` in four places |

So the symptom is not a wrong dot in the UI. The fleet reads the pane as free, the briefing tells the orchestrator that pane finished, and its next wake lands on an agent that never stopped.

## Same family as #733, opposite direction

There, a deleted guard blocked the only path that cleared a stuck status. Here, a nested event clears it too eagerly. Both end with the pane's status describing something other than the pane.

## The rest of the system already knew

Two neighbouring paths had this right and the status mapping just never got the same treatment:

- `agentLiveness.ts:100-102` special-cases it explicitly — `if (subagentStop) state = 'busy'` sits *above* the `complete → idle` branch, so the phone header was already correct.
- `driveApprovals` deliberately does not expire a pending prompt on `subagent_stop`, with a comment saying a subagent finishing says nothing about the main agent's question.

## The change

`subagent_stop` reports `running` instead of `complete`. Not dropped: the pane IS still working, and saying so is more accurate than saying nothing. The event still reaches the bus either way, so a consumer that genuinely wants subagent boundaries can still see them — only what the pane's own status is allowed to claim changes.

## Tests

The existing test asserted the old value, so it was pinning the bug; it now pins the new shape. A second test pins the **property** rather than the value: whatever `subagent_stop` reports, it must not be the same status `agent.stop` produces. Restoring symmetry between the two ("both are stops, right?") is how this comes back, and every other test stays green when it does.

## Context

Found while surveying hook insertion points for the remaining agents. Notably GitHub Copilot CLI exposes `agentStop` and `subagentStop` as separate events too, so this distinction is not a Claude Code quirk — any adapter added later inherits the same hazard, which is why the fix belongs in the ingest layer rather than per-adapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nested subagent completion no longer incorrectly marks the parent pane as finished while its main task is still running.
  - Parent panes now continue to display a running status after a subagent finishes.

- **Tests**
  - Added regression coverage to verify the corrected pane status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->