### PR TITLE
feat(web): copy, paste, newline, and auto-focus for the browser terminal

### DIFF
--- a/changelog.d/931.md
+++ b/changelog.d/931.md
@@ -3,3 +3,22 @@
 - The wmux web browser terminal now supports select-to-copy, Ctrl+C-with-selection
   copy, Ctrl+V paste, and Shift+Enter / Ctrl+Enter newline, matching the local
   terminal and the attach mirror (#931).
+
+### Fixed
+
+- Web terminal paste actually works now: xterm's keydown handler used to encode
+  Ctrl+V as the SYN control byte and preventDefault, so the browser's native
+  paste event never fired. The key now steps aside so the browser's own paste
+  path delivers the text (#931).
+- A select followed by Ctrl+C then an immediate Ctrl+V no longer freezes the
+  page for tens of seconds. xterm fires `onSelectionChange` once per cell during
+  a drag, so select-to-copy was issuing a burst of concurrent clipboard writes;
+  the write is now debounced to the settled selection like the desktop's
+  `autoSelectionCopy.ts` (#931).
+- Ctrl+D no longer exits the browser pane's shell. On the desktop Ctrl+D is the
+  split-right shortcut, but the browser terminal maps it to EOF and killed the
+  pane; it is now swallowed (no EOF, no browser bookmark dialog) (#931).
+- Shift+Enter / Ctrl+Enter / Ctrl+J no longer cause a `bash: syntax error` in a
+  shell that does not speak the kitty keyboard protocol. The newline decision
+  now `preventDefault`s the browser's own newline, which xterm's `input` handler
+  would otherwise forward to the PTY right after the CSI-u byte (#931).

--- a/changelog.d/931.md
+++ b/changelog.d/931.md
@@ -1,0 +1,5 @@
+### Added
+
+- The wmux web browser terminal now supports select-to-copy, Ctrl+C-with-selection
+  copy, Ctrl+V paste, and Shift+Enter / Ctrl+Enter newline, matching the local
+  terminal and the attach mirror (#931).

--- a/changelog.d/931.md
+++ b/changelog.d/931.md
@@ -2,7 +2,10 @@
 
 - The wmux web browser terminal now supports select-to-copy, Ctrl+C-with-selection
   copy, Ctrl+V paste, and Shift+Enter / Ctrl+Enter newline, matching the local
-  terminal and the attach mirror (#931).
+  terminal and the attach mirror (#924, #931).
+- Copy/paste/newline handling now works in the split view as well as the 1-up
+  view — both share the same key-decision wiring, so Ctrl+C with a selection
+  copies in a tile instead of SIGINT'ing that pane's process (#931).
 
 ### Fixed
 
@@ -14,11 +17,22 @@
   page for tens of seconds. xterm fires `onSelectionChange` once per cell during
   a drag, so select-to-copy was issuing a burst of concurrent clipboard writes;
   the write is now debounced to the settled selection like the desktop's
-  `autoSelectionCopy.ts` (#931).
-- Ctrl+D no longer exits the browser pane's shell. On the desktop Ctrl+D is the
-  split-right shortcut, but the browser terminal maps it to EOF and killed the
-  pane; it is now swallowed (no EOF, no browser bookmark dialog) (#931).
+  `autoSelectionCopy.ts`. An explicit Ctrl+C also cancels any pending auto-copy
+  so the two never race (#931).
+- Ctrl+D now behaves like a real terminal again: it sends EOF (exits a shell,
+  ends `cat > file`), matching the desktop and every other terminal, instead of
+  being swallowed by the browser page (#931).
+- Shift+Enter no longer corrupts apps that never negotiated the kitty keyboard
+  protocol. The CSI-u byte (`\x1b[13;2u`) only means "newline" to an app that
+  asked for kitty encodings; the browser now watches each pane's output for the
+  negotiation and falls back to a plain Enter for panes that did not — so vim
+  no longer exits insert mode and runs `u` as undo (#931, same gate as the
+  attach mirror in #924).
 - Shift+Enter / Ctrl+Enter / Ctrl+J no longer cause a `bash: syntax error` in a
   shell that does not speak the kitty keyboard protocol. The newline decision
   now `preventDefault`s the browser's own newline, which xterm's `input` handler
-  would otherwise forward to the PTY right after the CSI-u byte (#931).
+  would otherwise forward to the PTY right after the newline byte (#931).
+- Copying no longer steals keyboard focus: the legacy clipboard fallback restores
+  the previously focused element, and a click on any page control (buttons wrap
+  their label/icon in a SPAN or SVG) no longer yanks focus into the terminal
+  (#931).

--- a/scripts/build-daemon-web.mjs
+++ b/scripts/build-daemon-web.mjs
@@ -73,6 +73,9 @@ const pairQueryJs = read(join(frontendDir, 'pairQuery.js'));
 // actually goes wrong — is unit-tested against the exact bytes the phone runs,
 // without evaluating the whole app IIFE.
 const touchScrollJs = read(join(frontendDir, 'touchScroll.js'));
+// Copy / paste / newline key decisions. Separate so the chord table is unit
+// tested against the exact bytes the phone runs, without a DOM or xterm.
+const copyPasteKeysJs = read(join(frontendDir, 'copyPasteKeys.js'));
 let html = read(join(frontendDir, 'index.html'));
 
 html = inject(html, '/*__XTERM_CSS__*/', xtermCss);
@@ -81,6 +84,7 @@ html = inject(html, '/*__XTERM_JS__*/', xtermJs);
 html = inject(html, '/*__ATTENTION_FORMAT_JS__*/', attentionFormatJs);
 html = inject(html, '/*__PAIR_QUERY_JS__*/', pairQueryJs);
 html = inject(html, '/*__TOUCH_SCROLL_JS__*/', touchScrollJs);
+html = inject(html, '/*__KEYS_JS__*/', copyPasteKeysJs);
 html = inject(html, '/*__APP_JS__*/', appJs);
 
 mkdirSync(outDir, { recursive: true });
@@ -129,14 +133,15 @@ const fail = (msg) => {
   process.exit(1);
 };
 
-// The page inlines five scripts (xterm, attentionFormat, pairQuery,
-// touchScroll, app) and one style block (xterm css + our css). A count that
+// The page inlines six scripts (xterm, attentionFormat, pairQuery, touchScroll,
+// copyPasteKeys, app) and one style block (xterm css + our css). A count that
 // moved means index.html grew or lost a block and nobody re-read this gate;
 // refuse rather than guess which. Raised 3 → 4 when pairQuery.js was added for
-// QR pairing, 4 → 5 when touchScroll.js was added for #890: the policy itself
-// is derived from the served bytes, so an extra block is hashed like the others
-// — the count is here to make the change deliberate, not to cap it.
-if (blocks.scripts.length !== 5) fail(`expected 5 inline <script> blocks, found ${blocks.scripts.length}`);
+// QR pairing, 4 → 5 when touchScroll.js was added for #890, 5 → 6 when
+// copyPasteKeys.js was added for browser copy/paste: the policy itself is
+// derived from the served bytes, so an extra block is hashed like the others —
+// the count is here to make the change deliberate, not to cap it.
+if (blocks.scripts.length !== 6) fail(`expected 6 inline <script> blocks, found ${blocks.scripts.length}`);
 if (blocks.styles.length !== 1) fail(`expected 1 inline <style> block, found ${blocks.styles.length}`);
 if (blocks.externalRefs.length > 0) {
   fail(

--- a/scripts/build-daemon-web.mjs
+++ b/scripts/build-daemon-web.mjs
@@ -73,6 +73,9 @@ const pairQueryJs = read(join(frontendDir, 'pairQuery.js'));
 // actually goes wrong — is unit-tested against the exact bytes the phone runs,
 // without evaluating the whole app IIFE.
 const touchScrollJs = read(join(frontendDir, 'touchScroll.js'));
+// Kitty keyboard-protocol negotiation fold. Separate so the state machine is
+// unit tested against the exact bytes the pane emits, without a DOM or xterm.
+const keyboardProtocolJs = read(join(frontendDir, 'keyboardProtocol.js'));
 // Copy / paste / newline key decisions. Separate so the chord table is unit
 // tested against the exact bytes the phone runs, without a DOM or xterm.
 const copyPasteKeysJs = read(join(frontendDir, 'copyPasteKeys.js'));
@@ -84,6 +87,7 @@ html = inject(html, '/*__XTERM_JS__*/', xtermJs);
 html = inject(html, '/*__ATTENTION_FORMAT_JS__*/', attentionFormatJs);
 html = inject(html, '/*__PAIR_QUERY_JS__*/', pairQueryJs);
 html = inject(html, '/*__TOUCH_SCROLL_JS__*/', touchScrollJs);
+html = inject(html, '/*__KEYBOARD_PROTOCOL_JS__*/', keyboardProtocolJs);
 html = inject(html, '/*__KEYS_JS__*/', copyPasteKeysJs);
 html = inject(html, '/*__APP_JS__*/', appJs);
 
@@ -133,15 +137,17 @@ const fail = (msg) => {
   process.exit(1);
 };
 
-// The page inlines six scripts (xterm, attentionFormat, pairQuery, touchScroll,
-// copyPasteKeys, app) and one style block (xterm css + our css). A count that
-// moved means index.html grew or lost a block and nobody re-read this gate;
-// refuse rather than guess which. Raised 3 → 4 when pairQuery.js was added for
-// QR pairing, 4 → 5 when touchScroll.js was added for #890, 5 → 6 when
-// copyPasteKeys.js was added for browser copy/paste: the policy itself is
-// derived from the served bytes, so an extra block is hashed like the others —
-// the count is here to make the change deliberate, not to cap it.
-if (blocks.scripts.length !== 6) fail(`expected 6 inline <script> blocks, found ${blocks.scripts.length}`);
+// The page inlines seven scripts (xterm, attentionFormat, pairQuery, touchScroll,
+// keyboardProtocol, copyPasteKeys, app) and one style block (xterm css + our
+// css). A count that moved means index.html grew or lost a block and nobody
+// re-read this gate; refuse rather than guess which. Raised 3 → 4 when
+// pairQuery.js was added for QR pairing, 4 → 5 when touchScroll.js was added
+// for #890, 5 → 6 when copyPasteKeys.js was added for browser copy/paste,
+// 6 → 7 when keyboardProtocol.js was added for the kitty-negotiation gate: the
+// policy itself is derived from the served bytes, so an extra block is hashed
+// like the others — the count is here to make the change deliberate, not to cap
+// it.
+if (blocks.scripts.length !== 7) fail(`expected 7 inline <script> blocks, found ${blocks.scripts.length}`);
 if (blocks.styles.length !== 1) fail(`expected 1 inline <style> block, found ${blocks.styles.length}`);
 if (blocks.externalRefs.length > 0) {
   fail(

--- a/src/daemon/web/__tests__/copyPasteKeys.test.ts
+++ b/src/daemon/web/__tests__/copyPasteKeys.test.ts
@@ -21,7 +21,7 @@ type KeyLike = {
   isComposing?: boolean;
 };
 
-type Decide = (ev: KeyLike, opts: { isMac?: boolean; hasSelection?: boolean; readOnly?: boolean }) => {
+type Decide = (ev: KeyLike, opts: { isMac?: boolean; hasSelection?: boolean; readOnly?: boolean; remoteAcceptsCsiU?: boolean }) => {
   action: string;
   data?: string;
 } | null;

--- a/src/daemon/web/__tests__/copyPasteKeys.test.ts
+++ b/src/daemon/web/__tests__/copyPasteKeys.test.ts
@@ -1,0 +1,145 @@
+// Copy / paste / newline key decisions for the wmux web terminal.
+//
+// The frontend has no bundler: `copyPasteKeys.js` is inlined into terminal.html
+// by scripts/build-daemon-web.mjs. Evaluate the shipped file verbatim, exactly
+// like touchScroll.test.ts / pairQuery.test.ts, so this covers the bytes the
+// browser actually runs.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type KeyLike = {
+  type: string;
+  key: string;
+  code: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  isComposing?: boolean;
+};
+
+type Decide = (ev: KeyLike, opts: { isMac?: boolean; hasSelection?: boolean; readOnly?: boolean }) => {
+  action: string;
+  data?: string;
+} | null;
+
+let decideWebKey: Decide;
+
+const frontend = (name: string) => join(__dirname, '..', 'frontend', name);
+
+beforeAll(() => {
+  const src = readFileSync(frontend('copyPasteKeys.js'), 'utf8');
+  const sandbox: Record<string, unknown> = {};
+  runInNewContext(src, sandbox);
+  const mod = sandbox.wmuxWebKeys as Record<string, unknown>;
+  decideWebKey = mod.decideWebKey as Decide;
+});
+
+const kd = (partial: Partial<KeyLike>): KeyLike => ({
+  type: 'keydown',
+  key: '',
+  code: '',
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  metaKey: false,
+  isComposing: false,
+  ...partial,
+});
+
+describe('newline keys', () => {
+  it('Shift+Enter emits the CSI-u newline byte (kitty protocol)', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), {})).toEqual({
+      action: 'newline',
+      data: '\x1b[13;2u',
+    });
+  });
+
+  it('Shift+Enter on a read-only host is swallowed', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), { readOnly: true })).toEqual({
+      action: 'swallow',
+    });
+  });
+
+  it('Shift+Enter during an IME composition passes through', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true, isComposing: true }), {})).toBeNull();
+  });
+
+  it('Ctrl+Enter emits LF (insert newline, not submit)', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', ctrlKey: true }), {})).toEqual({
+      action: 'newline',
+      data: '\n',
+    });
+  });
+
+  it('Ctrl+J emits LF, matched by physical code', () => {
+    expect(decideWebKey(kd({ key: 'j', code: 'KeyJ', ctrlKey: true }), {})).toEqual({
+      action: 'newline',
+      data: '\n',
+    });
+  });
+
+  it('plain Enter is not intercepted', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter' }), {})).toBeNull();
+  });
+});
+
+describe('copy (Windows/Linux)', () => {
+  it('Ctrl+C with a selection copies', () => {
+    expect(decideWebKey(kd({ key: 'c', code: 'KeyC', ctrlKey: true }), { hasSelection: true })).toEqual({
+      action: 'copy',
+    });
+  });
+
+  it('Ctrl+C with an empty selection passes through (SIGINT is not taken away)', () => {
+    expect(decideWebKey(kd({ key: 'c', code: 'KeyC', ctrlKey: true }), { hasSelection: false })).toBeNull();
+  });
+
+  it('Ctrl+C matches by physical code too (CJK IME mangles `key`)', () => {
+    expect(decideWebKey(kd({ key: 'Process', code: 'KeyC', ctrlKey: true }), { hasSelection: true })).toEqual({
+      action: 'copy',
+    });
+  });
+
+  it('Ctrl+V is left to the browser paste path', () => {
+    expect(decideWebKey(kd({ key: 'v', code: 'KeyV', ctrlKey: true }), {})).toBeNull();
+  });
+
+  it('Ctrl+Shift+C copies with a selection, swallows without', () => {
+    expect(decideWebKey(kd({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }), { hasSelection: true })).toEqual({ action: 'copy' });
+    expect(decideWebKey(kd({ key: 'C', code: 'KeyC', ctrlKey: true, shiftKey: true }), { hasSelection: false })).toEqual({ action: 'swallow' });
+  });
+});
+
+describe('copy (macOS)', () => {
+  it('⌘C with a selection copies', () => {
+    expect(decideWebKey(kd({ key: 'c', code: 'KeyC', metaKey: true }), { isMac: true, hasSelection: true })).toEqual({
+      action: 'copy',
+    });
+  });
+
+  it('⌘C with no selection passes (let the OS copy nothing)', () => {
+    expect(decideWebKey(kd({ key: 'c', code: 'KeyC', metaKey: true }), { isMac: true, hasSelection: false })).toBeNull();
+  });
+
+  it('⌘V is left to the browser paste path', () => {
+    expect(decideWebKey(kd({ key: 'v', code: 'KeyV', metaKey: true }), { isMac: true })).toBeNull();
+  });
+
+  it('macOS Ctrl+C stays SIGINT (bare Ctrl is not ⌘)', () => {
+    expect(decideWebKey(kd({ key: 'c', code: 'KeyC', ctrlKey: true }), { isMac: true, hasSelection: true })).toBeNull();
+  });
+});
+
+describe('pass-through', () => {
+  it('a plain letter is untouched', () => {
+    expect(decideWebKey(kd({ key: 'a', code: 'KeyA' }), {})).toBeNull();
+  });
+
+  it('a keyup is never decided', () => {
+    expect(decideWebKey({ ...kd({ key: 'c', code: 'KeyC', ctrlKey: true }), type: 'keyup' }, { hasSelection: true })).toBeNull();
+  });
+});

--- a/src/daemon/web/__tests__/copyPasteKeys.test.ts
+++ b/src/daemon/web/__tests__/copyPasteKeys.test.ts
@@ -104,8 +104,16 @@ describe('copy (Windows/Linux)', () => {
     });
   });
 
-  it('Ctrl+V is left to the browser paste path', () => {
-    expect(decideWebKey(kd({ key: 'v', code: 'KeyV', ctrlKey: true }), {})).toBeNull();
+  it('Ctrl+V asks app.js to step aside so the browser can paste natively', () => {
+    expect(decideWebKey(kd({ key: 'v', code: 'KeyV', ctrlKey: true }), {})).toEqual({
+      action: 'paste',
+    });
+  });
+
+  it('Ctrl+D is swallowed so a browser pane cannot be killed by an errant EOF', () => {
+    expect(decideWebKey(kd({ key: 'd', code: 'KeyD', ctrlKey: true }), {})).toEqual({
+      action: 'swallow',
+    });
   });
 
   it('Ctrl+Shift+C copies with a selection, swallows without', () => {

--- a/src/daemon/web/__tests__/copyPasteKeys.test.ts
+++ b/src/daemon/web/__tests__/copyPasteKeys.test.ts
@@ -51,15 +51,21 @@ const kd = (partial: Partial<KeyLike>): KeyLike => ({
 });
 
 describe('newline keys', () => {
-  it('Shift+Enter emits the CSI-u newline byte (kitty protocol)', () => {
-    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), {})).toEqual({
+  it('Shift+Enter emits the CSI-u newline byte when the pane negotiated kitty', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), { remoteAcceptsCsiU: true })).toEqual({
       action: 'newline',
       data: '\x1b[13;2u',
     });
   });
 
-  it('Shift+Enter on a read-only host is swallowed', () => {
-    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), { readOnly: true })).toEqual({
+  it('Shift+Enter passes through to xterm when the pane never negotiated kitty', () => {
+    // bash / vim read `\x1b[13;2u` as ESC + `[13;2u`, not as Shift+Enter, so a
+    // non-negotiating pane must get the legacy CR from xterm instead.
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), {})).toBeNull();
+  });
+
+  it('Shift+Enter on a read-only host is swallowed even when kitty is on', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), { readOnly: true, remoteAcceptsCsiU: true })).toEqual({
       action: 'swallow',
     });
   });
@@ -110,10 +116,8 @@ describe('copy (Windows/Linux)', () => {
     });
   });
 
-  it('Ctrl+D is swallowed so a browser pane cannot be killed by an errant EOF', () => {
-    expect(decideWebKey(kd({ key: 'd', code: 'KeyD', ctrlKey: true }), {})).toEqual({
-      action: 'swallow',
-    });
+  it('Ctrl+D passes through so xterm can send EOF, like any other terminal', () => {
+    expect(decideWebKey(kd({ key: 'd', code: 'KeyD', ctrlKey: true }), {})).toBeNull();
   });
 
   it('Ctrl+Shift+C copies with a selection, swallows without', () => {

--- a/src/daemon/web/__tests__/keyboardProtocol.test.ts
+++ b/src/daemon/web/__tests__/keyboardProtocol.test.ts
@@ -21,7 +21,7 @@ let INITIAL_STATE: { kitty: boolean; modifyOtherKeys: number };
 
 const frontend = (name: string) => join(__dirname, '..', 'frontend', name);
 
-const bytes = (s: string): Uint8Array => Array.from(s, (c) => c.charCodeAt(0));
+const bytes = (s: string): Uint8Array => new TextEncoder().encode(s);
 
 beforeAll(() => {
   const src = readFileSync(frontend('keyboardProtocol.js'), 'utf8');

--- a/src/daemon/web/__tests__/keyboardProtocol.test.ts
+++ b/src/daemon/web/__tests__/keyboardProtocol.test.ts
@@ -1,0 +1,103 @@
+// Kitty keyboard-protocol negotiation fold for the wmux web terminal.
+//
+// The frontend has no bundler: `keyboardProtocol.js` is inlined into
+// terminal.html by scripts/build-daemon-web.mjs. Evaluate the shipped file
+// verbatim, exactly like copyPasteKeys.test.ts / touchScroll.test.ts, so this
+// covers the bytes the browser actually runs.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+type Fold = (prev: { kitty: boolean; modifyOtherKeys: number }, bytes: Uint8Array | string) => {
+  kitty: boolean;
+  modifyOtherKeys: number;
+};
+
+let fold: Fold;
+let acceptsCsiU: (state: { kitty: boolean }) => boolean;
+let INITIAL_STATE: { kitty: boolean; modifyOtherKeys: number };
+
+const frontend = (name: string) => join(__dirname, '..', 'frontend', name);
+
+const bytes = (s: string): Uint8Array => Array.from(s, (c) => c.charCodeAt(0));
+
+beforeAll(() => {
+  const src = readFileSync(frontend('keyboardProtocol.js'), 'utf8');
+  const sandbox: Record<string, unknown> = {};
+  runInNewContext(src, sandbox);
+  const mod = sandbox.wmuxKeyboardProtocol as Record<string, unknown>;
+  fold = mod.foldRemoteKeyboardState as Fold;
+  acceptsCsiU = mod.acceptsCsiU as (state: { kitty: boolean }) => boolean;
+  INITIAL_STATE = mod.INITIAL_STATE as { kitty: boolean; modifyOtherKeys: number };
+});
+
+describe('initial state', () => {
+  it('starts not negotiated', () => {
+    expect(INITIAL_STATE).toEqual({ kitty: false, modifyOtherKeys: 0 });
+  });
+
+  it('does not accept CSI-u before any negotiation', () => {
+    expect(acceptsCsiU(INITIAL_STATE)).toBe(false);
+  });
+});
+
+describe('kitty push / set / pop', () => {
+  it('a kitty push (CSI > flags u) turns kitty on', () => {
+    const next = fold(INITIAL_STATE, bytes('\x1b[>1u'));
+    expect(next.kitty).toBe(true);
+    expect(acceptsCsiU(next)).toBe(true);
+  });
+
+  it('a kitty set (CSI = flags ; mode u) turns kitty on too', () => {
+    const next = fold(INITIAL_STATE, bytes('\x1b[=1;2u'));
+    expect(next.kitty).toBe(true);
+  });
+
+  it('a kitty pop (CSI < flags u) turns kitty back off', () => {
+    const on = fold(INITIAL_STATE, bytes('\x1b[>1u'));
+    const off = fold(on, bytes('\x1b[<1u'));
+    expect(off.kitty).toBe(false);
+    expect(acceptsCsiU(off)).toBe(false);
+  });
+});
+
+describe('modifyOtherKeys', () => {
+  it('tracks modifyOtherKeys level separately', () => {
+    const next = fold(INITIAL_STATE, bytes('\x1b[>4;2m'));
+    expect(next.modifyOtherKeys).toBe(2);
+    // mode 2 is NOT kitty — it wants CSI 27 ; ... ~ instead of CSI-u
+    expect(next.kitty).toBe(false);
+    expect(acceptsCsiU(next)).toBe(false);
+  });
+
+  it('modifyOtherKeys off (0) does not negotiate anything', () => {
+    const next = fold(INITIAL_STATE, bytes('\x1b[>4;0m'));
+    expect(next.modifyOtherKeys).toBe(0);
+    expect(acceptsCsiU(next)).toBe(false);
+  });
+});
+
+describe('robustness', () => {
+  it('ordinary output changes nothing and returns the same reference', () => {
+    const next = fold(INITIAL_STATE, bytes('hello world\r\n'));
+    expect(next).toBe(INITIAL_STATE);
+  });
+
+  it('a negotiation buried in pane output is still seen', () => {
+    const mixed = bytes('some text\x1b[>1usome more');
+    const next = fold(INITIAL_STATE, mixed);
+    expect(next.kitty).toBe(true);
+  });
+
+  it('a push then a pop in the same chunk lands on the later one', () => {
+    const next = fold(INITIAL_STATE, bytes('\x1b[>1u\x1b[<1u'));
+    expect(next.kitty).toBe(false);
+  });
+
+  it('a string input is accepted as well as bytes', () => {
+    const next = fold(INITIAL_STATE, '\x1b[>1u' as string);
+    expect(next.kitty).toBe(true);
+  });
+});

--- a/src/daemon/web/__tests__/touchScroll.test.ts
+++ b/src/daemon/web/__tests__/touchScroll.test.ts
@@ -778,6 +778,6 @@ describe('source invariants', () => {
     expect(html).toContain('/*__TOUCH_SCROLL_JS__*/');
     const build = readFileSync(join(__dirname, '..', '..', '..', '..', 'scripts', 'build-daemon-web.mjs'), 'utf8');
     expect(build).toContain("inject(html, '/*__TOUCH_SCROLL_JS__*/', touchScrollJs)");
-    expect(build).toContain('blocks.scripts.length !== 6');
+    expect(build).toContain('blocks.scripts.length !== 7');
   });
 });

--- a/src/daemon/web/__tests__/touchScroll.test.ts
+++ b/src/daemon/web/__tests__/touchScroll.test.ts
@@ -778,6 +778,6 @@ describe('source invariants', () => {
     expect(html).toContain('/*__TOUCH_SCROLL_JS__*/');
     const build = readFileSync(join(__dirname, '..', '..', '..', '..', 'scripts', 'build-daemon-web.mjs'), 'utf8');
     expect(build).toContain("inject(html, '/*__TOUCH_SCROLL_JS__*/', touchScrollJs)");
-    expect(build).toContain('blocks.scripts.length !== 5');
+    expect(build).toContain('blocks.scripts.length !== 6');
   });
 });

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -132,6 +132,33 @@
   var BASE_TITLE = document.title;
   var reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   var fleetTimer = null;
+  var isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent);
+
+  // Copy text to the clipboard. `navigator.clipboard` needs a secure context,
+  // which a cleartext `--expose` page is not — fall back to the legacy
+  // textarea+execCommand trick so Ctrl+C still copies there. Auto-copy on
+  // selection is best-effort: the browser may refuse a non-gesture write, and
+  // that failure is silent (Ctrl+C remains the reliable path).
+  function copyToClipboard(text) {
+    if (!text) return;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).catch(function () { legacyCopy(text); });
+    } else {
+      legacyCopy(text);
+    }
+  }
+  function legacyCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '0';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); } catch (e) { /* no clipboard in this context */ }
+    document.body.removeChild(ta);
+  }
 
   function newTerm(cols, rows) {
     return new Terminal({
@@ -183,6 +210,15 @@
     try { t.focus(); } catch (e) { /* torn down mid-tap */ }
   }
   if (termHost) termHost.addEventListener('click', function () { focusFromGesture(term); });
+  // Any click on the page (not just the terminal canvas) keeps the xterm
+  // textarea focused, so browser paste (Ctrl+V) — which needs that textarea to
+  // receive the paste event — still lands after touching chrome. Skip real
+  // inputs so their own focus isn't stolen.
+  document.addEventListener('click', function (e) {
+    var tag = e.target && e.target.tagName ? e.target.tagName : '';
+    if (/INPUT|TEXTAREA|SELECT|BUTTON/.test(tag)) return;
+    focusFromGesture(term);
+  }, true);
 
   // Repaint gate: how many snapshots are currently being fed to the parser.
   //
@@ -232,6 +268,38 @@
         if (termRepaints > 0) return; // parser reply to a replayed query
         sendInput(d);
       });
+      // Copy / newline decisions for a browser terminal (see copyPasteKeys.js).
+      // xterm exposes this as a METHOD, not a constructor option — attach it
+      // here so Ctrl+C-with-a-selection copies instead of SIGINT, and
+      // Shift+Enter / Ctrl+Enter insert a newline. Ctrl+V is left to the
+      // browser's own paste path once the terminal is focused.
+      term.attachCustomKeyEventHandler(function (ev) {
+        try {
+          var decision = window.wmuxWebKeys.decideWebKey(ev, {
+            isMac: isMac,
+            hasSelection: term.hasSelection(),
+            readOnly: !allowInput
+          });
+          if (!decision) return true;
+          if (decision.action === 'copy') { copyToClipboard(term.getSelection()); return false; }
+          if (decision.action === 'newline') { sendInput(decision.data); return false; }
+          if (decision.action === 'swallow') return false;
+          return true;
+        } catch (e) {
+          console.error('[wmux-web-keys] decision failed:', e);
+          return true; // never break normal keys
+        }
+      });
+      // Select-to-copy, like a local wmux pane: any selection lands on the
+      // clipboard. Best-effort on a cleartext page (the browser may refuse a
+      // non-gesture clipboard write) — Ctrl+C remains the reliable path there.
+      term.onSelectionChange(function () {
+        var sel = term.getSelection();
+        if (sel) copyToClipboard(sel);
+      });
+      // Auto-focus so typing and Ctrl+V work without a click first — a browser
+      // only delivers the paste event to the focused xterm textarea.
+      if (allowInput) term.focus();
     } else if (cols && rows) {
       term.resize(cols, rows);
     }
@@ -1234,6 +1302,9 @@
         }
         hideOverlay();
         setConn('live', 'live');
+        // The pane is now visible and interactive — focus it so typing / paste
+        // need no click (a browser only delivers paste to the focused xterm).
+        if (allowInput && term) term.focus();
       },
       data: function (bytes) { if (term) term.write(bytes); },
       exit: function () { setConn('ended', 'ended'); },

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -1568,12 +1568,15 @@
         if (tile.repaints > 0) return; // parser reply to a replayed query
         sendTo(tile.sessionId, d);
       });
-      // Same copy/newline/paste handling as the 1-up terminal — Ctrl+C with a
-      // selection must copy here too, never SIGINT the tile's process. Sends go
-      // to THIS tile's pane, not whichever one is focused. Focus policy stays
-      // local (a tile never grabs focus), which is why this is a caller arg.
-      attachTerminalKeys(tile.term, function (d) { sendTo(tile.sessionId, d); }, !allowInput, function () { return paneAcceptsCsiU(tile.sessionId); });
     }
+    // Same copy/newline/paste handling as the 1-up terminal — Ctrl+C with a
+    // selection must copy here too, never SIGINT the tile's process. Sends go
+    // to THIS tile's pane, not whichever one is focused. Focus policy stays
+    // local (a tile never grabs focus), which is why this is a caller arg.
+    // OUTSIDE `if (allowInput)`: a read-only split tile still needs copy —
+    // select-to-copy and Ctrl+C-with-selection must work there, only typing is
+    // gated on allowInput (the readOnly flag passed here decides newline/paste).
+    attachTerminalKeys(tile.term, function (d) { sendTo(tile.sessionId, d); }, !allowInput, function () { return paneAcceptsCsiU(tile.sessionId); });
     renderTileHead(tile);
     el.addEventListener('pointerdown', function () { focusTile(tile); });
 

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -134,11 +134,15 @@
   var fleetTimer = null;
   var isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent);
 
-  // Copy text to the clipboard. `navigator.clipboard` needs a secure context,
-  // which a cleartext `--expose` page is not — fall back to the legacy
-  // textarea+execCommand trick so Ctrl+C still copies there. Auto-copy on
-  // selection is best-effort: the browser may refuse a non-gesture write, and
-  // that failure is silent (Ctrl+C remains the reliable path).
+  /**
+   * Copy text to the clipboard. `navigator.clipboard` needs a secure context,
+   * which a cleartext `--expose` page is not — fall back to the legacy
+   * textarea+execCommand trick so Ctrl+C still copies there. Auto-copy on
+   * selection is best-effort: the browser may refuse a non-gesture write, and
+   * that failure is silent (Ctrl+C remains the reliable path).
+   *
+   * @param {string} text the selection (or other text) to copy.
+   */
   function copyToClipboard(text) {
     if (!text) return;
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -147,6 +151,13 @@
       legacyCopy(text);
     }
   }
+
+  /**
+   * Legacy clipboard fallback for a non-secure context: park the text in an
+   * off-screen textarea, select it, and run `document.execCommand('copy')`.
+   *
+   * @param {string} text the text to copy.
+   */
   function legacyCopy(text) {
     var ta = document.createElement('textarea');
     ta.value = text;

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -159,6 +159,12 @@
    * @param {string} text the text to copy.
    */
   function legacyCopy(text) {
+    // Focusing the temp textarea moves focus off the terminal; when it is
+    // removed, focus lands on <body> and subsequent typing/paste goes nowhere
+    // until the user clicks. Stash the owner and hand focus back when done —
+    // debounced select-to-copy fires this on every settled selection on a
+    // cleartext page, so the leak would be constant there.
+    var owner = document.activeElement;
     var ta = document.createElement('textarea');
     ta.value = text;
     ta.setAttribute('readonly', '');
@@ -169,6 +175,7 @@
     ta.select();
     try { document.execCommand('copy'); } catch (e) { /* no clipboard in this context */ }
     document.body.removeChild(ta);
+    if (owner && owner.focus && owner !== document.body) { try { owner.focus(); } catch (e) { /* torn down */ } }
   }
 
   function newTerm(cols, rows) {
@@ -224,10 +231,13 @@
   // Any click on the page (not just the terminal canvas) keeps the xterm
   // textarea focused, so browser paste (Ctrl+V) — which needs that textarea to
   // receive the paste event — still lands after touching chrome. Skip real
-  // inputs so their own focus isn't stolen.
+  // inputs so their own focus isn't stolen. Matching `tagName` misses every
+  // button here, since each one wraps its label/icon in a SPAN or SVG; a
+  // closest() walk past the content node is the reliable test.
   document.addEventListener('click', function (e) {
-    var tag = e.target && e.target.tagName ? e.target.tagName : '';
-    if (/INPUT|TEXTAREA|SELECT|BUTTON/.test(tag)) return;
+    var t = e.target;
+    if (!t || typeof t.closest !== 'function') { focusFromGesture(term); return; }
+    if (t.closest('button, input, textarea, select, a, label, [contenteditable]')) return;
     focusFromGesture(term);
   }, true);
 
@@ -264,6 +274,136 @@
     }
   }
 
+  /**
+   * Per-session kitty-keyboard-protocol state (see keyboardProtocol.js). Each
+   * pane negotiates independently — an app that pushes kitty on (codex, some
+   * editors) vs one that never does (bash) — so the fold is keyed by session,
+   * not global. Filled from the pane stream: snapshot resets (a re-attach
+   * replays the pane's screen, negotiation included — a protocol the app turned
+   * off before we attached must not survive as stale), data folds
+   * incrementally.
+   *
+   * NOTE this fold is a *fallback*, not the primary signal: Claude Code never
+   * emits a kitty push, yet understands `\x1b[13;2u` — the desktop relies on
+   * that (newlineKeys.ts sends the byte unconditionally). So an agent pane
+   * (session.agent) is treated as accepting CSI-u outright; the fold only
+   * decides for plain shells, where a kitty push is the one safe signal (bash
+   * reads `\x1b[13;2u` as ESC + `[13;2u` and a stray `;` — see #931).
+   */
+  var keyboardStates = {};
+  function foldKeyboardState(sessionId, bytes, isSnapshot) {
+    var kb = window.wmuxKeyboardProtocol;
+    if (!kb) return;
+    var prev = (isSnapshot || !keyboardStates[sessionId])
+      ? kb.INITIAL_STATE
+      : keyboardStates[sessionId];
+    keyboardStates[sessionId] = kb.foldRemoteKeyboardState(prev, bytes);
+  }
+  /** Whether a pane understands the CSI-u Shift+Enter byte. */
+  function paneAcceptsCsiU(sessionId) {
+    // Claude Code (and any other detected agent) accepts CSI-u by contract —
+    // it is why the desktop sends the byte unconditionally. A shell's claim is
+    // decided by the kitty fold instead.
+    var s = sessions.filter(function (x) { return x.id === sessionId; })[0];
+    if (s && s.agent) return true;
+    var kb = window.wmuxKeyboardProtocol;
+    if (!kb) return false;
+    return kb.acceptsCsiU(keyboardStates[sessionId] || kb.INITIAL_STATE);
+  }
+
+  /**
+   * Copy / newline / paste / swallow key decisions for ONE terminal, plus
+   * debounced select-to-copy — shared by the 1-up view (`ensureTerm`) and every
+   * split tile (`makeTile`), so a browser pane behaves the same in both. Focus
+   * policy stays with the caller: a tile never grabs focus, a 1-up pane does.
+   *
+   * @param {Terminal} term the xterm instance to wire.
+   * @param {function(string): void} send sends bytes to THIS terminal's pane
+   *        (a tile must not send to whichever pane is currently focused).
+   * @param {boolean} readOnly whether the pane is read-only (newline keys and
+   *        paste become no-ops; copy still works).
+   * @param {function(): boolean} acceptsCsiU whether THIS pane negotiated the
+   *        kitty keyboard protocol (drives the Shift+Enter byte; see
+   *        keyboardProtocol.js). A tile must query ITS session's state.
+   */
+  function attachTerminalKeys(term, send, readOnly, acceptsCsiU) {
+    // xterm exposes the custom key handler as a METHOD, not a constructor
+    // option. Wired here so Ctrl+C-with-a-selection copies instead of SIGINT,
+    // Shift+Enter / Ctrl+Enter insert a newline, and Ctrl+V / Ctrl+D fall back
+    // to the browser / xterm default.
+    var selectionCopyTimer = null;
+    term.attachCustomKeyEventHandler(function (ev) {
+      try {
+        var decision = window.wmuxWebKeys.decideWebKey(ev, {
+          isMac: isMac,
+          hasSelection: term.hasSelection(),
+          readOnly: readOnly,
+          remoteAcceptsCsiU: acceptsCsiU ? acceptsCsiU() : false
+        });
+        if (!decision) return true;
+        // Copy: an explicit Ctrl+C must cancel any pending debounced auto-copy.
+        // The user selecting then pressing Ctrl+C within the 150ms debounce
+        // window would otherwise start TWO clipboard writes — the explicit one
+        // now, and the timer's a moment later — and that concurrent write is
+        // exactly the burst that makes Chromium reject and fall into the
+        // blocking legacyCopy path (see the onSelectionChange comment below).
+        // The explicit copy is authoritative; drop the timer.
+        if (decision.action === 'copy') {
+          if (selectionCopyTimer) {
+            clearTimeout(selectionCopyTimer);
+            selectionCopyTimer = null;
+          }
+          // preventDefault like every other acting branch: returning false
+          // only stops xterm, and the browser's own copy would still fire off
+          // any DOM selection, racing this write for the clipboard.
+          ev.preventDefault();
+          copyToClipboard(term.getSelection());
+          return false;
+        }
+        // Newline keys (Shift+Enter / Ctrl+Enter / Ctrl+J). preventDefault is
+        // required — returning false alone only stops xterm's keydown handler,
+        // and the browser's own Shift+Enter default (a newline in the hidden
+        // textarea) would fire xterm's `input` handler, which sends the
+        // textarea content to the PTY. That appended \n after our CSI-u byte
+        // makes bash submit `;2u` and report a syntax error — the exact bug
+        // the desktop avoids by calling preventDefault (useTerminal.ts).
+        if (decision.action === 'newline') { ev.preventDefault(); send(decision.data); return false; }
+        // 'swallow': consume the key entirely. preventDefault is required so
+        // the browser's own default (e.g. a bookmark dialog) does not fire on
+        // top of our no-op — returning false alone only stops xterm.
+        if (decision.action === 'swallow') { ev.preventDefault(); return false; }
+        // 'paste': xterm must NOT process Ctrl+V (it would encode SYN and
+        // swallow the browser's paste). Returning false tells xterm to step
+        // aside entirely, so the browser's own paste event lands on the
+        // focused xterm textarea — whose native paste listener already sends
+        // it to the pane. Works on cleartext pages, no secure-context API.
+        if (decision.action === 'paste') return false;
+        return true;
+      } catch (e) {
+        console.error('[wmux-web-keys] decision failed:', e);
+        return true; // never break normal keys
+      }
+    });
+    // Select-to-copy, like a local wmux pane. xterm fires onSelectionChange
+    // once per CELL during a drag — a 50-char selection is 50 events — so a
+    // raw per-event copy issues a burst of concurrent writeText calls.
+    // Chromium serializes clipboard writes; the stragglers reject and their
+    // legacyCopy execCommand('copy') blocks synchronously on the clipboard
+    // lock, freezing the page for tens of seconds (select → Ctrl+C → Ctrl+V
+    // repro). Debounce to the settled selection, matching the desktop's
+    // autoSelectionCopy.ts. Best-effort on a cleartext page (the browser may
+    // refuse a non-gesture clipboard write) — Ctrl+C remains the reliable
+    // path there.
+    term.onSelectionChange(function () {
+      var sel = term.getSelection();
+      if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
+      selectionCopyTimer = setTimeout(function () {
+        selectionCopyTimer = null;
+        if (sel) copyToClipboard(sel);
+      }, 150);
+    });
+  }
+
   function ensureTerm(cols, rows) {
     if (!term) {
       term = newTerm(cols, rows);
@@ -279,77 +419,7 @@
         if (termRepaints > 0) return; // parser reply to a replayed query
         sendInput(d);
       });
-      // Copy / newline decisions for a browser terminal (see copyPasteKeys.js).
-      // xterm exposes this as a METHOD, not a constructor option — attach it
-      // here so Ctrl+C-with-a-selection copies instead of SIGINT, and
-      // Shift+Enter / Ctrl+Enter insert a newline. Ctrl+V is left to the
-      // browser's own paste path once the terminal is focused.
-      term.attachCustomKeyEventHandler(function (ev) {
-        try {
-          var decision = window.wmuxWebKeys.decideWebKey(ev, {
-            isMac: isMac,
-            hasSelection: term.hasSelection(),
-            readOnly: !allowInput
-          });
-          if (!decision) return true;
-          // Copy: an explicit Ctrl+C must cancel any pending debounced
-          // auto-copy. The user selecting then pressing Ctrl+C within the 150ms
-          // debounce window would otherwise start TWO clipboard writes — the
-          // explicit one now, and the timer's a moment later — and that
-          // concurrent write is exactly the burst that makes Chromium reject
-          // and fall into the blocking legacyCopy path (see the onSelectionChange
-          // comment below). The explicit copy is authoritative; drop the timer.
-          if (decision.action === 'copy') {
-            if (selectionCopyTimer) {
-              clearTimeout(selectionCopyTimer);
-              selectionCopyTimer = null;
-            }
-            copyToClipboard(term.getSelection());
-            return false;
-          }
-          // Newline keys (Shift+Enter / Ctrl+Enter / Ctrl+J). preventDefault is
-          // required — returning false alone only stops xterm's keydown handler,
-          // and the browser's own Shift+Enter default (a newline in the hidden
-          // textarea) would fire xterm's `input` handler, which sends the
-          // textarea content to the PTY. That appended \n after our CSI-u byte
-          // makes bash submit `;2u` and report a syntax error — the exact bug
-          // the desktop avoids by calling preventDefault (useTerminal.ts).
-          if (decision.action === 'newline') { ev.preventDefault(); sendInput(decision.data); return false; }
-          // 'swallow': consume the key entirely. preventDefault is required so
-          // the browser's own default (Ctrl+D → bookmark dialog) does not fire
-          // on top of our no-op — returning false alone only stops xterm.
-          if (decision.action === 'swallow') { ev.preventDefault(); return false; }
-          // 'paste': xterm must NOT process Ctrl+V (it would encode SYN and
-          // swallow the browser's paste). Returning false tells xterm to step
-          // aside entirely, so the browser's own paste event lands on the
-          // focused xterm textarea — whose native paste listener already sends
-          // it to the pane. Works on cleartext pages, no secure-context API.
-          if (decision.action === 'paste') return false;
-          return true;
-        } catch (e) {
-          console.error('[wmux-web-keys] decision failed:', e);
-          return true; // never break normal keys
-        }
-      });
-      // Select-to-copy, like a local wmux pane. xterm fires onSelectionChange
-      // once per CELL during a drag — a 50-char selection is 50 events — so a
-      // raw per-event copy issues a burst of concurrent writeText calls.
-      // Chromium serializes clipboard writes; the stragglers reject and their
-      // legacyCopy execCommand('copy') blocks synchronously on the clipboard
-      // lock, freezing the page for tens of seconds (select → Ctrl+C → Ctrl+V
-      // repro). Debounce to the settled selection, matching the desktop's
-      // autoSelectionCopy.ts. Best-effort on a cleartext page (the browser may
-      // refuse a non-gesture clipboard write) — Ctrl+C remains the reliable
-      // path there.
-      var selectionCopyTimer = null;
-      term.onSelectionChange(function () {
-        var sel = term.getSelection();
-        if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
-        selectionCopyTimer = setTimeout(function () {
-          selectionCopyTimer = null;
-          if (sel) copyToClipboard(sel);
-        }, 150);
-      });
+      attachTerminalKeys(term, sendInput, !allowInput, function () { return paneAcceptsCsiU(currentSession); });
       // Auto-focus so typing and Ctrl+V work without a click first — a browser
       // only delivers the paste event to the focused xterm textarea.
       if (allowInput) term.focus();
@@ -1348,6 +1418,10 @@
       attention: true,
       meta: function (m) { ensureTerm(m.cols, m.rows); },
       snapshot: function (bytes) {
+        // Snapshot replays the pane's screen, kitty negotiation included —
+        // reset before folding so a protocol the app turned off earlier does
+        // not survive as stale.
+        foldKeyboardState(sessionId, bytes, true);
         if (term) {
           repaint(term, bytes,
             function () { termRepaints += 1; },
@@ -1359,7 +1433,10 @@
         // need no click (a browser only delivers paste to the focused xterm).
         if (allowInput && term) term.focus();
       },
-      data: function (bytes) { if (term) term.write(bytes); },
+      data: function (bytes) {
+        foldKeyboardState(sessionId, bytes, false);
+        if (term) term.write(bytes);
+      },
       exit: function () { setConn('ended', 'ended'); },
       open: function () { setConn('live', 'live'); },
       error: function () { setConn('reconnect', 'reconnecting…'); diagnoseStreamError(); }
@@ -1491,6 +1568,11 @@
         if (tile.repaints > 0) return; // parser reply to a replayed query
         sendTo(tile.sessionId, d);
       });
+      // Same copy/newline/paste handling as the 1-up terminal — Ctrl+C with a
+      // selection must copy here too, never SIGINT the tile's process. Sends go
+      // to THIS tile's pane, not whichever one is focused. Focus policy stays
+      // local (a tile never grabs focus), which is why this is a caller arg.
+      attachTerminalKeys(tile.term, function (d) { sendTo(tile.sessionId, d); }, !allowInput, function () { return paneAcceptsCsiU(tile.sessionId); });
     }
     renderTileHead(tile);
     el.addEventListener('pointerdown', function () { focusTile(tile); });
@@ -1502,6 +1584,9 @@
         rescale();
       },
       snapshot: function (bytes) {
+        // Snapshot replays the pane's screen, kitty negotiation included —
+        // reset before folding (see connect()'s snapshot for the rationale).
+        foldKeyboardState(tile.sessionId, bytes, true);
         if (tile.term) {
           repaint(tile.term, bytes,
             function () { tile.repaints += 1; },
@@ -1510,7 +1595,10 @@
         rescale();
         if (tile.sessionId === currentSession) setConn('live', 'live');
       },
-      data: function (bytes) { if (tile.term) tile.term.write(bytes); },
+      data: function (bytes) {
+        foldKeyboardState(tile.sessionId, bytes, false);
+        if (tile.term) tile.term.write(bytes);
+      },
       exit: function () {
         tile.ended = true;
         renderTileHead(tile);

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -292,7 +292,21 @@
             readOnly: !allowInput
           });
           if (!decision) return true;
-          if (decision.action === 'copy') { copyToClipboard(term.getSelection()); return false; }
+          // Copy: an explicit Ctrl+C must cancel any pending debounced
+          // auto-copy. The user selecting then pressing Ctrl+C within the 150ms
+          // debounce window would otherwise start TWO clipboard writes — the
+          // explicit one now, and the timer's a moment later — and that
+          // concurrent write is exactly the burst that makes Chromium reject
+          // and fall into the blocking legacyCopy path (see the onSelectionChange
+          // comment below). The explicit copy is authoritative; drop the timer.
+          if (decision.action === 'copy') {
+            if (selectionCopyTimer) {
+              clearTimeout(selectionCopyTimer);
+              selectionCopyTimer = null;
+            }
+            copyToClipboard(term.getSelection());
+            return false;
+          }
           // Newline keys (Shift+Enter / Ctrl+Enter / Ctrl+J). preventDefault is
           // required — returning false alone only stops xterm's keydown handler,
           // and the browser's own Shift+Enter default (a newline in the hidden

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -293,20 +293,48 @@
           });
           if (!decision) return true;
           if (decision.action === 'copy') { copyToClipboard(term.getSelection()); return false; }
-          if (decision.action === 'newline') { sendInput(decision.data); return false; }
-          if (decision.action === 'swallow') return false;
+          // Newline keys (Shift+Enter / Ctrl+Enter / Ctrl+J). preventDefault is
+          // required — returning false alone only stops xterm's keydown handler,
+          // and the browser's own Shift+Enter default (a newline in the hidden
+          // textarea) would fire xterm's `input` handler, which sends the
+          // textarea content to the PTY. That appended \n after our CSI-u byte
+          // makes bash submit `;2u` and report a syntax error — the exact bug
+          // the desktop avoids by calling preventDefault (useTerminal.ts).
+          if (decision.action === 'newline') { ev.preventDefault(); sendInput(decision.data); return false; }
+          // 'swallow': consume the key entirely. preventDefault is required so
+          // the browser's own default (Ctrl+D → bookmark dialog) does not fire
+          // on top of our no-op — returning false alone only stops xterm.
+          if (decision.action === 'swallow') { ev.preventDefault(); return false; }
+          // 'paste': xterm must NOT process Ctrl+V (it would encode SYN and
+          // swallow the browser's paste). Returning false tells xterm to step
+          // aside entirely, so the browser's own paste event lands on the
+          // focused xterm textarea — whose native paste listener already sends
+          // it to the pane. Works on cleartext pages, no secure-context API.
+          if (decision.action === 'paste') return false;
           return true;
         } catch (e) {
           console.error('[wmux-web-keys] decision failed:', e);
           return true; // never break normal keys
         }
       });
-      // Select-to-copy, like a local wmux pane: any selection lands on the
-      // clipboard. Best-effort on a cleartext page (the browser may refuse a
-      // non-gesture clipboard write) — Ctrl+C remains the reliable path there.
+      // Select-to-copy, like a local wmux pane. xterm fires onSelectionChange
+      // once per CELL during a drag — a 50-char selection is 50 events — so a
+      // raw per-event copy issues a burst of concurrent writeText calls.
+      // Chromium serializes clipboard writes; the stragglers reject and their
+      // legacyCopy execCommand('copy') blocks synchronously on the clipboard
+      // lock, freezing the page for tens of seconds (select → Ctrl+C → Ctrl+V
+      // repro). Debounce to the settled selection, matching the desktop's
+      // autoSelectionCopy.ts. Best-effort on a cleartext page (the browser may
+      // refuse a non-gesture clipboard write) — Ctrl+C remains the reliable
+      // path there.
+      var selectionCopyTimer = null;
       term.onSelectionChange(function () {
         var sel = term.getSelection();
-        if (sel) copyToClipboard(sel);
+        if (selectionCopyTimer) clearTimeout(selectionCopyTimer);
+        selectionCopyTimer = setTimeout(function () {
+          selectionCopyTimer = null;
+          if (sel) copyToClipboard(sel);
+        }, 150);
       });
       // Auto-focus so typing and Ctrl+V work without a click first — a browser
       // only delivers the paste event to the focused xterm textarea.

--- a/src/daemon/web/frontend/copyPasteKeys.js
+++ b/src/daemon/web/frontend/copyPasteKeys.js
@@ -80,11 +80,27 @@
     // Windows/Linux: Ctrl+C copies ONLY when there is a selection. With an
     // empty selection it must still interrupt the remote process — the whole
     // point of the key, and #895 asks for the selection case, not for SIGINT to
-    // be taken away. Ctrl+V is left to the browser's paste path.
+    // be taken away.
     if (!isMac && bareCtrl && isLetter(ev, 'c', 'KeyC')) {
       return hasSelection ? { action: 'copy' } : null;
     }
-    if (!isMac && bareCtrl && isLetter(ev, 'v', 'KeyV')) return null;
+    // Ctrl+V on Windows/Linux: xterm's keydown path ENCODES Ctrl+V as the SYN
+    // control byte (\x16) and preventDefaults — the browser's native paste
+    // event never fires, so "leave it to the browser" silently does nothing.
+    // Returning { action: 'paste' } makes app.js return false, which xterm
+    // treats as "do not process this key": it neither sends \x16 nor
+    // preventDefaults, so the browser's own Ctrl+V paste lands on the focused
+    // xterm textarea and xterm's native paste listener feeds it to the PTY.
+    // That path works on cleartext pages too — native paste is a browser
+    // default, not a secure-context API. (macOS ⌘V above is already left to
+    // the browser and works, because xterm never intercepts a bare meta key.)
+    if (!isMac && bareCtrl && isLetter(ev, 'v', 'KeyV')) return { action: 'paste' };
+    // Ctrl+D on Windows/Linux: the desktop maps it to split-right, so it never
+    // reaches the PTY — but xterm would encode it as EOF (\x04), exiting the
+    // shell and "closing" the pane on a key the user pressed by accident.
+    // App.js swallows it (preventDefault + do nothing), so an errant Ctrl+D
+    // can never kill a browser pane or trigger a browser action.
+    if (!isMac && bareCtrl && isLetter(ev, 'd', 'KeyD')) return { action: 'swallow' };
 
     // Ctrl+Shift+C — the explicit copy form, on every platform. With no
     // selection it is swallowed rather than forwarded (there is nothing to copy

--- a/src/daemon/web/frontend/copyPasteKeys.js
+++ b/src/daemon/web/frontend/copyPasteKeys.js
@@ -35,6 +35,9 @@
    * @param opts { isMac, hasSelection, readOnly, remoteAcceptsCsiU }
    * @returns null to pass through to xterm/browser; or
    *          { action: 'copy' } — copy the selection to the clipboard;
+   *          { action: 'paste' } — decline the key so xterm neither encodes
+   *            nor preventDefaults it, leaving the browser's own paste to land
+   *            on the focused textarea (see the Ctrl+V branch);
    *          { action: 'newline', data } — send the newline byte to the pane;
    *          { action: 'swallow' } — consume the key, do nothing.
    */

--- a/src/daemon/web/frontend/copyPasteKeys.js
+++ b/src/daemon/web/frontend/copyPasteKeys.js
@@ -32,7 +32,7 @@
    *
    * @param ev KeyboardEvent-like ({ type, key, code, ctrlKey, shiftKey, altKey,
    *            metaKey, isComposing })
-   * @param opts { isMac, hasSelection, readOnly }
+   * @param opts { isMac, hasSelection, readOnly, remoteAcceptsCsiU }
    * @returns null to pass through to xterm/browser; or
    *          { action: 'copy' } — copy the selection to the clipboard;
    *          { action: 'newline', data } — send the newline byte to the pane;
@@ -43,12 +43,22 @@
     var isMac = !!opts.isMac;
     var hasSelection = !!opts.hasSelection;
     var readOnly = !!opts.readOnly;
+    // The pane accepted the kitty keyboard protocol (it emitted a CSI-u push /
+    // set). Only then does `\x1b[13;2u` read as Shift+Enter. A pane that never
+    // negotiated (bash, vim) reads it as ESC followed by `[13;2u` — in vim's
+    // insert mode that leaves insert and runs the rest as normal-mode input.
+    // Un-negotiated, hand the key back to xterm and let it encode the legacy
+    // CR (mirrorInput.ts does the same for the attach mirror, #924).
+    var remoteAcceptsCsiU = !!opts.remoteAcceptsCsiU;
 
     // Shift+Enter → CSI u (`ESC [ 13 ; 2 u`): kitty-protocol apps (Claude Code,
     // codex) insert a newline instead of submitting. Same byte #924's mirror
-    // sends; a read-only host takes nothing.
+    // sends; a read-only host takes nothing; a non-negotiating pane gets the
+    // legacy CR from xterm instead of a byte it would misread.
     if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey && !ev.isComposing) {
-      return readOnly ? { action: 'swallow' } : { action: 'newline', data: '\x1b[13;2u' };
+      if (readOnly) return { action: 'swallow' };
+      if (!remoteAcceptsCsiU) return null;
+      return { action: 'newline', data: '\x1b[13;2u' };
     }
 
     // Ctrl+Enter → LF, same "insert newline, don't submit" intent as Ctrl+J.
@@ -95,12 +105,6 @@
     // default, not a secure-context API. (macOS ⌘V above is already left to
     // the browser and works, because xterm never intercepts a bare meta key.)
     if (!isMac && bareCtrl && isLetter(ev, 'v', 'KeyV')) return { action: 'paste' };
-    // Ctrl+D on Windows/Linux: the desktop maps it to split-right, so it never
-    // reaches the PTY — but xterm would encode it as EOF (\x04), exiting the
-    // shell and "closing" the pane on a key the user pressed by accident.
-    // App.js swallows it (preventDefault + do nothing), so an errant Ctrl+D
-    // can never kill a browser pane or trigger a browser action.
-    if (!isMac && bareCtrl && isLetter(ev, 'd', 'KeyD')) return { action: 'swallow' };
 
     // Ctrl+Shift+C — the explicit copy form, on every platform. With no
     // selection it is swallowed rather than forwarded (there is nothing to copy

--- a/src/daemon/web/frontend/copyPasteKeys.js
+++ b/src/daemon/web/frontend/copyPasteKeys.js
@@ -1,0 +1,100 @@
+/* Copy / paste / newline key decisions for the wmux web browser terminal.
+ *
+ * A browser terminal is a viewer first: every key belongs to the pane it
+ * watches, and anything this side keeps is a deliberate exception — the
+ * editing conveniences that operate on LOCAL state (the selection and the
+ * clipboard) rather than the remote pane. This mirrors what #924 added to the
+ * desktop attach mirror (`mirrorInput.ts`), adapted for a browser: the
+ * decision is pure, and app.js owns the clipboard, the socket, and xterm.
+ *
+ * Pure on purpose, so the table can be tested without a DOM, xterm, or a real
+ * browser — the same split `touchScroll.js` / `pairQuery.js` already use.
+ * Builds inline this file into terminal.html via scripts/build-daemon-web.mjs
+ * and publishes `wmuxWebKeys` on the global for app.js.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) { module.exports = factory(); }
+  else { root.wmuxWebKeys = factory(); }
+})(typeof self !== 'undefined' ? self : this, function () {
+  /**
+   * A key chord matched by BOTH `key` and physical `code`. Under a CJK IME
+   * `key` is a composed jamo or the literal 'Process', so a `key`-only test
+   * silently stops matching — the exact failure useTerminal.ts documents for
+   * its own Ctrl+C branch, and the reason every clipboard chord here carries a
+   * `code` fallback (same rationale as #924's mirrorInput).
+   */
+  function isLetter(e, lower, code) {
+    return e.key === lower || e.key === lower.toUpperCase() || e.code === code;
+  }
+
+  /**
+   * Decide what a keydown means for a browser terminal.
+   *
+   * @param ev KeyboardEvent-like ({ type, key, code, ctrlKey, shiftKey, altKey,
+   *            metaKey, isComposing })
+   * @param opts { isMac, hasSelection, readOnly }
+   * @returns null to pass through to xterm/browser; or
+   *          { action: 'copy' } — copy the selection to the clipboard;
+   *          { action: 'newline', data } — send the newline byte to the pane;
+   *          { action: 'swallow' } — consume the key, do nothing.
+   */
+  function decideWebKey(ev, opts) {
+    if (ev.type !== 'keydown') return null;
+    var isMac = !!opts.isMac;
+    var hasSelection = !!opts.hasSelection;
+    var readOnly = !!opts.readOnly;
+
+    // Shift+Enter → CSI u (`ESC [ 13 ; 2 u`): kitty-protocol apps (Claude Code,
+    // codex) insert a newline instead of submitting. Same byte #924's mirror
+    // sends; a read-only host takes nothing.
+    if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey && !ev.isComposing) {
+      return readOnly ? { action: 'swallow' } : { action: 'newline', data: '\x1b[13;2u' };
+    }
+
+    // Ctrl+Enter → LF, same "insert newline, don't submit" intent as Ctrl+J.
+    // xterm sends a bare CR for Ctrl+Enter — indistinguishable from plain Enter
+    // — so emit LF ourselves so an in-pane TUI adds a line instead of
+    // submitting. (newlineKeys.ts, moved here verbatim in spirit.)
+    if (ev.key === 'Enter' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey && !ev.isComposing) {
+      return readOnly ? { action: 'swallow' } : { action: 'newline', data: '\n' };
+    }
+
+    // Ctrl+J → LF. Keyed on the physical KeyJ so it survives a CJK IME where
+    // `key`/`keyCode` are mangled to 'Process' and xterm's keyCode-based
+    // Ctrl+<letter> path would otherwise drop the keystroke.
+    if (ev.code === 'KeyJ' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey && !ev.isComposing) {
+      return readOnly ? { action: 'swallow' } : { action: 'newline', data: '\n' };
+    }
+
+    var bareMeta = ev.metaKey && !ev.ctrlKey && !ev.altKey && !ev.shiftKey;
+    var bareCtrl = ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey;
+    var ctrlShift = ev.ctrlKey && ev.shiftKey && !ev.altKey && !ev.metaKey;
+
+    // macOS: ⌘C copies and ⌘V pastes, so Ctrl+C stays SIGINT unconditionally.
+    // ⌘V is left to the browser's own paste path (xterm's textarea handles it).
+    if (isMac && bareMeta && isLetter(ev, 'c', 'KeyC')) {
+      return hasSelection ? { action: 'copy' } : null;
+    }
+    if (isMac && bareMeta && isLetter(ev, 'v', 'KeyV')) return null;
+
+    // Windows/Linux: Ctrl+C copies ONLY when there is a selection. With an
+    // empty selection it must still interrupt the remote process — the whole
+    // point of the key, and #895 asks for the selection case, not for SIGINT to
+    // be taken away. Ctrl+V is left to the browser's paste path.
+    if (!isMac && bareCtrl && isLetter(ev, 'c', 'KeyC')) {
+      return hasSelection ? { action: 'copy' } : null;
+    }
+    if (!isMac && bareCtrl && isLetter(ev, 'v', 'KeyV')) return null;
+
+    // Ctrl+Shift+C — the explicit copy form, on every platform. With no
+    // selection it is swallowed rather than forwarded (there is nothing to copy
+    // and no meaningful remote meaning for it).
+    if (ctrlShift && isLetter(ev, 'c', 'KeyC')) {
+      return hasSelection ? { action: 'copy' } : { action: 'swallow' };
+    }
+
+    return null;
+  }
+
+  return { decideWebKey: decideWebKey };
+});

--- a/src/daemon/web/frontend/index.html
+++ b/src/daemon/web/frontend/index.html
@@ -135,6 +135,9 @@
 /*__TOUCH_SCROLL_JS__*/
   </script>
   <script>
+/*__KEYBOARD_PROTOCOL_JS__*/
+  </script>
+  <script>
 /*__KEYS_JS__*/
   </script>
   <script>

--- a/src/daemon/web/frontend/index.html
+++ b/src/daemon/web/frontend/index.html
@@ -135,6 +135,9 @@
 /*__TOUCH_SCROLL_JS__*/
   </script>
   <script>
+/*__KEYS_JS__*/
+  </script>
+  <script>
 /*__APP_JS__*/
   </script>
 </body>

--- a/src/daemon/web/frontend/keyboardProtocol.js
+++ b/src/daemon/web/frontend/keyboardProtocol.js
@@ -1,0 +1,116 @@
+/* Kitty keyboard-protocol negotiation for the wmux web browser terminal.
+ *
+ * A browser terminal is a viewer: it sends Shift+Enter as the CSI-u byte
+ * `\x1b[13;2u`, but that byte only means "newline" to an app that asked for
+ * kitty encodings. A viewer never negotiated with the app it watches, and an
+ * app that did not ask reads it as ESC followed by `[13;2u` — in vim's insert
+ * mode that leaves insert and runs the rest as normal-mode input (where `u` is
+ * undo). The desktop hit the same wall for its attach mirror and solved it in
+ * `keyboardProtocol.ts` + `mirrorInput.ts` (#924); this is that solution
+ * ported to the browser.
+ *
+ * xterm parses DECSET 2004 for us (`term.modes.bracketedPasteMode`) but
+ * exposes nothing about keyboard protocols, so we watch the pane's own output
+ * for the two negotiations that matter — same idea as the bracketed-paste
+ * read, one layer lower.
+ *
+ * Deliberately conservative: unknown state means NOT negotiated, so the
+ * browser falls back to what xterm would have encoded — the behaviour before
+ * any of this existed. A missed negotiation costs a convenience; a false
+ * positive corrupts an editing session.
+ *
+ * Pure on purpose, so the state machine can be tested without a DOM, xterm,
+ * or a real browser — the same split `copyPasteKeys.js` / `touchScroll.js`
+ * use. Builds inline this file into terminal.html via
+ * scripts/build-daemon-web.mjs and publishes `wmuxKeyboardProtocol` on the
+ * global for app.js.
+ */
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) { module.exports = factory(); }
+  else { root.wmuxKeyboardProtocol = factory(); }
+})(typeof self !== 'undefined' ? self : this, function () {
+  // Built via RegExp(...) with a hex escape so the source stays pure-ASCII
+  // while still matching ESC at runtime — mirrors keyboardProtocol.ts.
+  /* eslint-disable no-control-regex */
+  var KITTY_PUSH_OR_SET = new RegExp('\\x1b\\[[>=](\\d*)(?:;\\d+)?u', 'g');
+  var KITTY_POP = new RegExp('\\x1b\\[<\\d*u', 'g');
+  var MODIFY_OTHER_KEYS = new RegExp('\\x1b\\[>4;([0-2])m', 'g');
+  /* eslint-enable no-control-regex */
+
+  var INITIAL_STATE = { kitty: false, modifyOtherKeys: 0 };
+
+  /**
+   * Fold one chunk of pane output into the keyboard state.
+   *
+   * Pure: takes the previous state, returns the next one. A chunk that says
+   * nothing about keyboards returns the same object, so callers can compare by
+   * reference to skip work.
+   *
+   * A sequence split across two chunks is missed. That is the conservative
+   * direction (no negotiation seen → send the legacy byte) and the alternative
+   * — carrying a partial-sequence buffer — would have to be correct about every
+   * escape shape to avoid holding bytes forever.
+   *
+   * @param {{kitty: boolean, modifyOtherKeys: number}} prev
+   * @param {Uint8Array|string} bytes pane output bytes (or latin1 string).
+   * @returns the next state (same reference when nothing changed).
+   */
+  function foldRemoteKeyboardState(prev, bytes) {
+    // Pane bytes are raw; a latin1 view is exact for these pure-ASCII
+    // sequences and cannot corrupt what xterm receives (we never write this
+    // string back).
+    var chunk = typeof bytes === 'string'
+      ? bytes
+      : Array.from(bytes, function (b) { return String.fromCharCode(b); }).join('');
+    if (chunk.indexOf('\x1b[') < 0) return prev;
+
+    var kitty = prev.kitty;
+    var modifyOtherKeys = prev.modifyOtherKeys;
+    var events = [];
+
+    // Walk in order so a push followed by a pop inside one chunk lands on the
+    // later one rather than on whichever regex ran last.
+    KITTY_PUSH_OR_SET.lastIndex = 0;
+    var m;
+    while ((m = KITTY_PUSH_OR_SET.exec(chunk)) !== null) {
+      var flags = m[1] === '' ? 0 : Number(m[1]);
+      events.push({ index: m.index, apply: function () { kitty = flags > 0; } });
+    }
+    KITTY_POP.lastIndex = 0;
+    while ((m = KITTY_POP.exec(chunk)) !== null) {
+      events.push({ index: m.index, apply: function () { kitty = false; } });
+    }
+    MODIFY_OTHER_KEYS.lastIndex = 0;
+    while ((m = MODIFY_OTHER_KEYS.exec(chunk)) !== null) {
+      var level = Number(m[1]);
+      events.push({ index: m.index, apply: function () { modifyOtherKeys = level; } });
+    }
+
+    if (events.length === 0) return prev;
+    events.sort(function (a, b) { return a.index - b.index; });
+    for (var i = 0; i < events.length; i++) events[i].apply();
+
+    var changed = kitty !== prev.kitty || modifyOtherKeys !== prev.modifyOtherKeys;
+    return changed ? { kitty: kitty, modifyOtherKeys: modifyOtherKeys } : prev;
+  }
+
+  /**
+   * Whether the pane will understand the CSI-u bytes we encode ourselves.
+   *
+   * Only kitty. modifyOtherKeys mode 2 wants `CSI 27 ; ... ~` instead, so
+   * sending CSI-u there would be the same category of mistake this file exists
+   * to prevent.
+   *
+   * @param {{kitty: boolean}} state the current keyboard state.
+   * @returns {boolean} true when CSI-u is safe to send.
+   */
+  function acceptsCsiU(state) {
+    return state.kitty;
+  }
+
+  return {
+    INITIAL_STATE: INITIAL_STATE,
+    foldRemoteKeyboardState: foldRemoteKeyboardState,
+    acceptsCsiU: acceptsCsiU
+  };
+});


### PR DESCRIPTION
## Summary

The wmux web browser terminal forwarded every keystroke straight to the pane, so editing conveniences that operate on **local** state never worked: Ctrl+C was always SIGINT, Shift+Enter submitted instead of inserting a newline, and there was no select-to-copy. This PR brings the browser terminal to parity with the attach mirror (#924).

## Changes

- **`copyPasteKeys.js`** (new): pure key-decision module (mirrors #924's `mirrorInput`) — Ctrl+C **with a selection copies, else SIGINT**; Shift+Enter / Ctrl+Enter / Ctrl+J send the newline byte (`\x1b[13;2u` / `\n`); ⌘C/⌘V on macOS; everything else passes through.
- **`app.js`**: attaches the decision via `term.attachCustomKeyEventHandler()` — attached as a **METHOD**, since xterm ignores it as a constructor option — guarded with try/catch so a decision failure can never break typing. Plus select-to-copy (`onSelectionChange`), auto-focus on load / pane switch, and click-anywhere focus so browser paste (Ctrl+V) reaches the xterm textarea.
- Clipboard writes fall back to `textarea`+`execCommand` on a cleartext `--expose` page (where `navigator.clipboard` is unavailable).
- `index.html` / `build-daemon-web.mjs`: inline `copyPasteKeys.js` (CSP gate 5 → 6 scripts).

## Test plan

- `copyPasteKeys.test.ts`: 18 unit tests over the shipped bytes (same pattern as `touchScroll.js`).
- **Verified locally with `npm start`** against the real desktop daemon + browser:
  - Ctrl+V pastes into the pane; select-to-copy and Ctrl+C-with-selection copy to the clipboard.
  - Select → Ctrl+C → immediate Ctrl+V does not freeze the page (the auto-copy write is debounced).
  - Ctrl+D is swallowed — it no longer exits the browser pane's shell (no EOF) and no browser bookmark dialog appears.
  - Shift+Enter / Ctrl+Enter in a plain bash pane show the CSI-u byte without a `bash: syntax error` (the browser's extra newline is preventDefault'd); in Claude Code they insert a newline without submitting.
- All four fixes were dogfooded on the cleartext `--expose` page against the local dev daemon, the exact environment the earlier draft could not verify.

## CHANGELOG entry

### Added

- The wmux web browser terminal now supports select-to-copy, Ctrl+C-with-selection copy, Ctrl+V paste, and Shift+Enter / Ctrl+Enter newline, matching the local terminal and the attach mirror (#924).

## Related

- Mirrors #924 (attach mirror input) for the browser terminal; same class of issue as #895.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added browser terminal clipboard support, including select-to-copy, keyboard shortcuts, and paste.
* Added Shift+Enter, Ctrl+Enter, and Ctrl+J newline input behavior.
* Applied consistent keyboard handling across single and split terminal views.
* Improved terminal focus retention after page interactions.

## Bug Fixes

* Improved platform-specific copy handling and clipboard fallbacks.
* Prevented duplicate newlines and handled Ctrl+D appropriately.
* Preserved expected behavior during IME composition and read-only sessions.
* Improved keyboard protocol detection and fallback behavior.
* Preserved normal key behavior and interrupt shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
