### PR TITLE
fix(plugins): keep the plugin bridge alive across a workspace switch

### DIFF
--- a/changelog.d/928.md
+++ b/changelog.d/928.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **A plugin no longer goes silent when you switch workspace.** The host hands
+  each plugin iframe a message port once, when the frame loads. Re-subscribing
+  the plugin event feed on a workspace switch also tore that port down, and
+  there is no second load to rebuild it — so from the first switch onward the
+  plugin's requests were dropped and its palette commands stopped arriving. It
+  affected every mounted plugin, not only the ones receiving events; sidebar
+  panels came back if you collapsed and re-opened them, while status-bar
+  widgets stayed broken for the rest of the session. The port now outlives the
+  switch, and the event feed still follows the workspace you are in. (#928)

--- a/src/renderer/plugins/PluginFrame.tsx
+++ b/src/renderer/plugins/PluginFrame.tsx
@@ -77,6 +77,10 @@ export default function PluginFrame({
     let disposed = false;
     let unregisterFrame: (() => void) | null = null;
 
+    /**
+     * Unsolicited traffic (palette commands, forwarded events) goes to
+     * whatever port is CURRENT — that is the document on screen.
+     */
     const post = (msg: unknown) => {
       try {
         portRef.current?.postMessage(msg);
@@ -84,7 +88,19 @@ export default function PluginFrame({
         /* port may be closed mid-flight during unmount */
       }
     };
-    const respond = (msg: BridgeResponse) => post(msg);
+    /**
+     * A response goes back to the port the REQUEST came in on, not the current
+     * one. An rpc started before a reload resolves after it, and answering on
+     * the new port hands the fresh document a response to an id it never sent.
+     * Closed ports throw, which is the correct outcome: the asker is gone.
+     */
+    const respondOn = (port: MessagePort, msg: BridgeResponse) => {
+      try {
+        port.postMessage(msg);
+      } catch {
+        /* the document that asked is gone; nothing to deliver to */
+      }
+    };
 
     const onLoad = () => {
       portRef.current?.close();
@@ -100,9 +116,9 @@ export default function PluginFrame({
           .then((raw) => {
             const resp = raw as { ok?: boolean; result?: unknown; error?: string } | null;
             if (resp && resp.ok === true) {
-              respond({ v: PLUGIN_BRIDGE_VERSION, id: req.id, kind: 'response', result: resp.result });
+              respondOn(port, { v: PLUGIN_BRIDGE_VERSION, id: req.id, kind: 'response', result: resp.result });
             } else {
-              respond({
+              respondOn(port, {
                 v: PLUGIN_BRIDGE_VERSION,
                 id: req.id,
                 kind: 'response',
@@ -111,7 +127,7 @@ export default function PluginFrame({
             }
           })
           .catch((err: unknown) => {
-            respond({
+            respondOn(port, {
               v: PLUGIN_BRIDGE_VERSION,
               id: req.id,
               kind: 'response',
@@ -137,6 +153,12 @@ export default function PluginFrame({
       unregisterFrame = null;
       portRef.current?.close();
       portRef.current = null;
+      // Back to "no bridge". Without this the invariant only holds until the
+      // first teardown: a pluginName/entry change nulls the port but leaves
+      // the epoch at >= 1, so the poll effect restarts immediately and spends
+      // the window before the new `load` posting into a null port — events
+      // dropped, silently, with nothing to notice it.
+      setBridgeEpoch(0);
     };
   }, [pluginName, entry]);
 

--- a/src/renderer/plugins/PluginFrame.tsx
+++ b/src/renderer/plugins/PluginFrame.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useStore } from '../stores';
 import {
   PLUGIN_BRIDGE_VERSION,
@@ -41,6 +41,14 @@ const EVENT_POLL_INTERVAL_MS = 1000;
  * as `kind:'event'` envelopes. The cursor starts at the current ring head —
  * plugins see events from mount time, not a history replay. A rejected poll
  * stops the loop (the plugin didn't declare events.subscribe).
+ *
+ * Two effects, deliberately: the port is created once per iframe `load`, and
+ * `load` does not fire again for a frame whose `src` never changed. So the
+ * bridge effect may only depend on what identifies the frame. The poll must
+ * re-subscribe when the user switches workspace (#719); when that dependency
+ * lived on the single combined effect, the switch tore the port down with no
+ * `load` left to rebuild it and every later plugin request went unanswered.
+ * `bridgeEpoch` is how the poll effect waits for — and follows — the port.
  */
 export default function PluginFrame({
   pluginName,
@@ -54,74 +62,36 @@ export default function PluginFrame({
   className?: string;
 }) {
   const frameRef = useRef<HTMLIFrameElement>(null);
+  const portRef = useRef<MessagePort | null>(null);
+  // Bumped every time a fresh port is handed to the frame. Zero means no
+  // bridge yet, so the poll effect has nowhere to deliver events.
+  const [bridgeEpoch, setBridgeEpoch] = useState(0);
   // Fix: scope events.poll to the active workspace so plugins cannot observe
   // other workspaces' lifecycle events (TODOS: "Unscoped plugin events.poll").
   const activeWorkspaceId = useStore((s) => s.activeWorkspaceId);
 
+  // ── Bridge: port lifetime, request forwarding, palette commands ──────────
   useEffect(() => {
     const iframe = frameRef.current;
     if (!iframe) return;
-    let port: MessagePort | null = null;
     let disposed = false;
     let unregisterFrame: (() => void) | null = null;
-    let eventTimer: ReturnType<typeof setInterval> | null = null;
 
     const post = (msg: unknown) => {
       try {
-        port?.postMessage(msg);
+        portRef.current?.postMessage(msg);
       } catch {
         /* port may be closed mid-flight during unmount */
       }
     };
     const respond = (msg: BridgeResponse) => post(msg);
 
-    const stopEventLoop = () => {
-      if (eventTimer !== null) {
-        clearInterval(eventTimer);
-        eventTimer = null;
-      }
-    };
-
-    const startEventLoop = () => {
-      stopEventLoop();
-      let cursor: number | null = null; // null until the head is established
-      let inFlight = false;
-      eventTimer = setInterval(() => {
-        if (disposed || inFlight) return;
-        inFlight = true;
-        window.electronAPI.plugins
-          .rpc(pluginName, 'events.poll', cursor === null
-            ? { workspaceId: activeWorkspaceId }
-            : { cursor, workspaceId: activeWorkspaceId })
-          .then((raw) => {
-            const resp = raw as { ok?: boolean; result?: { events?: unknown[]; nextCursor?: number } } | null;
-            if (!resp || resp.ok !== true || !resp.result) {
-              // Rejected (capability missing) or malformed — stop polling.
-              stopEventLoop();
-              return;
-            }
-            const head = typeof resp.result.nextCursor === 'number' ? resp.result.nextCursor : 0;
-            if (cursor === null) {
-              // First poll establishes the head; its (historical) events
-              // are discarded so plugins start at "now".
-              cursor = head;
-              return;
-            }
-            cursor = head;
-            for (const event of resp.result.events ?? []) {
-              post({ v: PLUGIN_BRIDGE_VERSION, id: null, kind: 'event', event });
-            }
-          })
-          .catch(() => stopEventLoop())
-          .finally(() => { inFlight = false; });
-      }, EVENT_POLL_INTERVAL_MS);
-    };
-
     const onLoad = () => {
-      port?.close();
+      portRef.current?.close();
       unregisterFrame?.();
       const channel = new MessageChannel();
-      port = channel.port1;
+      const port = channel.port1;
+      portRef.current = port;
       port.onmessage = (e: MessageEvent) => {
         const req = parseBridgeRequest(e.data);
         if (!req || disposed) return;
@@ -156,20 +126,73 @@ export default function PluginFrame({
         post({ v: PLUGIN_BRIDGE_VERSION, id: null, kind: 'command', command });
       });
 
-      if (forwardEvents) startEventLoop();
+      setBridgeEpoch((n) => n + 1);
     };
 
     iframe.addEventListener('load', onLoad);
     return () => {
       disposed = true;
-      stopEventLoop();
       iframe.removeEventListener('load', onLoad);
       unregisterFrame?.();
       unregisterFrame = null;
-      port?.close();
-      port = null;
+      portRef.current?.close();
+      portRef.current = null;
     };
-  }, [pluginName, entry, forwardEvents, activeWorkspaceId]);
+  }, [pluginName, entry]);
+
+  // ── Event forwarding: re-subscribes when the active workspace changes ────
+  useEffect(() => {
+    if (!forwardEvents || bridgeEpoch === 0) return;
+    let cursor: number | null = null; // null until the head is established
+    let inFlight = false;
+    let stopped = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const stopEventLoop = () => {
+      stopped = true;
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    timer = setInterval(() => {
+      if (stopped || inFlight) return;
+      inFlight = true;
+      window.electronAPI.plugins
+        .rpc(pluginName, 'events.poll', cursor === null
+          ? { workspaceId: activeWorkspaceId }
+          : { cursor, workspaceId: activeWorkspaceId })
+        .then((raw) => {
+          const resp = raw as { ok?: boolean; result?: { events?: unknown[]; nextCursor?: number } } | null;
+          if (!resp || resp.ok !== true || !resp.result) {
+            // Rejected (capability missing) or malformed — stop polling.
+            stopEventLoop();
+            return;
+          }
+          const head = typeof resp.result.nextCursor === 'number' ? resp.result.nextCursor : 0;
+          if (cursor === null) {
+            // First poll establishes the head; its (historical) events
+            // are discarded so plugins start at "now".
+            cursor = head;
+            return;
+          }
+          cursor = head;
+          if (stopped) return;
+          for (const event of resp.result.events ?? []) {
+            try {
+              portRef.current?.postMessage({ v: PLUGIN_BRIDGE_VERSION, id: null, kind: 'event', event });
+            } catch {
+              /* port may be closed mid-flight during unmount */
+            }
+          }
+        })
+        .catch(() => stopEventLoop())
+        .finally(() => { inFlight = false; });
+    }, EVENT_POLL_INTERVAL_MS);
+
+    return stopEventLoop;
+  }, [pluginName, forwardEvents, activeWorkspaceId, bridgeEpoch]);
 
   return (
     <iframe

--- a/src/renderer/plugins/__tests__/PluginFrame.bridge.dynamic.test.tsx
+++ b/src/renderer/plugins/__tests__/PluginFrame.bridge.dynamic.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+//
+// PluginFrame — the postMessage bridge must outlive a workspace switch.
+//
+// The bridge port is created exactly once, inside the iframe's `load` handler.
+// #719 added `activeWorkspaceId` to the bridge effect's dependency list so the
+// events.poll loop re-subscribes when the user switches workspace. That is the
+// right behaviour for the poll, but the effect's cleanup also closes the
+// MessagePort and unregisters the palette-command frame — and `load` does not
+// fire a second time for an iframe whose `src` never changed. So after the
+// first workspace switch the plugin holds a port whose peer is closed: every
+// request it posts is dropped, and the promise it is waiting on never settles.
+//
+// This mounts the REAL <PluginFrame/> via react-dom/client so its effects run,
+// captures the transferred port from the `contentWindow.postMessage` call
+// (jsdom does not deliver a transfer list to a cross-document frame, and the
+// spy is the load-bearing observation either way), and drives a request across
+// it before and after the switch. It affects every mounted plugin, not only the
+// ones that poll events: `forwardEvents` is false here and the teardown still
+// happens.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import PluginFrame from '../PluginFrame';
+import { useStore } from '../../stores';
+import { PLUGIN_BRIDGE_VERSION } from '../../../shared/pluginHost';
+
+const act = React.act;
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let rpc: ReturnType<typeof vi.fn>;
+
+/** The port the host transferred to the frame, i.e. the plugin's own end. */
+function pluginPort(postMessage: ReturnType<typeof vi.fn>): MessagePort {
+  const init = postMessage.mock.calls.find((c) => (c[0] as { kind?: string })?.kind === 'init');
+  expect(init, 'host never posted the init envelope').toBeDefined();
+  const transferred = (init![2] as MessagePort[])[0];
+  expect(transferred, 'init envelope carried no MessagePort').toBeDefined();
+  return transferred;
+}
+
+/** Post a request from the plugin side and resolve with the host's reply. */
+function request(port: MessagePort, id: string, method: string): Promise<unknown> {
+  return new Promise((resolve) => {
+    port.addEventListener('message', function onMessage(e: MessageEvent) {
+      const msg = e.data as { id?: string; kind?: string };
+      if (msg?.kind === 'response' && msg.id === id) {
+        port.removeEventListener('message', onMessage);
+        resolve(msg);
+      }
+    });
+    port.postMessage({ v: PLUGIN_BRIDGE_VERSION, id, kind: 'request', method, params: {} });
+  });
+}
+
+/** Resolve once the port's peer has had a chance to answer, answered or not. */
+function settledOrTimedOut(p: Promise<unknown>, ms = 50): Promise<unknown | 'no-reply'> {
+  return Promise.race([p, new Promise((r) => setTimeout(() => r('no-reply'), ms))]);
+}
+
+beforeEach(() => {
+  rpc = vi.fn(async () => ({ ok: true, result: { id: 'ws-1' } }));
+  (window as unknown as { electronAPI: unknown }).electronAPI = { plugins: { rpc } };
+  useStore.setState({ activeWorkspaceId: 'ws-1' });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  vi.restoreAllMocks();
+});
+
+describe('PluginFrame — bridge lifetime across a workspace switch', () => {
+  it('keeps answering plugin requests after the active workspace changes', async () => {
+    act(() => {
+      root.render(React.createElement(PluginFrame, {
+        pluginName: 'demo',
+        entry: 'index.html',
+        forwardEvents: false,
+      }));
+    });
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe, 'PluginFrame rendered no iframe').not.toBeNull();
+
+    // Stand in for the frame's window: jsdom will not load a wmux-plugin:// URL,
+    // and the transfer list is what we need to observe anyway.
+    const framePostMessage = vi.fn();
+    Object.defineProperty(iframe!, 'contentWindow', {
+      configurable: true,
+      get: () => ({ postMessage: framePostMessage }),
+    });
+
+    await act(async () => { iframe!.dispatchEvent(new Event('load')); });
+
+    const port = pluginPort(framePostMessage);
+    port.start();
+
+    // Baseline: the bridge answers before any workspace switch.
+    expect(await settledOrTimedOut(request(port, 'before', 'workspace.current')))
+      .toMatchObject({ kind: 'response', id: 'before' });
+
+    // The user switches workspace. Nothing about the plugin changed.
+    await act(async () => { useStore.setState({ activeWorkspaceId: 'ws-2' }); });
+
+    expect(await settledOrTimedOut(request(port, 'after', 'workspace.current')))
+      .toMatchObject({ kind: 'response', id: 'after' });
+  });
+
+  // The reason #719 put activeWorkspaceId on the effect in the first place. It
+  // has to keep holding once the bridge stops depending on the workspace,
+  // otherwise the poll would keep reading the workspace that was active at
+  // mount after the user switched away.
+  it('re-scopes the events.poll loop to the workspace the user switched to', async () => {
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        root.render(React.createElement(PluginFrame, {
+          pluginName: 'demo',
+          entry: 'index.html',
+          forwardEvents: true,
+        }));
+      });
+
+      const iframe = container.querySelector('iframe')!;
+      Object.defineProperty(iframe, 'contentWindow', {
+        configurable: true,
+        get: () => ({ postMessage: vi.fn() }),
+      });
+      rpc.mockResolvedValue({ ok: true, result: { events: [], nextCursor: 7 } });
+
+      await act(async () => { iframe.dispatchEvent(new Event('load')); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+
+      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-1' });
+
+      await act(async () => { useStore.setState({ activeWorkspaceId: 'ws-2' }); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+
+      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-2' });
+      // ...and never keeps polling the workspace the user left.
+      const pollsAfterSwitch = rpc.mock.calls
+        .slice(rpc.mock.calls.findIndex((c) => c[2]?.workspaceId === 'ws-2'))
+        .filter((c) => c[1] === 'events.poll');
+      expect(pollsAfterSwitch.every((c) => c[2]?.workspaceId === 'ws-2')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/renderer/plugins/__tests__/PluginFrame.bridge.dynamic.test.tsx
+++ b/src/renderer/plugins/__tests__/PluginFrame.bridge.dynamic.test.tsx
@@ -114,6 +114,70 @@ describe('PluginFrame — bridge lifetime across a workspace switch', () => {
       .toMatchObject({ kind: 'response', id: 'after' });
   });
 
+  // A response belongs to the document that ASKED. The reload window is what
+  // makes that observable: an rpc started on the old port resolves after the
+  // new one exists, and answering on the current port hands the fresh document
+  // a response to an id it never sent.
+  //
+  // The rpc is held open deliberately — resolving it before the reload would
+  // make this pass no matter which port the answer went to.
+  it('does not deliver a pre-reload response to the reloaded document', async () => {
+    let settleFirst: ((v: unknown) => void) | null = null;
+    rpc.mockImplementation(() => new Promise((resolve) => { settleFirst = resolve; }));
+
+    act(() => {
+      root.render(React.createElement(PluginFrame, {
+        pluginName: 'demo',
+        entry: 'index.html',
+        forwardEvents: false,
+      }));
+    });
+    const iframe = container.querySelector('iframe')!;
+    const framePostMessage = vi.fn();
+    Object.defineProperty(iframe, 'contentWindow', {
+      configurable: true,
+      get: () => ({ postMessage: framePostMessage }),
+    });
+
+    await act(async () => { iframe.dispatchEvent(new Event('load')); });
+    const firstPort = pluginPort(framePostMessage);
+    firstPort.start();
+
+    // Ask on the OLD port. The host's rpc is now pending.
+    firstPort.postMessage({ v: PLUGIN_BRIDGE_VERSION, id: 'stale', kind: 'request', method: 'workspace.current' });
+    await act(async () => { await Promise.resolve(); });
+    expect(settleFirst, 'the host never called rpc for the pre-reload request').not.toBeNull();
+
+    // The frame reloads; the host mints a second port for the new document.
+    framePostMessage.mockClear();
+    await act(async () => { iframe.dispatchEvent(new Event('load')); });
+    const secondPort = pluginPort(framePostMessage);
+    const onSecond = vi.fn();
+    secondPort.addEventListener('message', onSecond);
+    secondPort.start();
+
+    // NOW the old request resolves.
+    await act(async () => {
+      settleFirst!({ ok: true, result: { id: 'ws-1' } });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    // 양성 통제: 새 포트가 정상 요청에는 응답을 받는가
+    rpc.mockImplementation(() => Promise.resolve({ ok: true, result: {} }));
+    secondPort.postMessage({ v: PLUGIN_BRIDGE_VERSION, id: 'live', kind: 'request', method: 'workspace.current' });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    await new Promise((r) => setTimeout(r, 20));
+    const allIds = onSecond.mock.calls.map((c) => (c[0] as MessageEvent).data?.id);
+    expect(allIds, '새 포트가 아무것도 못 받음 — 리스너 배선 문제').toContain('live');
+    const idsSeen = allIds;
+    expect(
+      idsSeen,
+      'the reloaded document was handed a response to an id it never sent',
+    ).not.toContain('stale');
+  });
+
   // The reason #719 put activeWorkspaceId on the effect in the first place. It
   // has to keep holding once the bridge stops depending on the workspace,
   // otherwise the poll would keep reading the workspace that was active at
@@ -150,6 +214,54 @@ describe('PluginFrame — bridge lifetime across a workspace switch', () => {
         .slice(rpc.mock.calls.findIndex((c) => c[2]?.workspaceId === 'ws-2'))
         .filter((c) => c[1] === 'events.poll');
       expect(pollsAfterSwitch.every((c) => c[2]?.workspaceId === 'ws-2')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // `bridgeEpoch === 0` is the poll's "there is nowhere to deliver" gate. It
+  // has to go back to 0 when the bridge is torn down, or the gate only works
+  // once: swapping the plugin nulls the port but leaves the epoch high, and
+  // the loop spends the window before the new `load` polling into nothing —
+  // events fetched from the ring and dropped, with no way to notice.
+  it('stops polling between a plugin swap and the new frame load', async () => {
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        root.render(React.createElement(PluginFrame, {
+          pluginName: 'demo',
+          entry: 'index.html',
+          forwardEvents: true,
+        }));
+      });
+      const iframe = container.querySelector('iframe')!;
+      Object.defineProperty(iframe, 'contentWindow', {
+        configurable: true,
+        get: () => ({ postMessage: vi.fn() }),
+      });
+      rpc.mockResolvedValue({ ok: true, result: { events: [], nextCursor: 7 } });
+
+      await act(async () => { iframe.dispatchEvent(new Event('load')); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
+      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-1' });
+
+      // Swap the plugin: the bridge effect tears down and the new frame has
+      // not loaded yet, so there is no port.
+      rpc.mockClear();
+      act(() => {
+        root.render(React.createElement(PluginFrame, {
+          pluginName: 'other',
+          entry: 'index.html',
+          forwardEvents: true,
+        }));
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+      const polls = rpc.mock.calls.filter((c) => c[1] === 'events.poll');
+      expect(
+        polls,
+        'polled while no port existed — the events it fetched went nowhere',
+      ).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts
+++ b/src/renderer/plugins/__tests__/pluginFrameEventScope.test.ts
@@ -13,12 +13,13 @@ import * as path from 'node:path';
  * user never granted it. The fix sends the active workspaceId on every poll and
  * re-subscribes when the active workspace changes.
  *
- * PluginFrame renders an iframe and opens a MessagePort, and the default vitest
- * environment here is `node`, so the component cannot be mounted in this suite.
- * These are source-structural guards — the same pattern used by
- * useRpcBridge.focus.test.ts / useRpcBridge.browserClose.test.ts for renderer
- * wiring that can't be imported under vitest. The server-side filter behaviour
- * itself is covered by events.rpc.test.ts.
+ * These are source-structural guards on the poll's params, which a behavioural
+ * test cannot pin as precisely. The re-subscribe itself is now asserted by
+ * mounting the component — see PluginFrame.bridge.dynamic.test.tsx, which also
+ * covers the constraint that came out of it: the bridge port must NOT be torn
+ * down by a workspace switch, so the two concerns live on separate effects and
+ * the poll's dependency list is no longer the whole component's. The
+ * server-side filter behaviour itself is covered by events.rpc.test.ts.
  */
 describe('PluginFrame — events.poll workspace scoping', () => {
   const src = fs.readFileSync(path.join(__dirname, '..', 'PluginFrame.tsx'), 'utf-8');
@@ -46,6 +47,13 @@ describe('PluginFrame — events.poll workspace scoping', () => {
   it('re-runs the subscribe effect when the active workspace changes', () => {
     // Without activeWorkspaceId in the deps the loop would keep polling the
     // workspace that was active at mount after the user switched away.
-    expect(src).toMatch(/\}, \[pluginName, entry, forwardEvents, activeWorkspaceId\]\);/);
+    expect(src).toMatch(/\}, \[pluginName, forwardEvents, activeWorkspaceId, bridgeEpoch\]\);/);
+  });
+
+  it('keeps the bridge effect off the active workspace', () => {
+    // The port is created once, in the iframe's `load` handler, and `load` does
+    // not fire again for an unchanged src. A workspace switch that re-runs this
+    // effect therefore closes the port with nothing left to rebuild it.
+    expect(src).toMatch(/\}, \[pluginName, entry\]\);/);
   });
 });


### PR DESCRIPTION
## What

A mounted plugin stops answering the moment the user switches workspace.

The host creates the plugin's `MessagePort` exactly once, inside the iframe's
`load` handler. `load` does not fire again for a frame whose `src` never
changed. #719 added `activeWorkspaceId` to that effect's dependency list so the
`events.poll` loop re-subscribes on a workspace switch — right for the poll, but
the same effect's cleanup closes the port and unregisters the palette-command
frame. From the first switch onward the plugin holds a port whose peer is gone:
every request it posts is dropped and the promise it awaits never settles.

It is not limited to plugins that forward events — `forwardEvents` is not in the
condition, only in the dependency list, so a plugin that never polls loses its
bridge just the same. Sidebar panels recover if the user collapses and re-expands
them (that unmounts the iframe); status-bar widgets stay mounted, so for those it
lasts the rest of the session.

## Change

Split the two concerns that were sharing one effect:

- the **bridge** effect depends on what identifies the frame (`pluginName`,
  `entry`) and owns the port, the request forwarding, and the palette-command
  registration;
- the **poll** effect keeps depending on `activeWorkspaceId` and reaches the port
  through a `bridgeEpoch` counter, so #719's re-subscribe still happens without
  taking the port with it.

No behaviour is added — this is the same two jobs with the lifetime each one
actually has.

## Tests

`PluginFrame.bridge.dynamic.test.tsx` mounts the real component, drives a request
across the transferred port before and after a workspace switch, and asserts the
poll re-scopes to the workspace the user switched to. The first assertion fails on
`main` (`'no-reply'`), the second passes there — so the guard against trading one
for the other is real.

The re-subscribe used to be asserted by regex-matching the dependency array in
source; `pluginFrameEventScope.test.ts` now points at the behavioural test for
that and keeps its structural guards on the poll's params, which a behavioural
test cannot pin as precisely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved plugin communication when switching workspaces, preventing loss of requests, palette commands, and status-bar functionality.
  - Updated plugin event feeds to automatically resubscribe to the active workspace.
  - Improved polling cleanup to prevent stale or invalid events after workspace changes.

- **Tests**
  - Added coverage confirming plugin requests continue working and event polling switches correctly between workspaces.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->