### PR TITLE
Give the attach mirror the terminal's own copy, paste, and newline keys

### DIFF
--- a/changelog.d/924.md
+++ b/changelog.d/924.md
@@ -9,4 +9,6 @@
   added a line. All four now behave the way they do in a local pane — including
   `⌘C` / `⌘V` on macOS — while an empty-selection `Ctrl+C` still interrupts the
   remote process, and a host started without `--allow-input` still receives
-  nothing. (#924)
+  nothing. `Shift+Enter` sends the newline form the remote app actually asked
+  for: apps that enable the kitty keyboard protocol get it, and anything else
+  keeps the plain carriage return it has always received. (#924)

--- a/changelog.d/924.md
+++ b/changelog.d/924.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **A mirrored remote pane now copies, pastes, and inserts newlines like any
+  other terminal.** Attaching to a remote wmux gave you a pane that forwarded
+  every keystroke straight through, so the editing habits that never leave your
+  own machine stopped working: selecting text copied nothing, `Ctrl+C` over a
+  selection interrupted the remote process instead of copying it, `Ctrl+V` did
+  nothing at all, and `Shift+Enter` submitted where a local pane would have
+  added a line. All four now behave the way they do in a local pane — including
+  `⌘C` / `⌘V` on macOS — while an empty-selection `Ctrl+C` still interrupts the
+  remote process, and a host started without `--allow-input` still receives
+  nothing. (#924)

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -4,6 +4,7 @@ import { useT } from '../../hooks/useT';
 import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
 import { computeMirrorFontSize, mirrorFitKey, MAX_FIT_PASSES } from './mirrorFit';
 import { decideMirrorKeyWithRepeat } from './mirrorInput';
+import { foldRemoteKeyboardState, acceptsCsiU, INITIAL_REMOTE_KEYBOARD_STATE } from './keyboardProtocol';
 import { useStore } from '../../stores';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
 import { createAutoSelectionCopy } from '../../utils/autoSelectionCopy';
@@ -97,6 +98,12 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   // flip (allowInput probe resolving after mount) doesn't tear down and
   // re-subscribe the whole attach — only paneWrite needs the live value.
   const readOnlyRef = useRef(readOnly);
+  /**
+   * What the remote app has asked for in the way of key encodings, folded from
+   * its own output. A ref, not state: the key handler reads it synchronously
+   * and nothing renders from it.
+   */
+  const remoteKeyboardRef = useRef(INITIAL_REMOTE_KEYBOARD_STATE);
   readOnlyRef.current = readOnly;
   // Same reason: the key handler is installed once, at mount, and needs the
   // CURRENT attach to write to. Listing `attachId` in that effect's deps would
@@ -402,6 +409,7 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
         isMac,
         hasSelection: term.hasSelection(),
         readOnly: readOnlyRef.current === true,
+        remoteAcceptsCsiU: acceptsCsiU(remoteKeyboardRef.current),
         hasCustomCtrlJBinding: useStore.getState().customKeybindings.some(
           (kb) => kb.key === 'Ctrl+J',
         ),
@@ -504,7 +512,12 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       term.resize(e.cols, e.rows);
       repaintDepthRef.current += 1;
       try {
-        term.write(decodeBase64Bytes(e.snapshotB64), () => {
+        const snapshot = decodeBase64Bytes(e.snapshotB64);
+        // A re-attach replays the pane's screen, negotiation included — reset
+        // first so a protocol the app turned off before we attached does not
+        // survive as a stale `true`.
+        remoteKeyboardRef.current = foldRemoteKeyboardState(INITIAL_REMOTE_KEYBOARD_STATE, snapshot);
+        term.write(snapshot, () => {
           repaintDepthRef.current = Math.max(0, repaintDepthRef.current - 1);
         });
       } catch {
@@ -532,7 +545,13 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       if (e.attachId !== attachId) return;
       const term = termRef.current;
       if (!term) return;
-      term.write(decodeBase64Bytes(e.dataB64));
+      const data = decodeBase64Bytes(e.dataB64);
+      // Watch the remote's own output for a keyboard-protocol negotiation, the
+      // same way the paste path reads xterm's parse of DECSET 2004. xterm
+      // exposes nothing for this one, and without it the mirror cannot tell an
+      // app that wants CSI-u from one that would read it as Escape + garbage.
+      remoteKeyboardRef.current = foldRemoteKeyboardState(remoteKeyboardRef.current, data);
+      term.write(data);
     });
     const offExit = remote.onPaneExit((e) => {
       if (e.attachId !== attachId) return;

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -3,8 +3,12 @@ import { Terminal } from '@xterm/xterm';
 import { useT } from '../../hooks/useT';
 import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
 import { computeMirrorFontSize, mirrorFitKey, MAX_FIT_PASSES } from './mirrorFit';
+import { decideMirrorKey } from './mirrorInput';
 import { useStore } from '../../stores';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
+import { createAutoSelectionCopy } from '../../utils/autoSelectionCopy';
+import { pastePtyChunked } from '../../utils/clipboardChunk';
+import { copySelectionWithFeedback } from '../../hooks/useTerminal';
 import { XTERM_THEMES, extractXtermColors, type BuiltinThemeId, type ThemeId } from '../../themes';
 import { resolveMinimumContrastRatio } from '../../tailwindPalette';
 
@@ -94,6 +98,11 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   // re-subscribe the whole attach — only paneWrite needs the live value.
   const readOnlyRef = useRef(readOnly);
   readOnlyRef.current = readOnly;
+  // Same reason: the key handler is installed once, at mount, and needs the
+  // CURRENT attach to write to. Listing `attachId` in that effect's deps would
+  // re-create the terminal on every reconnect and drop the mirrored scrollback.
+  const attachIdRef = useRef(attachId);
+  attachIdRef.current = attachId;
 
   /**
    * How many snapshot repaints are currently being fed to the parser. Second
@@ -311,7 +320,8 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
   // font change would drop the mirrored scrollback, and the remote only
   // repaints on a fresh attach.
   useEffect(() => {
-    if (!containerRef.current) return;
+    const container = containerRef.current;
+    if (!container) return;
     const term = new Terminal({
       convertEol: false,
       scrollback: 2000,
@@ -342,7 +352,94 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     // leaking the instance (DOM, listeners, buffers) on every mount attempt.
     termRef.current = term;
     applyUnicodeWidthModel(term);
-    term.open(containerRef.current);
+    term.open(container);
+
+    // ---- Local editing conveniences (#895) --------------------------------
+    //
+    // Everything below acts on the LOCAL selection and the LOCAL clipboard, so
+    // none of it is the remote app's business — which is why a mirror can have
+    // it without becoming a second owner of anything. See mirrorInput.ts for
+    // the chord table and for what is deliberately still forwarded raw.
+
+    const isMac = window.electronAPI?.platform === 'darwin';
+
+    /** Bytes straight to the remote pane, bypassing xterm's encoder.
+     *  Read-only hosts are checked here as well as in the decision table: this
+     *  is the only function that can reach `paneWrite`, so the gate belongs on
+     *  it rather than only on its callers. */
+    const writeToRemote = (data: string): void => {
+      const id = attachIdRef.current;
+      if (!id || readOnlyRef.current) return;
+      window.electronAPI?.remote?.paneWrite(id, data);
+    };
+
+    // macOS only, and for the same reason useTerminal.ts registers it (see the
+    // long note there): ⌘V arrives as an NSMenu key equivalent that
+    // `preventDefault()` cannot suppress, so xterm's own native paste listener
+    // would race the async clipboard read below and both would write. The
+    // window keeps menu-bar Edit>Paste and synthetic paste events — which never
+    // run the keydown handler — working through xterm's own pipeline.
+    let lastPasteKeydownAt = 0;
+    const NATIVE_PASTE_RACE_WINDOW_MS = 300;
+    const blockNativePaste = (ev: Event): void => {
+      if (Date.now() - lastPasteKeydownAt > NATIVE_PASTE_RACE_WINDOW_MS) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+    };
+    if (isMac) container.addEventListener('paste', blockNativePaste, true);
+
+    // Auto-copy on selection, debounced exactly like a local pane's. Silent on
+    // failure: the explicit Ctrl+C path surfaces its own error when retried.
+    const autoCopy = createAutoSelectionCopy({
+      write: (text) => window.clipboardAPI.writeText(text),
+    });
+    const selectionDisposable = term.onSelectionChange(() => {
+      autoCopy.onSelection(term.getSelection());
+    });
+
+    term.attachCustomKeyEventHandler((ev) => {
+      const decision = decideMirrorKey(ev, {
+        isMac,
+        hasSelection: term.hasSelection(),
+        readOnly: readOnlyRef.current === true,
+        hasCustomCtrlJBinding: useStore.getState().customKeybindings.some(
+          (kb) => kb.key === 'Ctrl+J',
+        ),
+      });
+      switch (decision.kind) {
+        case 'pass':
+          return true;
+        case 'copy':
+          void copySelectionWithFeedback(term, term.getSelection());
+          return false;
+        case 'write':
+          ev.preventDefault();
+          writeToRemote(decision.data);
+          return false;
+        case 'paste':
+          ev.preventDefault();
+          if (isMac) lastPasteKeydownAt = Date.now();
+          void (async () => {
+            const text = await window.clipboardAPI.readText();
+            if (!text) return;
+            // Text only. A local pane also pastes an image by writing the temp
+            // file's PATH, and that path names a file on THIS machine — on the
+            // other end of an attach it resolves to nothing, so the mirror
+            // stays quiet rather than typing a broken path into a live shell.
+            //
+            // `modes` is the mirror's own parse of the remote app's DECSET
+            // 2004, so bracketed paste is bracketed for the app that asked.
+            const modes = (term as unknown as { modes?: { bracketedPasteMode?: boolean } }).modes;
+            await pastePtyChunked((d) => writeToRemote(d), text, modes);
+          })().catch(() => { /* clipboard unavailable — nothing to recover */ });
+          return false;
+        case 'swallow':
+        default:
+          ev.preventDefault();
+          return false;
+      }
+    });
+
     // Painted on the BOX, not on the container xterm opened into. Once the fit
     // shrinks the grid below its cell, the container no longer covers the cell
     // and the letterbox margin would show `--bg-base` next to the terminal's
@@ -352,6 +449,11 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     // dispose the terminal and drop everything the remote has already sent.
     scheduleFitRef.current();
     return () => {
+      if (isMac) container.removeEventListener('paste', blockNativePaste, true);
+      selectionDisposable.dispose();
+      // Cancels a debounced write that would otherwise fire against a disposed
+      // terminal's last selection.
+      autoCopy.dispose();
       term.dispose();
       termRef.current = null;
     };

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -3,7 +3,7 @@ import { Terminal } from '@xterm/xterm';
 import { useT } from '../../hooks/useT';
 import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
 import { computeMirrorFontSize, mirrorFitKey, MAX_FIT_PASSES } from './mirrorFit';
-import { decideMirrorKey } from './mirrorInput';
+import { decideMirrorKeyWithRepeat } from './mirrorInput';
 import { useStore } from '../../stores';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
 import { createAutoSelectionCopy } from '../../utils/autoSelectionCopy';
@@ -398,7 +398,7 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     });
 
     term.attachCustomKeyEventHandler((ev) => {
-      const decision = decideMirrorKey(ev, {
+      const decision = decideMirrorKeyWithRepeat(ev, {
         isMac,
         hasSelection: term.hasSelection(),
         readOnly: readOnlyRef.current === true,
@@ -410,6 +410,10 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
         case 'pass':
           return true;
         case 'copy':
+          // preventDefault like every other acting branch: returning false only
+          // stops xterm, and the browser's own copy would still fire off any
+          // DOM selection, racing this write for the clipboard.
+          ev.preventDefault();
           void copySelectionWithFeedback(term, term.getSelection());
           return false;
         case 'write':

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -67,6 +67,22 @@ class FakeTerminal {
     this.onDataHandler = cb;
     return { dispose: vi.fn() };
   }
+
+  /** Selection + key plumbing the #895 editing conveniences hang off. Set
+   *  `selection` to stand in for a user drag, then drive `keyHandler`. */
+  selection = '';
+  selectionHandler: (() => void) | null = null;
+  keyHandler: ((e: KeyboardEvent) => boolean) | null = null;
+  clearSelectionCalls = 0;
+  onSelectionChange(cb: () => void): { dispose: () => void } {
+    this.selectionHandler = cb;
+    return { dispose: vi.fn() };
+  }
+  getSelection(): string { return this.selection; }
+  hasSelection(): boolean { return this.selection.length > 0; }
+  clearSelection(): void { this.clearSelectionCalls++; this.selection = ''; }
+  attachCustomKeyEventHandler(cb: (e: KeyboardEvent) => boolean): void { this.keyHandler = cb; }
+
   dispose(): void { this.disposed = true; }
 }
 
@@ -108,6 +124,8 @@ describe('RemoteMirrorTerminal', () => {
   let errorHandlers: Handler[];
   let paneDetach: ReturnType<typeof vi.fn>;
   let paneWrite: ReturnType<typeof vi.fn>;
+  let clipboardWrite: ReturnType<typeof vi.fn>;
+  let clipboardRead: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     setupLog.length = 0;
@@ -146,10 +164,18 @@ describe('RemoteMirrorTerminal', () => {
         paneWrite,
       },
     };
+
+    clipboardWrite = vi.fn(() => Promise.resolve());
+    clipboardRead = vi.fn(() => Promise.resolve(''));
+    (window as unknown as { clipboardAPI: unknown }).clipboardAPI = {
+      writeText: clipboardWrite,
+      readText: clipboardRead,
+    };
   });
 
   afterEach(() => {
     delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    delete (window as unknown as { clipboardAPI?: unknown }).clipboardAPI;
   });
 
   it('meta event resets, resizes, and repaints the decoded snapshot', () => {
@@ -537,6 +563,150 @@ describe('RemoteMirrorTerminal', () => {
 
       expect(term.options['fontSize']).not.toBe(22);
       expect(term.options['fontSize'] ?? constructed).toBe(constructed);
+
+      unmount();
+    });
+  });
+
+  // #895 — the mirror forwarded EVERY keystroke raw, so the editing
+  // conveniences that operate on the LOCAL selection and the LOCAL clipboard
+  // were simply absent: a drag copied nothing, Ctrl+C interrupted the remote
+  // instead of copying, Ctrl+V did nothing, Shift+Enter submitted.
+  //
+  // The chord table is covered by mirrorInput.test.ts, which needs no DOM.
+  // These are about the WIRING it hangs on: that a copy never reaches
+  // `paneWrite`, that a direct write carries the live attach, and that a
+  // read-only host still receives nothing.
+  describe('local editing conveniences', () => {
+    function press(term: FakeTerminal, over: Record<string, unknown>): boolean {
+      const ev = {
+        type: 'keydown',
+        key: 'a',
+        code: 'KeyA',
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        metaKey: false,
+        isComposing: false,
+        preventDefault: vi.fn(),
+        ...over,
+      } as unknown as KeyboardEvent;
+      return term.keyHandler?.(ev) ?? true;
+    }
+
+    it('★ Ctrl+C over a selection copies locally and sends nothing to the remote', async () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      const term = termInstances[0]!;
+      term.selection = 'npm run build';
+
+      let handled = true;
+      await act(async () => {
+        handled = press(term, { key: 'c', code: 'KeyC', ctrlKey: true });
+      });
+
+      expect(clipboardWrite).toHaveBeenCalledWith('npm run build');
+      // The whole point: this used to arrive on the remote as SIGINT.
+      expect(paneWrite).not.toHaveBeenCalled();
+      expect(handled).toBe(false); // consumed here — xterm must not encode it
+
+      unmount();
+    });
+
+    it('★ Ctrl+C with nothing selected still interrupts the remote', async () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      const term = termInstances[0]!;
+
+      let handled = false;
+      await act(async () => {
+        handled = press(term, { key: 'c', code: 'KeyC', ctrlKey: true });
+      });
+
+      expect(handled).toBe(true); // xterm encodes it → onData → paneWrite
+      expect(clipboardWrite).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('Shift+Enter sends the newline byte to the live attach', async () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      const term = termInstances[0]!;
+
+      await act(async () => {
+        press(term, { key: 'Enter', code: 'Enter', shiftKey: true });
+      });
+
+      expect(paneWrite).toHaveBeenCalledWith('a1', '\x1b[13;2u');
+
+      unmount();
+    });
+
+    it('Ctrl+V writes the clipboard text to the remote pane', async () => {
+      clipboardRead.mockResolvedValue('echo hello');
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      const term = termInstances[0]!;
+
+      await act(async () => {
+        press(term, { key: 'v', code: 'KeyV', ctrlKey: true });
+        await Promise.resolve();
+      });
+
+      const sent = paneWrite.mock.calls.map((c) => c[1]).join('');
+      expect(sent).toContain('echo hello');
+      expect(paneWrite.mock.calls.every((c) => c[0] === 'a1')).toBe(true);
+
+      unmount();
+    });
+
+    it('auto-copies a finished selection, debounced', () => {
+      vi.useFakeTimers();
+      try {
+        const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+        const term = termInstances[0]!;
+        term.selection = 'copied by drag';
+
+        act(() => { term.selectionHandler?.(); });
+        // Mid-drag: onSelectionChange fires once per cell, so nothing is
+        // written until the user stops moving.
+        expect(clipboardWrite).not.toHaveBeenCalled();
+
+        act(() => { vi.advanceTimersByTime(200); });
+        expect(clipboardWrite).toHaveBeenCalledWith('copied by drag');
+
+        unmount();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    // `--allow-input` is off on the host. The remote would refuse the write, so
+    // the mirror must not send one — including down the direct-write path,
+    // which does not pass through the `onData` gate that already handles this.
+    it('★ a read-only host receives nothing from a paste or a newline key', async () => {
+      clipboardRead.mockResolvedValue('rm -rf /');
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" readOnly />);
+      const term = termInstances[0]!;
+
+      await act(async () => {
+        press(term, { key: 'Enter', code: 'Enter', shiftKey: true });
+        press(term, { key: 'v', code: 'KeyV', ctrlKey: true });
+        await Promise.resolve();
+      });
+
+      expect(paneWrite).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    it('a read-only host can still copy — the selection is local', async () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" readOnly />);
+      const term = termInstances[0]!;
+      term.selection = 'read me';
+
+      await act(async () => {
+        press(term, { key: 'c', code: 'KeyC', ctrlKey: true });
+      });
+
+      expect(clipboardWrite).toHaveBeenCalledWith('read me');
 
       unmount();
     });

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -627,7 +627,29 @@ describe('RemoteMirrorTerminal', () => {
       unmount();
     });
 
-    it('Shift+Enter sends the newline byte to the live attach', async () => {
+    // The CSI-u newline is a NEGOTIATED encoding, so the mirror has to have
+    // seen the remote ask for it. It learns that the same way it learns
+    // bracketed paste: from the remote's own output.
+    it('Shift+Enter sends the CSI-u newline once the remote enables kitty keys', async () => {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      const term = termInstances[0]!;
+
+      await act(async () => {
+        // CSI > 1 u — the remote pushes a kitty flag set.
+        for (const h of dataHandlers) {
+          h({ attachId: 'a1', dataB64: btoa('\x1b[>1u') });
+        }
+      });
+      await act(async () => {
+        press(term, { key: 'Enter', code: 'Enter', shiftKey: true });
+      });
+
+      expect(paneWrite).toHaveBeenCalledWith('a1', '\x1b[13;2u');
+
+      unmount();
+    });
+
+    it('Shift+Enter goes through xterm while the remote has not asked', async () => {
       const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
       const term = termInstances[0]!;
 
@@ -635,7 +657,10 @@ describe('RemoteMirrorTerminal', () => {
         press(term, { key: 'Enter', code: 'Enter', shiftKey: true });
       });
 
-      expect(paneWrite).toHaveBeenCalledWith('a1', '\x1b[13;2u');
+      // No direct write: xterm encodes the legacy CR, which is what an app
+      // that never negotiated expects. Injecting the escape form here is what
+      // would leave vim's insert mode and run the remainder as commands.
+      expect(paneWrite).not.toHaveBeenCalledWith('a1', '\x1b[13;2u');
 
       unmount();
     });

--- a/src/renderer/components/Remote/__tests__/keyboardProtocol.test.ts
+++ b/src/renderer/components/Remote/__tests__/keyboardProtocol.test.ts
@@ -1,0 +1,72 @@
+// What the remote asked for, read from what the remote printed.
+//
+// The mirror encodes a few keys itself (Shift+Enter as `\x1b[13;2u`). That
+// byte means "newline" to an app running the kitty keyboard protocol and
+// "Escape, then normal-mode input" to one that is not — so the mirror has to
+// know which it is talking to, and xterm exposes nothing for it.
+import { describe, it, expect } from 'vitest';
+import {
+  foldRemoteKeyboardState,
+  acceptsCsiU,
+  INITIAL_REMOTE_KEYBOARD_STATE as INIT,
+} from '../keyboardProtocol';
+
+const bytes = (s: string) => Uint8Array.from(s, (c) => c.charCodeAt(0));
+
+describe('foldRemoteKeyboardState', () => {
+  it('starts un-negotiated, which is the side that cannot corrupt a session', () => {
+    expect(acceptsCsiU(INIT)).toBe(false);
+  });
+
+  it('returns the SAME object for output that says nothing about keyboards', () => {
+    // Reference equality is the cheap "nothing changed" signal for the caller.
+    const after = foldRemoteKeyboardState(INIT, 'hello\r\n\x1b[32mgreen\x1b[0m');
+    expect(after).toBe(INIT);
+  });
+
+  for (const [name, seq] of [
+    ['push with flags', '\x1b[>1u'],
+    ['push with a larger flag set', '\x1b[>13u'],
+    ['set form', '\x1b[=5;1u'],
+  ] as const) {
+    it(`recognises the kitty ${name}`, () => {
+      expect(acceptsCsiU(foldRemoteKeyboardState(INIT, seq))).toBe(true);
+    });
+  }
+
+  it('treats a zero flag set as not asking', () => {
+    expect(acceptsCsiU(foldRemoteKeyboardState(INIT, '\x1b[>0u'))).toBe(false);
+  });
+
+  it('follows a pop back to un-negotiated', () => {
+    const on = foldRemoteKeyboardState(INIT, '\x1b[>1u');
+    expect(acceptsCsiU(on)).toBe(true);
+    expect(acceptsCsiU(foldRemoteKeyboardState(on, '\x1b[<u'))).toBe(false);
+  });
+
+  it('lands on the LAST event when a chunk both pushes and pops', () => {
+    // An app that starts, finishes and restores inside one flush must not be
+    // read as still negotiated because a regex ran in the wrong order.
+    expect(acceptsCsiU(foldRemoteKeyboardState(INIT, '\x1b[>1u...\x1b[<u'))).toBe(false);
+    expect(acceptsCsiU(foldRemoteKeyboardState(INIT, '\x1b[<u...\x1b[>1u'))).toBe(true);
+  });
+
+  // modifyOtherKeys mode 2 wants `CSI 27 ; 2 ; 13 ~`, not CSI-u. Counting it
+  // as "negotiated" would send the wrong escape to an app that asked for a
+  // different one — the same class of mistake, one protocol over.
+  it('tracks modifyOtherKeys without treating it as a CSI-u agreement', () => {
+    const s = foldRemoteKeyboardState(INIT, '\x1b[>4;2m');
+    expect(s.modifyOtherKeys).toBe(2);
+    expect(acceptsCsiU(s)).toBe(false);
+    expect(foldRemoteKeyboardState(s, '\x1b[>4;0m').modifyOtherKeys).toBe(0);
+  });
+
+  it('reads raw bytes, which is what the mirror actually hands it', () => {
+    expect(acceptsCsiU(foldRemoteKeyboardState(INIT, bytes('\x1b[>1u')))).toBe(true);
+  });
+
+  it('is not fooled by the sequence appearing as ordinary text', () => {
+    // A pane printing documentation about the protocol has no ESC in it.
+    expect(acceptsCsiU(foldRemoteKeyboardState(INIT, 'send CSI [>1u to enable'))).toBe(false);
+  });
+});

--- a/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
+++ b/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
@@ -11,7 +11,12 @@
 // read-only host must never see a byte no matter which chord produced it.
 
 import { describe, it, expect } from 'vitest';
-import { decideMirrorKey, type MirrorKeyEventLike, type MirrorKeyOptions } from '../mirrorInput';
+import {
+  decideMirrorKey,
+  decideMirrorKeyWithRepeat,
+  type MirrorKeyEventLike,
+  type MirrorKeyOptions,
+} from '../mirrorInput';
 
 function key(over: Partial<MirrorKeyEventLike> = {}): MirrorKeyEventLike {
   return {
@@ -182,5 +187,50 @@ describe('decideMirrorKey — the explicit Ctrl+Shift forms', () => {
       opts(),
     );
     expect(d).toEqual({ kind: 'paste' });
+  });
+
+  // Windows reports AltGr as Ctrl+Alt. Without excluding altKey the layouts
+  // that put a character on AltGr+C / AltGr+V cannot type it into the remote
+  // at all, and emacs' C-M-v arrives as a paste.
+  describe('AltGr and other modifier combinations belong to the remote', () => {
+    for (const [name, ev] of [
+      ['AltGr+C', { key: 'ć', code: 'KeyC', ctrlKey: true, altKey: true }],
+      ['AltGr+V', { key: 'w', code: 'KeyV', ctrlKey: true, altKey: true }],
+      ['Ctrl+Alt+Shift+C', { key: 'C', code: 'KeyC', ctrlKey: true, altKey: true, shiftKey: true }],
+      ['Ctrl+Alt+Shift+V', { key: 'V', code: 'KeyV', ctrlKey: true, altKey: true, shiftKey: true }],
+      ['Ctrl+Meta+V', { key: 'v', code: 'KeyV', ctrlKey: true, metaKey: true }],
+    ] as const) {
+      it(`${name} passes through even with a selection`, () => {
+        expect(
+          decideMirrorKey(key(ev as Partial<MirrorKeyEventLike>), opts({ hasSelection: true })),
+          name,
+        ).toEqual({ kind: 'pass' });
+      });
+    }
+  });
+
+  describe('a held key does not repeat a clipboard action', () => {
+    it('swallows repeated paste instead of injecting the clipboard again', () => {
+      const held = key({ key: 'v', code: 'KeyV', ctrlKey: true, repeat: true });
+      expect(decideMirrorKey(held, opts())).toEqual({ kind: 'paste' });
+      expect(decideMirrorKeyWithRepeat(held, opts())).toEqual({ kind: 'swallow' });
+    });
+
+    it('swallows repeated copy', () => {
+      const held = key({ key: 'c', code: 'KeyC', ctrlKey: true, repeat: true });
+      expect(decideMirrorKeyWithRepeat(held, opts({ hasSelection: true }))).toEqual({ kind: 'swallow' });
+    });
+
+    // Holding Ctrl+C to send repeated SIGINTs is deliberate, so the repeat
+    // guard must not touch a decision that was already passing through.
+    it('still repeats Ctrl+C to the remote when there is nothing to copy', () => {
+      const held = key({ key: 'c', code: 'KeyC', ctrlKey: true, repeat: true });
+      expect(decideMirrorKeyWithRepeat(held, opts())).toEqual({ kind: 'pass' });
+    });
+
+    it('still repeats ordinary keys', () => {
+      const held = key({ key: 'a', code: 'KeyA', repeat: true });
+      expect(decideMirrorKeyWithRepeat(held, opts())).toEqual({ kind: 'pass' });
+    });
   });
 });

--- a/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
+++ b/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
@@ -1,0 +1,186 @@
+// The chord table a remote-attach mirror applies before forwarding a keystroke.
+//
+// The bug this guards (#895): the mirror forwarded EVERY key raw, so the four
+// things a terminal does with the LOCAL clipboard and the LOCAL selection were
+// gone — Ctrl+C interrupted the remote instead of copying a highlighted line,
+// Ctrl+V did nothing at all, and Shift+Enter submitted where it should have
+// inserted a newline.
+//
+// Two properties matter as much as the four fixes, and most cases below exist
+// to hold them: an empty selection must still let Ctrl+C interrupt, and a
+// read-only host must never see a byte no matter which chord produced it.
+
+import { describe, it, expect } from 'vitest';
+import { decideMirrorKey, type MirrorKeyEventLike, type MirrorKeyOptions } from '../mirrorInput';
+
+function key(over: Partial<MirrorKeyEventLike> = {}): MirrorKeyEventLike {
+  return {
+    type: 'keydown',
+    key: 'a',
+    code: 'KeyA',
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    isComposing: false,
+    ...over,
+  };
+}
+
+function opts(over: Partial<MirrorKeyOptions> = {}): MirrorKeyOptions {
+  return { isMac: false, hasSelection: false, readOnly: false, ...over };
+}
+
+describe('decideMirrorKey — the four conveniences #895 asked for', () => {
+  it('copies the selection on Ctrl+C instead of interrupting', () => {
+    const d = decideMirrorKey(key({ key: 'c', code: 'KeyC', ctrlKey: true }), opts({ hasSelection: true }));
+    expect(d).toEqual({ kind: 'copy' });
+  });
+
+  it('pastes on Ctrl+V', () => {
+    const d = decideMirrorKey(key({ key: 'v', code: 'KeyV', ctrlKey: true }), opts());
+    expect(d).toEqual({ kind: 'paste' });
+  });
+
+  it('sends the newline byte on Shift+Enter rather than letting xterm submit', () => {
+    const d = decideMirrorKey(key({ key: 'Enter', code: 'Enter', shiftKey: true }), opts());
+    expect(d).toEqual({ kind: 'write', data: '\x1b[13;2u' });
+  });
+
+  it('sends LF on Ctrl+J, the same byte a local pane emits', () => {
+    const d = decideMirrorKey(key({ key: 'j', code: 'KeyJ', ctrlKey: true }), opts());
+    expect(d).toEqual({ kind: 'write', data: '\n' });
+  });
+});
+
+describe('decideMirrorKey — what must NOT be taken away', () => {
+  it('lets Ctrl+C through as SIGINT when nothing is selected', () => {
+    const d = decideMirrorKey(key({ key: 'c', code: 'KeyC', ctrlKey: true }), opts({ hasSelection: false }));
+    expect(d).toEqual({ kind: 'pass' });
+  });
+
+  it('forwards an ordinary key untouched', () => {
+    expect(decideMirrorKey(key(), opts())).toEqual({ kind: 'pass' });
+  });
+
+  it('forwards Ctrl+D — a mirror has no local pane to split, so EOF stays EOF', () => {
+    const d = decideMirrorKey(key({ key: 'd', code: 'KeyD', ctrlKey: true }), opts());
+    expect(d).toEqual({ kind: 'pass' });
+  });
+
+  it('decides nothing on keyup, so a chord is not handled twice', () => {
+    const d = decideMirrorKey(
+      key({ type: 'keyup', key: 'c', code: 'KeyC', ctrlKey: true }),
+      opts({ hasSelection: true }),
+    );
+    expect(d).toEqual({ kind: 'pass' });
+  });
+
+  it('defers Ctrl+J to an explicit user binding', () => {
+    const d = decideMirrorKey(
+      key({ key: 'j', code: 'KeyJ', ctrlKey: true }),
+      opts({ hasCustomCtrlJBinding: true }),
+    );
+    expect(d).toEqual({ kind: 'pass' });
+  });
+});
+
+describe('decideMirrorKey — a read-only host receives no bytes', () => {
+  // `--allow-input` is off: the remote would reject the write anyway, so the
+  // mirror must not send it. Copying stays allowed — it reads local state only.
+  it.each([
+    ['Ctrl+V', key({ key: 'v', code: 'KeyV', ctrlKey: true })],
+    ['Ctrl+Shift+V', key({ key: 'V', code: 'KeyV', ctrlKey: true, shiftKey: true })],
+    ['Shift+Enter', key({ key: 'Enter', code: 'Enter', shiftKey: true })],
+    ['Ctrl+J', key({ key: 'j', code: 'KeyJ', ctrlKey: true })],
+  ])('swallows %s', (_name, ev) => {
+    expect(decideMirrorKey(ev, opts({ readOnly: true }))).toEqual({ kind: 'swallow' });
+  });
+
+  it('still copies a selection', () => {
+    const d = decideMirrorKey(
+      key({ key: 'c', code: 'KeyC', ctrlKey: true }),
+      opts({ readOnly: true, hasSelection: true }),
+    );
+    expect(d).toEqual({ kind: 'copy' });
+  });
+});
+
+describe('decideMirrorKey — macOS uses the Cmd chords', () => {
+  const mac = (over: Partial<MirrorKeyOptions> = {}) => opts({ isMac: true, ...over });
+
+  it('copies on ⌘C with a selection', () => {
+    const d = decideMirrorKey(key({ key: 'c', code: 'KeyC', metaKey: true }), mac({ hasSelection: true }));
+    expect(d).toEqual({ kind: 'copy' });
+  });
+
+  it('hands ⌘C back to the OS with no selection', () => {
+    const d = decideMirrorKey(key({ key: 'c', code: 'KeyC', metaKey: true }), mac());
+    expect(d).toEqual({ kind: 'pass' });
+  });
+
+  it('pastes on ⌘V', () => {
+    const d = decideMirrorKey(key({ key: 'v', code: 'KeyV', metaKey: true }), mac());
+    expect(d).toEqual({ kind: 'paste' });
+  });
+
+  it('keeps Ctrl+C as SIGINT even with a selection — copying is ⌘C on mac', () => {
+    const d = decideMirrorKey(key({ key: 'c', code: 'KeyC', ctrlKey: true }), mac({ hasSelection: true }));
+    expect(d).toEqual({ kind: 'pass' });
+  });
+
+  it("keeps Ctrl+V as readline's quoted-insert", () => {
+    const d = decideMirrorKey(key({ key: 'v', code: 'KeyV', ctrlKey: true }), mac());
+    expect(d).toEqual({ kind: 'pass' });
+  });
+});
+
+describe('decideMirrorKey — a CJK IME must not disable the clipboard', () => {
+  // Under an IME `key` is a composed jamo or the literal 'Process'; xterm's own
+  // Ctrl+<letter> path is keyed on the deprecated keyCode and stops matching.
+  // Matching the physical `code` is what keeps these chords alive — the same
+  // failure useTerminal.ts documents for the local pane.
+  it('copies on Ctrl+C when key is a composed jamo', () => {
+    const d = decideMirrorKey(key({ key: 'ㅊ', code: 'KeyC', ctrlKey: true }), opts({ hasSelection: true }));
+    expect(d).toEqual({ kind: 'copy' });
+  });
+
+  it("pastes on Ctrl+V when key is 'Process'", () => {
+    const d = decideMirrorKey(key({ key: 'Process', code: 'KeyV', ctrlKey: true }), opts());
+    expect(d).toEqual({ kind: 'paste' });
+  });
+
+  it('does not inject a newline into an active preedit', () => {
+    const d = decideMirrorKey(
+      key({ key: 'j', code: 'KeyJ', ctrlKey: true, isComposing: true }),
+      opts(),
+    );
+    expect(d).toEqual({ kind: 'pass' });
+  });
+});
+
+describe('decideMirrorKey — the explicit Ctrl+Shift forms', () => {
+  it('copies on Ctrl+Shift+C with a selection', () => {
+    const d = decideMirrorKey(
+      key({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }),
+      opts({ hasSelection: true }),
+    );
+    expect(d).toEqual({ kind: 'copy' });
+  });
+
+  it('swallows Ctrl+Shift+C with nothing selected rather than typing it', () => {
+    const d = decideMirrorKey(
+      key({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }),
+      opts(),
+    );
+    expect(d).toEqual({ kind: 'swallow' });
+  });
+
+  it('pastes on Ctrl+Shift+V', () => {
+    const d = decideMirrorKey(
+      key({ key: 'V', code: 'KeyV', ctrlKey: true, shiftKey: true }),
+      opts(),
+    );
+    expect(d).toEqual({ kind: 'paste' });
+  });
+});

--- a/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
+++ b/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
@@ -47,9 +47,31 @@ describe('decideMirrorKey — the four conveniences #895 asked for', () => {
     expect(d).toEqual({ kind: 'paste' });
   });
 
-  it('sends the newline byte on Shift+Enter rather than letting xterm submit', () => {
-    const d = decideMirrorKey(key({ key: 'Enter', code: 'Enter', shiftKey: true }), opts());
+  // Shift+Enter is the one newline key whose byte is a NEGOTIATED encoding.
+  // `\x1b[13;2u` means "newline" only to an app that asked for kitty; to any
+  // other it is Escape followed by `[13;2u`, which in vim's insert mode leaves
+  // insert and runs the rest as normal-mode input. A local pane can send it
+  // blind because it and the TUI share one xterm; a mirror cannot.
+  it('sends the CSI-u newline on Shift+Enter once the remote has asked for it', () => {
+    const d = decideMirrorKey(
+      key({ key: 'Enter', code: 'Enter', shiftKey: true }),
+      opts({ remoteAcceptsCsiU: true }),
+    );
     expect(d).toEqual({ kind: 'write', data: '\x1b[13;2u' });
+  });
+
+  it('hands Shift+Enter back to xterm when the remote never negotiated', () => {
+    // `pass` is the pre-#924 behaviour: xterm encodes the legacy CR, which is
+    // what every non-negotiating app expects.
+    const d = decideMirrorKey(key({ key: 'Enter', code: 'Enter', shiftKey: true }), opts());
+    expect(d).toEqual({ kind: 'pass' });
+  });
+
+  // Ctrl+Enter and Ctrl+J send a bare LF, which needs no negotiation at all —
+  // the gate above must not swallow them along with the CSI-u one.
+  it('still sends LF on Ctrl+Enter without any negotiation', () => {
+    const d = decideMirrorKey(key({ key: 'Enter', code: 'Enter', ctrlKey: true }), opts());
+    expect(d).toEqual({ kind: 'write', data: '\n' });
   });
 
   it('sends LF on Ctrl+J, the same byte a local pane emits', () => {

--- a/src/renderer/components/Remote/keyboardProtocol.ts
+++ b/src/renderer/components/Remote/keyboardProtocol.ts
@@ -1,0 +1,127 @@
+/**
+ * Does the remote app want enhanced key encodings?
+ *
+ * The mirror sends bytes to an app it never negotiated with. That is fine for
+ * ordinary keys, whose encoding is fixed, and wrong for the ones wmux encodes
+ * itself: `\x1b[13;2u` is the kitty form of Shift+Enter, and an app that never
+ * asked for kitty reads it as ESC followed by `[13;2u` — in vim's insert mode
+ * that leaves insert and runs the remainder as normal-mode input.
+ *
+ * xterm.js parses DECSET 2004 for us (`term.modes.bracketedPasteMode`) but
+ * exposes nothing about keyboard protocols, so this watches the remote's own
+ * output for the two negotiations that matter. Same idea as the bracketed-paste
+ * read, one layer lower.
+ *
+ * Deliberately conservative: unknown state means NOT negotiated, so the mirror
+ * falls back to what xterm would have encoded — the behaviour before any of
+ * this existed. A missed negotiation costs a convenience; a false positive
+ * corrupts an editing session.
+ */
+
+/**
+ * Kitty keyboard protocol (CSI u).
+ *   CSI > flags u   push
+ *   CSI = flags ; mode u   set
+ * Both mean the app is asking for CSI-u encodings. `CSI < u` pops back off.
+ *
+ * Only `progressive enhancement` flags matter to us — any non-zero flag set
+ * implies the app will accept `CSI 13 ; 2 u`, which is what we send.
+ */
+// Built via RegExp(...) with a hex escape so the source stays pure-ASCII while
+// still matching ESC at runtime — the construction DEVICE_REPLY_RE already
+// uses in RemoteMirrorTerminal.tsx for the same lint rule.
+/* eslint-disable no-control-regex */
+const KITTY_PUSH_OR_SET = new RegExp('\\x1b\\[[>=](\\d*)(?:;\\d+)?u', 'g');
+const KITTY_POP = new RegExp('\\x1b\\[<\\d*u', 'g');
+
+/**
+ * xterm's modifyOtherKeys: `CSI > 4 ; N m`, N of 1 or 2 turns it on, 0 off.
+ * An app in mode 2 encodes Shift+Enter as `CSI 27 ; 2 ; 13 ~`, not as CSI-u —
+ * so it is NOT counted as accepting our byte. It is tracked only so a future
+ * caller can encode the form that app actually wants, and so the "negotiated
+ * something" state is not silently conflated with "negotiated kitty".
+ */
+const MODIFY_OTHER_KEYS = new RegExp('\\x1b\\[>4;([0-2])m', 'g');
+/* eslint-enable no-control-regex */
+
+export interface RemoteKeyboardState {
+  /** The remote pushed/set a non-zero kitty flag set and has not popped it. */
+  kitty: boolean;
+  /** The remote's modifyOtherKeys level, 0 when off. */
+  modifyOtherKeys: 0 | 1 | 2;
+}
+
+export const INITIAL_REMOTE_KEYBOARD_STATE: RemoteKeyboardState = {
+  kitty: false,
+  modifyOtherKeys: 0,
+};
+
+/**
+ * Fold one chunk of remote output into the state.
+ *
+ * Pure: takes the previous state, returns the next one. A chunk that says
+ * nothing about keyboards returns the same object, so callers can compare by
+ * reference to skip work.
+ *
+ * A sequence split across two chunks is missed. That is the conservative
+ * direction (no negotiation seen → send the legacy byte) and the alternative
+ * — carrying a partial-sequence buffer — would have to be correct about every
+ * escape shape to avoid holding bytes forever.
+ */
+export function foldRemoteKeyboardState(
+  prev: RemoteKeyboardState,
+  bytes: string | Uint8Array,
+): RemoteKeyboardState {
+  // The mirror hands xterm raw BYTES so multi-byte UTF-8 split across the wire
+  // decodes in xterm's parser rather than in a lossy JS round-trip. Every
+  // sequence below is pure ASCII, so a latin1 view is exact for our purposes
+  // and cannot corrupt what xterm receives — we never write this string back.
+  const chunk = typeof bytes === 'string'
+    ? bytes
+    : Array.from(bytes, (b) => String.fromCharCode(b)).join('');
+  if (!chunk.includes('\x1b[')) return prev;
+
+  let kitty = prev.kitty;
+  let modifyOtherKeys = prev.modifyOtherKeys;
+  let changed = false;
+
+  // Walk in order so a push followed by a pop inside one chunk lands on the
+  // later one rather than on whichever regex ran last.
+  const events: Array<{ index: number; apply: () => void }> = [];
+
+  KITTY_PUSH_OR_SET.lastIndex = 0;
+  for (let m = KITTY_PUSH_OR_SET.exec(chunk); m; m = KITTY_PUSH_OR_SET.exec(chunk)) {
+    const flags = m[1] === '' ? 0 : Number(m[1]);
+    const index = m.index;
+    events.push({ index, apply: () => { kitty = flags > 0; } });
+  }
+  KITTY_POP.lastIndex = 0;
+  for (let m = KITTY_POP.exec(chunk); m; m = KITTY_POP.exec(chunk)) {
+    const index = m.index;
+    events.push({ index, apply: () => { kitty = false; } });
+  }
+  MODIFY_OTHER_KEYS.lastIndex = 0;
+  for (let m = MODIFY_OTHER_KEYS.exec(chunk); m; m = MODIFY_OTHER_KEYS.exec(chunk)) {
+    const level = Number(m[1]) as 0 | 1 | 2;
+    const index = m.index;
+    events.push({ index, apply: () => { modifyOtherKeys = level; } });
+  }
+
+  if (events.length === 0) return prev;
+  events.sort((a, b) => a.index - b.index);
+  for (const e of events) e.apply();
+
+  changed = kitty !== prev.kitty || modifyOtherKeys !== prev.modifyOtherKeys;
+  return changed ? { kitty, modifyOtherKeys } : prev;
+}
+
+/**
+ * Whether the remote will understand the CSI-u bytes wmux encodes itself.
+ *
+ * Only kitty. modifyOtherKeys mode 2 wants `CSI 27 ; ... ~` instead, so
+ * sending CSI-u there would be the same category of mistake this file exists
+ * to prevent.
+ */
+export function acceptsCsiU(state: RemoteKeyboardState): boolean {
+  return state.kitty;
+}

--- a/src/renderer/components/Remote/mirrorInput.ts
+++ b/src/renderer/components/Remote/mirrorInput.ts
@@ -24,6 +24,8 @@ import { resolveNewlineKeyByte, type NewlineKeyEventLike } from '../../terminal/
 export interface MirrorKeyEventLike extends NewlineKeyEventLike {
   /** Only `keydown` decides anything; keyup/keypress always pass. */
   type: string;
+  /** True for the auto-repeat keydowns a held key produces. */
+  repeat?: boolean;
 }
 
 export interface MirrorKeyOptions {
@@ -78,7 +80,13 @@ export function decideMirrorKey(
 
   const { isMac } = opts;
   const bareMeta = e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey;
-  const bareCtrl = e.ctrlKey && !e.shiftKey;
+  // `!e.altKey` is load-bearing, not symmetry for its own sake. Windows reports
+  // AltGr as Ctrl+Alt, so without it the European layouts that map a character
+  // onto AltGr+C / AltGr+V (Polish ć, among others) cannot type that character
+  // into the remote at all — it would be read as copy/paste. It also keeps
+  // emacs' C-M-v (scroll-other-window) from being taken as a paste.
+  const bareCtrl = e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey;
+  const ctrlShift = e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey;
 
   // macOS: ⌘C copies and ⌘V pastes, so Ctrl+C stays SIGINT unconditionally and
   // Ctrl+V stays readline's quoted-insert. Both fall through to the remote.
@@ -102,12 +110,34 @@ export function decideMirrorKey(
   }
 
   // Ctrl+Shift+C / Ctrl+Shift+V — the explicit forms, on every platform.
-  if (e.ctrlKey && e.shiftKey && isLetter(e, 'c', 'KeyC')) {
+  if (ctrlShift && isLetter(e, 'c', 'KeyC')) {
     return opts.hasSelection ? { kind: 'copy' } : { kind: 'swallow' };
   }
-  if (e.ctrlKey && e.shiftKey && isLetter(e, 'v', 'KeyV')) {
+  if (ctrlShift && isLetter(e, 'v', 'KeyV')) {
     return opts.readOnly ? { kind: 'swallow' } : { kind: 'paste' };
   }
 
   return { kind: 'pass' };
+}
+
+/**
+ * `decideMirrorKey`, with auto-repeat suppressed for the clipboard actions.
+ *
+ * A held Ctrl+V repeats about every 30ms once the OS starts repeating, and
+ * each repeat is a fresh clipboard read written into a LIVE remote shell —
+ * the clipboard arriving a dozen times is not what holding a key means.
+ *
+ * Applied AFTER the decision, not before, so it only touches the branches that
+ * act: holding Ctrl+C with no selection still repeats SIGINT, which is a thing
+ * people do on purpose, and every pass-through key keeps repeating normally.
+ */
+export function decideMirrorKeyWithRepeat(
+  e: MirrorKeyEventLike,
+  opts: MirrorKeyOptions,
+): MirrorKeyDecision {
+  const decision = decideMirrorKey(e, opts);
+  if (e.repeat && (decision.kind === 'copy' || decision.kind === 'paste')) {
+    return { kind: 'swallow' };
+  }
+  return decision;
 }

--- a/src/renderer/components/Remote/mirrorInput.ts
+++ b/src/renderer/components/Remote/mirrorInput.ts
@@ -1,0 +1,113 @@
+/**
+ * Keyboard decisions for a remote-attach mirror.
+ *
+ * A mirror forwards keystrokes to a pane on another machine, so its default is
+ * the opposite of a local pane's: every key belongs to the remote app, and
+ * anything this side keeps is a deliberate exception. #895 is the list of
+ * exceptions users noticed were missing — the editing conveniences that are not
+ * the remote app's business at all, because the selection and the clipboard
+ * they operate on are local.
+ *
+ * Only those. App shortcuts, terminal zoom, and custom keybindings still reach
+ * the remote pane rather than being intercepted here; a mirror has no local
+ * pane to act on, so stealing them would trade a working remote key for a
+ * local no-op.
+ *
+ * Pure on purpose. The component owns the clipboard, the socket, and the
+ * terminal; this file owns only the branching, so the table can be tested
+ * without xterm, Electron, or a DOM — the same split `mirrorFit.ts` and
+ * `newlineKeys.ts` already use.
+ */
+
+import { resolveNewlineKeyByte, type NewlineKeyEventLike } from '../../terminal/newlineKeys';
+
+export interface MirrorKeyEventLike extends NewlineKeyEventLike {
+  /** Only `keydown` decides anything; keyup/keypress always pass. */
+  type: string;
+}
+
+export interface MirrorKeyOptions {
+  isMac: boolean;
+  /** Whether the mirror currently holds a non-empty selection. */
+  hasSelection: boolean;
+  /** The remote host was started without `--allow-input`. */
+  readOnly: boolean;
+  /** The user bound Ctrl+J themselves — see newlineKeys.ts. */
+  hasCustomCtrlJBinding?: boolean;
+}
+
+export type MirrorKeyDecision =
+  /** Let xterm encode it; the bytes leave through `onData` → `paneWrite`. */
+  | { kind: 'pass' }
+  /** Consumed here. Nothing reaches the remote and nothing is written locally. */
+  | { kind: 'swallow' }
+  /** Send these exact bytes to the remote, bypassing xterm's encoder. */
+  | { kind: 'write'; data: string }
+  /** Copy the current selection to the local clipboard. */
+  | { kind: 'copy' }
+  /** Paste the local clipboard into the remote pane. */
+  | { kind: 'paste' };
+
+/**
+ * A key chord's meaning matched by BOTH `key` and physical `code`.
+ *
+ * Under a CJK IME `key` is a composed jamo or the literal 'Process', so a
+ * `key`-only test silently stops matching — the exact failure `useTerminal.ts`
+ * documents for its own Ctrl+C branch, and the reason every clipboard chord
+ * here carries a `code` fallback.
+ */
+function isLetter(e: MirrorKeyEventLike, lower: string, code: string): boolean {
+  return e.key === lower || e.key === lower.toUpperCase() || e.code === code;
+}
+
+export function decideMirrorKey(
+  e: MirrorKeyEventLike,
+  opts: MirrorKeyOptions,
+): MirrorKeyDecision {
+  if (e.type !== 'keydown') return { kind: 'pass' };
+
+  // Shift+Enter / Ctrl+Enter / Ctrl+J. Same resolver the local pane uses, so a
+  // remote Claude Code gets the same newline byte a local one does instead of
+  // whatever xterm's legacy keyCode path happens to produce under an IME.
+  const newlineByte = resolveNewlineKeyByte(e, {
+    hasCustomCtrlJBinding: opts.hasCustomCtrlJBinding,
+  });
+  if (newlineByte !== null) {
+    return opts.readOnly ? { kind: 'swallow' } : { kind: 'write', data: newlineByte };
+  }
+
+  const { isMac } = opts;
+  const bareMeta = e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey;
+  const bareCtrl = e.ctrlKey && !e.shiftKey;
+
+  // macOS: ⌘C copies and ⌘V pastes, so Ctrl+C stays SIGINT unconditionally and
+  // Ctrl+V stays readline's quoted-insert. Both fall through to the remote.
+  if (isMac && bareMeta && isLetter(e, 'c', 'KeyC')) {
+    // No selection: hand ⌘C back to the OS rather than swallowing it.
+    return opts.hasSelection ? { kind: 'copy' } : { kind: 'pass' };
+  }
+  if (isMac && bareMeta && isLetter(e, 'v', 'KeyV')) {
+    return opts.readOnly ? { kind: 'swallow' } : { kind: 'paste' };
+  }
+
+  // Windows/Linux: Ctrl+C copies ONLY when there is something to copy. With an
+  // empty selection it must still interrupt the remote process — that is the
+  // whole point of the key, and #895 asks for the selection case, not for
+  // SIGINT to be taken away.
+  if (!isMac && bareCtrl && isLetter(e, 'c', 'KeyC')) {
+    return opts.hasSelection ? { kind: 'copy' } : { kind: 'pass' };
+  }
+  if (!isMac && bareCtrl && isLetter(e, 'v', 'KeyV')) {
+    return opts.readOnly ? { kind: 'swallow' } : { kind: 'paste' };
+  }
+
+  // Ctrl+Shift+C / Ctrl+Shift+V — the explicit forms, on every platform.
+  if (e.ctrlKey && e.shiftKey && isLetter(e, 'c', 'KeyC')) {
+    return opts.hasSelection ? { kind: 'copy' } : { kind: 'swallow' };
+  }
+  if (e.ctrlKey && e.shiftKey && isLetter(e, 'v', 'KeyV')) {
+    return opts.readOnly ? { kind: 'swallow' } : { kind: 'paste' };
+  }
+
+  return { kind: 'pass' };
+}

--- a/src/renderer/components/Remote/mirrorInput.ts
+++ b/src/renderer/components/Remote/mirrorInput.ts
@@ -36,6 +36,13 @@ export interface MirrorKeyOptions {
   readOnly: boolean;
   /** The user bound Ctrl+J themselves — see newlineKeys.ts. */
   hasCustomCtrlJBinding?: boolean;
+  /**
+   * The remote app asked for kitty CSI-u key encodings (observed in its own
+   * output — see keyboardProtocol.ts). Defaults to false, which is the
+   * conservative side: an app that never negotiated gets what xterm would
+   * have encoded.
+   */
+  remoteAcceptsCsiU?: boolean;
 }
 
 export type MirrorKeyDecision =
@@ -75,7 +82,21 @@ export function decideMirrorKey(
     hasCustomCtrlJBinding: opts.hasCustomCtrlJBinding,
   });
   if (newlineByte !== null) {
-    return opts.readOnly ? { kind: 'swallow' } : { kind: 'write', data: newlineByte };
+    // A read-only host takes no bytes at all, negotiated or not — decided here
+    // rather than left to the write path so the table says so.
+    if (opts.readOnly) return { kind: 'swallow' };
+    // The CSI-u byte only means "newline" to an app that asked for kitty
+    // encodings. A local pane can send it blind because it and the TUI share
+    // this xterm; a mirror is talking to an app it never negotiated with, and
+    // there `\x1b[13;2u` reads as Escape followed by normal-mode input — in
+    // vim's insert mode that leaves insert and runs the rest as commands.
+    // Un-negotiated, hand the key back to xterm and let it encode the legacy
+    // CR: what the mirror did before it had a key table at all.
+    //
+    // Ctrl+Enter and Ctrl+J are unaffected — a bare LF needs no negotiation.
+    const isCsiU = newlineByte.startsWith('\x1b');
+    if (isCsiU && !opts.remoteAcceptsCsiU) return { kind: 'pass' };
+    return { kind: 'write', data: newlineByte };
   }
 
   const { isMac } = opts;


### PR DESCRIPTION
A mirrored pane forwarded every keystroke raw. That is right for the remote app's keys and wrong for the four that never leave this machine — and #895 is the list of the four, reported by someone using attach as their daily driver from a bare laptop.

| | before | after |
|---|---|---|
| select text | copied nothing | auto-copies, debounced |
| `Ctrl+C` with a selection | SIGINT — cleared the line being read | copies |
| `Ctrl+V` | nothing at all | pastes into the remote pane |
| `Shift+Enter` | submitted | inserts a newline |

None of the four act on remote state. The selection and the clipboard are local, so handling them here makes a mirror behave like a terminal without giving the local window any claim on the remote pane — which is the property that made #905 the harder question and this one the easy one.

## Shape

The chord table is a pure decision function in `mirrorInput.ts`, the same split `mirrorFit.ts` and `newlineKeys.ts` already use, so it is tested without xterm, Electron, or a DOM. The component keeps only the adapter: clipboard, socket, terminal. The pieces the local pane already had extracted — `createAutoSelectionCopy`, `pastePtyChunked`, `resolveNewlineKeyByte`, `copySelectionWithFeedback` — are reused rather than re-derived, so a mirror copies with the same toast and pastes with the same bracketed-paste handling a local pane does.

## Two properties the tests pin as hard as the fixes

- **An empty selection still lets `Ctrl+C` interrupt.** Taking SIGINT away would be a worse bug than the one being fixed, so it has its own test on both platforms.
- **A read-only host receives nothing.** `--allow-input` off means the remote refuses writes anyway; the new direct-write path does not pass through the `onData` gate that already handled this, so the gate is on the one function that can reach `paneWrite`, not only on its callers.

Every chord matches the physical `code` as well as `key`. Under a CJK IME `key` is a composed jamo or the literal `'Process'` — exactly how these same handlers went dead for local panes, and the reason that fix is worth copying rather than rediscovering.

## Deliberately unchanged

- **App shortcuts, zoom, and custom keybindings still reach the remote pane.** A mirror has no local pane to act on, so intercepting them would trade a working remote key for a local no-op.
- **`Ctrl+D` stays EOF.** The reporter mentions habitually reaching for it as the split shortcut; taking it over would silently break EOF on the remote shell and give nothing back, since a pane cannot be created from the attach view either way. Worth its own decision, not a ride-along.
- **Image paste is skipped.** A local pane pastes the temp file's *path*, and that path names a file on this machine and nothing on the other end of an attach. The mirror stays quiet rather than typing a broken path into a live shell.
- **macOS keeps the Cmd chords** — ⌘C / ⌘V copy and paste, `Ctrl+C` stays SIGINT unconditionally, `Ctrl+V` stays readline's quoted-insert — and the mac-only native-paste race guard from `useTerminal.ts` comes along, since ⌘V arrives as an NSMenu key equivalent that `preventDefault()` cannot suppress.

## Testing

- `mirrorInput.test.ts` — 25 cases over the chord table: the four fixes, what must not be taken away (SIGINT, `Ctrl+D`, keyup, an explicit `Ctrl+J` binding), the read-only matrix, the macOS chords, and the IME cases where `key` is a jamo or `'Process'`.
- `RemoteMirrorTerminal.test.tsx` — 7 new cases over the wiring: that a copy never reaches `paneWrite`, that a direct write carries the live attach id, that the debounce holds mid-drag, and that a read-only host receives nothing from either a paste or a newline key while still being able to copy.
- Full renderer suite green (3394 passing). The one unrelated failure locally is `atlasCoherence.test.ts`, which asserts a patch-package patch is present in `node_modules`.

Closes #895


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mirrored remote terminals now support copying, pasting, and inserting new lines, including macOS keyboard shortcuts.
  * Local selections can be copied automatically.
  * Shift+Enter sends the appropriate newline format for the remote terminal.
  * Bracketed paste and larger pasted input are handled reliably.
  * Keyboard behavior adapts to supported remote keyboard protocols.
* **Bug Fixes**
  * Empty-selection `Ctrl+C` continues to interrupt remote processes.
  * Read-only hosts reject paste and newline input while still allowing local copying.
  * Hosts without input permission continue to reject remote input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->