### PR TITLE
Report Kiro turn boundaries from a hook instead of guessing

### DIFF
--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -1,0 +1,99 @@
+# wmux ↔ Kiro CLI
+
+Turns "is this Kiro pane done?" from a guess into a fact.
+
+Without a hook, wmux infers a Kiro turn boundary by scraping the terminal
+(`AgentDetector`, a two-stage regex gate on Kiro's chrome and prompt lines).
+That works until the model prints something prompt-shaped, or Kiro changes its
+UI. With the hook, Kiro reports the turn ending itself, and wmux's turn-end
+consumers — notifications, the orchestrator's "what's still busy" count,
+`wmux_events_poll(blockMs)` — get a fact instead of an inference.
+
+**Not wired into wmux's installer yet.** The bridge, its tests and its
+harmlessness coverage ship here; automatic installation is deliberately held
+back until the end-to-end path can be verified on a machine with a Kiro
+account. Set it up by hand today with the steps below.
+
+## What it reports
+
+| Kiro trigger | wmux signal |
+|---|---|
+| `stop` | `agent.stop` — the turn ended |
+| `agentSpawn` | `agent.session_start` |
+
+Deliberately **not** registered:
+
+- `preToolUse` / `postToolUse` — an activity stamp would cost a process spawn
+  per tool call. That is the one path that actually makes things heavier.
+- `userPromptSubmit` → `agent.awaiting_input` — Kiro has no approval-specific
+  event, and "a prompt was submitted" is not "a human is being waited on".
+  Conflating those is what issue #898 punished; no signal beats a false one.
+
+## What it cannot do (measured, not assumed)
+
+- **No resume binding.** Kiro's `stop` payload is
+  `{hook_event_name, cwd, assistant_response}` — there is no session id, so
+  there is nothing to bind a resumable session to.
+- **Pane attribution comes only from `WMUX_PTY_ID`**, inherited from the pane
+  environment. A payload without it is dropped rather than attached to a guess.
+- **Only panes launched with `--agent wmux`.** A hand-run `kiro-cli chat` keeps
+  using the detector, exactly as before.
+
+## Privacy
+
+Kiro's payloads carry content: `prompt` is the user's whole input and
+`assistant_response` is the model's whole reply. wmux's bridges are
+metadata-only, so the envelope builder reads `hook_event_name` and `cwd` and
+nothing else. The test asserts on the serialized envelope, so a future field
+that happens to carry content fails it too.
+
+## Manual setup
+
+1. Put the bridge somewhere stable, e.g. `~/.wmux/hooks/wmux-kiro-bridge.mjs`.
+2. Write `~/.kiro/agents/wmux.json` with the config
+   `agent/wmuxAgent.mjs` builds, pointing `command` at that path:
+
+   ```json
+   {
+     "name": "wmux",
+     "description": "wmux-managed: kiro-lifecycle-agent",
+     "prompt": "",
+     "tools": ["*"],
+     "includeMcpJson": true,
+     "resources": ["file://AmazonQ.md", "file://AGENTS.md", "file://README.md",
+                   "skill://.kiro/skills/*/SKILL.md",
+                   "skill://<home>/.kiro/skills/*/SKILL.md",
+                   "file://<home>/.kiro/steering/**/*.md"],
+     "hooks": {
+       "stop":       [{ "command": "node \"<path>/wmux-kiro-bridge.mjs\"", "timeout_ms": 2500 }],
+       "agentSpawn": [{ "command": "node \"<path>/wmux-kiro-bridge.mjs\"", "timeout_ms": 2500 }]
+     }
+   }
+   ```
+
+3. Launch Kiro panes with `kiro-cli chat --agent wmux`.
+
+Confirm Kiro picked it up with `kiro-cli agent list` — it appears under
+`Global`, and the `*` stays on `kiro_default`, because this does not change
+your default agent.
+
+## Why the agent config looks like that
+
+It mirrors `kiro_default` in everything except the prompt. `allowedTools` is
+`[]` in the built-in too, which is why approval behaviour cannot change.
+`includeMcpJson` and `resources` are carried over because dropping them
+silently costs MCP access and project context. The empty prompt is the one
+intended difference: measured 3x on a tool-using task, thin and built-in both
+scored 3/3 with no time or cost penalty, and cloning the built-in's 1.7KB
+prompt would freeze it at install time and drift.
+
+`scripts/kiro-agent-equivalence.mjs` re-checks that against the live built-in —
+run it after a Kiro upgrade.
+
+## Harmlessness
+
+Covered by the P-5 gate (`scripts/__tests__/hookHarmlessness.runtime.test.mjs`)
+in five environment scenarios: the bridge writes zero bytes to stdout, always
+exits 0, adds ~90ms, and leaves no process holding the host's stdio. Measured
+separately on 2.15.1: Kiro tolerates even a hook that writes stderr and exits
+2, but this bridge does neither.

--- a/integrations/kiro/README.md
+++ b/integrations/kiro/README.md
@@ -73,6 +73,15 @@ that happens to carry content fails it too.
 
 3. Launch Kiro panes with `kiro-cli chat --agent wmux`.
 
+Replace **both** placeholders with absolute paths, and use forward slashes so
+the JSON needs no escaping:
+
+- `<path>` — the directory holding `wmux-kiro-bridge.mjs`.
+- `<home>` — your home directory (`C:/Users/you`, `/Users/you`, `/home/you`).
+  Kiro does not expand `~` or `<home>` here: a literal one resolves to nothing
+  and the skills and steering entries are dropped **without an error**, which
+  looks exactly like having no skills.
+
 Confirm Kiro picked it up with `kiro-cli agent list` — it appears under
 `Global`, and the `*` stays on `kiro_default`, because this does not change
 your default agent.

--- a/integrations/kiro/__tests__/kiroAgentConfig.test.ts
+++ b/integrations/kiro/__tests__/kiroAgentConfig.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildKiroAgentConfig,
+  isWmuxOwnedKiroAgent,
+  KIRO_AGENT_MANAGED_MARKER,
+  INTENDED_DIFFERENCES,
+} from '../agent/wmuxAgent.mjs';
+
+const HOME = 'C:\\Users\\someone';
+
+// Values read from a materialized kiro_default (`kiro-cli agent create --from`)
+// on 2.15.1. The rule is: equivalent to the built-in except the prompt.
+const BUILT_IN_DEFAULTS: Record<string, unknown> = {
+  tools: ['*'],
+  allowedTools: [],
+  toolAliases: {},
+  toolsSettings: {},
+  mcpServers: {},
+  model: null,
+  includeMcpJson: true,
+};
+
+describe('buildKiroAgentConfig', () => {
+  // The one intended difference. Cloning kiro_default's 1.7KB prompt would
+  // freeze it at install time and drift as Kiro updates its own; measured 3x on
+  // the same tool-using task, thin and built-in both scored 3/3 with no time or
+  // cost penalty. A future "let's copy the real prompt for quality" change
+  // should have to argue with this test.
+  it('ships no prompt of its own', () => {
+    expect(buildKiroAgentConfig('/b', HOME).prompt).toBe('');
+  });
+
+  // Why approval behaviour cannot change: the built-in pre-approves nothing
+  // either, so anything we omit is not more restrictive than the default.
+  it('matches the built-in on every field it sets', () => {
+    const config = buildKiroAgentConfig('/b', HOME) as Record<string, unknown>;
+    for (const [key, builtIn] of Object.entries(BUILT_IN_DEFAULTS)) {
+      if (config[key] === undefined) continue; // omitted → Kiro's own default
+      expect(config[key], `${key} diverges from kiro_default`).toEqual(builtIn);
+    }
+  });
+
+  // The two fields an earlier revision dropped. Both are SILENT losses: the
+  // agent keeps answering, it just cannot reach wmux's MCP tools and stops
+  // seeing the project's docs. The measurement that cleared the empty prompt
+  // ran in a temp directory, where neither could have shown up.
+  it('keeps the MCP servers the built-in loads', () => {
+    expect(buildKiroAgentConfig('/b', HOME).includeMcpJson).toBe(true);
+  });
+
+  it('keeps the project context resources the built-in loads', () => {
+    const resources = buildKiroAgentConfig('/b', HOME).resources as string[];
+    expect(resources).toContain('file://AGENTS.md');
+    expect(resources).toContain('file://README.md');
+    expect(resources).toContain('skill://.kiro/skills/*/SKILL.md');
+    // The globs Kiro bakes with an absolute home — hence a `home` parameter
+    // instead of a hardcoded list.
+    expect(resources.some((r) => r.startsWith('skill://') && r.includes(HOME))).toBe(true);
+    expect(resources.some((r) => r.startsWith('file://') && r.includes('steering'))).toBe(true);
+  });
+
+  it('registers only the triggers wmux can act on', () => {
+    // userPromptSubmit exists in Kiro and is deliberately absent: no
+    // approval-specific event means no honest awaiting_input (#898).
+    expect(Object.keys(buildKiroAgentConfig('/b', HOME).hooks as object).sort())
+      .toEqual(['agentSpawn', 'stop']);
+  });
+
+  // Kiro's hook timeout defaults to 10s; the bridge caps itself at 2s. The
+  // configured value has to sit between them so our cap fires first and Kiro's
+  // is a real backstop rather than a ten-second stall.
+  it('gives Kiro a backstop just above the bridge cap', () => {
+    const hooks = buildKiroAgentConfig('/b', HOME).hooks as Record<string, Array<{ timeout_ms: number }>>;
+    for (const trigger of ['stop', 'agentSpawn']) {
+      expect(hooks[trigger][0].timeout_ms).toBeGreaterThan(2000);
+      expect(hooks[trigger][0].timeout_ms).toBeLessThan(10_000);
+    }
+  });
+
+  it('quotes the bridge path so a space in it survives', () => {
+    const hooks = buildKiroAgentConfig('C:\\Program Files\\wmux\\b.mjs', HOME).hooks as
+      Record<string, Array<{ command: string }>>;
+    expect(hooks.stop[0].command).toBe('node "C:\\Program Files\\wmux\\b.mjs"');
+  });
+
+  it('declares exactly the fields it means to differ on', () => {
+    // Guards the equivalence checker's allowlist: adding a field here without
+    // thinking is how "equivalent except the prompt" quietly stops being true.
+    expect(INTENDED_DIFFERENCES).toEqual(['name', 'description', 'prompt', 'hooks']);
+  });
+});
+
+describe('isWmuxOwnedKiroAgent', () => {
+  // An installer must never replace a file it cannot prove it wrote.
+  it('recognises our own config', () => {
+    expect(isWmuxOwnedKiroAgent(buildKiroAgentConfig('/b', HOME))).toBe(true);
+  });
+
+  it('refuses anything else, including a same-named user agent', () => {
+    for (const other of [null, undefined, 'x', 42, [], {}, { name: 'wmux' },
+      { name: 'wmux', description: 'mine' }]) {
+      expect(isWmuxOwnedKiroAgent(other), JSON.stringify(other)).toBe(false);
+    }
+    expect(isWmuxOwnedKiroAgent({ description: KIRO_AGENT_MANAGED_MARKER })).toBe(true);
+  });
+});

--- a/integrations/kiro/__tests__/kiroEnvelope.test.ts
+++ b/integrations/kiro/__tests__/kiroEnvelope.test.ts
@@ -98,15 +98,34 @@ describe('buildKiroEnvelope', () => {
 });
 
 describe('shouldTryNextTarget', () => {
-  // Same no-double-fire rule the Codex bridge uses: only advance when the
-  // request PROVABLY never reached a server, or a fallback could deliver a
-  // second turn boundary for one turn.
+  // The walk stops at an answered call, and at an ambiguous write — unless
+  // re-delivering that kind is harmless. `agent.stop` and
+  // `agent.session_start` assert a state rather than append a record, and the
+  // server dedups a repeat inside its window, so for those the cost of
+  // stopping (a pane that reads as still-working until hook authority ages
+  // out) is worse than the cost of a duplicate (nothing).
   it('stops on an answered call', () => {
-    expect(shouldTryNextTarget({ ok: true })).toBe(false);
+    expect(shouldTryNextTarget({ ok: true }, 'agent.stop')).toBe(false);
   });
 
-  it('stops when the bytes were written but no answer came back', () => {
+  it('stops on an ambiguous write for a kind that is not idempotent', () => {
     expect(shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false })).toBe(false);
+    expect(
+      shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false }, 'agent.activity'),
+    ).toBe(false);
+  });
+
+  it('keeps walking on an ambiguous write for an idempotent kind', () => {
+    for (const kind of ['agent.stop', 'agent.session_start']) {
+      expect(
+        shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false }, kind),
+        kind,
+      ).toBe(true);
+      expect(
+        shouldTryNextTarget({ ok: false, error: 'closed-without-response', retryable: false }, kind),
+        kind,
+      ).toBe(true);
+    }
   });
 
   it('advances on a connect failure that never wrote', () => {
@@ -115,5 +134,17 @@ describe('shouldTryNextTarget', () => {
 
   it('advances on an explicit refusal from an older endpoint', () => {
     expect(shouldTryNextTarget({ ok: false, error: 'Unknown method' })).toBe(true);
+  });
+
+  // A trigger name that resolves through Object.prototype used to sail past
+  // the `!kind` guard and produce an envelope whose kind was a function or
+  // `{}`, which then went to the daemon instead of being dropped.
+  it('drops trigger names that only exist on the prototype chain', () => {
+    for (const trigger of ['constructor', 'toString', 'valueOf', '__proto__', 'hasOwnProperty']) {
+      expect(
+        buildKiroEnvelope({ hook_event_name: trigger, cwd: 'C:/x' }, { env: { WMUX_PTY_ID: 'p1' }, now: 1 }),
+        trigger,
+      ).toBeNull();
+    }
   });
 });

--- a/integrations/kiro/__tests__/kiroEnvelope.test.ts
+++ b/integrations/kiro/__tests__/kiroEnvelope.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+// The bridge is plain .mjs (Kiro spawns it directly); it exports the pure
+// envelope builder so this test can validate the shape without a live kiro-cli.
+import { buildKiroEnvelope, shouldTryNextTarget } from '../bin/wmux-kiro-bridge.mjs';
+import { isAgentSignal } from '../../shared/signal-types';
+
+// The payloads below are the ones kiro-cli 2.15.1 actually sends, captured live
+// (2026-08-16). Notably: no session id anywhere, and both carry raw content.
+const STOP_PAYLOAD = {
+  hook_event_name: 'stop',
+  cwd: 'C:\\work\\proj',
+  assistant_response: 'here is the answer, at length',
+};
+const PROMPT_PAYLOAD = {
+  hook_event_name: 'userPromptSubmit',
+  cwd: 'C:\\work\\proj',
+  prompt: 'the user typed this',
+};
+
+const baseEnv = {
+  WMUX_PTY_ID: 'pty-123',
+  WMUX_WORKSPACE_ID: 'ws-abc',
+  WMUX_SURFACE_ID: 'surf-9',
+} as NodeJS.ProcessEnv;
+
+describe('buildKiroEnvelope', () => {
+  it('maps stop to a canonical agent.stop envelope', () => {
+    expect(buildKiroEnvelope(STOP_PAYLOAD, { env: baseEnv, now: 42 })).toEqual({
+      kind: 'agent.stop',
+      agent: 'kiro',
+      ptyId: 'pty-123',
+      workspaceId: 'ws-abc',
+      surfaceId: 'surf-9',
+      cwd: 'C:\\work\\proj',
+      payload: {},
+      ts: 42,
+    });
+  });
+
+  it('maps agentSpawn to agent.session_start', () => {
+    const envelope = buildKiroEnvelope(
+      { hook_event_name: 'agentSpawn', cwd: '/proj' },
+      { env: baseEnv, now: 1 },
+    );
+    expect(envelope?.kind).toBe('agent.session_start');
+  });
+
+  it('produces an envelope the wmux daemon accepts', () => {
+    expect(isAgentSignal(buildKiroEnvelope(STOP_PAYLOAD, { env: baseEnv, now: 1 }))).toBe(true);
+  });
+
+  // The privacy contract. Kiro hands us the user's whole prompt and the model's
+  // whole reply; wmux's bridges are metadata-only, so neither may survive into
+  // anything we send. Asserted on the serialized envelope, not field-by-field,
+  // so a future field that happens to carry content fails this too.
+  it('never carries the user prompt or the assistant reply', () => {
+    const serialized = JSON.stringify(buildKiroEnvelope(STOP_PAYLOAD, { env: baseEnv, now: 1 }));
+    expect(serialized).not.toContain('here is the answer');
+    expect(serialized).not.toContain('assistant_response');
+    expect(buildKiroEnvelope(STOP_PAYLOAD, { env: baseEnv, now: 1 })?.payload).toEqual({});
+  });
+
+  // Kiro sends no session id, so WMUX_PTY_ID is the ONLY thing that can
+  // attribute a signal to a pane. With none, dropping beats guessing —
+  // attaching a turn boundary to the wrong pane is worse than losing it.
+  it('drops the signal when the pane cannot be identified', () => {
+    expect(buildKiroEnvelope(STOP_PAYLOAD, { env: {}, now: 1 })).toBeNull();
+    expect(buildKiroEnvelope(STOP_PAYLOAD, { env: { WMUX_PTY_ID: '' }, now: 1 })).toBeNull();
+  });
+
+  // userPromptSubmit exists in kiro and is deliberately NOT mapped: Kiro has no
+  // approval-specific event, and calling "a prompt was submitted" awaiting_input
+  // is the conflation #898 punished. Pinning it keeps a later "while we're here"
+  // mapping from landing unnoticed.
+  it('ignores triggers wmux has no faithful mapping for', () => {
+    expect(buildKiroEnvelope(PROMPT_PAYLOAD, { env: baseEnv, now: 1 })).toBeNull();
+    for (const trigger of ['preToolUse', 'postToolUse', 'somethingNew']) {
+      expect(buildKiroEnvelope({ hook_event_name: trigger, cwd: '/p' }, { env: baseEnv, now: 1 })).toBeNull();
+    }
+  });
+
+  it('survives payloads that are not the shape kiro documents', () => {
+    for (const bad of [null, undefined, 'a string', 42, [], {}, { hook_event_name: 5 }]) {
+      expect(buildKiroEnvelope(bad, { env: baseEnv, now: 1 })).toBeNull();
+    }
+  });
+
+  it('falls back to the process cwd when the payload omits one', () => {
+    const envelope = buildKiroEnvelope({ hook_event_name: 'stop' }, { env: baseEnv, now: 1 });
+    expect(envelope?.cwd).toBe(process.cwd());
+  });
+
+  it('omits workspace and surface ids rather than emitting empty ones', () => {
+    const envelope = buildKiroEnvelope(STOP_PAYLOAD, { env: { WMUX_PTY_ID: 'p1' }, now: 1 });
+    expect(envelope).not.toHaveProperty('workspaceId');
+    expect(envelope).not.toHaveProperty('surfaceId');
+  });
+});
+
+describe('shouldTryNextTarget', () => {
+  // Same no-double-fire rule the Codex bridge uses: only advance when the
+  // request PROVABLY never reached a server, or a fallback could deliver a
+  // second turn boundary for one turn.
+  it('stops on an answered call', () => {
+    expect(shouldTryNextTarget({ ok: true })).toBe(false);
+  });
+
+  it('stops when the bytes were written but no answer came back', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false })).toBe(false);
+  });
+
+  it('advances on a connect failure that never wrote', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'connect-error', retryable: true })).toBe(true);
+  });
+
+  it('advances on an explicit refusal from an older endpoint', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'Unknown method' })).toBe(true);
+  });
+});

--- a/integrations/kiro/agent/wmuxAgent.mjs
+++ b/integrations/kiro/agent/wmuxAgent.mjs
@@ -1,0 +1,86 @@
+// The Kiro agent config that carries wmux's hooks.
+//
+// Kiro's hooks can only live inside an agent config — there is no global hooks
+// directory (measured: `~/.kiro/hooks/` is inert on 2.15.1) and no config-dir
+// environment variable to redirect. The user's default agent is BUILT IN, so
+// there is no file of theirs to add a hook to. wmux therefore ships its OWN
+// agent and panes opt in with `kiro-cli chat --agent wmux`; nothing the user
+// owns is ever written, and their default agent stays their default.
+//
+// THE RULE: equivalent to `kiro_default` except the prompt.
+//
+// Values below were read from a materialized built-in
+// (`kiro-cli agent create --from kiro_default`) on 2.15.1:
+//
+//   tools ["*"]  allowedTools []  toolAliases {}  toolsSettings {}
+//   mcpServers {}  model null  includeMcpJson true  prompt 1696 bytes
+//   resources [AmazonQ.md, AGENTS.md, README.md, skills×2, steering]
+//
+// `allowedTools: []` is why approval behaviour cannot change: the built-in
+// pre-approves nothing either, so omitting the key is not more restrictive.
+//
+// Two fields are NOT free to omit, and an earlier revision omitted both:
+//   - `includeMcpJson` — without it the agent loads no MCP servers, so a
+//     wmux-launched Kiro pane cannot reach wmux's own MCP tools.
+//   - `resources` — without it AGENTS.md, README.md, skills and steering docs
+//     stop being auto-loaded and the agent quietly loses project context.
+// The measurement that cleared the empty prompt ran a synthetic task in a temp
+// directory, where neither could have shown up. Hence `_kiro-equivalence.mjs`,
+// which diffs this against the live built-in.
+//
+// The empty prompt IS deliberate. Measured 3x on the same tool-using task:
+// thin and built-in both 3/3 correct, 17.4s vs 18.0s, thin slightly cheaper.
+// Cloning the 1.7KB built-in prompt would freeze it at install time and drift
+// as Kiro updates its own.
+
+/** Marks the file as wmux-owned, so an installer never clobbers a user's. */
+export const KIRO_AGENT_MANAGED_MARKER = 'wmux-managed: kiro-lifecycle-agent';
+
+/** Kiro's hook timeout defaults to 10s. The bridge caps itself at 2s
+ *  (HOOK_TIMEOUT_MS), so 2500 lets our cap fire first and leaves Kiro a hard
+ *  backstop that cannot hold a turn for ten seconds if the bridge wedges. */
+export const KIRO_HOOK_TIMEOUT_MS = 2500;
+
+/** Fields this agent intends to differ on. Everything else must match the
+ *  built-in — that is what the equivalence check enforces. */
+export const INTENDED_DIFFERENCES = ['name', 'description', 'prompt', 'hooks'];
+
+/**
+ * Build the agent config.
+ *
+ * `home` is a parameter because the built-in bakes ABSOLUTE paths into
+ * `resources` (`<home>/.kiro/skills`, `<home>/.kiro/steering`), so the list has
+ * to be generated per machine rather than hardcoded. The separators below
+ * reproduce what Kiro itself writes.
+ */
+export function buildKiroAgentConfig(bridgeScript, home, { sep = '\\' } = {}) {
+  const command = `node "${bridgeScript}"`;
+  const hook = [{ command, timeout_ms: KIRO_HOOK_TIMEOUT_MS }];
+  const kiroHome = `${home}${sep}.kiro`;
+  return {
+    name: 'wmux',
+    description: KIRO_AGENT_MANAGED_MARKER,
+    prompt: '',
+    tools: ['*'],
+    includeMcpJson: true,
+    resources: [
+      'file://AmazonQ.md',
+      'file://AGENTS.md',
+      'file://README.md',
+      'skill://.kiro/skills/*/SKILL.md',
+      `skill://${kiroHome}/skills/*/SKILL.md`,
+      `file://${kiroHome}${sep}steering/**/*.md`,
+    ],
+    hooks: { stop: hook, agentSpawn: hook },
+  };
+}
+
+/** True when a parsed agent config is one wmux wrote. */
+export function isWmuxOwnedKiroAgent(parsed) {
+  return (
+    !!parsed
+    && typeof parsed === 'object'
+    && !Array.isArray(parsed)
+    && parsed.description === KIRO_AGENT_MANAGED_MARKER
+  );
+}

--- a/integrations/kiro/agent/wmuxAgent.mjs
+++ b/integrations/kiro/agent/wmuxAgent.mjs
@@ -53,7 +53,17 @@ export const INTENDED_DIFFERENCES = ['name', 'description', 'prompt', 'hooks'];
  * to be generated per machine rather than hardcoded. The separators below
  * reproduce what Kiro itself writes.
  */
-export function buildKiroAgentConfig(bridgeScript, home, { sep = '\\' } = {}) {
+export function buildKiroAgentConfig(
+  bridgeScript,
+  home,
+  // Default from the PLATFORM, not a constant. A hardcoded `\\` bakes
+  // backslash resources on POSIX whenever a caller omits the option, and Kiro
+  // drops a resource path it cannot resolve without saying so — the same
+  // silent loss of skills and steering this file exists to prevent. Callers
+  // that need the other separator still pass it explicitly (the equivalence
+  // check does).
+  { sep = process.platform === 'win32' ? '\\' : '/' } = {},
+) {
   const command = `node "${bridgeScript}"`;
   const hook = [{ command, timeout_ms: KIRO_HOOK_TIMEOUT_MS }];
   const kiroHome = `${home}${sep}.kiro`;

--- a/integrations/kiro/bin/wmux-kiro-bridge.mjs
+++ b/integrations/kiro/bin/wmux-kiro-bridge.mjs
@@ -1,0 +1,439 @@
+// wmux-managed: kiro-lifecycle-bridge
+// wmux ↔ Kiro CLI hook bridge.
+//
+// Registered inside a wmux-owned Kiro agent config (`~/.kiro/agents/wmux.json`):
+//   "hooks": { "stop": [{ "command": "node <abs path to this file>" }] }
+// Kiro spawns it on the hook trigger and writes the event JSON to STDIN. The
+// spawned process inherits the pane env, so WMUX_PTY_ID pins the signal to the
+// exact pane and WMUX_DATA_SUFFIX pins every endpoint/file to that instance.
+//
+// This script:
+//   1. Reads the Kiro hook payload from stdin (JSON).
+//   2. Maps `hook_event_name` to a canonical AgentSignal kind.
+//   3. Builds a METADATA-ONLY envelope and sends it to the first wmux endpoint
+//      that answers: the DAEMON control pipe (`daemon.hooks.signal`), else the
+//      MAIN pipe (`hooks.signal`). WMUX_HOOKS_TO_MAIN=1 forces main-only.
+//   4. Exits 0 ALWAYS, under a hard timeout, so a wmux problem never stalls Kiro.
+//
+// ----- What Kiro measurably does and does not give us (2026-08-16, kiro-cli
+//       2.15.1, measured live — see plans/r2-neutral-syntax-kiro-gemini) -----
+//
+//   * Triggers: agentSpawn | userPromptSubmit | preToolUse | postToolUse | stop.
+//   * Neutral = no output, exit 0. Same contract as Claude Code.
+//   * A FAILING hook does not block the turn: stderr + exit 2 still let the
+//     agent answer normally. We still never write stdout and always exit 0 —
+//     "the host tolerates it" is not a reason to be noisy.
+//   * The `stop` payload is `{hook_event_name, cwd, assistant_response}`.
+//     There is NO session id. Two consequences, both deliberate:
+//       - pane attribution comes from WMUX_PTY_ID only, and a payload with no
+//         pty id is DROPPED rather than guessed at;
+//       - resume binding is impossible, so unlike the Codex bridge this one has
+//         no spool. Nothing durable is lost by a failed send.
+//   * The payload carries CONTENT: `prompt` is the user's full input and
+//     `assistant_response` is the model's full reply. wmux's bridges are
+//     metadata-only, so those fields are never read, logged, or forwarded. The
+//     allowlist below is the enforcement — not a filter applied afterwards.
+//
+// SELF-CONTAINED: JS-only, Node built-ins only — no imports from src/ or
+// integrations/shared/. Mirrors integrations/codex/bin/wmux-codex-notify.mjs;
+// the duplication across bridges is by design (a bridge runs in the agent's
+// runtime, where wmux's TypeScript is unreachable).
+//
+// NO SHEBANG, deliberately. Kiro always invokes this as `node "<path>"` (the
+// agent config says so), so the line bought nothing — and Vitest cannot parse
+// a `.mjs` that starts with one, which would make the pure envelope builder
+// below untestable except through a subprocess. The OpenCode plugin is
+// shebang-free for the same reason and its tests import it directly.
+
+import { readFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import { homedir, userInfo } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createConnection } from 'node:net';
+import { randomUUID } from 'node:crypto';
+
+const HOOK_TIMEOUT_MS = 2000; // hard cap so we never stall a Kiro turn
+// Stamped on every kiro-bridge.log line; bump on behavior changes.
+//   0.1.0 — initial: stop + agentSpawn, metadata-only, no resume binding.
+const BRIDGE_VERSION = '0.1.0';
+const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
+const TRANSIENT_CONNECT_CODES = new Set([
+  'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
+]);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Kiro's own default hook output cap is 10240 bytes; its payloads carry whole
+// assistant replies, so cap what we will even hold in memory. Anything past
+// this is a payload we have no business reading.
+const MAX_STDIN_BYTES = 256 * 1024;
+
+// ----- Trigger → AgentSignal kind -----------------------------------------
+//
+// Only the two triggers wmux can act on. `preToolUse`/`postToolUse` are
+// deliberately absent: an activity stamp would cost a process spawn per tool
+// call for a signal the server already throttles. `userPromptSubmit` is absent
+// because Kiro has no approval-specific event, and mapping "a prompt was
+// submitted" to awaiting_input would be the exact conflation #898 punished —
+// no signal beats a false one.
+const TRIGGER_TO_KIND = {
+  stop: 'agent.stop',
+  agentSpawn: 'agent.session_start',
+};
+
+// ----- Path helpers (Node built-ins only) ---------------------------------
+//
+// Kept in lockstep with src/shared/constants.ts. A non-empty suffix is an
+// instance boundary: this bridge never probes production paths as a fallback
+// when its selected namespace is suffixed.
+function dataSuffix() {
+  return process.env.WMUX_DATA_SUFFIX || '';
+}
+
+function getHomeDir() {
+  return process.env.USERPROFILE || process.env.HOME || homedir();
+}
+
+function getWmuxHomeDir() {
+  return join(getHomeDir(), `.wmux${dataSuffix()}`);
+}
+
+function getAuthTokenPath() {
+  return join(getHomeDir(), `.wmux${dataSuffix()}-auth-token`);
+}
+
+function getPipeName() {
+  const override = process.env.WMUX_PIPE_NAME;
+  if (typeof override === 'string' && override.length > 0) return override;
+  if (process.platform === 'win32') {
+    const username = userInfo().username || 'default';
+    return `\\\\.\\pipe\\wmux${dataSuffix()}-${username}`;
+  }
+  return join(homedir() || '/tmp', `.wmux${dataSuffix()}.sock`);
+}
+
+function getDaemonAuthTokenPath() {
+  return join(getWmuxHomeDir(), 'daemon-auth-token');
+}
+
+// Prefer the suffix-scoped `daemon-pipe` hint the daemon writes at boot (the
+// name it ACTUALLY bound, which differs from the convention after a zombie-pipe
+// fallback rename), then derive within the same namespace.
+function getDaemonPipeName() {
+  try {
+    const fromFile = readFileSync(join(getWmuxHomeDir(), 'daemon-pipe'), 'utf8').trim();
+    if (fromFile) return fromFile;
+  } catch {
+    // Hint absent/unreadable — derive within the selected namespace.
+  }
+  if (process.platform === 'win32') {
+    const username = userInfo().username || 'default';
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
+  }
+  return join(getWmuxHomeDir(), 'daemon.sock');
+}
+
+function readTokenFile(tokenPath) {
+  try {
+    const token = readFileSync(tokenPath, 'utf8').trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+// Ordered endpoints, daemon first (it is the always-on process and owns hook
+// ingest). A target with no token file is skipped — that endpoint has never run.
+function resolveTargets() {
+  const mainToken = readTokenFile(getAuthTokenPath());
+  const pipeOverride = process.env.WMUX_PIPE_NAME;
+  if (typeof pipeOverride === 'string' && pipeOverride.length > 0) {
+    return mainToken ? [{ name: 'main', pipe: pipeOverride, token: mainToken, method: 'hooks.signal' }] : [];
+  }
+  const targets = [];
+  if (process.env.WMUX_HOOKS_TO_MAIN !== '1') {
+    const token = readTokenFile(getDaemonAuthTokenPath());
+    if (token) {
+      targets.push({ name: 'daemon', pipe: getDaemonPipeName(), token, method: 'daemon.hooks.signal' });
+    }
+  }
+  if (mainToken) {
+    targets.push({ name: 'main', pipe: getPipeName(), token: mainToken, method: 'hooks.signal' });
+  }
+  return targets;
+}
+
+function getLogPath() {
+  const dir = getWmuxHomeDir();
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch { /* appendFileSync below also fails → swallowed */ }
+  return join(dir, 'kiro-bridge.log');
+}
+
+// Never logs a caller-supplied payload field. `extra` is built by this file
+// only, from the allowlist in main() — a log line is a place content leaks too.
+function logEvent(outcome, extra) {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    bridge: BRIDGE_VERSION,
+    pid: process.pid,
+    outcome,
+    ...(extra ?? {}),
+  });
+  try {
+    appendFileSync(getLogPath(), line + '\n', { encoding: 'utf8' });
+  } catch { /* no writable home → swallow */ }
+}
+
+// ----- stdin reader -------------------------------------------------------
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    process.stdin.on('data', (c) => {
+      if (total >= MAX_STDIN_BYTES) return; // keep draining; stop accumulating
+      chunks.push(c);
+      total += c.length;
+    });
+    process.stdin.on('end', () => {
+      const buf = Buffer.concat(chunks).toString('utf8').trim();
+      if (!buf) {
+        resolve(null);
+        return;
+      }
+      // Over the cap the JSON is truncated and will not parse; that lands in
+      // the reject path and exits 0 silently, which is the right outcome for a
+      // payload this bridge was never going to forward anyway.
+      try {
+        resolve(JSON.parse(buf));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+// ----- RPC over named pipe (mirrors the Codex bridge) ---------------------
+
+function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    const sock = createConnection(pipePath);
+    let buffer = '';
+    let settled = false;
+    let wrote = false;
+
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch { /* already dead */ }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => settle({ ok: false, error: 'timeout', retryable: !wrote }), timeoutMs);
+
+    sock.on('connect', () => {
+      sock.write(JSON.stringify(request) + '\n');
+      wrote = true;
+    });
+    sock.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      // Match OUR response by id and skip everything else: the daemon control
+      // pipe BROADCASTS session events (no `id`) to every connected socket, and
+      // one landing before the reply would otherwise be settled as the reply.
+      for (;;) {
+        const nl = buffer.indexOf('\n');
+        if (nl === -1) return;
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        let parsed;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (!parsed || parsed.id !== request.id) continue;
+        clearTimeout(timer);
+        settle(parsed);
+        return;
+      }
+    });
+    sock.on('error', (err) => {
+      clearTimeout(timer);
+      settle({ ok: false, error: 'connect-error', detail: err.code ?? err.message, retryable: !wrote });
+    });
+    sock.on('close', () => {
+      clearTimeout(timer);
+      settle({ ok: false, error: 'closed-without-response', retryable: !wrote });
+    });
+  });
+}
+
+// `deadline` is passed in so a multi-target walk shares ONE HOOK_TIMEOUT_MS budget.
+async function sendRpcWithRetry(pipePath, request, deadline = Date.now() + HOOK_TIMEOUT_MS) {
+  let attempt = 0;
+  let last = { ok: false, error: 'timeout' };
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return last;
+    last = await sendRpc(pipePath, request, remaining);
+    if (last.error !== 'connect-error') return last;
+    if (last.retryable === false
+        || !TRANSIENT_CONNECT_CODES.has(last.detail)
+        || attempt >= CONNECT_RETRY_BACKOFFS_MS.length) {
+      return last;
+    }
+    const backoff = CONNECT_RETRY_BACKOFFS_MS[attempt++];
+    if (Date.now() + backoff >= deadline) return last;
+    await sleep(backoff);
+  }
+}
+
+// Advance to the next endpoint only when the request PROVABLY never reached a
+// server. An answered call owns the signal; a written-but-unanswered one is
+// ambiguous and re-sending risks a duplicate turn boundary.
+export function shouldTryNextTarget(result) {
+  if (result && result.ok === true) return false;
+  if (result && result.retryable === false) return false;
+  return true;
+}
+
+async function sendToTargets(targets, buildRequest) {
+  const deadline = Date.now() + HOOK_TIMEOUT_MS;
+  let result = { ok: false, error: 'no-target' };
+  let target = null;
+  for (const candidate of targets) {
+    if (Date.now() >= deadline) break;
+    target = candidate;
+    result = await sendRpcWithRetry(candidate.pipe, buildRequest(candidate), deadline);
+    if (!shouldTryNextTarget(result)) break;
+  }
+  return { result, target };
+}
+
+// ----- Envelope (pure — exported for unit testing) -------------------------
+
+function nonEmptyStr(v) {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Build the canonical wmux AgentSignal for a Kiro hook payload.
+ *
+ * Returns null when the event is not one wmux acts on, or when the pane cannot
+ * be identified. Dropping beats guessing: Kiro sends no session id, so a
+ * payload with no WMUX_PTY_ID has nothing that could attribute it to a pane,
+ * and attaching it to the wrong one is worse than losing it.
+ *
+ * The ONLY payload fields read are `hook_event_name` and `cwd`. `prompt` and
+ * `assistant_response` are user and model content; this bridge is
+ * metadata-only, and the allowlist here is where that is enforced.
+ */
+export function buildKiroEnvelope(payload, { env = process.env, now = Date.now() } = {}) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const trigger = nonEmptyStr(payload.hook_event_name);
+  const kind = trigger ? TRIGGER_TO_KIND[trigger] : undefined;
+  if (!kind) return null;
+
+  const ptyId = nonEmptyStr(env.WMUX_PTY_ID);
+  if (!ptyId) return null;
+
+  const workspaceId = nonEmptyStr(env.WMUX_WORKSPACE_ID);
+  const surfaceId = nonEmptyStr(env.WMUX_SURFACE_ID);
+  return {
+    kind,
+    agent: 'kiro',
+    ptyId,
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(surfaceId ? { surfaceId } : {}),
+    cwd: nonEmptyStr(payload.cwd) ?? process.cwd(),
+    // Metadata only. Kiro gives no session id, so there is no agentSessionId
+    // and no resume binding to capture — see the header.
+    payload: {},
+    ts: now,
+  };
+}
+
+// ----- Main ---------------------------------------------------------------
+
+async function main() {
+  let payload;
+  try {
+    payload = await readStdin();
+  } catch {
+    // Parse diagnostics can quote the input; never copy them to the log.
+    logEvent('malformed-stdin');
+    return;
+  }
+
+  const envelope = buildKiroEnvelope(payload);
+  if (!envelope) {
+    // Two reasons, and the log distinguishes them without echoing content: an
+    // event wmux does not act on, or a pane we cannot identify.
+    const trigger = nonEmptyStr(payload?.hook_event_name);
+    logEvent(trigger && TRIGGER_TO_KIND[trigger] ? 'no-pty-id' : 'ignored-trigger', {
+      trigger: trigger && TRIGGER_TO_KIND[trigger] ? trigger : undefined,
+    });
+    return;
+  }
+
+  const targets = resolveTargets();
+  if (targets.length === 0) {
+    logEvent('no-auth-token', { paths: [getDaemonAuthTokenPath(), getAuthTokenPath()] });
+    return;
+  }
+
+  // One id across the walk so a fallback is correlatable in the log; each
+  // target carries its own method + token (see resolveTargets).
+  const requestId = `kiro-hook-${randomUUID()}`;
+  const { result: rpcResult, target } = await sendToTargets(targets, (t) => ({
+    id: requestId,
+    method: t.method,
+    params: envelope,
+    token: t.token,
+  }));
+  const outerOk = rpcResult && rpcResult.ok === true;
+  const innerOk = outerOk && rpcResult.result && rpcResult.result.ok === true;
+
+  if (innerOk) {
+    logEvent('ok', { kind: envelope.kind, target: target?.name });
+  } else {
+    // Nothing to spool: with no session id there is no durable binding a later
+    // daemon boot could reconcile. A lost turn boundary is re-derived by the
+    // detector, which is where kiro panes lived before this bridge existed.
+    logEvent(outerOk ? 'rpc-rejected' : 'rpc-failed', {
+      kind: envelope.kind,
+      target: target?.name,
+      reason: rpcResult?.result?.reason,
+      error: rpcResult?.error,
+      detail: rpcResult?.detail,
+    });
+  }
+}
+
+// Run only when Kiro spawned this file as a script. Under `import` (the unit
+// tests, which exercise buildKiroEnvelope directly) the module must stay inert
+// — otherwise it would read stdin and call process.exit(0) inside the test
+// runner. Fails OPEN: anything it cannot determine is treated as a real launch,
+// because a bridge that silently declines to run is the worse failure.
+function invokedAsScript() {
+  try {
+    if (!process.argv[1]) return true;
+    const self = fileURLToPath(import.meta.url);
+    const entry = resolve(process.argv[1]);
+    const norm = (p) => (process.platform === 'win32' ? p.toLowerCase() : p);
+    return norm(self) === norm(entry);
+  } catch {
+    return true;
+  }
+}
+
+if (invokedAsScript()) {
+  main()
+    .catch((err) => logEvent('uncaught', { error: String(err) }))
+    // `process.exit(0)`, not just a resolved promise: this bridge never writes
+    // stdout, so there is no pending flush to lose, and an explicit 0 keeps a
+    // stray listener from holding the turn open.
+    .finally(() => process.exit(0));
+}

--- a/integrations/kiro/bin/wmux-kiro-bridge.mjs
+++ b/integrations/kiro/bin/wmux-kiro-bridge.mjs
@@ -27,8 +27,11 @@
 //     There is NO session id. Two consequences, both deliberate:
 //       - pane attribution comes from WMUX_PTY_ID only, and a payload with no
 //         pty id is DROPPED rather than guessed at;
-//       - resume binding is impossible, so unlike the Codex bridge this one has
-//         no spool. Nothing durable is lost by a failed send.
+//       - resume binding is impossible, so unlike the Codex bridge this one
+//         has no spool — that spool carries a session id + launch command,
+//         and there is none to write. A failed send still costs the turn
+//         boundary itself; see the send path for what that means and why the
+//         idempotent kinds keep walking.
 //   * The payload carries CONTENT: `prompt` is the user's full input and
 //     `assistant_response` is the model's full reply. wmux's bridges are
 //     metadata-only, so those fields are never read, logged, or forwarded. The
@@ -45,7 +48,7 @@
 // below untestable except through a subprocess. The OpenCode plugin is
 // shebang-free for the same reason and its tests import it directly.
 
-import { readFileSync, existsSync, mkdirSync, appendFileSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, appendFileSync, realpathSync } from 'node:fs';
 import { homedir, userInfo } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -290,24 +293,46 @@ async function sendRpcWithRetry(pipePath, request, deadline = Date.now() + HOOK_
   }
 }
 
-// Advance to the next endpoint only when the request PROVABLY never reached a
-// server. An answered call owns the signal; a written-but-unanswered one is
-// ambiguous and re-sending risks a duplicate turn boundary.
-export function shouldTryNextTarget(result) {
+// Signals whose re-delivery cannot corrupt anything: each asserts a state
+// ("this turn ended", "this session began") rather than appending a record, and
+// wmux's HookSignalRouter keeps a dedup ledger, so a duplicate that lands
+// inside its window is dropped before any user-visible dispatch.
+//
+// That matters because the alternative is not "one lost signal". Once ANY
+// bridge signal reaches wmux the pane is hook-governed, and while that
+// authority is fresh the detector's turn-end emissions are vetoed
+// (HookIngest) — so a dropped `stop` is not re-derived from the screen, and
+// the pane reads as still-working until the next signal lands or the authority
+// ages out. Trading a possible duplicate (deduped) for a possible stall
+// (minutes) is the right side of that bargain for these two kinds.
+const IDEMPOTENT_KINDS = new Set(['agent.stop', 'agent.session_start']);
+
+// Advance to the next endpoint when the request provably never reached a
+// server — or when re-sending is harmless. An answered call owns the signal;
+// a written-but-unanswered one is ambiguous, and for anything NOT in
+// IDEMPOTENT_KINDS the ambiguity is where the walk stops.
+export function shouldTryNextTarget(result, kind) {
   if (result && result.ok === true) return false;
-  if (result && result.retryable === false) return false;
+  if (result && result.retryable === false) return IDEMPOTENT_KINDS.has(kind);
   return true;
 }
 
-async function sendToTargets(targets, buildRequest) {
+async function sendToTargets(targets, buildRequest, kind) {
   const deadline = Date.now() + HOOK_TIMEOUT_MS;
   let result = { ok: false, error: 'no-target' };
   let target = null;
-  for (const candidate of targets) {
-    if (Date.now() >= deadline) break;
+  for (let i = 0; i < targets.length; i++) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const candidate = targets[i];
     target = candidate;
-    result = await sendRpcWithRetry(candidate.pipe, buildRequest(candidate), deadline);
-    if (!shouldTryNextTarget(result)) break;
+    // Per-target slice, not the whole remaining budget: a pipe that accepts
+    // the connection and then hangs would otherwise spend every millisecond
+    // here and the fallback endpoint would never be tried at all — the walk
+    // would exist on paper only.
+    const slice = Math.max(1, Math.floor(remaining / (targets.length - i)));
+    result = await sendRpcWithRetry(candidate.pipe, buildRequest(candidate), Date.now() + slice);
+    if (!shouldTryNextTarget(result, kind)) break;
   }
   return { result, target };
 }
@@ -333,7 +358,14 @@ function nonEmptyStr(v) {
 export function buildKiroEnvelope(payload, { env = process.env, now = Date.now() } = {}) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
   const trigger = nonEmptyStr(payload.hook_event_name);
-  const kind = trigger ? TRIGGER_TO_KIND[trigger] : undefined;
+  // hasOwn, not a bare index: `constructor` / `toString` / `__proto__` resolve
+  // through the prototype chain to truthy values, sail past a `!kind` guard,
+  // and produce an envelope whose `kind` is a function or `{}` — sent to the
+  // daemon instead of being dropped. Measured before the fix:
+  //   constructor -> kind=undefined (serialized), __proto__ -> kind={}
+  const kind = trigger && Object.hasOwn(TRIGGER_TO_KIND, trigger)
+    ? TRIGGER_TO_KIND[trigger]
+    : undefined;
   if (!kind) return null;
 
   const ptyId = nonEmptyStr(env.WMUX_PTY_ID);
@@ -372,8 +404,9 @@ async function main() {
     // Two reasons, and the log distinguishes them without echoing content: an
     // event wmux does not act on, or a pane we cannot identify.
     const trigger = nonEmptyStr(payload?.hook_event_name);
-    logEvent(trigger && TRIGGER_TO_KIND[trigger] ? 'no-pty-id' : 'ignored-trigger', {
-      trigger: trigger && TRIGGER_TO_KIND[trigger] ? trigger : undefined,
+    const known = Boolean(trigger) && Object.hasOwn(TRIGGER_TO_KIND, trigger);
+    logEvent(known ? 'no-pty-id' : 'ignored-trigger', {
+      trigger: known ? trigger : undefined,
     });
     return;
   }
@@ -392,16 +425,27 @@ async function main() {
     method: t.method,
     params: envelope,
     token: t.token,
-  }));
+  }), envelope.kind);
   const outerOk = rpcResult && rpcResult.ok === true;
   const innerOk = outerOk && rpcResult.result && rpcResult.result.ok === true;
 
   if (innerOk) {
     logEvent('ok', { kind: envelope.kind, target: target?.name });
   } else {
-    // Nothing to spool: with no session id there is no durable binding a later
-    // daemon boot could reconcile. A lost turn boundary is re-derived by the
-    // detector, which is where kiro panes lived before this bridge existed.
+    // Nothing to spool: the existing spool carries a RESUME BINDING (session
+    // id + launch command) for the daemon to reconcile at boot, and Kiro gives
+    // no session id, so there is no such record to write.
+    //
+    // What a dropped signal costs, stated accurately: once any bridge signal
+    // has reached wmux the pane is hook-governed, and while that authority is
+    // fresh the detector's turn-end emissions are vetoed — so a lost `stop` is
+    // NOT re-derived from the screen. The pane reads as still-working until
+    // the next signal lands, the daemon restarts (authority is in-memory), or
+    // the authority TTL expires. That bound is deliberate and shared with
+    // every bridge (HOOK_AUTHORITY_TTL_MS: "short enough that a bridge killed
+    // with -9 eventually returns the pane to the detector backstop"), but it
+    // is minutes, not instant — which is why the walk above re-tries an
+    // idempotent kind rather than stopping at the first ambiguous write.
     logEvent(outerOk ? 'rpc-rejected' : 'rpc-failed', {
       kind: envelope.kind,
       target: target?.name,
@@ -422,7 +466,19 @@ function invokedAsScript() {
     if (!process.argv[1]) return true;
     const self = fileURLToPath(import.meta.url);
     const entry = resolve(process.argv[1]);
-    const norm = (p) => (process.platform === 'win32' ? p.toLowerCase() : p);
+    // realpath both sides before comparing. A textual match fails on a
+    // symlinked install, an 8.3 short path, or a `subst` drive — and the only
+    // symptom would be a bridge that silently never runs, which is the one
+    // outcome this guard must not produce. realpathSync throws if the path is
+    // gone; that lands in the catch, which fails OPEN by design.
+    const real = (p) => {
+      try {
+        return realpathSync.native ? realpathSync.native(p) : realpathSync(p);
+      } catch {
+        return p;
+      }
+    };
+    const norm = (p) => (process.platform === 'win32' ? real(p).toLowerCase() : real(p));
     return norm(self) === norm(entry);
   } catch {
     return true;
@@ -430,6 +486,17 @@ function invokedAsScript() {
 }
 
 if (invokedAsScript()) {
+  // Self-enforced hard stop. The header promises "exits 0 ALWAYS, under a hard
+  // timeout", but HOOK_TIMEOUT_MS only bounds the SEND — a stdin that never
+  // reaches EOF would hang before that, leaving the invariant resting entirely
+  // on the host's own kill. Kiro was measured tolerating a hook that fails; it
+  // was not measured killing one that hangs, so the bridge bounds itself.
+  // `unref` so this never keeps the process alive on the normal path.
+  const watchdog = setTimeout(() => {
+    logEvent('watchdog-exit');
+    process.exit(0);
+  }, HOOK_TIMEOUT_MS * 2);
+  watchdog.unref?.();
   main()
     .catch((err) => logEvent('uncaught', { error: String(err) }))
     // `process.exit(0)`, not just a resolved promise: this bridge never writes

--- a/scripts/__tests__/hookHarmlessness.runtime.test.mjs
+++ b/scripts/__tests__/hookHarmlessness.runtime.test.mjs
@@ -411,7 +411,8 @@ describe('every installed hook is indistinguishable from a no-op', () => {
 // 3. stdin drain.
 //
 // A hook that stops reading stdin leaves the host writing into a pipe with no
-// reader. The bridges cap stdin at 1MB by design and drop the signal past it;
+// reader. The bridges cap stdin by design (1MB for the Claude family, 256KB
+// for Kiro, whose payloads carry whole assistant replies) and drop past it;
 // that is a delivery choice, not a harmlessness one. What must hold is that
 // the host's write SETTLES — errored is fine, wedged is not — and that the
 // hook still exits 0 and silently.

--- a/scripts/__tests__/hookHarmlessness.runtime.test.mjs
+++ b/scripts/__tests__/hookHarmlessness.runtime.test.mjs
@@ -230,7 +230,7 @@ describe('the matrix covers what wmux actually installs', () => {
     const agents = new Set(cases.map((c) => c.agent));
     // opencode is absent by design: it is an in-process plugin, not a spawned
     // hook, so it gets its own measurement below rather than a silent skip.
-    expect([...agents].sort()).toEqual(['claude', 'codex', 'openclaude']);
+    expect([...agents].sort()).toEqual(['claude', 'codex', 'kiro', 'openclaude']);
     for (const c of cases) expect(c.script).toMatch(/\.mjs$/);
     // The permission gate — the surface #898 lived on — must be in the matrix.
     expect(cases.some((c) => c.args.includes('--permission-gate'))).toBe(true);

--- a/scripts/kiro-agent-equivalence.mjs
+++ b/scripts/kiro-agent-equivalence.mjs
@@ -1,0 +1,77 @@
+// Drift detector: is the wmux Kiro agent still equivalent to kiro_default?
+//
+// The install ships a wmux-owned agent whose only intended difference from the
+// built-in is an empty prompt. That claim is only true for the Kiro version it
+// was checked against — a later Kiro can add a field, and our agent would
+// silently stop matching. Nothing in CI can catch that (it needs a real
+// kiro-cli), so this runs on demand wherever Kiro is installed.
+//
+// Reads the built-in by materializing it with `kiro-cli agent create --from`,
+// which is Kiro's own answer to "what does the default actually contain".
+import { spawnSync } from 'node:child_process';
+import { readFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir, homedir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+
+const KIRO = join(process.env.LOCALAPPDATA ?? '', 'Kiro-Cli', 'kiro-cli.exe');
+const dir = mkdtempSync(join(tmpdir(), 'wmux-kiroeq-'));
+
+// Load the real builder rather than restating it, so this compares what ships.
+const { buildKiroAgentConfig, INTENDED_DIFFERENCES } = await import(
+  pathToFileURL(join(process.cwd(), 'integrations', 'kiro', 'agent', 'wmuxAgent.mjs')).href
+);
+
+try {
+  const created = spawnSync(KIRO, ['agent', 'create', '--from', 'kiro_default', '--directory', dir, 'probe'], {
+    encoding: 'utf8',
+  });
+  let builtIn;
+  try {
+    builtIn = JSON.parse(readFileSync(join(dir, 'probe.json'), 'utf8'));
+  } catch {
+    console.error('could not materialize kiro_default (is kiro-cli installed?):', created.stderr?.slice(0, 300));
+    process.exit(2);
+  }
+
+  const ours = buildKiroAgentConfig('/bridge.mjs', homedir());
+
+  // Fields we deliberately differ on. Everything else must either match or be
+  // absent-with-the-same-effect. The list comes from the module under test, so
+  // widening it is a code change someone has to justify.
+  const intended = new Set(INTENDED_DIFFERENCES);
+
+  const problems = [];
+  for (const [key, value] of Object.entries(builtIn)) {
+    if (intended.has(key)) continue;
+    const mine = ours[key];
+    if (mine === undefined) {
+      // Absent is fine only when the built-in's value is itself empty/neutral.
+      const neutral = value === null
+        || (Array.isArray(value) && value.length === 0)
+        || (value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0);
+      if (!neutral) problems.push(`MISSING  ${key} = ${JSON.stringify(value).slice(0, 160)}`);
+      continue;
+    }
+    if (JSON.stringify(mine) !== JSON.stringify(value)) {
+      problems.push(`DIFFERS  ${key}\n    built-in: ${JSON.stringify(value).slice(0, 200)}\n    ours:     ${JSON.stringify(mine).slice(0, 200)}`);
+    }
+  }
+  for (const key of Object.keys(ours)) {
+    if (intended.has(key)) continue;
+    if (!(key in builtIn)) problems.push(`EXTRA    ${key} — we set something the built-in does not`);
+  }
+
+  console.log('built-in keys:', Object.keys(builtIn).join(', '));
+  console.log('ours keys:    ', Object.keys(ours).join(', '));
+  console.log();
+  if (problems.length === 0) {
+    console.log('EQUIVALENT — differs only in:', [...intended].join(', '));
+  } else {
+    console.log(`${problems.length} divergence(s):`);
+    for (const p of problems) console.log('  ' + p);
+  }
+  process.exitCode = problems.length === 0 ? 0 : 1;
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -119,6 +119,21 @@ export const HOST_CONTRACTS = {
     if (exitCode !== 0) return 'nonzero-exit-ignored-by-host';
     return 'none';
   },
+
+  // Kiro CLI. Measured live on 2.15.1 (2026-08-16): a hook that writes JSON to
+  // stdout and one that writes stderr and exits 2 BOTH left the turn completely
+  // unaffected — the agent answered normally either way. So Kiro is permissive,
+  // and its neutral is the same "no output, exit 0" as Claude Code's.
+  //
+  // The classifier is still strict about both. "The host tolerates it" is not
+  // the property under test: the claim is that a wmux hook is indistinguishable
+  // from one with no opinion, and a hook that prints or fails is distinguishable
+  // whether or not this particular host currently cares.
+  kiroHook(exitCode, stdout) {
+    if (stdout !== '') return 'stdout-noise';
+    if (exitCode !== 0) return 'nonzero-exit-tolerated-by-host';
+    return 'none';
+  },
 };
 
 // ----- Case manifest ------------------------------------------------------
@@ -160,6 +175,7 @@ export function discoverHookManifests() {
 // wired into the gate, and the coverage test says so rather than passing.
 export const NON_MANIFEST_INTEGRATIONS = {
   codex: 'notify program registered in config.toml; payload arrives as argv, covered explicitly',
+  kiro: 'hooks live inside a wmux-owned agent config, not a hooks.json; covered explicitly',
   opencode: 'in-process plugin, not a spawned hook; measured separately',
   shared: 'not an agent — shared type declarations',
 };
@@ -308,6 +324,34 @@ export function buildCases(payloadOpts) {
       args: [],
       stdin: 'none',
       argvPayload: payload,
+      payload,
+    });
+  }
+
+  // Kiro's hooks live inside a wmux-owned agent config rather than a hooks.json
+  // manifest, so its triggers are spelled out here too. These are the payloads
+  // kiro-cli 2.15.1 actually sends, captured live — including the content
+  // fields (`prompt`, `assistant_response`) the bridge must never forward, so
+  // the harness exercises the real shape rather than a sanitized one.
+  const kiroScript = join(REPO_ROOT, 'integrations', 'kiro', 'bin', 'wmux-kiro-bridge.mjs');
+  const kiroCwd = payloadOpts?.cwd ?? '/tmp/harness';
+  for (const [label, payload] of [
+    ['stop', { hook_event_name: 'stop', cwd: kiroCwd, assistant_response: 'the model said this' }],
+    ['agentSpawn', { hook_event_name: 'agentSpawn', cwd: kiroCwd }],
+    // Triggers wmux deliberately does not map. "Ignored" must still mean silent
+    // and fast, not a slow no-op.
+    ['userPromptSubmit', { hook_event_name: 'userPromptSubmit', cwd: kiroCwd, prompt: 'the user typed this' }],
+    ['postToolUse', { hook_event_name: 'postToolUse', cwd: kiroCwd }],
+  ]) {
+    cases.push({
+      agent: 'kiro',
+      contract: 'kiroHook',
+      id: `kiro:${label}`,
+      event: label,
+      matcher: label,
+      script: kiroScript,
+      args: [],
+      stdin: 'json',
       payload,
     });
   }


### PR DESCRIPTION
wmux answers "is this pane done?" for Kiro by scraping the terminal — a two-stage regex gate on Kiro's chrome and prompt lines (`AgentDetector.ts:329`). That holds until the model prints something prompt-shaped, or Kiro changes its UI. The answer feeds notifications, `deckBriefing`, the stop gate, the orchestrator's count of what is still busy, and `wmux_events_poll(blockMs)` — so when it is wrong, the fleet sends work to a pane that never stopped. That is the failure mode #914 just fixed for subagents.

This lets Kiro say it itself.

| Kiro trigger | wmux signal |
|---|---|
| `stop` | `agent.stop` |
| `agentSpawn` | `agent.session_start` |

## Measured on kiro-cli 2.15.1, not assumed

Running it corrected three entries of the earlier hook survey:

| Assumed | Measured |
|---|---|
| `session_id` is in the payload | **Absent.** `stop` is `{hook_event_name, cwd, assistant_response}` |
| `~/.kiro/hooks/` applies globally | **Inert** — 0 invocations, both plausible layouts |
| copilot should be first | It has no CLI here; Kiro is the one that can be verified at all |

Also measured: Kiro's neutral is no output and exit 0, the same contract as Claude Code's. A *failing* hook does not block a turn — stderr plus exit 2 still let the agent answer normally — though this bridge does neither.

Consequences, all deliberate:

- **No resume binding.** No session id means nothing to bind, so unlike the Codex bridge there is no spool. A lost signal is re-derived by the detector.
- **Pane attribution is `WMUX_PTY_ID` only**, inherited from the pane environment (verified: the hook process does inherit it). A payload without it is **dropped**, not attached to a guess.
- **`preToolUse`/`postToolUse` unregistered.** An activity stamp would cost a process spawn per tool call — the one path that actually makes anything heavier. The Claude bridge needed a 2.5s source-side throttle for exactly this.
- **`userPromptSubmit` unmapped.** Kiro has no approval-specific event, and calling "a prompt was submitted" `awaiting_input` is the conflation #898 punished. No signal beats a false one.

## Privacy

Kiro hands the hook the user's whole prompt and the model's whole reply. wmux's bridges are metadata-only, so the envelope builder reads `hook_event_name` and `cwd` and nothing else. The test asserts on the **serialized envelope** rather than field by field, so a future field that happens to carry content fails it too.

## The agent config, and why it looks like that

Kiro's hooks can only live inside an agent config, and the user's default agent is built in — there is no file of theirs to add a hook to. So wmux ships its own agent and panes opt in with `--agent wmux`. The user's default stays their default; `kiro-cli agent list` confirms it (`wmux` appears under `Global`, the `*` stays on `kiro_default`).

The rule is **equivalent to `kiro_default` except the prompt**, checked against a materialized built-in:

- `allowedTools` is `[]` in the built-in too, which is why **approval behaviour cannot change** — anything omitted is not more restrictive than the default.
- `includeMcpJson: true` and `resources` are carried over. An earlier revision dropped both, which would have cost the pane its MCP access (including wmux's own tools) and its project context — silently, since the agent keeps answering either way. The measurement that cleared the empty prompt ran a synthetic task in a temp directory, where neither could have shown up. That miss is now pinned by tests.
- The empty prompt is the one intended difference. Measured 3× on the same tool-using task: thin and built-in both 3/3 correct, 17.4s vs 18.0s, thin slightly cheaper. Cloning the built-in's 1.7KB prompt would freeze it at install time and drift.

`scripts/kiro-agent-equivalence.mjs` re-checks that against the live built-in after a Kiro upgrade — no CI can, since it needs a real kiro-cli. Current output:

```
EQUIVALENT — differs only in: name, description, prompt, hooks
```

## Installation is NOT wired up

The end-to-end path (global agent + `--agent wmux` + hook fires + daemon receives) needs a Kiro account to verify, and this machine has none. Three of its four links are verified live — hooks fire from an agent config, the global agent is discovered and validated, the default agent is untouched — but their composition is not. So the bridge ships with a manual setup guide instead of an install nobody has watched work; wiring it into `McpRegistrar`/`lifecycleIntegrations` is a small follow-up once someone can dogfood it.

If the composition turns out not to work, the cost is a silent no-op: Kiro panes keep using the detector, exactly as today.

## Harmlessness

Covered by the P-5 gate (#915) across five environment scenarios: zero bytes to stdout **and stderr**, always exit 0, ~90ms, no process left holding the host's stdio.

The gate also caught this integration on its own. Creating `integrations/kiro/` failed the coverage test before any wiring existed:

```
new integration(s) with no hook manifest and no stated reason — wire them into
the harmlessness gate, or record why: expected [ 'kiro' ] to deeply equal []
```

## Notes

- No shebang on the bridge, deliberately: Kiro always invokes it as `node "<path>"`, and Vitest cannot parse a `.mjs` that starts with one — which would leave the pure envelope builder testable only through a subprocess. The OpenCode plugin is shebang-free for the same reason.
- tsc clean · lint clean · 23 new tests · harmlessness gate 18 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kiro CLI integration with lifecycle signal support for agent stop and spawn events.
  * Added automatic Kiro agent configuration with MCP access, project resources, and supported hooks.
  * Added secure event handling that forwards metadata only and avoids transmitting conversation content.
  * Added configuration equivalence validation tooling and setup guidance.

* **Tests**
  * Added comprehensive coverage for configuration, event handling, endpoint fallback, and hook harmlessness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->