### PR TITLE
Measure that wmux's hooks are harmless instead of claiming it

### DIFF
--- a/scripts/__tests__/hookHarmlessness.runtime.test.mjs
+++ b/scripts/__tests__/hookHarmlessness.runtime.test.mjs
@@ -1,0 +1,394 @@
+// P-5 — the A/B harmlessness gate, wired into CI.
+//
+// wmux installs hooks into other people's agents. #898 is what it costs when
+// one of them says something the host reads as an instruction: the permission
+// gate emitted `ask` on every "wmux has no opinion" path, `ask` is not
+// neutral, and a bypassPermissions session started asking permission to run
+// `Read` — with the documented escape hatch emitting `ask` too. The claim this
+// file defends is narrow and testable:
+//
+//   installing a wmux hook is indistinguishable, to the host, from installing
+//   a hook that provably has no opinion.
+//
+// Every case runs a CONTROL (a no-op hook) and a TREATMENT (the real hook,
+// invoked the way the integration's own manifest invokes it) and compares what
+// the host would observe. The measurement lives in
+// scripts/lib/hookHarmlessness.mjs; the pass criteria live here.
+//
+// Two properties keep this from decaying into a green no-op:
+//   - the matrix is DERIVED from hooks.json, so a hook added to a manifest is
+//     covered the moment it is added;
+//   - the gate is re-proven against the real bridge on every run, by putting
+//     #898 back into a copy of it and requiring rejection.
+// The second one is not theoretical: the first draft of this harness passed a
+// bridge with #898 reintroduced, because its sandbox had no auth token and
+// every bridge bailed before reaching the decision path at all.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { rmSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  REPO_ROOT,
+  buildCases,
+  discoverHookManifests,
+  NON_MANIFEST_INTEGRATIONS,
+  setupScenarios,
+  makeSandbox,
+  writeFixtureHooks,
+  writeMutatedBridge,
+  runHookCase,
+  classifyDecision,
+} from '../lib/hookHarmlessness.mjs';
+
+// Kill budget. Well above any honest hook; a hang lands here.
+const KILL_BUDGET_MS = 15_000;
+// How much wall clock a wmux hook may add over the no-op control. This is the
+// live A/B's "duration within ±50%" criterion expressed against a simulated
+// host: there the baseline is the agent's task, here it is a hook that does
+// nothing. The band sits deliberately BELOW the bridges' own 2s transport cap
+// (HOOK_TIMEOUT_MS) — a hook that waits out a dead daemon on the host's thread
+// is the stall this criterion forbids, so a budget above 2s could not fail it.
+// Measured headroom: every hook lands within ~110ms of the control locally.
+// (Review: Grok, P1.)
+const MAX_ADDED_MS = 1_500;
+// A descendant still holding the host's stdout/stderr this long after the hook
+// exited is a survivor, not scheduling noise.
+const MAX_SURVIVOR_GAP_MS = 500;
+
+let sandbox;
+let fixtures;
+let scenarios;
+let wedgedDaemonEnv;
+let disposeScenarios;
+let cases;
+
+beforeAll(async () => {
+  sandbox = makeSandbox();
+  fixtures = writeFixtureHooks(sandbox.home);
+  ({ scenarios, wedgedDaemonEnv, dispose: disposeScenarios } = await setupScenarios(sandbox));
+  cases = buildCases();
+}, 60_000);
+
+afterAll(async () => {
+  await disposeScenarios?.();
+  try {
+    // Guarded: beforeAll can throw before the sandbox exists, and an
+    // unguarded teardown would then bury the real failure. (Review: Grok, P3.)
+    if (sandbox?.home) rmSync(sandbox.home, { recursive: true, force: true });
+  } catch {
+    // A temp dir the OS will reap anyway; never fail the suite on cleanup.
+  }
+});
+
+/** Apply the three pass criteria; returns human-readable violations. */
+function violations(id, result, decision, control) {
+  const found = [];
+  // Criterion 1 — the host's decision is the control's decision.
+  if (decision !== 'none') found.push(`${id}: decision=${decision}`);
+  // Stricter form of the same thing, and the precise #898 pin: an observation
+  // hook writes zero bytes.
+  if ((result.stdout ?? '') !== '') {
+    found.push(`${id}: stdout=${JSON.stringify(result.stdout).slice(0, 160)}`);
+  }
+  // Exit 2 is Claude Code's "block this action". No observation hook may reach
+  // it, however it fails internally.
+  if (result.exitCode !== 0) found.push(`${id}: exit=${result.exitCode}`);
+
+  // Criterion 2 — completion and added latency.
+  if (result.timedOut) found.push(`${id}: timed out`);
+  if (control && result.wallMs > control.wallMs + MAX_ADDED_MS) {
+    found.push(`${id}: +${Math.round(result.wallMs - control.wallMs)}ms over control (cap ${MAX_ADDED_MS})`);
+  }
+
+  // Criterion 3 — nothing outlives the hook holding the host's stdio. Fail
+  // closed on a missing measurement: `?? 0` would let a refactor that stops
+  // reporting the gap read as a clean pass. (Review: Grok, P3.)
+  if (typeof result.survivorGapMs !== 'number') {
+    found.push(`${id}: survivor gap not measured`);
+  } else if (result.survivorGapMs > MAX_SURVIVOR_GAP_MS) {
+    found.push(`${id}: survivor held host stdio for ${Math.round(result.survivorGapMs)}ms`);
+  }
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// 0. The gate has to be able to fail.
+// ---------------------------------------------------------------------------
+
+describe('the gate detects the failures it exists to detect', () => {
+  it('rejects a hook that emits `ask`', async () => {
+    const result = await runHookCase({
+      script: fixtures.opinionated,
+      env: scenarios[0].env,
+      payload: { hook_event_name: 'PreToolUse' },
+      budgetMs: KILL_BUDGET_MS,
+    });
+    // `ask` looks neutral and is not: it forces a prompt and overrides the
+    // session's permission mode. Measured on Claude Code 2.1.233 (PR #899).
+    expect(classifyDecision('claudeCode', result)).toBe('ask');
+  }, 60_000);
+
+  it('rejects a hook that never returns', async () => {
+    const result = await runHookCase({
+      script: fixtures.hanging,
+      env: scenarios[0].env,
+      payload: {},
+      budgetMs: 2_500,
+    });
+    expect(result.timedOut).toBe(true);
+    expect(classifyDecision('claudeCode', result)).toBe('timeout');
+  }, 60_000);
+
+  it('rejects a hook that exits cleanly but leaves a process holding the host stdio', async () => {
+    const result = await runHookCase({
+      script: fixtures.orphan,
+      env: scenarios[0].env,
+      payload: {},
+      budgetMs: KILL_BUDGET_MS,
+    });
+    // The tell is NOT the exit: this fixture exits 0, promptly, silently.
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    // It is the gap between exit and the host's pipes finally closing.
+    expect(result.survivorGapMs).toBeGreaterThan(1_000);
+  }, 60_000);
+
+  it('accepts the no-op control', async () => {
+    const result = await runHookCase({
+      script: fixtures.noop,
+      env: scenarios[0].env,
+      payload: {},
+      budgetMs: KILL_BUDGET_MS,
+    });
+    expect(classifyDecision('claudeCode', result)).toBe('none');
+    // Asserted directly too: if the classifier ever softened, a dirty control
+    // would bless every treatment compared against it. (Review: Grok, P3.)
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.survivorGapMs).toBeLessThan(MAX_SURVIVOR_GAP_MS);
+  }, 60_000);
+
+  // The one that matters: not a fixture, the REAL bridge with #898 put back.
+  // This is what proves the scenarios below actually reach the decision path.
+  it('rejects the real bridge with #898 reintroduced', async () => {
+    const mutant = writeMutatedBridge(sandbox.home);
+    const gateCase = cases.find((c) => c.agent === 'claude' && c.args.includes('--permission-gate'));
+    expect(gateCase, 'the permission gate is missing from the matrix').toBeTruthy();
+
+    const decisions = {};
+    for (const scenario of scenarios) {
+      const result = await runHookCase({
+        ...gateCase,
+        script: mutant,
+        env: scenario.env,
+        budgetMs: KILL_BUDGET_MS,
+      });
+      decisions[scenario.id] = classifyDecision(gateCase.contract, result);
+    }
+    // The assertion is `ask`, NOT "some violation". A mutant that merely
+    // crashes, times out, or exits non-zero also violates the criteria, and
+    // accepting that would prove only that a broken file behaves badly —
+    // exactly the kind of false proof this test exists to rule out.
+    // (Review: Grok, P1.)
+    //
+    // Not every scenario reaches the gate's verdict path: a headless agent and
+    // a disabled gate both return earlier, by design. What must hold is that
+    // the states where #898 actually bit are caught, red-handed, emitting the
+    // one value that looks neutral and is not.
+    expect(decisions['installed-daemon-down']).toBe('ask');
+    expect(decisions['installed-daemon-no-verdict']).toBe('ask');
+  }, 120_000);
+});
+
+// ---------------------------------------------------------------------------
+// 1. Coverage — every hook wmux ships as a subprocess is in the matrix.
+// ---------------------------------------------------------------------------
+
+describe('the matrix covers what wmux actually installs', () => {
+  it('derives its cases from the shipped manifests', () => {
+    const agents = new Set(cases.map((c) => c.agent));
+    // opencode is absent by design: it is an in-process plugin, not a spawned
+    // hook, so it gets its own measurement below rather than a silent skip.
+    expect([...agents].sort()).toEqual(['claude', 'codex', 'openclaude']);
+    for (const c of cases) expect(c.script).toMatch(/\.mjs$/);
+    // The permission gate — the surface #898 lived on — must be in the matrix.
+    expect(cases.some((c) => c.args.includes('--permission-gate'))).toBe(true);
+  });
+
+  // "Derived from hooks.json, so a new hook is covered the moment it is added"
+  // is a claim about a count, and it is worth checking as one: a manifest
+  // entry the derivation quietly drops would otherwise leave this file green
+  // while that hook goes unmeasured. (Review: Grok, P2.)
+  it('turns every manifest entry into a case', () => {
+    for (const manifest of discoverHookManifests()) {
+      const declared = Object.values(JSON.parse(readFileSync(manifest.manifestPath, 'utf8')).hooks ?? {})
+        .flatMap((entries) => entries.flatMap((entry) => entry.hooks ?? []));
+      const derived = cases.filter((c) => c.agent === manifest.agent);
+      expect(derived.length, `${manifest.agent}: manifest entries not all turned into cases`)
+        .toBe(declared.length);
+    }
+  });
+
+  // The teeth. Adding integrations/<agent>/ without either a hook manifest or
+  // an entry in NON_MANIFEST_INTEGRATIONS fails here, which is the only thing
+  // stopping the next adapter from shipping outside this gate.
+  it('accounts for every integration directory', () => {
+    const integrations = readdirSync(join(REPO_ROOT, 'integrations'), { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+    const withManifests = new Set(discoverHookManifests().map((m) => m.agent));
+    const unaccounted = integrations.filter(
+      (name) => !withManifests.has(name) && !(name in NON_MANIFEST_INTEGRATIONS),
+    );
+    expect(
+      unaccounted,
+      'new integration(s) with no hook manifest and no stated reason — wire them into the '
+      + 'harmlessness gate, or record why they need no hook, in NON_MANIFEST_INTEGRATIONS',
+    ).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The gate itself: silent, prompt, and leaving nothing behind, in every
+//    state a user is actually in.
+// ---------------------------------------------------------------------------
+
+describe('every installed hook is indistinguishable from a no-op', () => {
+  for (const scenarioId of [
+    'not-installed',
+    'installed-daemon-down',
+    'installed-daemon-no-verdict',
+    'gate-disabled',
+    'headless',
+  ]) {
+    it(`${scenarioId}: no hook has an opinion, adds latency, or survives`, async () => {
+      const scenario = scenarios.find((s) => s.id === scenarioId);
+      const control = await runHookCase({
+        script: fixtures.noop,
+        env: scenario.env,
+        payload: { hook_event_name: 'Stop' },
+        budgetMs: KILL_BUDGET_MS,
+      });
+      // Asserted on the raw observation rather than through one contract:
+      // exit 0 with empty stdout is "no opinion" under every contract in the
+      // table, so the control needs no per-agent interpretation to be a
+      // control. (Review: Grok, P3.)
+      expect(control.exitCode).toBe(0);
+      expect(control.stdout).toBe('');
+
+      const found = [];
+      for (const testCase of cases) {
+        const result = await runHookCase({ ...testCase, env: scenario.env, budgetMs: KILL_BUDGET_MS });
+        found.push(...violations(testCase.id, result, classifyDecision(testCase.contract, result), control));
+      }
+      expect(found, `${scenarioId} — ${scenario.why}`).toEqual([]);
+    }, 180_000);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. stdin drain.
+//
+// A hook that stops reading stdin leaves the host writing into a pipe with no
+// reader. The bridges cap stdin at 1MB by design and drop the signal past it;
+// that is a delivery choice, not a harmlessness one. What must hold is that
+// the host's write SETTLES — errored is fine, wedged is not — and that the
+// hook still exits 0 and silently.
+// ---------------------------------------------------------------------------
+
+describe('an oversized payload cannot wedge the host', () => {
+  it('settles the write and still exits silently', async () => {
+    const scenario = scenarios.find((s) => s.id === 'installed-daemon-down');
+    const oversized = JSON.stringify({
+      session_id: 'harness-session',
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read',
+      tool_response: { text: 'x'.repeat(3 * 1024 * 1024) },
+    });
+    // Every stdin-taking hook, not just PostToolUse — excluding the
+    // permission gate would leave the one surface that already lied to a host
+    // out of the deadlock test. (Review: Grok, P2.)
+    const stdinCases = cases.filter((c) => c.stdin === 'json');
+    expect(stdinCases.length).toBeGreaterThan(0);
+
+    for (const testCase of stdinCases) {
+      const result = await runHookCase({
+        ...testCase,
+        env: scenario.env,
+        payload: oversized,
+        budgetMs: KILL_BUDGET_MS,
+      });
+      // The 3MB really left this process; otherwise the pipe was never put
+      // under pressure and the case is decorative. (Review: Grok, P1.)
+      expect(result.stdinBytes, testCase.id).toBeGreaterThan(1024 * 1024);
+      expect(result.timedOut, `${testCase.id} wedged the host`).toBe(false);
+      // The write reached a terminal state — completed or errored — rather
+      // than sitting in the pipe with nobody reading. That is the deadlock
+      // this criterion is about. (Review: Grok, P1.)
+      expect(result.stdinSettled, `${testCase.id} left the host's write pending`).toBe(true);
+      expect(result.exitCode, testCase.id).toBe(0);
+      expect(result.stdout, testCase.id).toBe('');
+      expect(result.survivorGapMs, testCase.id).toBeLessThan(MAX_SURVIVOR_GAP_MS);
+    }
+  }, 180_000);
+});
+
+// ---------------------------------------------------------------------------
+// 4. opencode — the in-process case.
+//
+// opencode loads a JS plugin into its own process instead of spawning a hook,
+// so "exit code" and "surviving process" do not apply. The equivalent harms
+// are throwing into the host's event loop and blocking it. The plugin's own
+// comment claims it detaches the pipe RPC from the event handler precisely so
+// a wedged endpoint cannot add the 2s transport cap to the TUI's idle
+// transition — that claim is what this measures.
+// ---------------------------------------------------------------------------
+
+describe('the opencode plugin does not block or throw into its host', () => {
+  it('returns promptly with no decision, against a daemon that never answers', async () => {
+    // A WEDGED endpoint, not an absent one. Against an absent pipe the RPC
+    // fails instantly and a plugin that forgot to detach would still look
+    // fast; here a non-detached handler sits on the 2s transport cap and this
+    // test catches it.
+    const keys = ['USERPROFILE', 'HOME', 'WMUX_DATA_SUFFIX', 'WMUX_PTY_ID'];
+    const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+    for (const k of keys) {
+      const value = wedgedDaemonEnv[k];
+      if (value === undefined) delete process.env[k];
+      else process.env[k] = value;
+    }
+    try {
+      const { WmuxBridge } = await import('../../integrations/opencode/plugins/wmux.js');
+      const plugin = await WmuxBridge({ directory: sandbox.home, client: undefined });
+
+      const events = [
+        { type: 'session.idle', properties: { sessionID: 'harness-session' } },
+        { type: 'permission.asked', properties: { id: 'perm-1', sessionID: 'harness-session', title: 'Run ls' } },
+        { type: 'permission.replied', properties: { id: 'perm-1' } },
+        { type: 'some.future.event', properties: {} },
+        // Malformed shapes the host could hand it. Never throw upward.
+        { type: 'session.idle' },
+        {},
+        null,
+      ];
+      for (const event of events) {
+        const startedAt = process.hrtime.bigint();
+        const returned = await plugin.event({ event });
+        const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+        // No decision channel: the handler's value must stay undefined.
+        expect(returned, JSON.stringify(event)).toBeUndefined();
+        // The detachment claim. Generous enough for a cold CI runner, still
+        // well below the 2s transport cap this is there to keep off the loop —
+        // and the daemon above is wedged, so a non-detached handler would sit
+        // on that full cap and land outside this bound.
+        expect(elapsedMs, `${JSON.stringify(event)} blocked the host loop`).toBeLessThan(1_000);
+      }
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  }, 60_000);
+});

--- a/scripts/__tests__/hookHarmlessness.runtime.test.mjs
+++ b/scripts/__tests__/hookHarmlessness.runtime.test.mjs
@@ -38,6 +38,7 @@ import {
   writeFixtureHooks,
   writeMutatedBridge,
   writeTranscriptFixture,
+  isHarnessAddress,
   runHookCase,
   classifyDecision,
 } from '../lib/hookHarmlessness.mjs';
@@ -258,6 +259,25 @@ describe('the matrix covers what wmux actually installs', () => {
   // daemon, not ours. Every instance therefore carries an explicit hint in the
   // harness namespace. This pins that: a run must never post harness
   // envelopes into a daemon someone is actually using.
+  // The predicate the check below leans on, pinned against both platforms'
+  // real spellings AND the derived names it exists to reject — otherwise a
+  // regex that matched everything would make that check vacuous.
+  it('recognises harness addresses on either platform and rejects real ones', () => {
+    for (const ours of [
+      '\\\\.\\pipe\\wmux-harness-1234-0-noverdict',
+      '\\\\.\\pipe\\wmux-harness-1234-0-down-never-bound',
+      '/var/folders/g3/abc/T/wmh-44488-0-notinstalled.sock-never-bound',
+      '/tmp/wmh-1-0-silent.sock',
+    ]) expect(isHarnessAddress(ours), ours).toBe(true);
+
+    for (const theirs of [
+      '\\\\.\\pipe\\wmux-daemon-rizz',
+      '\\\\.\\pipe\\wmux-rizz',
+      '/home/someone/.wmux/daemon.sock',
+      '/Users/someone/.wmux/daemon.sock',
+    ]) expect(isHarnessAddress(theirs), theirs).toBe(false);
+  });
+
   it('points every instance at the harness namespace, never a real daemon', () => {
     const homes = new Set(scenarios.map((s) => s.env.HOME));
     expect(homes.size, 'scenarios share a home — they would see each other').toBe(
@@ -273,10 +293,11 @@ describe('the matrix covers what wmux actually installs', () => {
       for (const dir of ['.wmux', ...suffixedDirs]) {
         const hint = join(home, dir, 'daemon-pipe');
         expect(existsSync(hint), `${dir}: no daemon-pipe hint — the bridge would derive one`).toBe(true);
+        const address = readFileSync(hint, 'utf8').trim();
         expect(
-          readFileSync(hint, 'utf8'),
-          `${dir}: hint escapes the harness namespace`,
-        ).toContain('harness');
+          isHarnessAddress(address),
+          `${dir}: hint escapes the harness namespace → ${address}`,
+        ).toBe(true);
       }
     }
   });

--- a/scripts/__tests__/hookHarmlessness.runtime.test.mjs
+++ b/scripts/__tests__/hookHarmlessness.runtime.test.mjs
@@ -37,6 +37,7 @@ import {
   makeSandbox,
   writeFixtureHooks,
   writeMutatedBridge,
+  writeTranscriptFixture,
   runHookCase,
   classifyDecision,
 } from '../lib/hookHarmlessness.mjs';
@@ -61,13 +62,24 @@ let fixtures;
 let scenarios;
 let wedgedDaemonEnv;
 let disposeScenarios;
+let daemonRequests;
+let daemonFurnishedScenarioIds;
 let cases;
 
 beforeAll(async () => {
   sandbox = makeSandbox();
   fixtures = writeFixtureHooks(sandbox.home);
-  ({ scenarios, wedgedDaemonEnv, dispose: disposeScenarios } = await setupScenarios(sandbox));
-  cases = buildCases();
+  const transcriptPath = writeTranscriptFixture(sandbox.home);
+  ({
+    scenarios,
+    wedgedDaemonEnv,
+    daemonRequests,
+    daemonFurnishedScenarioIds,
+    dispose: disposeScenarios,
+  } = await setupScenarios(sandbox));
+  // Payloads name a transcript that EXISTS, so the tail-read + JSONL parse is
+  // measured instead of returning at the bridges' `existsSync` guard.
+  cases = buildCases({ transcriptPath, cwd: sandbox.home });
 }, 60_000);
 
 afterAll(async () => {
@@ -94,6 +106,13 @@ function violations(id, result, decision, control) {
   // Exit 2 is Claude Code's "block this action". No observation hook may reach
   // it, however it fails internally.
   if (result.exitCode !== 0) found.push(`${id}: exit=${result.exitCode}`);
+  // stderr counts too. Claude Code puts a hook's stderr in the transcript even
+  // on exit 0, and the codex `notify` host logs it — so "an observation hook
+  // writes zero bytes" is a claim about BOTH streams. Checking only stdout let
+  // a hook narrate every invocation into the user's session and still pass.
+  if ((result.stderr ?? '') !== '') {
+    found.push(`${id}: stderr=${JSON.stringify(result.stderr).slice(0, 160)}`);
+  }
 
   // Criterion 2 — completion and added latency.
   if (result.timedOut) found.push(`${id}: timed out`);
@@ -229,6 +248,50 @@ describe('the matrix covers what wmux actually installs', () => {
         .toBe(declared.length);
     }
   });
+
+  // The positive control. Everything else here is an assertion that nothing
+  // happened, and a hook that never runs satisfies all of it: exit 0, no
+  // output, fast, no survivor. This is the one check that fails when the
+  // scenarios stop reaching the thing they claim to be testing against.
+  //
+  // It has already earned its place. Provisioning wrote only the SUFFIXED
+  // token layout, and the openclaude bridge reads the unsuffixed one, so all
+  // five of its cases returned at `no-auth-token` in all five scenarios —
+  // 25 of the 70 cells measuring an early bail. Nothing in the suite went
+  // red. This would have.
+  it('actually reaches the daemon in the scenarios that furnish one', async () => {
+    const before = daemonRequests();
+    const scenario = scenarios.find((s) => daemonFurnishedScenarioIds.includes(s.id));
+    expect(scenario, 'no daemon-furnished scenario in the matrix').toBeTruthy();
+
+    const served = new Map();
+    for (const testCase of cases) {
+      const at = daemonRequests();
+      await runHookCase({ ...testCase, env: scenario.env, budgetMs: KILL_BUDGET_MS });
+      served.set(testCase.id, daemonRequests() - at);
+    }
+
+    expect(
+      daemonRequests() - before,
+      `${scenario.id} served no daemon requests — the hooks bailed before the endpoint`,
+    ).toBeGreaterThan(0);
+
+    // Per AGENT, not per case: some events are deliberately dropped before any
+    // RPC (the codex ignored-type case is one), so requiring every case to
+    // talk would pin behaviour this file has no opinion about. Requiring every
+    // agent to talk at least once is what rules out a whole bridge silently
+    // sitting out the matrix.
+    const byAgent = new Map();
+    for (const testCase of cases) {
+      byAgent.set(testCase.agent, (byAgent.get(testCase.agent) ?? 0) + served.get(testCase.id));
+    }
+    const mute = [...byAgent].filter(([, n]) => n === 0).map(([agent]) => agent);
+    expect(
+      mute,
+      'agent(s) whose every case bailed before the daemon — their cells measure an early '
+      + 'return, not the hook. Check the token/pipe layout each bridge actually reads.',
+    ).toEqual([]);
+  }, 180_000);
 
   // The teeth. Adding integrations/<agent>/ without either a hook manifest or
   // an entry in NON_MANIFEST_INTEGRATIONS fails here, which is the only thing

--- a/scripts/__tests__/hookHarmlessness.runtime.test.mjs
+++ b/scripts/__tests__/hookHarmlessness.runtime.test.mjs
@@ -25,7 +25,7 @@
 // every bridge bailed before reaching the decision path at all.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { rmSync, readdirSync, readFileSync } from 'node:fs';
+import { rmSync, readdirSync, readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -249,6 +249,38 @@ describe('the matrix covers what wmux actually installs', () => {
     }
   });
 
+  // Nothing in the sandbox may address a real endpoint.
+  //
+  // Furnishing the unsuffixed token layout (needed so the openclaude cases
+  // reach a decision at all) also made every instance capable of CONNECTING,
+  // and a bridge with no `daemon-pipe` hint derives its address — openclaude
+  // derives `\\.\pipe\wmux-daemon-<username>`, which is the operator's live
+  // daemon, not ours. Every instance therefore carries an explicit hint in the
+  // harness namespace. This pins that: a run must never post harness
+  // envelopes into a daemon someone is actually using.
+  it('points every instance at the harness namespace, never a real daemon', () => {
+    const homes = new Set(scenarios.map((s) => s.env.HOME));
+    expect(homes.size, 'scenarios share a home — they would see each other').toBe(
+      new Set(scenarios.map((s) => s.env.WMUX_DATA_SUFFIX)).size,
+    );
+
+    for (const home of homes) {
+      // Both layouts, because the two bridge families read different ones.
+      // Directories only: the suffixed auth-token FILE shares the prefix.
+      const suffixedDirs = readdirSync(home, { withFileTypes: true })
+        .filter((e) => e.isDirectory() && e.name.startsWith('.wmux-harness'))
+        .map((e) => e.name);
+      for (const dir of ['.wmux', ...suffixedDirs]) {
+        const hint = join(home, dir, 'daemon-pipe');
+        expect(existsSync(hint), `${dir}: no daemon-pipe hint — the bridge would derive one`).toBe(true);
+        expect(
+          readFileSync(hint, 'utf8'),
+          `${dir}: hint escapes the harness namespace`,
+        ).toContain('harness');
+      }
+    }
+  });
+
   // The positive control. Everything else here is an assertion that nothing
   // happened, and a hook that never runs satisfies all of it: exit 0, no
   // output, fast, no survivor. This is the one check that fails when the
@@ -264,11 +296,15 @@ describe('the matrix covers what wmux actually installs', () => {
     const scenario = scenarios.find((s) => daemonFurnishedScenarioIds.includes(s.id));
     expect(scenario, 'no daemon-furnished scenario in the matrix').toBeTruthy();
 
-    const served = new Map();
-    for (const testCase of cases) {
+    // Keyed by INDEX, not by `testCase.id`: two manifest entries with the same
+    // event + matcher produce the same id, and a Map keyed on it would drop
+    // one of their counts — turning the only case that talks into a phantom
+    // "this agent never reached the daemon" failure.
+    const served = cases.map(() => 0);
+    for (const [i, testCase] of cases.entries()) {
       const at = daemonRequests();
       await runHookCase({ ...testCase, env: scenario.env, budgetMs: KILL_BUDGET_MS });
-      served.set(testCase.id, daemonRequests() - at);
+      served[i] = daemonRequests() - at;
     }
 
     expect(
@@ -282,8 +318,8 @@ describe('the matrix covers what wmux actually installs', () => {
     // agent to talk at least once is what rules out a whole bridge silently
     // sitting out the matrix.
     const byAgent = new Map();
-    for (const testCase of cases) {
-      byAgent.set(testCase.agent, (byAgent.get(testCase.agent) ?? 0) + served.get(testCase.id));
+    for (const [i, testCase] of cases.entries()) {
+      byAgent.set(testCase.agent, (byAgent.get(testCase.agent) ?? 0) + served[i]);
     }
     const mute = [...byAgent].filter(([, n]) => n === 0).map(([agent]) => agent);
     expect(

--- a/scripts/hook-ab-live.mjs
+++ b/scripts/hook-ab-live.mjs
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+// P-5 — the LIVE half of the A/B harmlessness gate.
+//
+// The CI half (scripts/__tests__/hookHarmlessness.runtime.test.mjs) simulates
+// the host: it drives the real hooks and applies each host's documented
+// contract to what they emit. That catches #898 and every hang/orphan class of
+// failure without an API key, and it runs on every PR.
+//
+// What it cannot do is prove the REAL host agrees with our reading of its
+// contract. This driver does that: it runs the same task twice through the
+// actual agent CLI — once with wmux's hooks installed, once without — and
+// compares the outcomes. It is opt-in and NOT in CI, because it costs tokens
+// and needs credentials.
+//
+//   node scripts/hook-ab-live.mjs --agent claude [--runs 1] [--json]
+//
+// SCOPE, measured not assumed: a headless `claude -p` run exercises every
+// OBSERVATION hook (SessionStart/PostToolUse/Stop/SubagentStop) end to end,
+// and NOT the PreToolUse permission gate — the gate defers unless
+// CLAUDE_CODE_ENTRYPOINT names an interactive entrypoint, and the agent sets
+// that variable itself when it spawns a hook, so the parent cannot present a
+// headless run as interactive. Verified: a bridge with #898 reintroduced
+// passes this driver. The gate path is covered by the CI half instead, which
+// proves it by mutating the real bridge on every run.
+//
+// The three pass criteria (plan §6), and which agents can actually report each
+// (from the P-3 hook-insertion survey):
+//
+//   1. Approval/denial set identical.
+//      claude   — `--output-format json` carries `permission_denials`.
+//      copilot  — has a `permissionRequest` event; equivalent measurement.
+//      kiro     — NO approval-specific event. Not measurable; criterion 2 is
+//                 the primary judgment there.
+//      gemini   — no approval event either, AND its docs say a hook "must not
+//                 print any plain text to stdout other than the final JSON",
+//                 so an empty stdout may be a parse failure rather than the
+//                 neutral we rely on everywhere else. That is the inverse of
+//                 Claude's contract and the exact shape of #898, which is why
+//                 gemini stays unsupported here until measured.
+//   2. Task completed, and duration within ±50%.  All agents.
+//   3. No hook process outlives the agent.        All agents.
+//
+// Agents are listed as `unsupported` rather than quietly omitted: a missing
+// row is a measurement nobody has taken, not a pass.
+
+import { spawn } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { startFakeDaemon, fakeDaemonAddress } from './lib/hookHarmlessness.mjs';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// An isolated wmux instance for the run: the owner's live daemon never sees a
+// fake pane signal, and the run gets a bridge.log nobody else writes to.
+//
+// It is a FURNISHED instance, not an empty one — auth token plus a stand-in
+// daemon on the other end. Without those the hooks bail at `no-auth-token` in
+// milliseconds and the A/B measures hooks that immediately give up rather than
+// hooks doing their work. (Review: Grok, P1.)
+const ABLIVE_SUFFIX = `-ablive-${process.pid}`;
+const ABLIVE_HOME = join(homedir(), `.wmux${ABLIVE_SUFFIX}`);
+const ABLIVE_LOG = join(ABLIVE_HOME, 'bridge.log');
+// The agent itself gets no bound here (a model turn is as long as it is), but
+// a hung CLI must not hang the driver forever.
+const AGENT_TIMEOUT_MS = 300_000;
+
+// The task. Deliberately dull and single-step: we are measuring the hooks, not
+// the model. It must touch the filesystem so "completed" is checkable from the
+// outside rather than from the agent's own say-so.
+const TASK = 'Create a file named done.txt in the current directory containing exactly the word ready. Then stop.';
+const COMPLETION_FILE = 'done.txt';
+
+const AGENTS = {
+  claude: {
+    bin: 'claude',
+    measuresDenials: true,
+    /** argv for one headless run against `settingsPath` in `cwd`. */
+    argv: (settingsPath) => [
+      '-p', TASK,
+      '--output-format', 'json',
+      '--permission-mode', 'bypassPermissions',
+      '--settings', settingsPath,
+    ],
+    /** The settings file that installs (or omits) wmux's hooks. */
+    settings: (withHooks) => {
+      if (!withHooks) return { hooks: {} };
+      const bridge = join(REPO_ROOT, 'integrations', 'claude', 'bin', 'wmux-bridge.mjs').replace(/\\/g, '/');
+      // Reuse the shipped manifest so this measures what users install, not
+      // a restatement of it that can drift.
+      const manifest = JSON.parse(
+        readFileSync(join(REPO_ROOT, 'integrations', 'claude', 'hooks', 'hooks.json'), 'utf8'),
+      );
+      const substituted = JSON.parse(
+        JSON.stringify(manifest).split('${CLAUDE_PLUGIN_ROOT}/bin/wmux-bridge.mjs').join(bridge),
+      );
+      return substituted;
+    },
+    parse: (stdout) => {
+      try {
+        const parsed = JSON.parse(stdout);
+        return {
+          denials: (parsed.permission_denials ?? []).map((d) => d.tool_name ?? String(d)).sort(),
+          agentReportedError: parsed.is_error === true,
+        };
+      } catch {
+        return { denials: null, agentReportedError: null };
+      }
+    },
+  },
+  // Filled in when the adapter lands; see the P-3 survey for why this order.
+  copilot: { unsupported: 'adapter not built yet — P-3 ranks it first' },
+  kiro: { unsupported: 'adapter not built yet; no approval event, criterion 1 not measurable' },
+  gemini: { unsupported: 'blocked: empty stdout may be a parse failure, not neutral (P-3 R2)' },
+};
+
+function parseArgs(argv) {
+  const args = { agent: 'claude', runs: 1, json: false };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--agent') args.agent = argv[++i];
+    else if (argv[i] === '--runs') {
+      args.runs = Number(argv[++i]);
+      if (!Number.isInteger(args.runs) || args.runs < 1) throw new Error('--runs must be a positive integer');
+    }
+    else if (argv[i] === '--json') args.json = true;
+    else throw new Error(`unknown argument: ${argv[i]}`);
+  }
+  return args;
+}
+
+// Agent CLIs ship as `.cmd` shims on Windows, and Node refuses to spawn those
+// without a shell. A shell then re-splits the argv on whitespace, which
+// silently truncated the task prompt to its first word on the first run of
+// this driver — both arms "completed" nothing and the comparison looked clean.
+// Quote every argument so the agent receives what we meant to send.
+function quoteForShell(arg) {
+  const text = String(arg);
+  if (process.platform !== 'win32') return text;
+  // cmd.exe doubles an embedded quote; a backslash escape would split the
+  // argv — the same class of bug that truncated the prompt above.
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function runAgent(profile, { cwd, settingsPath, env }) {
+  return new Promise((resolve) => {
+    const startedAt = process.hrtime.bigint();
+    const useShell = process.platform === 'win32';
+    const argv = profile.argv(settingsPath);
+    const child = spawn(profile.bin, useShell ? argv.map(quoteForShell) : argv, {
+      cwd,
+      env,
+      shell: useShell,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, AGENT_TIMEOUT_MS);
+    child.stdout.on('data', (c) => { stdout += c.toString('utf8'); });
+    child.stderr.on('data', (c) => { stderr += c.toString('utf8'); });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({ spawnError: String(err), wallMs: Number(process.hrtime.bigint() - startedAt) / 1e6 });
+    });
+    // 'close', not 'exit' — the same survivor probe the CI half uses: a hook
+    // process that outlives the agent while holding its stdio delays this.
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const wallMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+      resolve({ exitCode: code, stdout, stderr, wallMs, timedOut });
+    });
+  });
+}
+
+async function measure(profile, { withHooks, sandbox, label }) {
+  const cwd = join(sandbox, label);
+  mkdirSync(cwd, { recursive: true });
+  const settingsPath = join(sandbox, `${label}-settings.json`);
+  writeFileSync(settingsPath, JSON.stringify(profile.settings(withHooks), null, 2), 'utf8');
+
+  const env = { ...process.env };
+  // Both arms run against an isolated wmux instance. Two reasons, both
+  // load-bearing: a live A/B must not inject fake pane signals into the
+  // owner's running daemon, and an isolated instance gets its own bridge.log,
+  // which is the only way to PROVE the hooks fired rather than assume it.
+  env.WMUX_DATA_SUFFIX = ABLIVE_SUFFIX;
+  // The hooks must believe they are inside a pane, or every decision path
+  // short-circuits and the run measures nothing.
+  if (withHooks) env.WMUX_PTY_ID = 'ab-live-pty';
+  else delete env.WMUX_PTY_ID;
+
+  const hookLinesBefore = countHookLines();
+  const result = await runAgent(profile, { cwd, settingsPath, env });
+  // Contents, not just existence: an empty file the agent touched and gave up
+  // on is not a completed task. (Review: Grok, P3.)
+  const donePath = join(cwd, COMPLETION_FILE);
+  const completed = existsSync(donePath) && readFileSync(donePath, 'utf8').toLowerCase().includes('ready');
+  return {
+    ...result,
+    ...(profile.parse?.(result.stdout ?? '') ?? {}),
+    completed,
+    cwd,
+    hookInvocations: countHookLines() - hookLinesBefore,
+  };
+}
+
+// How many times a wmux hook ran during a window. Without this the driver
+// cannot tell "the hooks are harmless" from "the hooks never ran" — and a
+// silently unwired treatment arm passes every criterion.
+function countHookLines() {
+  try {
+    return readFileSync(ABLIVE_LOG, 'utf8').split('\n').filter((l) => l.trim()).length;
+  } catch {
+    return 0;
+  }
+}
+
+function compare(a, b, profile) {
+  const findings = [];
+  // Criterion 0 — the arms have to be what they claim to be. This check found
+  // a real flaw on its first run: `--settings` MERGES with the user's config,
+  // so on a machine where the wmux plugin is already installed the "without
+  // hooks" arm still fired three of them. Silently, the driver had been
+  // comparing 3 hooks against 7 and calling it hooks-vs-no-hooks.
+  if (b.hookInvocations <= a.hookInvocations) {
+    findings.push({
+      level: 'fail',
+      text: `the injected hooks never fired (control=${a.hookInvocations}, treatment=${b.hookInvocations}) — nothing was measured`,
+    });
+  }
+  if (a.hookInvocations > 0) {
+    findings.push({
+      level: 'unmeasured',
+      text: `wmux hooks are installed globally on this machine, so the control arm ran ${a.hookInvocations} of them. `
+        + 'This run measures the MARGINAL effect of the injected hooks, not hooks-vs-no-hooks. '
+        + 'Isolating that would need CLAUDE_CONFIG_DIR, which drops the credentials with the config — '
+        + 'so the absolute claim comes from the CI half, which needs no agent at all.',
+    });
+  }
+  // Criterion 1 — the approval/denial set.
+  if (a.denials === null || b.denials === null) {
+    // For an agent whose profile says the denial list IS available, failing to
+    // parse it means the run measured nothing — not that criterion 1 is
+    // inapplicable. Only an agent with no denial channel gets `unmeasured`.
+    // (Review: Grok, P2.)
+    findings.push({
+      level: profile.measuresDenials ? 'fail' : 'unmeasured',
+      text: 'denial list not parseable from this agent output',
+    });
+  } else if (JSON.stringify(a.denials) !== JSON.stringify(b.denials)) {
+    findings.push({
+      level: 'fail',
+      text: `denials differ: without=${JSON.stringify(a.denials)} with=${JSON.stringify(b.denials)}`,
+    });
+  }
+  // The agent itself has to have run, in both arms and the same way.
+  if (a.spawnError || b.spawnError) {
+    findings.push({ level: 'fail', text: `agent failed to spawn: ${a.spawnError ?? b.spawnError}` });
+  }
+  if (a.timedOut || b.timedOut) {
+    findings.push({ level: 'fail', text: 'an arm hit the agent timeout' });
+  }
+  if (a.exitCode !== b.exitCode) {
+    findings.push({ level: 'fail', text: `exit codes differ: without=${a.exitCode} with=${b.exitCode}` });
+  }
+  if (a.agentReportedError !== b.agentReportedError) {
+    findings.push({
+      level: 'fail',
+      text: `agent error flag differs: without=${a.agentReportedError} with=${b.agentReportedError}`,
+    });
+  }
+
+  // Criterion 2 — completion, then duration.
+  if (a.completed !== b.completed) {
+    findings.push({ level: 'fail', text: `completion differs: without=${a.completed} with=${b.completed}` });
+  } else if (!a.completed) {
+    findings.push({ level: 'unmeasured', text: 'neither run completed the task — the A/B says nothing' });
+  }
+  // Duration says nothing when neither arm did the work. (Review: Grok, P3.)
+  const ratio = b.wallMs / a.wallMs;
+  if (a.completed && b.completed && (ratio > 1.5 || ratio < 0.5)) {
+    findings.push({
+      level: 'fail',
+      text: `duration outside ±50%: without=${Math.round(a.wallMs)}ms with=${Math.round(b.wallMs)}ms (${ratio.toFixed(2)}x)`,
+    });
+  }
+  return findings;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const profile = AGENTS[args.agent];
+  if (!profile) throw new Error(`unknown agent: ${args.agent}. known: ${Object.keys(AGENTS).join(', ')}`);
+  if (profile.unsupported) {
+    console.error(`${args.agent}: ${profile.unsupported}`);
+    process.exitCode = 2;
+    return;
+  }
+
+  const sandbox = mkdtempSync(join(tmpdir(), 'wmux-ab-live-'));
+  const rounds = [];
+  let threw = false;
+
+  // Furnish the isolated instance: a token the bridges will accept and a
+  // stand-in daemon that answers. Both arms point at it, so the hooks under
+  // test actually connect, send, and read a reply.
+  mkdirSync(ABLIVE_HOME, { recursive: true });
+  writeFileSync(join(ABLIVE_HOME, 'daemon-auth-token'), 'ab-live-token', 'utf8');
+  writeFileSync(join(homedir(), `.wmux${ABLIVE_SUFFIX}-auth-token`), 'ab-live-token', 'utf8');
+  const daemonAddress = fakeDaemonAddress({ seq: 'live' }, 'ablive');
+  const daemon = await startFakeDaemon(daemonAddress, (request) => ({
+    ok: true,
+    result: { ok: true, received: request.method },
+  }));
+  writeFileSync(join(ABLIVE_HOME, 'daemon-pipe'), daemonAddress, 'utf8');
+
+  try {
+    for (let i = 0; i < args.runs; i++) {
+      // Order matters less than isolation: each run gets its own cwd, so a
+      // file left by one never makes the other look complete.
+      const without = await measure(profile, { withHooks: false, sandbox, label: `r${i}-without` });
+      const withHooks = await measure(profile, { withHooks: true, sandbox, label: `r${i}-with` });
+      rounds.push({ run: i, without, with: withHooks, findings: compare(without, withHooks, profile) });
+    }
+  } catch (err) {
+    // A throw mid-run is exactly when the transcripts are worth keeping — the
+    // earlier version deleted them, because `rounds` was empty and therefore
+    // "clean". (Review: Grok, P2.)
+    threw = true;
+    console.error(String(err));
+  } finally {
+    await daemon.close();
+    rmSync(ABLIVE_HOME, { recursive: true, force: true });
+    rmSync(join(homedir(), `.wmux${ABLIVE_SUFFIX}-auth-token`), { force: true });
+    const failed = threw || rounds.some((r) => r.findings.some((f) => f.level === 'fail'));
+    if (!failed) rmSync(sandbox, { recursive: true, force: true });
+    else console.error(`sandbox kept for inspection: ${sandbox} (${readdirSync(sandbox).join(', ')})`);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({ agent: args.agent, rounds }, null, 2));
+  } else {
+    for (const round of rounds) {
+      console.log(`--- run ${round.run} (${args.agent}) ---`);
+      for (const [label, m] of [['without hooks', round.without], ['with hooks', round.with]]) {
+        console.log(
+          `  ${label.padEnd(14)} exit=${m.exitCode} ${Math.round(m.wallMs)}ms `
+          + `completed=${m.completed} hooks=${m.hookInvocations} `
+          + `denials=${m.denials === null ? 'unparsed' : JSON.stringify(m.denials)}`,
+        );
+      }
+      if (round.findings.length === 0) console.log('  PASS — indistinguishable on all measured criteria');
+      for (const f of round.findings) console.log(`  ${f.level.toUpperCase()} — ${f.text}`);
+    }
+  }
+
+  // Three outcomes, not two. "Nothing was measured" must not read as a pass:
+  // an unparseable result, a machine whose global hooks pollute the control,
+  // or zero rounds all leave the claim unestablished. (Review: Grok, P1.)
+  //   0 = every measured criterion matched
+  //   1 = a criterion failed
+  //   2 = the run did not establish the claim
+  const anyFail = threw || rounds.some((r) => r.findings.some((f) => f.level === 'fail'));
+  const anyUnmeasured = rounds.length === 0
+    || rounds.some((r) => r.findings.some((f) => f.level === 'unmeasured'));
+  if (anyFail) process.exitCode = 1;
+  else if (anyUnmeasured) process.exitCode = 2;
+  else process.exitCode = 0;
+}
+
+main().catch((err) => {
+  console.error(String(err));
+  process.exitCode = 1;
+});

--- a/scripts/hook-ab-live.mjs
+++ b/scripts/hook-ab-live.mjs
@@ -43,7 +43,7 @@
 // Agents are listed as `unsupported` rather than quietly omitted: a missing
 // row is a measurement nobody has taken, not a pass.
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, readdirSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { tmpdir, homedir } from 'node:os';
@@ -102,7 +102,14 @@ const AGENTS = {
       try {
         const parsed = JSON.parse(stdout);
         return {
-          denials: (parsed.permission_denials ?? []).map((d) => d.tool_name ?? String(d)).sort(),
+          // ABSENT is not EMPTY. A CLI that does not emit the field at all
+          // (older builds) would otherwise compare `[]` against `[]` and read
+          // as "criterion 1 measured, both arms clean" — a pass this run never
+          // earned. `null` routes to the unmeasured path, same as unparseable
+          // output does below.
+          denials: parsed.permission_denials === undefined
+            ? null
+            : parsed.permission_denials.map((d) => d.tool_name ?? String(d)).sort(),
           agentReportedError: parsed.is_error === true,
         };
       } catch {
@@ -157,7 +164,22 @@ function runAgent(profile, { cwd, settingsPath, env }) {
     let stdout = '';
     let stderr = '';
     let timedOut = false;
-    const timer = setTimeout(() => { timedOut = true; child.kill('SIGKILL'); }, AGENT_TIMEOUT_MS);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // With `shell: true` the child is cmd.exe and the agent is its GRANDchild,
+      // so TerminateProcess on the child leaves the CLI running — still burning
+      // tokens, still holding the inherited stdio that 'close' waits on. Kill
+      // the tree. `taskkill` failing (already exited, race) is not actionable,
+      // and the SIGKILL below still reaps the direct child either way.
+      if (useShell && process.platform === 'win32' && child.pid) {
+        try {
+          spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+        } catch {
+          // Fall through to the direct kill.
+        }
+      }
+      child.kill('SIGKILL');
+    }, AGENT_TIMEOUT_MS);
     child.stdout.on('data', (c) => { stdout += c.toString('utf8'); });
     child.stderr.on('data', (c) => { stderr += c.toString('utf8'); });
     child.on('error', (err) => {

--- a/scripts/hook-ab-live.mjs
+++ b/scripts/hook-ab-live.mjs
@@ -107,9 +107,9 @@ const AGENTS = {
           // as "criterion 1 measured, both arms clean" — a pass this run never
           // earned. `null` routes to the unmeasured path, same as unparseable
           // output does below.
-          denials: parsed.permission_denials === undefined
-            ? null
-            : parsed.permission_denials.map((d) => d.tool_name ?? String(d)).sort(),
+          denials: Array.isArray(parsed.permission_denials)
+            ? parsed.permission_denials.map((d) => d.tool_name ?? String(d)).sort()
+            : null,
           agentReportedError: parsed.is_error === true,
         };
       } catch {

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -164,7 +164,7 @@ export const NON_MANIFEST_INTEGRATIONS = {
   shared: 'not an agent — shared type declarations',
 };
 
-function casesFromHooksJson({ agent, manifestPath, pluginRoot, contract }) {
+function casesFromHooksJson({ agent, manifestPath, pluginRoot, contract, payloadOpts }) {
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
   const cases = [];
   for (const [event, entries] of Object.entries(manifest.hooks ?? {})) {
@@ -192,7 +192,7 @@ function casesFromHooksJson({ agent, manifestPath, pluginRoot, contract }) {
           script: argv[1],
           args: argv.slice(2),
           stdin: 'json',
-          payload: payloadFor(event, entry.matcher),
+          payload: payloadFor(event, entry.matcher, payloadOpts),
         });
       }
     }
@@ -200,13 +200,51 @@ function casesFromHooksJson({ agent, manifestPath, pluginRoot, contract }) {
   return cases;
 }
 
+/**
+ * Write a transcript the bridges will actually READ.
+ *
+ * `transcript_path` used to name a file that never existed, so
+ * `extractUsageFromTranscript` and the permission-mode walk both returned at
+ * their `existsSync` guard. That left the largest block of work a Stop /
+ * SubagentStop / SessionStart hook does — tail-read plus JSONL parse, the part
+ * that can actually throw on a real payload — outside the measurement, in
+ * every scenario.
+ *
+ * Shaped to the records the parsers look for: an assistant entry carrying
+ * `message.usage`, a dedicated `permission-mode` record, and a truncated line
+ * (transcripts are appended live, so a half-written tail is normal) that the
+ * parsers are supposed to skip rather than die on.
+ */
+export function writeTranscriptFixture(sandboxHome) {
+  const path = join(sandboxHome, 'harness-session.jsonl');
+  const lines = [
+    JSON.stringify({ type: 'user', message: { role: 'user', content: 'hi' }, permissionMode: 'default' }),
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        usage: {
+          input_tokens: 120,
+          cache_creation_input_tokens: 8,
+          cache_read_input_tokens: 4096,
+          output_tokens: 64,
+        },
+      },
+    }),
+    JSON.stringify({ type: 'permission-mode', permissionMode: 'bypassPermissions' }),
+    '{"type":"assistant","message":{"usage":{"input_toke',
+  ];
+  writeFileSync(path, lines.join('\n') + '\n', 'utf8');
+  return path;
+}
+
 // Representative host payloads. Shape matters (the bridge reads tool_name,
 // transcript_path, session_id); content does not.
-function payloadFor(event, matcher) {
+function payloadFor(event, matcher, { transcriptPath, cwd } = {}) {
   const base = {
     session_id: 'harness-session',
-    transcript_path: '/tmp/harness/harness-session.jsonl',
-    cwd: '/tmp/harness',
+    transcript_path: transcriptPath ?? '/tmp/harness/harness-session.jsonl',
+    cwd: cwd ?? '/tmp/harness',
     hook_event_name: event,
   };
   if (event === 'PreToolUse') {
@@ -224,10 +262,17 @@ function payloadFor(event, matcher) {
 // grade it against the wrong rules.
 const CONTRACT_OVERRIDES = {};
 
-export function buildCases() {
+/**
+ * @param {{transcriptPath?: string, cwd?: string}} [payloadOpts] Point the
+ *   payloads at a transcript that EXISTS (writeTranscriptFixture) so the
+ *   bridges' tail-read + JSONL parse is inside the measurement rather than
+ *   short-circuited at their `existsSync` guard.
+ */
+export function buildCases(payloadOpts) {
   const cases = discoverHookManifests().flatMap((manifest) => casesFromHooksJson({
     ...manifest,
     contract: CONTRACT_OVERRIDES[manifest.agent] ?? 'claudeCode',
+    payloadOpts,
   }));
   // Codex takes its payload as the LAST argv token, not on stdin, and is
   // registered in config.toml rather than a hooks manifest — so it is spelled
@@ -245,8 +290,8 @@ export function buildCases() {
     }],
     ['legacy', {
       session_id: 'harness-session',
-      transcript_path: '/tmp/harness/harness-session.jsonl',
-      cwd: '/tmp/harness',
+      transcript_path: payloadOpts?.transcriptPath ?? '/tmp/harness/harness-session.jsonl',
+      cwd: payloadOpts?.cwd ?? '/tmp/harness',
       hook_event_name: 'Stop',
     }],
     // A type Codex emits that wmux deliberately ignores. "Ignored" must still
@@ -292,15 +337,40 @@ export function makeSandbox() {
 // lived in, so it would pass a bridge with #898 reintroduced. (Measured:
 // the mutation check below fails without this.)
 export function provisionInstance(sandbox, { token = false, daemonPipeName = null } = {}) {
-  const suffix = `-harness-${process.pid}-${sandbox.seq++}`;
-  const wmuxHome = join(sandbox.home, `.wmux${suffix}`);
-  mkdirSync(wmuxHome, { recursive: true });
+  const seq = sandbox.seq++;
+  const suffix = `-harness-${process.pid}-${seq}`;
+  // Each instance gets its OWN home, not a shared one keyed by suffix.
+  //
+  // Not every bridge honours WMUX_DATA_SUFFIX: the openclaude fork reads the
+  // UNSUFFIXED `~/.wmux/daemon-auth-token` and `~/.wmux-auth-token` (its own
+  // source says so: "Same ~/.wmux (no data-suffix) limitation"). Provisioning
+  // only the suffixed layout meant every openclaude case returned at
+  // `no-auth-token` — exit 0, no output, fast — which passes every criterion
+  // in this file while measuring nothing about the hook. That is the same
+  // early-bail trap the mutation check exists to catch, one bridge over.
+  //
+  // Writing the unsuffixed layout into a SHARED home would fix that case and
+  // break scenario isolation instead: `not-installed` would see the token
+  // `installed-daemon-down` wrote. A home per instance lets both layouts be
+  // furnished without either scenario seeing the other's.
+  const home = join(sandbox.home, `inst-${seq}`);
+  const suffixedWmux = join(home, `.wmux${suffix}`);
+  const plainWmux = join(home, '.wmux');
+  mkdirSync(suffixedWmux, { recursive: true });
+  mkdirSync(plainWmux, { recursive: true });
   if (token) {
-    writeFileSync(join(wmuxHome, 'daemon-auth-token'), 'harness-daemon-token', 'utf8');
-    writeFileSync(join(sandbox.home, `.wmux${suffix}-auth-token`), 'harness-main-token', 'utf8');
+    for (const dir of [suffixedWmux, plainWmux]) {
+      writeFileSync(join(dir, 'daemon-auth-token'), 'harness-daemon-token', 'utf8');
+    }
+    writeFileSync(join(home, `.wmux${suffix}-auth-token`), 'harness-main-token', 'utf8');
+    writeFileSync(join(home, '.wmux-auth-token'), 'harness-main-token', 'utf8');
   }
-  if (daemonPipeName) writeFileSync(join(wmuxHome, 'daemon-pipe'), daemonPipeName, 'utf8');
-  return suffix;
+  if (daemonPipeName) {
+    for (const dir of [suffixedWmux, plainWmux]) {
+      writeFileSync(join(dir, 'daemon-pipe'), daemonPipeName, 'utf8');
+    }
+  }
+  return { suffix, home };
 }
 
 export function fakeDaemonAddress(sandbox, label) {
@@ -408,20 +478,29 @@ export async function setupScenarios(sandbox) {
   // a pre-gate daemon, a non-gated tool, or the broker deferring to the
   // session's own permission flow. Silence is the only faithful encoding.
   const noVerdictAddress = fakeDaemonAddress(sandbox, 'noverdict');
-  const noVerdictServer = await startFakeDaemon(noVerdictAddress, (request) => ({
-    ok: true,
-    result: { ok: true, received: request.method },
-  }));
+  // Counted, not just answered. "The daemon-furnished scenario reached the
+  // daemon" is otherwise unobservable: a broken pipe hint, a renamed token
+  // path, a layout the bridge does not read — each makes the bridge behave
+  // exactly like `installed-daemon-down` (fast, silent, exit 0) and the
+  // scenario still passes. Asserting a non-zero count is what turns "these
+  // hooks were measured against a live daemon" from a label into a fact.
+  let noVerdictRequests = 0;
+  const noVerdictServer = await startFakeDaemon(noVerdictAddress, (request) => {
+    noVerdictRequests += 1;
+    return { ok: true, result: { ok: true, received: request.method } };
+  });
   cleanups.push(() => noVerdictServer.close());
   const installedNoVerdict = provisionInstance(sandbox, {
     token: true,
     daemonPipeName: noVerdictAddress,
   });
 
-  const env = (suffix, extra) => ({
-    USERPROFILE: sandbox.home,
-    HOME: sandbox.home,
-    WMUX_DATA_SUFFIX: suffix,
+  const env = (instance, extra) => ({
+    // Per-instance home: see provisionInstance for why the suffix alone is
+    // not enough to isolate a scenario.
+    USERPROFILE: instance.home,
+    HOME: instance.home,
+    WMUX_DATA_SUFFIX: instance.suffix,
     CLAUDE_CODE_ENTRYPOINT: 'cli',
     ...extra,
   });
@@ -472,6 +551,12 @@ export async function setupScenarios(sandbox) {
   return {
     scenarios,
     wedgedDaemonEnv: env(installedSilent, { WMUX_PTY_ID: 'harness-pty-1' }),
+    /** Requests the no-verdict daemon has actually served. The positive
+     *  control: see the comment where it is incremented. */
+    daemonRequests: () => noVerdictRequests,
+    /** Scenarios furnished with that daemon — the ones whose name claims a
+     *  daemon was reached, and so the ones the control applies to. */
+    daemonFurnishedScenarioIds: ['installed-daemon-no-verdict'],
     dispose: async () => { for (const fn of cleanups) await fn(); },
   };
 }

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -1,0 +1,706 @@
+// P-5 — the A/B harmlessness gate for wmux's agent hooks.
+//
+// wmux installs observation hooks into other people's agents. #898 is what
+// happens when one of those hooks says something the host reads as an
+// instruction: the Claude Code permission gate emitted `ask` on every
+// "wmux has no opinion" path, and `ask` is not neutral — it forces a prompt
+// and overrides the session's permission mode. A bypassPermissions session
+// started asking for permission to run `Read`, and the documented escape
+// hatch (`WMUX_GATE=0`) emitted `ask` too, so there was no way to turn it off.
+//
+// "Observation hooks are harmless" is a claim, not a fact. This harness
+// MEASURES it. The claim being tested is precise:
+//
+//   Installing a wmux hook must be indistinguishable, to the host, from
+//   installing a hook that provably has no opinion.
+//
+// So every case runs twice — a CONTROL (a no-op hook: drain stdin, exit 0,
+// write nothing) and a TREATMENT (the real wmux hook, invoked byte-for-byte
+// the way the host's own manifest invokes it) — and the two are compared.
+//
+// The three pass criteria from the plan (§6), and how each is measured here:
+//
+//   1. Approval/denial set identical.
+//      The host's decision is a pure function of (exit code, stdout). Each
+//      host's contract is pinned in HOST_CONTRACTS below with its source, and
+//      classifyDecision() applies it. Control and treatment must classify the
+//      same. For an observation hook that means `none` — and stdout must be
+//      byte-empty, which is the direct #898 regression pin.
+//
+//   2. Completion and duration.
+//      In a live A/B this is the agent's task duration (±50%). Here the host
+//      is simulated, so the equivalent — and the thing that actually reaches
+//      the agent — is the hook's own wall clock. A hook that hangs blows the
+//      budget; a hook that never completes is caught by the same timeout.
+//      The ±50% band is not applicable against a no-op baseline (a no-op is
+//      pure node startup), so this layer asserts an ABSOLUTE per-hook budget
+//      instead. The ±50% comparison lives in the live layer.
+//
+//   3. Hook process lifetime.
+//      Measured without walking the process tree: the host holds the hook's
+//      stdout/stderr pipes and waits on them. If any descendant outlives the
+//      hook while holding those pipes, 'close' fires later than 'exit' — or
+//      never. So closeMs - exitMs is the survivor signal, and it is exactly
+//      the survivor that would matter to the host. stdin drain is measured by
+//      writing a payload larger than the bridge's own cap and requiring the
+//      write to settle (ok or EPIPE) rather than deadlock.
+//
+// Deliberately NOT tested here: whether the signal actually reached wmux.
+// This harness runs with no daemon reachable on purpose — "wmux is not
+// running" is the single most common state a plugin user is in, and it is the
+// state #898 broke. Delivery is covered by the integration's own tests.
+
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import {
+  readFileSync, writeFileSync, mkdtempSync, mkdirSync, unlinkSync, readdirSync, existsSync,
+} from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = join(HERE, '..', '..');
+
+// The no-op reference hook. This is the "provably has no opinion" control:
+// it consumes stdin to the end (so the host's write always completes), writes
+// nothing, and exits 0. Anything the real hook does beyond this is a
+// difference the host can observe.
+const NOOP_HOOK_SOURCE = [
+  'process.stdin.resume();',
+  "process.stdin.on('data', () => {});",
+  "process.stdin.on('error', () => {});",
+  "process.stdin.on('end', () => { process.exitCode = 0; });",
+].join('\n');
+
+// ----- Host contracts -----------------------------------------------------
+//
+// How each host turns (exit code, stdout) into a decision. These are the
+// documented contracts, not guesses; a wrong entry here would make the whole
+// harness lie, so each one carries its source.
+
+export const HOST_CONTRACTS = {
+  // Claude Code (and openclaude, which reuses the same hook runner).
+  // "Exit code 0 with no output means the hook has no decision to report, so
+  // the tool call continues through the normal permission flow." Exit 2 is
+  // "do not let this action proceed" and feeds stderr to the model. Any other
+  // non-zero is a non-blocking error the host logs and moves past.
+  // `ask` is a DECISION, not a default — measured in #898 (see PR #899).
+  claudeCode(exitCode, stdout) {
+    if (exitCode === 2) return 'block';
+    if (exitCode !== 0) return 'nonblocking-error';
+    // Byte-empty, not trim-empty. The neutral contract is "exit 0 with no
+    // output"; a lone newline is output, and folding it into `none` would let
+    // a hook that writes whitespace read as identical to a hook that writes
+    // nothing. (Review: Grok, P2.)
+    if (stdout === '') return 'none';
+    const text = stdout.trim();
+    if (text === '') return 'stdout-noise';
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // Not JSON: the host surfaces it as transcript noise rather than a
+      // decision. Still a difference from the control, so it gets its own
+      // label instead of being folded into `none`.
+      return 'stdout-noise';
+    }
+    const decision = parsed?.hookSpecificOutput?.permissionDecision;
+    if (decision === 'allow' || decision === 'deny' || decision === 'ask') return decision;
+    if (parsed?.decision === 'block') return 'block';
+    return 'stdout-noise';
+  },
+
+  // Codex's `notify` program has no decision channel at all: Codex spawns it
+  // and ignores both its exit code and its stdout. The only ways it can harm
+  // a turn are latency and a surviving process, which criteria 2 and 3 cover.
+  codexNotify(exitCode, stdout) {
+    if (stdout !== '') return 'stdout-noise';
+    if (exitCode !== 0) return 'nonzero-exit-ignored-by-host';
+    return 'none';
+  },
+};
+
+// ----- Case manifest ------------------------------------------------------
+//
+// Derived from the integrations' own manifests rather than restated here, so
+// a hook added to hooks.json is covered by this gate the moment it is added.
+// That is the same property §5 wants from the HookIngest filter: safety has
+// to live at the single point every adapter passes through, or the next
+// adapter is unprotected by default.
+
+// Split a hooks.json command line into argv, honouring double quotes (the
+// manifests quote the plugin-root path because it contains spaces on Windows).
+function tokenizeCommand(command) {
+  const tokens = [];
+  const re = /"([^"]*)"|(\S+)/g;
+  let m;
+  while ((m = re.exec(command)) !== null) tokens.push(m[1] !== undefined ? m[1] : m[2]);
+  return tokens;
+}
+
+// Every integration directory that ships a Claude-Code-shaped hook manifest.
+// DISCOVERED, not listed: a hardcoded list is exactly how the next adapter
+// ends up outside the gate. `integrations/` is small and flat, so scanning it
+// is both cheap and the honest source of truth.
+export function discoverHookManifests() {
+  const root = join(REPO_ROOT, 'integrations');
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      agent: entry.name,
+      pluginRoot: join(root, entry.name),
+      manifestPath: join(root, entry.name, 'hooks', 'hooks.json'),
+    }))
+    .filter((candidate) => existsSync(candidate.manifestPath));
+}
+
+// Integrations that ship no hooks.json, with the reason. An integration that
+// appears in neither this map nor the discovery above is an adapter nobody
+// wired into the gate, and the coverage test says so rather than passing.
+export const NON_MANIFEST_INTEGRATIONS = {
+  codex: 'notify program registered in config.toml; payload arrives as argv, covered explicitly',
+  opencode: 'in-process plugin, not a spawned hook; measured separately',
+  shared: 'not an agent — shared type declarations',
+};
+
+function casesFromHooksJson({ agent, manifestPath, pluginRoot, contract }) {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const cases = [];
+  for (const [event, entries] of Object.entries(manifest.hooks ?? {})) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks ?? []) {
+        if (hook.type !== 'command') {
+          throw new Error(`${agent}: unsupported hook type ${hook.type} for ${event}`);
+        }
+        // Substitute whatever plugin-root variable this host uses
+        // (${CLAUDE_PLUGIN_ROOT}, ${OPENCLAUDE_PLUGIN_ROOT}, …) rather than
+        // being told the name — one less thing a new adapter has to register.
+        const command = hook.command.replace(/\$\{[A-Z0-9_]+\}/g, pluginRoot);
+        const argv = tokenizeCommand(command);
+        if (argv[0] !== 'node') {
+          throw new Error(`${agent}: hook command does not start with node: ${hook.command}`);
+        }
+        cases.push({
+          agent,
+          contract,
+          id: `${agent}:${event}${entry.matcher ? `[${entry.matcher}]` : ''}${
+            argv.includes('--permission-gate') ? '+gate' : ''
+          }`,
+          event,
+          matcher: entry.matcher ?? '',
+          script: argv[1],
+          args: argv.slice(2),
+          stdin: 'json',
+          payload: payloadFor(event, entry.matcher),
+        });
+      }
+    }
+  }
+  return cases;
+}
+
+// Representative host payloads. Shape matters (the bridge reads tool_name,
+// transcript_path, session_id); content does not.
+function payloadFor(event, matcher) {
+  const base = {
+    session_id: 'harness-session',
+    transcript_path: '/tmp/harness/harness-session.jsonl',
+    cwd: '/tmp/harness',
+    hook_event_name: event,
+  };
+  if (event === 'PreToolUse') {
+    return { ...base, tool_name: matcher || 'Read', tool_input: { file_path: '/tmp/harness/x.txt' } };
+  }
+  if (event === 'PostToolUse') {
+    return { ...base, tool_name: matcher || 'Read', tool_response: { ok: true } };
+  }
+  return base;
+}
+
+// A hooks.json manifest IS the Claude Code hook format, so anything shipping
+// one speaks that contract. An agent that borrows the file shape with
+// different semantics has to say so here — silence would make the harness
+// grade it against the wrong rules.
+const CONTRACT_OVERRIDES = {};
+
+export function buildCases() {
+  const cases = discoverHookManifests().flatMap((manifest) => casesFromHooksJson({
+    ...manifest,
+    contract: CONTRACT_OVERRIDES[manifest.agent] ?? 'claudeCode',
+  }));
+  // Codex takes its payload as the LAST argv token, not on stdin, and is
+  // registered in config.toml rather than a hooks manifest — so it is spelled
+  // out here instead of derived. Both official and legacy payload shapes are
+  // exercised because the bridge routes on them.
+  const codexScript = join(REPO_ROOT, 'integrations', 'codex', 'bin', 'wmux-codex-notify.mjs');
+  for (const [label, payload] of [
+    ['official', {
+      type: 'agent-turn-complete',
+      'thread-id': 'harness-thread',
+      'turn-id': 'harness-turn',
+      cwd: '/tmp/harness',
+      'input-messages': ['hi'],
+      'last-assistant-message': 'done',
+    }],
+    ['legacy', {
+      session_id: 'harness-session',
+      transcript_path: '/tmp/harness/harness-session.jsonl',
+      cwd: '/tmp/harness',
+      hook_event_name: 'Stop',
+    }],
+    // A type Codex emits that wmux deliberately ignores. "Ignored" must still
+    // mean silent and fast, not a slow no-op.
+    ['ignored-type', { type: 'some-future-codex-event', cwd: '/tmp/harness' }],
+  ]) {
+    cases.push({
+      agent: 'codex',
+      contract: 'codexNotify',
+      id: `codex:notify[${label}]`,
+      event: 'notify',
+      matcher: label,
+      script: codexScript,
+      args: [],
+      stdin: 'none',
+      argvPayload: payload,
+      payload,
+    });
+  }
+  return cases;
+}
+
+// ----- Environment scenarios ----------------------------------------------
+//
+// The same hook has to be silent in all of these. They are the states a real
+// user is actually in, and the middle one is where #898 lived: a hook that is
+// installed, inside a pane, with nothing on the other end of the pipe.
+
+// A sandbox home. Every endpoint the hooks resolve lands inside it, so nothing
+// the harness runs can reach a real wmux; the per-run suffix also keeps the
+// derived pipe names from colliding with a live daemon on a developer's box.
+export function makeSandbox() {
+  const dir = mkdtempSync(join(tmpdir(), 'wmux-harmless-'));
+  return { home: dir, seq: 0 };
+}
+
+// One wmux "installation" inside the sandbox.
+//
+// `token` is the difference between "wmux was never installed" and "wmux is
+// installed and the daemon is not answering" — and it MATTERS: with no token
+// on disk the bridges bail at `no-auth-token` long before any decision path
+// runs. A matrix built only on token-less homes never reaches the code #898
+// lived in, so it would pass a bridge with #898 reintroduced. (Measured:
+// the mutation check below fails without this.)
+export function provisionInstance(sandbox, { token = false, daemonPipeName = null } = {}) {
+  const suffix = `-harness-${process.pid}-${sandbox.seq++}`;
+  const wmuxHome = join(sandbox.home, `.wmux${suffix}`);
+  mkdirSync(wmuxHome, { recursive: true });
+  if (token) {
+    writeFileSync(join(wmuxHome, 'daemon-auth-token'), 'harness-daemon-token', 'utf8');
+    writeFileSync(join(sandbox.home, `.wmux${suffix}-auth-token`), 'harness-main-token', 'utf8');
+  }
+  if (daemonPipeName) writeFileSync(join(wmuxHome, 'daemon-pipe'), daemonPipeName, 'utf8');
+  return suffix;
+}
+
+export function fakeDaemonAddress(sandbox, label) {
+  // The sandbox sequence is part of the name so a second setupScenarios() in
+  // the same process cannot collide with a still-listening first one.
+  const unique = `${process.pid}-${sandbox.seq}-${label}`;
+  if (process.platform === 'win32') return `\\\\.\\pipe\\wmux-harness-${unique}`;
+  // Directly under tmpdir, with a short name, NOT inside the sandbox: a unix
+  // socket path is capped near 104 bytes on macOS, and the runners' tmpdir is
+  // already long enough (/var/folders/ab/cdef…/T/) that another nested
+  // mkdtemp segment would put us at the edge of it.
+  return join(tmpdir(), `wmh-${unique}.sock`);
+}
+
+/**
+ * A stand-in daemon that answers the bridges' RPC.
+ *
+ * `reply(request)` returns the object to send back, or null to stay silent.
+ * Newline-delimited JSON in both directions, matching the real control pipe.
+ */
+export function startFakeDaemon(address, reply) {
+  // A hook killed mid-request leaves a half-open connection, and `close()`
+  // waits for every one of them — enough to hang the suite's teardown. Track
+  // them so dispose can drop them. (Review: Grok, P2.)
+  const sockets = new Set();
+  const server = createServer((sock) => {
+    sockets.add(sock);
+    sock.on('close', () => sockets.delete(sock));
+    let buffer = '';
+    // A hook that drops the socket the moment it has its answer is normal;
+    // an unhandled 'error' here would take the harness down with it.
+    sock.on('error', () => { /* client hung up */ });
+    sock.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      for (;;) {
+        const nl = buffer.indexOf('\n');
+        if (nl === -1) return;
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        let request;
+        try {
+          request = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const response = reply(request);
+        if (response) sock.write(JSON.stringify({ id: request.id, ...response }) + '\n');
+      }
+    });
+  });
+  // A unix socket left behind by a killed run makes listen() fail with
+  // EADDRINUSE; named pipes have no such file to clear.
+  if (process.platform !== 'win32') {
+    try {
+      unlinkSync(address);
+    } catch {
+      // Nothing to clear — the normal case.
+    }
+  }
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(address, () => {
+      // A pipe error AFTER listen must not reject an already-settled promise.
+      server.off('error', reject);
+      server.on('error', () => { /* post-listen transport noise */ });
+      resolve({
+        address,
+        close: () => new Promise((done) => {
+          for (const sock of sockets) sock.destroy();
+          server.close(() => {
+            if (process.platform !== 'win32') {
+              try {
+                unlinkSync(address);
+              } catch {
+                // Already gone; the socket outliving the run is what mattered.
+              }
+            }
+            done();
+          });
+        }),
+      });
+    });
+  });
+}
+
+// ----- Environment scenarios ----------------------------------------------
+//
+// The same hook has to be silent in all of these. They are the states a real
+// user is actually in. The last two are where #898 lived — a hook that is
+// installed, inside a pane, with a daemon that either is not there or has
+// nothing to say about this tool call.
+//
+// Deliberately absent: a daemon that accepts the gate request and never
+// answers. The permission gate blocks there on purpose (up to
+// GATE_PERMISSION_TIMEOUT_MS, waiting for a remote approval), so it would fail
+// the latency criterion for a reason that is the feature working. Bounding
+// that wait is the gate's own contract, not this harness's.
+export async function setupScenarios(sandbox) {
+  const cleanups = [];
+
+  const notInstalled = provisionInstance(sandbox, { token: false });
+  const installedDown = provisionInstance(sandbox, { token: true });
+
+  // A daemon that answers, successfully, with no verdict about this call —
+  // a pre-gate daemon, a non-gated tool, or the broker deferring to the
+  // session's own permission flow. Silence is the only faithful encoding.
+  const noVerdictAddress = fakeDaemonAddress(sandbox, 'noverdict');
+  const noVerdictServer = await startFakeDaemon(noVerdictAddress, (request) => ({
+    ok: true,
+    result: { ok: true, received: request.method },
+  }));
+  cleanups.push(() => noVerdictServer.close());
+  const installedNoVerdict = provisionInstance(sandbox, {
+    token: true,
+    daemonPipeName: noVerdictAddress,
+  });
+
+  const env = (suffix, extra) => ({
+    USERPROFILE: sandbox.home,
+    HOME: sandbox.home,
+    WMUX_DATA_SUFFIX: suffix,
+    CLAUDE_CODE_ENTRYPOINT: 'cli',
+    ...extra,
+  });
+
+  const scenarios = [
+    {
+      id: 'not-installed',
+      why: 'plugin present, wmux never set up, agent outside any pane',
+      env: env(notInstalled, { WMUX_PTY_ID: undefined }),
+    },
+    {
+      id: 'installed-daemon-down',
+      why: 'wmux installed, inside a pane, daemon not answering — the #898 state',
+      env: env(installedDown, { WMUX_PTY_ID: 'harness-pty-1' }),
+    },
+    {
+      id: 'installed-daemon-no-verdict',
+      why: 'daemon answers and has no opinion about this call',
+      env: env(installedNoVerdict, { WMUX_PTY_ID: 'harness-pty-1' }),
+    },
+    {
+      id: 'gate-disabled',
+      why: 'operator turned the gate off; the escape hatch must be silent too',
+      env: env(installedNoVerdict, { WMUX_PTY_ID: 'harness-pty-1', WMUX_GATE: '0' }),
+    },
+    {
+      id: 'headless',
+      why: '`claude -p` / CI / subagents read the same manifest',
+      env: env(installedNoVerdict, { WMUX_PTY_ID: 'harness-pty-1', CLAUDE_CODE_ENTRYPOINT: 'sdk-cli' }),
+    },
+  ];
+
+  // A daemon that accepts the connection and NEVER answers. Kept out of the
+  // hook matrix on purpose — the permission gate blocks there by design,
+  // waiting for a remote approval, so it would fail the latency criterion for
+  // a reason that is the feature working.
+  //
+  // It is exactly what the in-process opencode plugin needs, though: that
+  // plugin claims to detach its pipe RPC from the event handler so a wedged
+  // endpoint cannot add the 2s transport cap to the TUI's idle transition.
+  // Against an absent endpoint (instant ENOENT) a NON-detached handler would
+  // look just as fast, and the claim would go untested. (Review: Grok, P2.)
+  const silentAddress = fakeDaemonAddress(sandbox, 'silent');
+  const silentServer = await startFakeDaemon(silentAddress, () => null);
+  cleanups.push(() => silentServer.close());
+  const installedSilent = provisionInstance(sandbox, { token: true, daemonPipeName: silentAddress });
+
+  return {
+    scenarios,
+    wedgedDaemonEnv: env(installedSilent, { WMUX_PTY_ID: 'harness-pty-1' }),
+    dispose: async () => { for (const fn of cleanups) await fn(); },
+  };
+}
+
+// ----- Fixtures: hooks that are supposed to FAIL --------------------------
+//
+// A gate that cannot fail is not a gate. Each criterion gets a fixture hook
+// that violates exactly that criterion, and the gate is required to reject
+// each one. Without these, a broken classifyDecision() would quietly turn the
+// whole harness into an always-pass, which is the failure mode R3 warns about
+// — a test that pins nothing while looking green.
+
+const FIXTURE_SOURCES = {
+  // The control: provably no opinion.
+  noop: NOOP_HOOK_SOURCE,
+
+  // #898 in a bottle. `ask` reads as neutral and is not: it forces a prompt
+  // and overrides bypassPermissions. If the gate lets this through, it would
+  // have let #898 through.
+  opinionated: [
+    'process.stdin.resume();',
+    "process.stdin.on('data', () => {});",
+    "process.stdin.on('error', () => {});",
+    "process.stdin.on('end', () => {",
+    "  process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'PreToolUse', permissionDecision: 'ask' } }) + '\\n');",
+    '});',
+  ].join('\n'),
+
+  // Criterion 2: a hook that never returns. The host waits on it.
+  hanging: [
+    'process.stdin.resume();',
+    'setInterval(() => {}, 1000);',
+  ].join('\n'),
+
+  // Criterion 3: exits promptly and cleanly, but leaves a descendant holding
+  // the host's stdout/stderr. `exit` looks perfect; `close` is the tell.
+  orphan: [
+    "import { spawn } from 'node:child_process';",
+    'process.stdin.resume();',
+    "process.stdin.on('error', () => {});",
+    "spawn(process.execPath, ['-e', 'setTimeout(() => {}, 3000)'], { stdio: 'inherit', detached: true }).unref();",
+    'process.exitCode = 0;',
+    "process.stdin.on('end', () => {});",
+    'setTimeout(() => process.exit(0), 50);',
+  ].join('\n'),
+};
+
+/** Write the control and the three violation fixtures; returns {name: path}. */
+export function writeFixtureHooks(sandboxHome) {
+  const paths = {};
+  for (const [name, source] of Object.entries(FIXTURE_SOURCES)) {
+    const path = join(sandboxHome, `fixture-${name}.mjs`);
+    writeFileSync(path, source, 'utf8');
+    paths[name] = path;
+  }
+  return paths;
+}
+
+export function writeNoopHook(sandboxHome) {
+  return writeFixtureHooks(sandboxHome).noop;
+}
+
+// The fixtures above prove the CLASSIFIER works. They do not prove the matrix
+// REACHES the code #898 lived in — and the first version of this harness did
+// not: with no auth token in the sandbox every bridge bailed at
+// `no-auth-token` long before any decision path ran, so a bridge with #898
+// reintroduced sailed through. The scenarios were fixed; this keeps them
+// fixed, by putting #898 back into a copy of the real bridge on every run and
+// requiring the gate to reject it.
+const MUTATION_ANCHOR = "  if (decision !== 'allow' && decision !== 'deny') return;";
+const MUTATION_REPLACEMENT = "  if (decision !== 'allow' && decision !== 'deny') decision = 'ask';";
+
+/**
+ * Write a copy of the real Claude bridge with #898 put back: every "wmux has
+ * no opinion" verdict becomes `ask`. Throws if the anchor is gone, which is
+ * the point — a refactor that moves this logic must re-prove the gate rather
+ * than silently leave it defending nothing.
+ */
+export function writeMutatedBridge(sandboxHome) {
+  const source = join(REPO_ROOT, 'integrations', 'claude', 'bin', 'wmux-bridge.mjs');
+  const text = readFileSync(source, 'utf8');
+  if (!text.includes(MUTATION_ANCHOR)) {
+    throw new Error(
+      'hookHarmlessness: the #898 mutation anchor is gone from wmux-bridge.mjs. '
+      + 'The neutral-decision guard moved or changed shape, so this gate is no longer '
+      + 'proven to catch #898. Re-derive MUTATION_ANCHOR against the current bridge.',
+    );
+  }
+  const path = join(sandboxHome, 'mutant-wmux-bridge.mjs');
+  writeFileSync(path, text.replace(MUTATION_ANCHOR, MUTATION_REPLACEMENT), 'utf8');
+  return path;
+}
+
+// ----- The measurement ----------------------------------------------------
+
+export const DEFAULT_BUDGET_MS = 6000;
+
+/**
+ * Run one hook invocation the way its host would, and report what the host
+ * would have observed.
+ *
+ * Resolves rather than rejects on every failure mode — a timeout is a
+ * measurement ('timedOut: true'), not an exception, so one hanging hook still
+ * produces a comparable row instead of collapsing the run.
+ */
+export function runHookCase({ script, args = [], env = {}, payload, stdin = 'json', argvPayload, budgetMs = DEFAULT_BUDGET_MS }) {
+  return new Promise((resolve) => {
+    // Seal the environment before applying the scenario. The harness itself is
+    // often run from inside a wmux pane under a wmux-integrated agent, so the
+    // parent process carries WMUX_* and CLAUDE_* variables that change what
+    // the hooks do — WMUX_HOOKS_TO_MAIN alone reroutes every signal. Leaving
+    // them in would make each scenario mean "whatever this developer's box is
+    // doing". (Review: Grok, P2.)
+    const childEnv = { ...process.env };
+    for (const key of Object.keys(childEnv)) {
+      if (key.startsWith('WMUX_') || key.startsWith('CLAUDE_')) delete childEnv[key];
+    }
+    for (const [k, v] of Object.entries(env)) {
+      if (v === undefined) delete childEnv[k];
+      else childEnv[k] = v;
+    }
+    const argv = [script, ...args];
+    if (argvPayload !== undefined) argv.push(JSON.stringify(argvPayload));
+
+    const startedAt = process.hrtime.bigint();
+    const ms = () => Number(process.hrtime.bigint() - startedAt) / 1e6;
+
+    const child = spawn(process.execPath, argv, {
+      env: childEnv,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode = null;
+    let signal = null;
+    let exitMs = null;
+    let stdinError = null;
+    let stdinSettled = stdin === 'json' ? false : true;
+    let stdinBytes = 0;
+    let timedOut = false;
+    let settled = false;
+
+    child.stdout.on('data', (c) => { stdout += c.toString('utf8'); });
+    child.stderr.on('data', (c) => { stderr += c.toString('utf8'); });
+
+    const finish = (extra = {}) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      clearTimeout(graceTimer);
+      const closeMs = ms();
+      resolve({
+        exitCode,
+        signal,
+        stdout,
+        stderr,
+        exitMs,
+        closeMs,
+        wallMs: closeMs,
+        // Positive when something outlived the hook while still holding the
+        // host's stdio. Zero-ish on a clean hook.
+        survivorGapMs: exitMs === null ? null : Math.max(0, closeMs - exitMs),
+        stdinError,
+        stdinSettled,
+        stdinBytes,
+        timedOut,
+        ...extra,
+      });
+    };
+
+    let graceTimer = null;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+      // Killing the direct child does NOT reap a descendant that inherited its
+      // stdout/stderr — which is precisely the criterion-3 failure. Waiting on
+      // 'close' alone would then never settle, and an unbounded survivor would
+      // hang the suite for the whole test timeout instead of being REPORTED as
+      // one. Give 'close' a short grace period, then let go of our ends of the
+      // pipes and report what we have. (Review: Grok, P1.)
+      graceTimer = setTimeout(() => {
+        child.stdout.destroy();
+        child.stderr.destroy();
+        finish({ survivorOutlivedProbe: true });
+      }, 300);
+    }, budgetMs);
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      clearTimeout(graceTimer);
+      if (settled) return;
+      settled = true;
+      resolve({ spawnError: String(err), wallMs: ms() });
+    });
+
+    child.on('exit', (code, sig) => {
+      exitCode = code;
+      signal = sig;
+      exitMs = ms();
+    });
+
+    // 'close' — not 'exit'. This is the survivor probe: it fires only once
+    // every handle on the child's stdout/stderr is gone, which includes any
+    // descendant that inherited them. A hook that leaves a process behind
+    // holding the host's pipes shows up here as a gap, or as a timeout.
+    child.on('close', () => finish());
+
+    if (stdin === 'json') {
+      // A string payload is written RAW; anything else is encoded. The
+      // oversized-stdin case relies on that, so the byte count is reported
+      // rather than inferred from the caller's intent. (Review: Grok, P1.)
+      const body = typeof payload === 'string' ? payload : JSON.stringify(payload ?? {});
+      stdinBytes = Buffer.byteLength(body, 'utf8');
+      // A hook that destroys stdin mid-write EPIPEs the host. That is allowed
+      // (the host tolerates it); deadlocking is not — so what gets recorded is
+      // whether the write SETTLED, either way. A write still pending when the
+      // budget fires is the deadlock this criterion exists to catch.
+      child.stdin.on('error', (err) => { stdinError = String(err); stdinSettled = true; });
+      child.stdin.end(body, () => { stdinSettled = true; });
+    } else {
+      child.stdin.end();
+    }
+  });
+}
+
+export function classifyDecision(contract, result) {
+  if (!result || result.spawnError) return 'spawn-error';
+  if (result.timedOut) return 'timeout';
+  return HOST_CONTRACTS[contract](result.exitCode, result.stdout ?? '');
+}

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -284,7 +284,7 @@ export function buildCases(payloadOpts) {
       type: 'agent-turn-complete',
       'thread-id': 'harness-thread',
       'turn-id': 'harness-turn',
-      cwd: '/tmp/harness',
+      cwd: payloadOpts?.cwd ?? '/tmp/harness',
       'input-messages': ['hi'],
       'last-assistant-message': 'done',
     }],
@@ -386,6 +386,22 @@ export function fakeDaemonAddress(sandbox, label) {
 }
 
 /**
+ * An address in the harness namespace that nothing will ever bind.
+ *
+ * "Daemon down" has to be furnished, not left blank. With no `daemon-pipe`
+ * hint the bridges fall back to a DERIVED name, and the openclaude fork
+ * derives `\\.\pipe\wmux-daemon-<username>` — no data suffix, so that is the
+ * real daemon's pipe on a developer machine. A furnished token plus a blank
+ * hint would therefore point the harness at the operator's live daemon, and
+ * on a refusal it walks on to the main pipe too. Handing it a dead address in
+ * our own namespace keeps "down" meaning ENOENT, deterministically, whatever
+ * is running on the box.
+ */
+export function deadDaemonAddress(sandbox, label) {
+  return `${fakeDaemonAddress(sandbox, label)}-never-bound`;
+}
+
+/**
  * A stand-in daemon that answers the bridges' RPC.
  *
  * `reply(request)` returns the object to send back, or null to stay silent.
@@ -471,8 +487,16 @@ export function startFakeDaemon(address, reply) {
 export async function setupScenarios(sandbox) {
   const cleanups = [];
 
-  const notInstalled = provisionInstance(sandbox, { token: false });
-  const installedDown = provisionInstance(sandbox, { token: true });
+  // Both get a dead hint so no instance can fall back to a derived name and
+  // find the operator's real daemon — see deadDaemonAddress.
+  const notInstalled = provisionInstance(sandbox, {
+    token: false,
+    daemonPipeName: deadDaemonAddress(sandbox, 'notinstalled'),
+  });
+  const installedDown = provisionInstance(sandbox, {
+    token: true,
+    daemonPipeName: deadDaemonAddress(sandbox, 'down'),
+  });
 
   // A daemon that answers, successfully, with no verdict about this call —
   // a pre-gate daemon, a non-gated tool, or the broker deferring to the

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -402,6 +402,19 @@ export function deadDaemonAddress(sandbox, label) {
 }
 
 /**
+ * Is this an address the harness owns?
+ *
+ * Lives here rather than in the test so the naming has ONE home: the two
+ * platforms deliberately differ (`wmux-harness-` in the Windows pipe
+ * namespace, the short `wmh-` under tmpdir because a unix socket path is
+ * capped near 104 bytes on macOS), and a test that restated either prefix
+ * would pass on one platform and fail on the other.
+ */
+export function isHarnessAddress(address) {
+  return /(^|[\\/])wmux-harness-|(^|[\\/])wmh-/.test(String(address));
+}
+
+/**
  * A stand-in daemon that answers the bridges' RPC.
  *
  * `reply(request)` returns the object to send back, or null to stay silent.


### PR DESCRIPTION
wmux installs observation hooks into other people's agents. #898 is what that costs when one of them says something the host reads as an instruction: the permission gate emitted `ask` on every "wmux has no opinion" path, `ask` is not neutral — it forces a prompt and overrides the session's permission mode — so a `bypassPermissions` session started asking permission to run `Read`, and the documented escape hatch (`WMUX_GATE=0`) emitted `ask` too. Nothing in the tree could have caught it, because "observation hooks are harmless" was an assumption rather than a measurement.

This makes it a measurement, and it is the gate the next agent adapters have to pass before they ship.

## The claim under test

> Installing a wmux hook must be indistinguishable, to the host, from installing a hook that provably has no opinion.

Every case runs twice — a no-op control (drain stdin, exit 0, write nothing) and the real hook, invoked byte-for-byte the way the integration's own manifest invokes it — and the two are compared on what the host would actually observe.

| Criterion | How it is measured |
|---|---|
| Approval/denial set identical | The host's decision is a pure function of (exit code, stdout). Each host's documented contract is pinned in `HOST_CONTRACTS` with its source. An observation hook must classify as `none` and write **zero bytes** — the direct #898 pin. |
| Completion and duration | The hook's own wall clock, capped at 1.5s over the control. The cap sits deliberately *below* the bridges' 2s transport cap, so a hook that waits out a dead daemon on the host's thread cannot pass. |
| No process outlives the hook | `close`, not `exit`. The host holds the hook's stdout/stderr and waits on them, so a descendant that inherits those pipes shows up as a gap between the two — no process-tree walking, and it is exactly the survivor that would matter to the host. |

Five environment scenarios, because the same hook has to be silent in all of them: wmux not installed; installed with the daemon down; a daemon that answers and has no verdict; the gate disabled; headless.

## What keeps it from becoming a green no-op

Fixtures that violate exactly one criterion each — a hook that emits `ask`, one that never returns, one that exits cleanly but leaves a process behind — must all be rejected.

And on every run the **real bridge** is copied with #898 put back into it, and the gate must catch it emitting `ask` in the two states where #898 actually bit. That check is not decoration. The first draft of this harness passed a bridge with #898 reintroduced: its sandbox had no auth token, so every bridge exited at `no-auth-token` long before reaching a decision at all. The scenarios were fixed, and this keeps them fixed — if the neutral-decision guard is ever refactored away from its current shape, the check fails loudly and asks to be re-derived rather than quietly defending nothing.

## Coverage that survives the next adapter

The matrix is derived from the shipped `hooks.json` files, and `integrations/` is **scanned** rather than listed. A hook added to a manifest is covered the moment it is added; an integration with neither a manifest nor a stated reason fails the run. That is the same property `HookIngest` needs from its `subagent_stop` filter — safety has to live where every adapter passes through, or the next adapter is unprotected by default.

opencode is not in the subprocess matrix because it is an in-process plugin, so it gets a different measurement rather than a silent skip: driven against a stand-in daemon that accepts and never answers, its event handler must still return in well under the 2s transport cap. That is the plugin's own detachment claim, and against an *absent* endpoint it would have gone untested.

## The live half

`scripts/hook-ab-live.mjs` runs the same task twice through the real agent CLI. Opt-in — it needs credentials and spends tokens — and it reports what it cannot establish instead of passing quietly:

- a headless `claude -p` never reaches the permission gate, because the agent sets `CLAUDE_CODE_ENTRYPOINT` itself when it spawns a hook, so the parent cannot present the run as interactive. Measured, after a flag built on the opposite assumption let a #898 mutant straight through;
- `--settings` merges with the user's config, so on a machine where the wmux plugin is already installed the control arm is not hook-free. It says so and exits 2 ("did not establish the claim") rather than 0.

## Measured

- CI gate: 15 tests, ~15s, every hook silent in every scenario, added latency ~110ms over control, survivor gap 0ms.
- Mutation check: the real bridge with #898 reintroduced fails in both affected scenarios; restored, it passes.
- Live A/B against Claude Code: completion equal, `permission_denials` equal, duration within 1%, injected hooks confirmed to reach the stand-in daemon (`outcome: ok`).

## Notes

- Test-only; no runtime code changes and no changelog fragment (same as #904).
- One thing found and left alone as out of scope: a >1MB `PostToolUse` payload is truncated past `MAX_STDIN_BYTES`, the JSON no longer parses, and the signal is dropped entirely. That is the documented, intended behaviour and a delivery question, not a harmlessness one — but it means a turn that read a large file loses its activity stamp.

Part of the step-3 moat work, after #903 (`pane_list` contract + blocking poll) and #914 (subagent status). Unblocks the copilot and kiro adapters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive runtime checks to ensure integrations remain silent, neutral, responsive, and clean up processes correctly.
  * Added coverage for hangs, blocking prompts, orphaned processes, malformed events, oversized input, and historical regressions.
  * Added validation across supported hook integrations and representative daemon scenarios.

* **New Features**
  * Added an opt-in live comparison tool to measure agent behavior with and without hooks, including timing, failures, and hook activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->