### PR TITLE
Decide a pane's agent from process truth, not screen text

### DIFF
--- a/changelog.d/932.md
+++ b/changelog.d/932.md
@@ -1,18 +1,21 @@
 ### Fixed
 
-- **A pane's agent label now comes from process truth, not screen text.** The
+- **A pane's agent label now prefers process truth over screen text.** The
   label, roster entry, and status events for a pane are decided by a
   precedence of signals — a corroborated or fresh hook self-report first, then
   the live attributed agent process, and only then what the terminal happened
-  to print. A confirmed-dead same-slug read on screen is treated as sticky
-  residue instead of relabeling the dead agent "alive". This fixes the class
-  of mislabels where a Grok pane was shown as Claude: the screen gates cannot
-  tell an agent from a sentence about an agent, and until now they were the
-  only identity source. (#932)
+  to print. Screen text still names the pane when nothing stronger is
+  available, which is what remote and SSH panes rely on. A confirmed-dead
+  same-slug read on screen is treated as sticky residue instead of relabeling
+  the dead agent "alive". This fixes the class of mislabels where a Grok pane
+  was shown as Claude: the screen gates cannot tell an agent from a sentence
+  about an agent, and until now they were the only identity source. (#932)
 
 - **Detector notifications contradicted by a live agent of another kind are
   suppressed.** A screen-detected "agent finished" that disagrees with the
   pane's hook- or process-backed identity no longer notifies, and the pane's
-  label self-heals on the next output burst. The 30-minute detector veto also
-  expires with the launch that earned it, so a relaunched agent with broken
-  hooks gets its completions through. (#932)
+  label self-heals on the next output burst. A banner this build cannot map to
+  a known agent is not treated as a disagreement, so an unrecognised name never
+  costs a pane its status updates. The 30-minute detector veto is scoped to the
+  agent launch that earned it and expires when that process is seen to die, so
+  a relaunched agent with broken hooks gets its completions through. (#932)

--- a/changelog.d/932.md
+++ b/changelog.d/932.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **A pane's agent label now comes from process truth, not screen text.** The
+  label, roster entry, and status events for a pane are decided by a
+  precedence of signals — a corroborated or fresh hook self-report first, then
+  the live attributed agent process, and only then what the terminal happened
+  to print. A confirmed-dead same-slug read on screen is treated as sticky
+  residue instead of relabeling the dead agent "alive". This fixes the class
+  of mislabels where a Grok pane was shown as Claude: the screen gates cannot
+  tell an agent from a sentence about an agent, and until now they were the
+  only identity source. (#932)
+
+- **Detector notifications contradicted by a live agent of another kind are
+  suppressed.** A screen-detected "agent finished" that disagrees with the
+  pane's hook- or process-backed identity no longer notifies, and the pane's
+  label self-heals on the next output burst. The 30-minute detector veto also
+  expires with the launch that earned it, so a relaunched agent with broken
+  hooks gets its completions through. (#932)

--- a/src/daemon/AgentProcessTracker.ts
+++ b/src/daemon/AgentProcessTracker.ts
@@ -1,6 +1,7 @@
 /**
  * Edge-triggered "is this pane's agent process still alive?" tracker — the
- * process-truth gate for the persistent resume chip (ResumeInfoChip).
+ * process-truth gate for the persistent resume chip (ResumeInfoChip) and,
+ * since #919, tier-2 of the pane's canonical agent identity.
  *
  * Problem it solves: on panes WITHOUT OSC 133 shell integration the chip's
  * only busy signal was a decaying activity heuristic (HOOK_RUNNING_TTL_MS).
@@ -11,36 +12,57 @@
  * and flip exactly once, on the alive→dead transition, no matter how the
  * agent exits (double Ctrl+C, /exit, Ctrl+D, crash).
  *
+ * Identity (#919): the picked process now also answers WHICH agent runs in
+ * the pane — a native agent stem (`claude`, `grok`, …) or a runtime whose
+ * command line resolves to one (`node …/@anthropic-ai/claude-code/cli.js`).
+ * identityFor() feeds the canonical tier rule (src/daemon/canonicalAgent.ts);
+ * a slugless pick (unknown wrapper, direct child) still answers liveness
+ * only, which is all the resume chip ever needed.
+ *
  * Mechanism:
  *  1. arm(sessionId, shellPid) — called when something PROVES the agent is
  *     running right now (a claude hook reaching daemon.setResumeBinding, or
  *     a live AgentDetector banner). Takes ONE process-table snapshot
- *     (pid/ppid/name), walks the pane shell's descendant tree, and picks the
- *     agent process (see selectAgentPid).
+ *     (pid/ppid/name/cmdline), walks the pane shell's descendant tree, and
+ *     picks the agent process (see selectAgentProcess). rearm() is the
+ *     forced variant for conflicting-agent evidence (the old pick's death
+ *     poll can lag a fresh launch by up to one ProcessMonitor cadence).
  *  2. The picked PID is handed to the daemon's existing ProcessMonitor batch
  *     (one shared tasklist per tick — no new spawn train; #538 discipline),
  *     which also guards against PID reuse via image-name identity.
  *  3. onDead → the session's state flips to alive=false and STAYS false until
- *     a fresh arm() (agent relaunched → new hook/banner) re-probes.
+ *     a fresh arm()/rearm() (agent relaunched → new hook/banner) re-probes.
+ *     The flip also fires the state-change listener so the daemon can expire
+ *     the pane's hook authority and recompute canonical identity.
  *
- * statusFor() is tri-state on purpose: `undefined` (never armed / couldn't
- * attribute) keeps the renderer on its old heuristic, so this tracker only
- * ever REPLACES guesswork with process truth — it never invents a state.
+ * statusFor()/identityFor() are tri-state on purpose: `undefined` (never
+ * armed / couldn't attribute) keeps the renderer on its old heuristic, so
+ * this tracker only ever REPLACES guesswork with process truth — it never
+ * invents a state. Both are synchronous map reads; the ONLY enumeration
+ * lives inside arm()/rearm().
  *
  * Cost: one process-table enumeration per agent LAUNCH per pane (not per
- * poll), then a piggyback ride on the ProcessMonitor cadence.
+ * poll), then a piggyback ride on the ProcessMonitor cadence. Unattributable
+ * or failed probes back off for ARM_BACKOFF_MS so a chatty banner cannot
+ * re-run `ps` per event.
  */
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
+import { AGENT_SLUG_SET, type AgentSlug } from '../shared/agentIdentity';
 
 const execFileAsync = promisify(execFile);
 
 export interface ProcessTreeEntry {
   pid: number;
   ppid: number;
-  /** Executable image name (basename), platform-cased. */
+  /** Executable image name (basename). On POSIX derived from argv[0] of the
+   *  args column — `comm` was dropped (macOS prints the full path there and
+   *  spaces in it misalign every column). */
   name: string;
+  /** Full command line (POSIX args / Windows CommandLine) when available —
+   *  the input for runtime→agent resolution. */
+  cmdline?: string;
 }
 
 /** The watcher surface the tracker needs — ProcessMonitor satisfies it
@@ -50,15 +72,35 @@ export interface PidWatcher {
   unwatch(key: string): void;
 }
 
-/** Agent launcher binaries (native installs): a descendant with one of these
- *  stems IS the agent — the strongest possible attribution. */
-const AGENT_STEMS: ReadonlySet<string> = new Set(['claude', 'codex']);
+/** Native agent stems derive from the identity table (#919: the old
+ *  hand-written two-entry set was 2 of 9 agents and a second list to drift).
+ *  Membership test uses AGENT_SLUG_SET (ReadonlySet<string>) so raw stems
+ *  narrow without a cast dance. */
+const RUNTIME_STEMS: ReadonlySet<string> = new Set(['node', 'bun', 'deno', 'python', 'python3']);
 
-/** JS/TS runtime stems: an npm-installed agent runs as `node` (via a cmd shim
- *  on Windows), so the SHALLOWEST runtime in the tree is the CLI itself —
- *  deeper ones are its children (MCP servers), which the agent can restart
- *  mid-session and must not be watched. */
-const RUNTIME_STEMS: ReadonlySet<string> = new Set(['node', 'bun', 'deno']);
+/** Package-manager runners: when the script token is one of these (or
+ *  python's `-m`), the agent name rides the NEXT non-flag argument
+ *  (`npx -y gemini`, `python -m aider`). */
+const RUNNER_STEMS: ReadonlySet<string> = new Set(['npx', 'npx-cli', 'bunx', 'yarn']);
+
+/** Launcher-package spellings → slug. Keys are npm package names, values are
+ *  table slugs — the aliases belong here (they are launcher trivia), not in
+ *  agentIdentity.ts. */
+const ALIAS_TO_SLUG: ReadonlyMap<string, AgentSlug> = new Map([
+  ['claude-code', 'claude'],
+  ['@anthropic-ai/claude-code', 'claude'],
+  ['gemini-cli', 'gemini'],
+  ['@google/gemini-cli', 'gemini'],
+]);
+
+/** How long an unattributable/failed probe keeps `arm()` from re-enumerating
+ *  (#919 panel: without this, a chatty banner re-runs `ps` per event). */
+const ARM_BACKOFF_MS = 30_000;
+
+/** Forced re-probes are stronger evidence than a plain arm, but still
+ *  rate-limited: repeated conflicting banners against an OLD pick that keeps
+ *  winning add no new information. */
+const REARM_COOLDOWN_MS = 10_000;
 
 /** `claude.exe` → `claude`; `C:\...\node.EXE` → `node`; `pwsh` → `pwsh`. */
 function imageStem(name: string): string {
@@ -67,61 +109,173 @@ function imageStem(name: string): string {
 }
 
 /**
- * Parse the normalized `pid|ppid|name` lines produced by the Windows
- * enumeration script. Malformed lines (PowerShell banners, blank tails) are
- * skipped. Pure — exported for unit tests.
+ * Quote-aware command-line tokenizer. Windows CommandLine carries quoted
+ * paths (`"C:\Program Files\node.exe" …`) that a bare whitespace split would
+ * tear apart. Escaped quotes are not handled — agent command lines don't
+ * carry them. Pure — exported for unit tests.
+ */
+export function tokenizeCmdline(cmdline: string): string[] {
+  const tokens: string[] = [];
+  let cur = '';
+  let quote: '"' | "'" | null = null;
+  for (const ch of cmdline) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else cur += ch;
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (ch === ' ' || ch === '\t') {
+      if (cur) {
+        tokens.push(cur);
+        cur = '';
+      }
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur) tokens.push(cur);
+  return tokens;
+}
+
+/** Token → lookup form: basename (separators split, which also unwraps
+ *  `@scope/pkg` → `pkg`), lowercased, script/binary extension stripped. */
+function lookupForm(token: string): string {
+  const base = token.split(/[\\/]/).pop() ?? '';
+  return base.toLowerCase().replace(/\.(js|mjs|cjs|exe|cmd|bat|py|pyw)$/, '');
+}
+
+/**
+ * Resolve a runtime-hosted process (`node …`, `python …`) to an agent slug
+ * from its command line. Token discipline (#919 panel): ONLY these
+ * candidates are ever matched —
+ *   • the script token right after the runtime (`argv[1]`),
+ *   • the first non-flag token after a package runner or `python -m`,
+ *   • the `node_modules/<pkg>` / `node_modules/@scope/<pkg>` boundary of any
+ *     of the above.
+ * Arbitrary ancestor directories NEVER match: `node /work/claude/scratch.js`
+ * must not resolve claude, and `node demo.js claude` must not either (the
+ * trailing positional is never a candidate). Every candidate must EQUAL a
+ * slug stem or alias key — no substrings, no prefixes. Pure — exported for
+ * unit tests.
+ */
+export function resolveAgentSlug(cmdline: string | undefined): AgentSlug | undefined {
+  if (!cmdline) return undefined;
+  const argv = tokenizeCmdline(cmdline);
+  if (argv.length < 2) return undefined;
+  const candidates: string[] = [argv[1]];
+  const form0 = lookupForm(argv[0]);
+  const form1 = lookupForm(argv[1]);
+  // Package runners and `python -m`: the agent name rides the next non-flag
+  // positional AFTER the runner token — index 1 when the runner is the image
+  // itself (shebang `npx -y gemini`), index 2 when a runtime hosts the runner
+  // script (`node …/npx-cli.js -y gemini`).
+  const scanFrom =
+    RUNNER_STEMS.has(form0) || form0 === '-m' ? 1
+      : RUNNER_STEMS.has(form1) || form1 === '-m' ? 2
+        : -1;
+  if (scanFrom >= 0) {
+    const next = argv.slice(scanFrom).find((t) => !t.startsWith('-'));
+    if (next) candidates.push(next);
+  }
+  for (const c of [...candidates]) {
+    const idx = c.lastIndexOf('node_modules');
+    if (idx === -1) continue;
+    const segs = c.slice(idx + 'node_modules'.length).split(/[\\/]/).filter(Boolean);
+    if (segs.length > 0) {
+      candidates.push(
+        segs[0].startsWith('@') && segs.length > 1 ? `${segs[0]}/${segs[1]}` : segs[0],
+      );
+    }
+  }
+  for (const c of candidates) {
+    const form = lookupForm(c);
+    if (AGENT_SLUG_SET.has(form)) return form as AgentSlug;
+    const alias = ALIAS_TO_SLUG.get(form);
+    if (alias) return alias;
+  }
+  return undefined;
+}
+
+/**
+ * Parse the normalized `pid|ppid|name|cmdline` lines produced by the Windows
+ * enumeration script. CommandLine may itself contain pipes, so everything
+ * after the image name joins back into the cmdline. Malformed lines
+ * (PowerShell banners, blank tails) are skipped. Pure — exported for tests.
  */
 export function parsePipeDelimited(stdout: string): ProcessTreeEntry[] {
   const entries: ProcessTreeEntry[] = [];
   for (const line of stdout.split('\n')) {
     const m = line.trim().match(/^(\d+)\|(\d+)\|(.+)$/);
     if (!m) continue;
-    entries.push({ pid: parseInt(m[1], 10), ppid: parseInt(m[2], 10), name: m[3] });
+    const parts = m[3].split('|');
+    const cmdline = parts.slice(1).join('|');
+    entries.push({
+      pid: parseInt(m[1], 10),
+      ppid: parseInt(m[2], 10),
+      name: parts[0] ?? '',
+      ...(cmdline ? { cmdline } : {}),
+    });
   }
   return entries;
 }
 
 /**
- * Parse `ps -axo pid=,ppid=,comm=` output. `comm` may be a full path on
- * macOS — the stem logic basenames it later, so it is kept verbatim here.
- * Pure — exported for unit tests.
+ * Parse `ps -axo pid=,ppid=,args=` output. `comm` is gone entirely (macOS
+ * comm is a full path; spaces in it misaligned every column) — argv[0] (the
+ * first whitespace token of args) carries the image, the whole tail is the
+ * cmdline. Known limit: an argv[0] containing spaces is unparseable; agent
+ * binaries don't ship in spaced paths. Pure — exported for unit tests.
  */
 export function parsePsOutput(stdout: string): ProcessTreeEntry[] {
   const entries: ProcessTreeEntry[] = [];
   for (const line of stdout.split('\n')) {
     const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
     if (!m) continue;
-    entries.push({ pid: parseInt(m[1], 10), ppid: parseInt(m[2], 10), name: m[3] });
+    const cmdline = m[3];
+    const argv0 = cmdline.split(/\s+/)[0] ?? cmdline;
+    entries.push({ pid: parseInt(m[1], 10), ppid: parseInt(m[2], 10), name: argv0, cmdline });
   }
   return entries;
 }
 
+/** The picked process: `pid` always (liveness), `slug` only when the image
+ *  or command line identifies the agent. */
+export interface AgentProcessPick {
+  pid: number;
+  slug?: AgentSlug;
+}
+
 /**
  * Pick the agent process among `shellPid`'s descendants:
- *   1. the shallowest descendant whose stem is a known agent binary
- *      (`claude.exe` — native installs), else
- *   2. the shallowest descendant whose stem is a JS runtime (`node` — npm
- *      installs run through a cmd shim, so the CLI sits at depth 2; its own
- *      node children are MCP servers and must NOT be picked), else
+ *   1. the SHALLOWEST descendant that RESOLVES to an agent — native stem
+ *      (`claude`) or slug-resolved runtime (`node …/claude-code/cli.js`)
+ *      compared by depth regardless of class (#919 panel: the old
+ *      native-beats-runtime priority let a deeper native MCP-server binary
+ *      steal the identity from a shallower node-hosted primary CLI),
+ *   2. the shallowest UNRESOLVED runtime (a `node` we cannot name — watch
+ *      it for death, claim no identity),
  *   3. the first DIRECT child (depth 1) — an unknown wrapper still dies with
- *      the foreground command, so its death is the same edge, else
+ *      the foreground command, so its death is the same edge,
  *   4. undefined — nothing attributable (the caller stays undecided).
  *
- * BFS with a visited set: Windows PPIDs can be stale/reused and form cycles.
- * Pure — exported for unit tests.
+ * An exact-depth tie between two DIFFERENT slugs is ambiguous (two agents at
+ * equal depth) → the pick keeps the pid for the death edge but drops the slug
+ * rather than guessing. BFS with a visited set: Windows PPIDs can be
+ * stale/reused and form cycles. Pure — exported for unit tests.
  */
-export function selectAgentPid(
+export function selectAgentProcess(
   entries: ReadonlyArray<ProcessTreeEntry>,
   shellPid: number,
-): number | undefined {
+): AgentProcessPick | undefined {
   const byParent = new Map<number, ProcessTreeEntry[]>();
   for (const e of entries) {
     const list = byParent.get(e.ppid);
     if (list) list.push(e);
     else byParent.set(e.ppid, [e]);
   }
-  let agentHit: { pid: number; depth: number } | undefined;
-  let runtimeHit: { pid: number; depth: number } | undefined;
+  let attributed: { pid: number; depth: number; slug: AgentSlug } | undefined;
+  let ambiguous = false;
+  let sluglessRuntime: { pid: number; depth: number } | undefined;
   let directChild: number | undefined;
   const visited = new Set<number>([shellPid]);
   const queue: Array<{ pid: number; depth: number }> = [{ pid: shellPid, depth: 0 }];
@@ -133,21 +287,34 @@ export function selectAgentPid(
       const childDepth = depth + 1;
       if (childDepth === 1 && directChild === undefined) directChild = child.pid;
       const stem = imageStem(child.name);
-      if (AGENT_STEMS.has(stem) && (!agentHit || childDepth < agentHit.depth)) {
-        agentHit = { pid: child.pid, depth: childDepth };
-      } else if (RUNTIME_STEMS.has(stem) && (!runtimeHit || childDepth < runtimeHit.depth)) {
-        runtimeHit = { pid: child.pid, depth: childDepth };
+      const slug = AGENT_SLUG_SET.has(stem)
+        ? (stem as AgentSlug)
+        : RUNTIME_STEMS.has(stem)
+          ? resolveAgentSlug(child.cmdline)
+          : undefined;
+      if (slug) {
+        if (!attributed || childDepth < attributed.depth) {
+          attributed = { pid: child.pid, depth: childDepth, slug };
+          ambiguous = false;
+        } else if (childDepth === attributed.depth && slug !== attributed.slug) {
+          ambiguous = true;
+        }
+      } else if (RUNTIME_STEMS.has(stem) && (!sluglessRuntime || childDepth < sluglessRuntime.depth)) {
+        sluglessRuntime = { pid: child.pid, depth: childDepth };
       }
       queue.push({ pid: child.pid, depth: childDepth });
     }
   }
-  return agentHit?.pid ?? runtimeHit?.pid ?? directChild;
+  if (attributed) return ambiguous ? { pid: attributed.pid } : { pid: attributed.pid, slug: attributed.slug };
+  if (sluglessRuntime) return { pid: sluglessRuntime.pid };
+  return directChild !== undefined ? { pid: directChild } : undefined;
 }
 
-/** One full process-table snapshot (pid/ppid/name). Windows has no PPID in
- *  tasklist, so this shells out to Windows PowerShell 5.1 (always present,
- *  absolute System32 path — no PATH trust) for a single CIM enumeration.
- *  POSIX uses one `ps`. Throws on failure — the caller stays undecided. */
+/** One full process-table snapshot (pid/ppid/name[/cmdline]). Windows has no
+ *  PPID in tasklist, so this shells out to Windows PowerShell 5.1 (always
+ *  present, absolute System32 path — no PATH trust) for a single CIM
+ *  enumeration. POSIX uses one `ps`. Throws on failure — the caller stays
+ *  undecided. */
 async function enumerateProcesses(): Promise<ProcessTreeEntry[]> {
   if (process.platform === 'win32') {
     const psPath = path.join(
@@ -159,8 +326,9 @@ async function enumerateProcesses(): Promise<ProcessTreeEntry[]> {
       [
         '-NoProfile', '-NonInteractive', '-Command',
         // Pipe-delimited to keep the parser trivial (image names never
-        // contain '|'). Win32_Process is one WMI query — no per-PID walks.
-        "Get-CimInstance -ClassName Win32_Process | ForEach-Object { '{0}|{1}|{2}' -f $_.ProcessId, $_.ParentProcessId, $_.Name }",
+        // contain '|'; CommandLine may — the parser rejoins it). Win32_Process
+        // is one WMI query — no per-PID walks.
+        "Get-CimInstance -ClassName Win32_Process | ForEach-Object { '{0}|{1}|{2}|{3}' -f $_.ProcessId, $_.ParentProcessId, $_.Name, $_.CommandLine }",
       ],
       { encoding: 'utf-8', timeout: 10_000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 },
     );
@@ -168,7 +336,7 @@ async function enumerateProcesses(): Promise<ProcessTreeEntry[]> {
   }
   const { stdout } = await execFileAsync(
     'ps',
-    ['-axo', 'pid=,ppid=,comm='],
+    ['-axo', 'pid=,ppid=,args='],
     { encoding: 'utf-8', timeout: 10_000, maxBuffer: 8 * 1024 * 1024 },
   );
   return parsePsOutput(stdout as string);
@@ -177,19 +345,36 @@ async function enumerateProcesses(): Promise<ProcessTreeEntry[]> {
 interface TrackedAgent {
   pid: number;
   alive: boolean;
+  slug?: AgentSlug;
+}
+
+/** Identity/liveness snapshot handed to the state-change listener. */
+export interface TrackedAgentState {
+  slug?: AgentSlug;
+  alive: boolean;
 }
 
 export class AgentProcessTracker {
   private readonly states = new Map<string, TrackedAgent>();
-  /** In-flight arm() per session — coalesces the hook-storm case (a claude
-   *  turn can fire several hooks back-to-back) into one probe. */
+  /** In-flight probe per session — coalesces the hook-storm case (a claude
+   *  turn can fire several hooks back-to-back) into one enumeration. */
   private readonly inFlight = new Set<string>();
-  /** Bumped by disarm(); an arm() that resolves after its session was
+  /** Bumped by disarm(); a probe that resolves after its session was
    *  disarmed must not resurrect state for a destroyed pane. */
   private readonly generation = new Map<string, number>();
-  /** Shared snapshot promise — concurrent arms across sessions ride one
+  /** Last shell pid per session — a force-queued rearm replays against it. */
+  private readonly shellPids = new Map<string, number>();
+  /** Negative cache: last unattributable/failed probe per session (#919
+   *  panel — bounds re-enumeration on chatty banners). */
+  private readonly lastFailedAt = new Map<string, number>();
+  /** Last forced rearm per session (cooldown clock). */
+  private readonly lastRearmAt = new Map<string, number>();
+  /** rearm() called while a probe was in flight → replay once it lands. */
+  private readonly forceQueued = new Set<string>();
+  /** Shared snapshot promise — concurrent probes across sessions ride one
    *  enumeration instead of spawning one each. */
   private snapshotInFlight: Promise<ProcessTreeEntry[]> | null = null;
+  private stateListener: ((sessionId: string, state: TrackedAgentState) => void) | undefined;
 
   constructor(
     private readonly watcher: PidWatcher,
@@ -202,14 +387,59 @@ export class AgentProcessTracker {
     return `agent:${sessionId}`;
   }
 
+  /** Daemon wiring point for #919: attribution completion and the
+   *  alive→false edge both re-evaluate canonical identity and expire hook
+   *  authority (see daemon/index.ts). */
+  setStateChangeListener(cb: (sessionId: string, state: TrackedAgentState) => void): void {
+    this.stateListener = cb;
+  }
+
+  private emitState(sessionId: string, state: TrackedAgentState): void {
+    try {
+      this.stateListener?.(sessionId, state);
+    } catch {
+      // Listener errors must never break tracking.
+    }
+  }
+
   /**
    * (Re)attach to the session's live agent process. Fire-and-forget: callers
    * sit on hot paths (hook RPC, banner event) and must not await a probe.
-   * No-op while a live agent is already being watched — the probe runs once
-   * per agent LAUNCH, not per hook.
+   * No-op while a live agent is already being watched or within the failure
+   * backoff — the probe runs once per agent LAUNCH, not per hook.
    */
   arm(sessionId: string, shellPid: number): void {
+    this.shellPids.set(sessionId, shellPid);
     if (this.states.get(sessionId)?.alive) return;
+    const failedAt = this.lastFailedAt.get(sessionId);
+    if (failedAt !== undefined && Date.now() - failedAt < ARM_BACKOFF_MS) return;
+    this.probe(sessionId, shellPid);
+  }
+
+  /**
+   * FORCED probe for conflicting-agent evidence: a banner/hook naming a
+   * DIFFERENT agent than the tracked one is launch evidence that invalidates
+   * the "already alive" assumption — the old pick's death poll can lag a
+   * fresh launch by up to one ProcessMonitor cadence (≤28 s), during which
+   * plain arm() would no-op and keep the dead slug winning. Bypasses the
+   * failure backoff (explicit evidence beats it) but rate-limits itself:
+   * repeated conflicting banners against a pick that keeps winning add
+   * nothing new.
+   */
+  rearm(sessionId: string, shellPid: number): void {
+    this.shellPids.set(sessionId, shellPid);
+    const last = this.lastRearmAt.get(sessionId);
+    if (last !== undefined && Date.now() - last < REARM_COOLDOWN_MS) return;
+    this.lastRearmAt.set(sessionId, Date.now());
+    this.lastFailedAt.delete(sessionId);
+    if (this.inFlight.has(sessionId)) {
+      this.forceQueued.add(sessionId);
+      return;
+    }
+    this.probe(sessionId, shellPid);
+  }
+
+  private probe(sessionId: string, shellPid: number): void {
     if (this.inFlight.has(sessionId)) return;
     this.inFlight.add(sessionId);
     const gen = this.generation.get(sessionId) ?? 0;
@@ -217,21 +447,40 @@ export class AgentProcessTracker {
       try {
         const entries = await this.snapshot();
         if ((this.generation.get(sessionId) ?? 0) !== gen) return; // disarmed meanwhile
-        const agentPid = selectAgentPid(entries, shellPid);
+        const pick = selectAgentProcess(entries, shellPid);
         // No attributable descendant (agent already gone, or an exotic launch
         // we can't see) → stay undecided so the renderer keeps its heuristic.
-        if (agentPid === undefined) return;
-        this.states.set(sessionId, { pid: agentPid, alive: true });
-        this.watcher.watch(AgentProcessTracker.watchKey(sessionId), agentPid, () => {
-          const cur = this.states.get(sessionId);
-          // Only the SAME watched pid may flip the flag — a re-arm that
-          // landed after this watch was superseded must win.
-          if (cur && cur.pid === agentPid) cur.alive = false;
+        if (!pick) {
+          this.lastFailedAt.set(sessionId, Date.now());
+          return;
+        }
+        this.states.set(sessionId, {
+          pid: pick.pid,
+          alive: true,
+          ...(pick.slug ? { slug: pick.slug } : {}),
         });
+        this.watcher.watch(AgentProcessTracker.watchKey(sessionId), pick.pid, () => {
+          const cur = this.states.get(sessionId);
+          // Only the SAME watched pid may flip the flag — a re-probe that
+          // landed after this watch was superseded must win.
+          if (cur && cur.pid === pick.pid) {
+            cur.alive = false;
+            this.emitState(sessionId, {
+              ...(cur.slug ? { slug: cur.slug } : {}),
+              alive: false,
+            });
+          }
+        });
+        this.emitState(sessionId, { ...(pick.slug ? { slug: pick.slug } : {}), alive: true });
       } catch {
         // Enumeration failed (timeout, spawn error) — undecided, never a lie.
+        this.lastFailedAt.set(sessionId, Date.now());
       } finally {
         this.inFlight.delete(sessionId);
+        if (this.forceQueued.delete(sessionId)) {
+          const pid = this.shellPids.get(sessionId);
+          if (pid !== undefined) this.rearm(sessionId, pid);
+        }
       }
     })();
   }
@@ -242,11 +491,24 @@ export class AgentProcessTracker {
     return this.states.get(sessionId)?.alive;
   }
 
+  /** #919 tier-2 input: the attributed process's identity and liveness.
+   *  Synchronous map read — NEVER enumerates. `slug` undefined = slugless
+   *  pick (wrapper/direct child): answers liveness, claims no name. */
+  identityFor(sessionId: string): TrackedAgentState | undefined {
+    const s = this.states.get(sessionId);
+    if (!s) return undefined;
+    return { ...(s.slug ? { slug: s.slug } : {}), alive: s.alive };
+  }
+
   /** Drop all tracking for a session (died / interrupted / killed). */
   disarm(sessionId: string): void {
     this.generation.set(sessionId, (this.generation.get(sessionId) ?? 0) + 1);
     this.watcher.unwatch(AgentProcessTracker.watchKey(sessionId));
     this.states.delete(sessionId);
+    this.shellPids.delete(sessionId);
+    this.lastFailedAt.delete(sessionId);
+    this.lastRearmAt.delete(sessionId);
+    this.forceQueued.delete(sessionId);
   }
 
   private snapshot(): Promise<ProcessTreeEntry[]> {

--- a/src/daemon/AgentProcessTracker.ts
+++ b/src/daemon/AgentProcessTracker.ts
@@ -91,6 +91,17 @@ const ALIAS_TO_SLUG: ReadonlyMap<string, AgentSlug> = new Map([
   ['@anthropic-ai/claude-code', 'claude'],
   ['gemini-cli', 'gemini'],
   ['@google/gemini-cli', 'gemini'],
+  // The Kiro integration ships a `kiro-cli` executable (see KNOWN_AGENT_STEMS
+  // in orchestratorRole.ts); its slug in the identity table is `kiro`.
+  ['kiro-cli', 'kiro'],
+]);
+
+/** Native executable stems whose binary name differs from the slug — the
+ *  selectAgentProcess image-stem check consults this alongside the slug set
+ *  (a `kiro-cli` process IS the kiro agent even though `kiro-cli` is not a
+ *  slug). */
+const NATIVE_STEM_TO_SLUG: ReadonlyMap<string, AgentSlug> = new Map([
+  ['kiro-cli', 'kiro'],
 ]);
 
 /** How long an unattributable/failed probe keeps `arm()` from re-enumerating
@@ -178,16 +189,25 @@ export function resolveAgentSlug(cmdline: string | undefined): AgentSlug | undef
     if (next) candidates.push(next);
   }
   for (const c of [...candidates]) {
-    const idx = c.lastIndexOf('node_modules');
-    if (idx === -1) continue;
-    const segs = c.slice(idx + 'node_modules'.length).split(/[\\/]/).filter(Boolean);
-    if (segs.length > 0) {
-      candidates.push(
-        segs[0].startsWith('@') && segs.length > 1 ? `${segs[0]}/${segs[1]}` : segs[0],
-      );
-    }
+    // Exact path SEGMENT only: `not_node_modules` or a directory literally
+    // named `xnode_modulesx` must not open a boundary (review: lastIndexOf
+    // substring-matched both).
+    const segs = c.split(/[\\/]/).filter(Boolean);
+    const idx = segs.indexOf('node_modules');
+    if (idx === -1 || idx + 1 >= segs.length) continue;
+    const pkg = segs[idx + 1]!;
+    candidates.push(pkg.startsWith('@') && idx + 2 < segs.length ? `${pkg}/${segs[idx + 2]}` : pkg);
   }
   for (const c of candidates) {
+    // Scoped-package spellings never basename-match: `@acme/claude` must not
+    // resolve claude (lookupForm unwraps the scope, so it cannot be trusted
+    // here). Only an exact alias entry may speak for a scoped name.
+    const scoped = c.startsWith('@') || /[/\\]@[^/\\]+[\\/]/.test(c);
+    if (scoped) {
+      const alias = ALIAS_TO_SLUG.get(c.replace(/\\/g, '/').toLowerCase());
+      if (alias) return alias;
+      continue;
+    }
     const form = lookupForm(c);
     if (AGENT_SLUG_SET.has(form)) return form as AgentSlug;
     const alias = ALIAS_TO_SLUG.get(form);
@@ -289,9 +309,8 @@ export function selectAgentProcess(
       const stem = imageStem(child.name);
       const slug = AGENT_SLUG_SET.has(stem)
         ? (stem as AgentSlug)
-        : RUNTIME_STEMS.has(stem)
-          ? resolveAgentSlug(child.cmdline)
-          : undefined;
+        : NATIVE_STEM_TO_SLUG.get(stem) ??
+          (RUNTIME_STEMS.has(stem) ? resolveAgentSlug(child.cmdline) : undefined);
       if (slug) {
         if (!attributed || childDepth < attributed.depth) {
           attributed = { pid: child.pid, depth: childDepth, slug };
@@ -477,9 +496,13 @@ export class AgentProcessTracker {
         this.lastFailedAt.set(sessionId, Date.now());
       } finally {
         this.inFlight.delete(sessionId);
+        // Replay a queued forced rearm DIRECTLY — routing it through rearm()
+        // again would hit the cooldown already paid when the rearm queued it
+        // (lastRearmAt was set seconds ago, so rearm() no-opped and the forced
+        // probe was lost). forceQueued is a single bit: no self-retrigger.
         if (this.forceQueued.delete(sessionId)) {
           const pid = this.shellPids.get(sessionId);
-          if (pid !== undefined) this.rearm(sessionId, pid);
+          if (pid !== undefined) this.probe(sessionId, pid);
         }
       }
     })();

--- a/src/daemon/AgentProcessTracker.ts
+++ b/src/daemon/AgentProcessTracker.ts
@@ -157,10 +157,14 @@ function lookupForm(token: string): string {
 
 /**
  * Resolve a runtime-hosted process (`node …`, `python …`) to an agent slug
- * from its command line. Token discipline (#919 panel): ONLY these
+ * from its command line. Token discipline (#919 panels): ONLY these
  * candidates are ever matched —
- *   • the script token right after the runtime (`argv[1]`),
- *   • the first non-flag token after a package runner or `python -m`,
+ *   • the script token right after the runtime (`argv[1]`, or the first
+ *     non-flag token when runtime flags precede it) — PATH FORM ONLY: a
+ *     bare `claude.js`/`aider.py` in the script slot is the user's own
+ *     file, never an agent,
+ *   • the first non-flag token after a package runner or `python -m`
+ *     (that slot names a PACKAGE — `npx -y gemini` — so bare is fine),
  *   • the `node_modules/<pkg>` / `node_modules/@scope/<pkg>` boundary of any
  *     of the above.
  * Arbitrary ancestor directories NEVER match: `node /work/claude/scratch.js`
@@ -173,7 +177,6 @@ export function resolveAgentSlug(cmdline: string | undefined): AgentSlug | undef
   if (!cmdline) return undefined;
   const argv = tokenizeCmdline(cmdline);
   if (argv.length < 2) return undefined;
-  const candidates: string[] = [argv[1]];
   const form0 = lookupForm(argv[0]);
   const form1 = lookupForm(argv[1]);
   // Package runners and `python -m`: the agent name rides the next non-flag
@@ -184,21 +187,34 @@ export function resolveAgentSlug(cmdline: string | undefined): AgentSlug | undef
     RUNNER_STEMS.has(form0) || form0 === '-m' ? 1
       : RUNNER_STEMS.has(form1) || form1 === '-m' ? 2
         : -1;
+  // Script slot: argv[1], or the first non-flag beyond it when the launcher
+  // prefixed runtime flags (`node --max-old-space-size=… cli.js` used to
+  // lose its identity entirely — Claude panel #919). `bare` marks a name
+  // with no path separator, which in THIS slot never matches.
+  const scriptToken = argv[1].startsWith('-')
+    ? argv.slice(2).find((t) => !t.startsWith('-'))
+    : argv[1];
+  const candidates: Array<{ token: string; bare: boolean }> = [];
+  if (scriptToken) candidates.push({ token: scriptToken, bare: !/[/\\]/.test(scriptToken) });
   if (scanFrom >= 0) {
     const next = argv.slice(scanFrom).find((t) => !t.startsWith('-'));
-    if (next) candidates.push(next);
+    if (next) candidates.push({ token: next, bare: false });
   }
-  for (const c of [...candidates]) {
+  for (const { token } of [...candidates]) {
     // Exact path SEGMENT only: `not_node_modules` or a directory literally
     // named `xnode_modulesx` must not open a boundary (review: lastIndexOf
     // substring-matched both).
-    const segs = c.split(/[\\/]/).filter(Boolean);
+    const segs = token.split(/[\\/]/).filter(Boolean);
     const idx = segs.indexOf('node_modules');
     if (idx === -1 || idx + 1 >= segs.length) continue;
-    const pkg = segs[idx + 1]!;
-    candidates.push(pkg.startsWith('@') && idx + 2 < segs.length ? `${pkg}/${segs[idx + 2]}` : pkg);
+    const pkg = segs[idx + 1];
+    candidates.push({
+      token: pkg.startsWith('@') && idx + 2 < segs.length ? `${pkg}/${segs[idx + 2]}` : pkg,
+      bare: false,
+    });
   }
-  for (const c of candidates) {
+  for (const { token: c, bare } of candidates) {
+    if (bare) continue;
     // Scoped-package spellings never basename-match: `@acme/claude` must not
     // resolve claude (lookupForm unwraps the scope, so it cannot be trusted
     // here). Only an exact alias entry may speak for a scoped name.

--- a/src/daemon/ProcessMonitor.ts
+++ b/src/daemon/ProcessMonitor.ts
@@ -272,7 +272,11 @@ export class ProcessMonitor {
         const reuseSuspects: Array<[string, { pid: number; onDead: () => void; imageName?: string }]> = [];
         for (const entry of entries) {
           const [sessionId, info] = entry;
-          if (!this.watchedPids.has(sessionId)) continue;
+          // Identity guard, not just membership: this batch snapshot can be
+          // stale by the time we act on it — if a re-probe replaced this
+          // session's watch while the batch ran, this cycle holds the OLD
+          // entry object and must not touch (or unwatch) the NEW one.
+          if (this.watchedPids.get(sessionId) !== info) continue;
           if (!aliveSet.has(info.pid)) {
             apparentlyDead.push(entry);
             continue;
@@ -294,7 +298,7 @@ export class ProcessMonitor {
         // Re-verify reuse suspects with an independent per-PID probe before
         // declaring death — same unknown-is-never-dead discipline as below.
         for (const [sessionId, info] of reuseSuspects) {
-          if (!this.watchedPids.has(sessionId)) continue;
+          if (this.watchedPids.get(sessionId) !== info) continue;
           try {
             const probe = await ProcessMonitor.probeWindowsPid(info.pid);
             if (!probe.present) {
@@ -308,7 +312,7 @@ export class ProcessMonitor {
             ) {
               // Confirmed: same PID, different process. The watched process
               // is gone — fire onDead exactly as a confirmed death.
-              if (!this.watchedPids.has(sessionId)) continue;
+              if (this.watchedPids.get(sessionId) !== info) continue;
               this.unwatch(sessionId);
               info.onDead();
             }
@@ -320,9 +324,11 @@ export class ProcessMonitor {
 
         if (apparentlyDead.length === 0) return;
 
-        for (const [sessionId, { pid, onDead }] of apparentlyDead) {
-          // Skip if unwatched during async re-verification
-          if (!this.watchedPids.has(sessionId)) continue;
+        for (const [sessionId, info] of apparentlyDead) {
+          const { pid, onDead } = info;
+          // Skip if this cycle's entry went stale during async
+          // re-verification — superseded by a newer watch (see above)
+          if (this.watchedPids.get(sessionId) !== info) continue;
 
           let confirmedDead = false;
           try {
@@ -343,7 +349,7 @@ export class ProcessMonitor {
           }
 
           if (!confirmedDead) continue;
-          if (!this.watchedPids.has(sessionId)) continue;
+          if (this.watchedPids.get(sessionId) !== info) continue;
           this.unwatch(sessionId);
           onDead();
         }

--- a/src/daemon/__tests__/AgentProcessTracker.test.ts
+++ b/src/daemon/__tests__/AgentProcessTracker.test.ts
@@ -74,6 +74,23 @@ describe('resolveAgentSlug', () => {
     expect(resolveAgentSlug('node /work/claude-notes/server.mjs')).toBeUndefined();
   });
 
+  it('a BARE script-slot name is the user\'s own file, never an agent', () => {
+    // Claude panel #919: `node claude.js` / `python aider.py` used to
+    // attribute by bare basename. The script slot must be a path —
+    // `node /usr/local/bin/claude` (npm global bin via env shebang) still is.
+    expect(resolveAgentSlug('node claude.js')).toBeUndefined();
+    expect(resolveAgentSlug('python aider.py')).toBeUndefined();
+    expect(resolveAgentSlug('node /usr/local/bin/claude')).toBe('claude');
+  });
+
+  it('runtime flags before the script do not lose the identity', () => {
+    // Claude panel #919: a launcher that injects node flags ahead of the
+    // script (`--max-old-space-size`) used to leave the pane unresolved.
+    expect(
+      resolveAgentSlug('node --max-old-space-size=4096 /x/node_modules/@anthropic-ai/claude-code/cli.js'),
+    ).toBe('claude');
+  });
+
   it('never resolves a scoped name by basename or a non-segment node_modules', () => {
     // @acme/claude is NOT claude — scoped spellings match exact alias keys only
     expect(resolveAgentSlug('node /x/node_modules/@acme/claude/index.js')).toBeUndefined();

--- a/src/daemon/__tests__/AgentProcessTracker.test.ts
+++ b/src/daemon/__tests__/AgentProcessTracker.test.ts
@@ -3,83 +3,131 @@ import {
   AgentProcessTracker,
   parsePipeDelimited,
   parsePsOutput,
-  selectAgentPid,
+  resolveAgentSlug,
+  selectAgentProcess,
+  tokenizeCmdline,
   type PidWatcher,
   type ProcessTreeEntry,
 } from '../AgentProcessTracker';
 
-const entry = (pid: number, ppid: number, name: string): ProcessTreeEntry => ({ pid, ppid, name });
+const entry = (pid: number, ppid: number, name: string, cmdline?: string): ProcessTreeEntry => ({
+  pid,
+  ppid,
+  name,
+  ...(cmdline !== undefined ? { cmdline } : {}),
+});
 
 describe('parsePipeDelimited', () => {
-  it('parses pid|ppid|name lines and skips garbage', () => {
+  it('parses pid|ppid|name|cmdline lines, rejoining pipes inside the cmdline', () => {
     const out = parsePipeDelimited(
-      'Windows PowerShell banner\r\n4|0|System\r\n123|4|pwsh.exe\r\n\r\nnot-a-line\r\n77|123|claude.exe\r\n',
+      'Windows PowerShell banner\r\n4|0|System\r\n123|4|pwsh.exe\r\n\r\nnot-a-line\r\n'
+        + '77|123|claude.exe|claude --foo|bar\r\n'
+        + '78|123|codex.exe\r\n',
     );
     expect(out).toEqual([
       entry(4, 0, 'System'),
       entry(123, 4, 'pwsh.exe'),
-      entry(77, 123, 'claude.exe'),
+      entry(77, 123, 'claude.exe', 'claude --foo|bar'),
+      entry(78, 123, 'codex.exe'),
     ]);
   });
 });
 
 describe('parsePsOutput', () => {
-  it('parses ps -axo pid=,ppid=,comm= output, keeping path comms verbatim', () => {
-    const out = parsePsOutput('    1     0 /sbin/launchd\n  500     1 -zsh\n  600   500 node\n');
+  it('derives the image from argv[0] of the args tail and keeps the full cmdline', () => {
+    const out = parsePsOutput(
+      '    1     0 /sbin/launchd\n  500     1 -zsh\n  600   500 node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js\n',
+    );
     expect(out).toEqual([
-      entry(1, 0, '/sbin/launchd'),
-      entry(500, 1, '-zsh'),
-      entry(600, 500, 'node'),
+      entry(1, 0, '/sbin/launchd', '/sbin/launchd'),
+      entry(500, 1, '-zsh', '-zsh'),
+      entry(600, 500, 'node', 'node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'),
     ]);
   });
 });
 
-describe('selectAgentPid', () => {
+describe('tokenizeCmdline', () => {
+  it('keeps quoted paths with spaces as single tokens', () => {
+    expect(tokenizeCmdline('"C:\\Program Files\\node.exe" "C:\\my work\\cli.js" --flag')).toEqual([
+      'C:\\Program Files\\node.exe',
+      'C:\\my work\\cli.js',
+      '--flag',
+    ]);
+  });
+});
+
+describe('resolveAgentSlug', () => {
+  it('resolves the real install spellings', () => {
+    expect(resolveAgentSlug('node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js')).toBe('claude');
+    expect(resolveAgentSlug('node /opt/homebrew/lib/node_modules/gemini/bin/gemini.js')).toBe('gemini');
+    expect(resolveAgentSlug('node /x/node_modules/@google/gemini-cli/dist/index.js')).toBe('gemini');
+    expect(resolveAgentSlug('node /x/node_modules/npx-cli.js -y gemini')).toBe('gemini');
+    expect(resolveAgentSlug('npx -y gemini')).toBe('gemini');
+    expect(resolveAgentSlug('python -m aider')).toBe('aider');
+    expect(resolveAgentSlug('claude --resume')).toBeUndefined(); // < 2 tokens is not a runtime cmdline
+    expect(resolveAgentSlug(undefined)).toBeUndefined();
+  });
+
+  it('never matches arbitrary ancestor directories or trailing positionals', () => {
+    expect(resolveAgentSlug('node /work/claude/scratch.js')).toBeUndefined();
+    expect(resolveAgentSlug('node demo.js claude')).toBeUndefined();
+    expect(resolveAgentSlug('node /work/claude-notes/server.mjs')).toBeUndefined();
+  });
+});
+
+describe('selectAgentProcess', () => {
   const SHELL = 100;
 
   it('picks a native agent binary among descendants (over its MCP node children)', () => {
     const table = [
       entry(SHELL, 1, 'pwsh.exe'),
       entry(200, SHELL, 'claude.exe'),
-      entry(300, 200, 'node.exe'), // MCP server child of claude
+      entry(300, 200, 'node.exe', 'node mcp-server.js'), // MCP server child of claude
     ];
-    expect(selectAgentPid(table, SHELL)).toBe(200);
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 200, slug: 'claude' });
   });
 
-  it('prefers the agent binary even when a runtime sits shallower', () => {
+  it('compares attributed candidates by DEPTH regardless of class: a shallower node-hosted primary beats a deeper native child', () => {
+    // #919 panel: the old native-beats-runtime priority let a deeper native
+    // MCP-server binary steal the identity from the node-hosted primary CLI.
     const table = [
-      entry(200, SHELL, 'node.exe'), // some wrapper at depth 1
-      entry(300, 200, 'claude.exe'), // the agent at depth 2
+      entry(200, SHELL, 'node', 'node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'),
+      entry(300, 200, 'codex'), // claude-code's MCP server for another agent
     ];
-    expect(selectAgentPid(table, SHELL)).toBe(300);
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 200, slug: 'claude' });
   });
 
-  it('falls back to the SHALLOWEST runtime for npm installs (cmd shim → node CLI → MCP node)', () => {
+  it('an exact-depth tie between two different slugs drops the slug but keeps the death watch', () => {
+    const table = [entry(200, SHELL, 'claude'), entry(300, SHELL, 'codex')];
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 200 });
+  });
+
+  it('falls back to the SHALLOWEST unattributed runtime (cmd shim → node CLI → MCP node)', () => {
     const table = [
       entry(200, SHELL, 'cmd.exe'), // claude.cmd shim
-      entry(300, 200, 'node.exe'), // the CLI itself
-      entry(400, 300, 'node.exe'), // its MCP server — deeper, must not win
+      entry(300, 200, 'node.exe', 'node mystery.js'), // the CLI itself, unresolvable cmdline
+      entry(400, 300, 'node.exe', 'node mcp.js'), // its MCP server — deeper, must not win
     ];
-    expect(selectAgentPid(table, SHELL)).toBe(300);
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 300 });
   });
 
   it('falls back to the first direct child for unknown wrappers', () => {
     const table = [entry(200, SHELL, 'somewrapper.exe')];
-    expect(selectAgentPid(table, SHELL)).toBe(200);
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 200 });
   });
 
   it('returns undefined when the shell has no descendants', () => {
     const table = [entry(SHELL, 1, 'pwsh.exe'), entry(999, 1, 'claude.exe')];
-    expect(selectAgentPid(table, SHELL)).toBeUndefined();
+    expect(selectAgentProcess(table, SHELL)).toBeUndefined();
   });
 
   it('survives PPID cycles (stale/reused parent ids)', () => {
     const table = [
       entry(200, SHELL, 'cmd.exe'),
-      entry(300, 200, 'node.exe'),
+      entry(300, 200, 'node.exe', 'node /usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'),
       entry(SHELL, 300, 'pwsh.exe'), // cycle back to the shell
     ];
-    expect(selectAgentPid(table, SHELL)).toBe(300);
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 300, slug: 'claude' });
   });
 });
 
@@ -104,7 +152,7 @@ describe('AgentProcessTracker', () => {
   const SHELL = 100;
   const TABLE = [entry(200, SHELL, 'claude.exe')];
 
-  it('arm → alive; onDead flips to the dead edge; re-arm re-probes', async () => {
+  it('arm → alive with identity; onDead flips to the dead edge; re-arm re-probes', async () => {
     const watcher = makeWatcher();
     const enumerate = vi.fn(async () => TABLE);
     const tracker = new AgentProcessTracker(watcher, enumerate);
@@ -113,6 +161,7 @@ describe('AgentProcessTracker', () => {
     tracker.arm('s1', SHELL);
     await flush();
     expect(tracker.statusFor('s1')).toBe(true);
+    expect(tracker.identityFor('s1')).toEqual({ slug: 'claude', alive: true });
     expect(watcher.watches.get('agent:s1')?.pid).toBe(200);
 
     // Hook storm: arming a live watch is a no-op (one probe per launch).
@@ -123,6 +172,7 @@ describe('AgentProcessTracker', () => {
     // The edge: the watched process died.
     watcher.watches.get('agent:s1')?.onDead();
     expect(tracker.statusFor('s1')).toBe(false);
+    expect(tracker.identityFor('s1')).toEqual({ slug: 'claude', alive: false });
 
     // Agent relaunched → a fresh hook re-arms and re-probes.
     tracker.arm('s1', SHELL);
@@ -131,12 +181,54 @@ describe('AgentProcessTracker', () => {
     expect(tracker.statusFor('s1')).toBe(true);
   });
 
-  it('stays undecided when nothing is attributable or enumeration fails', async () => {
+  it('a slugless pick answers liveness but claims no identity', async () => {
     const watcher = makeWatcher();
-    const empty = new AgentProcessTracker(watcher, async () => []);
-    empty.arm('s1', SHELL);
+    const tracker = new AgentProcessTracker(watcher, async () => [entry(200, SHELL, 'somewrapper.exe')]);
+    tracker.arm('s1', SHELL);
     await flush();
-    expect(empty.statusFor('s1')).toBeUndefined();
+    expect(tracker.statusFor('s1')).toBe(true);
+    expect(tracker.identityFor('s1')).toEqual({ alive: true });
+  });
+
+  it('rearm forces a probe past a stale alive pick when the agent changed', async () => {
+    const watcher = makeWatcher();
+    let table = [entry(200, SHELL, 'claude.exe')];
+    const enumerate = vi.fn(async () => table);
+    const tracker = new AgentProcessTracker(watcher, enumerate);
+
+    tracker.arm('s1', SHELL);
+    await flush();
+    expect(tracker.identityFor('s1')?.slug).toBe('claude');
+
+    // Claude exited, codex launched — but the old pick's death poll hasn't
+    // fired yet (alive still true). A plain arm no-ops; a CONFLICTING banner
+    // must force the probe.
+    table = [entry(300, SHELL, 'codex')];
+    tracker.arm('s1', SHELL);
+    await flush();
+    expect(enumerate).toHaveBeenCalledTimes(1);
+    tracker.rearm('s1', SHELL);
+    await flush();
+    expect(enumerate).toHaveBeenCalledTimes(2);
+    expect(tracker.identityFor('s1')).toEqual({ slug: 'codex', alive: true });
+  });
+
+  it('unattributable and failed probes back off; rearm ignores the backoff', async () => {
+    const watcher = makeWatcher();
+    const enumerate = vi.fn(async () => []);
+    const tracker = new AgentProcessTracker(watcher, enumerate);
+
+    tracker.arm('s1', SHELL);
+    await flush();
+    expect(tracker.statusFor('s1')).toBeUndefined();
+
+    tracker.arm('s1', SHELL); // negative backoff: no re-enumeration
+    await flush();
+    expect(enumerate).toHaveBeenCalledTimes(1);
+
+    tracker.rearm('s1', SHELL); // explicit launch evidence beats the backoff
+    await flush();
+    expect(enumerate).toHaveBeenCalledTimes(2);
 
     const failing = new AgentProcessTracker(watcher, async () => {
       throw new Error('tasklist timeout');
@@ -147,9 +239,23 @@ describe('AgentProcessTracker', () => {
     expect(watcher.watches.size).toBe(0);
   });
 
+  it('fires the state listener on attribution and on the death edge', async () => {
+    const watcher = makeWatcher();
+    const listener = vi.fn();
+    const tracker = new AgentProcessTracker(watcher, async () => TABLE);
+    tracker.setStateChangeListener(listener);
+
+    tracker.arm('s1', SHELL);
+    await flush();
+    expect(listener).toHaveBeenCalledWith('s1', { slug: 'claude', alive: true });
+
+    watcher.watches.get('agent:s1')?.onDead();
+    expect(listener).toHaveBeenCalledWith('s1', { slug: 'claude', alive: false });
+  });
+
   it('disarm clears state, and a disarm racing an in-flight arm wins', async () => {
     const watcher = makeWatcher();
-    let release: (v: ProcessTreeEntry[]) => void = () => {};
+    let release: (v: ProcessTreeEntry[]) => void = () => undefined;
     const gated = new Promise<ProcessTreeEntry[]>((r) => { release = r; });
     const tracker = new AgentProcessTracker(watcher, () => gated);
 

--- a/src/daemon/__tests__/AgentProcessTracker.test.ts
+++ b/src/daemon/__tests__/AgentProcessTracker.test.ts
@@ -73,6 +73,17 @@ describe('resolveAgentSlug', () => {
     expect(resolveAgentSlug('node demo.js claude')).toBeUndefined();
     expect(resolveAgentSlug('node /work/claude-notes/server.mjs')).toBeUndefined();
   });
+
+  it('never resolves a scoped name by basename or a non-segment node_modules', () => {
+    // @acme/claude is NOT claude — scoped spellings match exact alias keys only
+    expect(resolveAgentSlug('node /x/node_modules/@acme/claude/index.js')).toBeUndefined();
+    // `not_node_modules` is not a path segment boundary
+    expect(resolveAgentSlug('node /x/not_node_modules/claude/index.js')).toBeUndefined();
+  });
+
+  it('resolves launcher spellings whose name differs from the slug (kiro)', () => {
+    expect(resolveAgentSlug('node /x/node_modules/kiro-cli/dist/cli.js')).toBe('kiro');
+  });
 });
 
 describe('selectAgentProcess', () => {
@@ -128,6 +139,11 @@ describe('selectAgentProcess', () => {
       entry(SHELL, 300, 'pwsh.exe'), // cycle back to the shell
     ];
     expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 300, slug: 'claude' });
+  });
+
+  it('maps a native stem that is not itself a slug (kiro-cli → kiro)', () => {
+    const table = [entry(200, SHELL, 'kiro-cli')];
+    expect(selectAgentProcess(table, SHELL)).toEqual({ pid: 200, slug: 'kiro' });
   });
 });
 
@@ -208,6 +224,24 @@ describe('AgentProcessTracker', () => {
     await flush();
     expect(enumerate).toHaveBeenCalledTimes(1);
     tracker.rearm('s1', SHELL);
+    await flush();
+    expect(enumerate).toHaveBeenCalledTimes(2);
+    expect(tracker.identityFor('s1')).toEqual({ slug: 'codex', alive: true });
+  });
+
+  it('a rearm queued behind an in-flight probe replays as a probe (cooldown already paid)', async () => {
+    // Review bug: the replay used to route through rearm() again, which hit
+    // the 10s cooldown the QUEUING rearm had just paid — the forced probe was
+    // silently dropped and the stale pick kept winning.
+    const watcher = makeWatcher();
+    let table = [entry(200, SHELL, 'claude.exe')];
+    const enumerate = vi.fn(async () => table);
+    const tracker = new AgentProcessTracker(watcher, enumerate);
+
+    tracker.arm('s1', SHELL); // probe A in flight
+    table = [entry(300, SHELL, 'codex')];
+    tracker.rearm('s1', SHELL); // queues the forced probe behind A
+    await flush();
     await flush();
     expect(enumerate).toHaveBeenCalledTimes(2);
     expect(tracker.identityFor('s1')).toEqual({ slug: 'codex', alive: true });

--- a/src/daemon/__tests__/ProcessMonitor.reuse.test.ts
+++ b/src/daemon/__tests__/ProcessMonitor.reuse.test.ts
@@ -132,4 +132,39 @@ describe('ProcessMonitor — PID reuse detection (watch loop)', () => {
     expect(onDead).not.toHaveBeenCalled();
     monitor.unwatchAll();
   });
+
+  it('a stale batch never removes a REPLACED watch (identity guard)', async () => {
+    // A cycle that snapshotted watch A must not unwatch/fire when the entry
+    // was replaced by watch B while the death re-verify was in flight.
+    const onDeadOld = vi.fn();
+    const onDeadNew = vi.fn();
+    const monitor = new ProcessMonitor(60_000);
+    let alive = new Set([100]);
+    vi.spyOn(ProcessMonitor, 'batchCheckAliveDetailed').mockImplementation(async () => ({
+      alive,
+      images: new Map([[100, 'pwsh.exe']]),
+    }));
+    let releaseDeath: () => void = () => undefined;
+    const deathGate = new Promise<void>((r) => { releaseDeath = r; });
+    vi.spyOn(ProcessMonitor, 'isDefinitelyDead').mockImplementation(async () => {
+      await deathGate; // hold the re-verify open so the watch can be replaced
+      return true;
+    });
+
+    monitor.watch('sess-1', 100, onDeadOld); // binds the image
+    await settle();
+    alive = new Set(); // pid 100 gone in the next batch snapshot
+    await tick(monitor); // collects apparentlyDead, gates on the re-verify
+    monitor.watch('sess-1', 200, onDeadNew); // re-probe replaced the watch
+    releaseDeath(); // the STALE cycle now confirms 100 dead
+    await settle();
+
+    expect(onDeadOld).not.toHaveBeenCalled(); // stale entry: no fire
+    expect(onDeadNew).not.toHaveBeenCalled(); // and no collateral fire
+    // The replacement watch survives — the stale cycle must not unwatch it.
+    const watched = (monitor as unknown as { watchedPids: Map<string, { pid: number }> })
+      .watchedPids.get('sess-1');
+    expect(watched?.pid).toBe(200);
+    monitor.unwatchAll();
+  });
 });

--- a/src/daemon/__tests__/canonicalAgent.test.ts
+++ b/src/daemon/__tests__/canonicalAgent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { IDENTITY_TTL_MS, resolveCanonicalAgentIdentity } from '../canonicalAgent';
+import { IDENTITY_TTL_MS, resolveCanonicalAgentIdentity, detectorSuppressedBy } from '../canonicalAgent';
 import type { AgentSlug } from '../../shared/agentIdentity';
 
 const proc = (slug: AgentSlug | undefined, alive: boolean) =>
@@ -121,5 +121,33 @@ describe('resolveCanonicalAgentIdentity (#919 tier rule)', () => {
         screenSlug: 'grok',
       }),
     ).toEqual({ slug: 'grok', source: 'screen' });
+  });
+});
+
+describe('detectorSuppressedBy (#919 detector veto)', () => {
+  it('suppresses a screen read contradicted by a tier-1/2 identity', () => {
+    expect(detectorSuppressedBy({ slug: 'codex', source: 'process' }, 'claude')).toBe(true);
+    expect(detectorSuppressedBy({ slug: 'codex', source: 'hook' }, 'claude')).toBe(true);
+  });
+
+  it('lets an agreeing read through', () => {
+    expect(detectorSuppressedBy({ slug: 'claude', source: 'process' }, 'claude')).toBe(false);
+  });
+
+  it('never vetoes on the screen tier — nothing stronger than the screen itself', () => {
+    expect(detectorSuppressedBy({ slug: 'codex', source: 'screen' }, 'claude')).toBe(false);
+  });
+
+  it('lets an unconstrained event through', () => {
+    expect(detectorSuppressedBy(undefined, 'claude')).toBe(false);
+  });
+
+  it('does NOT veto a display name this build cannot map', () => {
+    // An unmappable banner (a new agent, a renamed one) says nothing about
+    // identity. These events carry status and liveness too, so treating
+    // "could not parse" as "contradicted" cost the pane its running/idle
+    // updates over a name we merely failed to read.
+    expect(detectorSuppressedBy({ slug: 'codex', source: 'process' }, undefined)).toBe(false);
+    expect(detectorSuppressedBy({ slug: 'codex', source: 'hook' }, undefined)).toBe(false);
   });
 });

--- a/src/daemon/__tests__/canonicalAgent.test.ts
+++ b/src/daemon/__tests__/canonicalAgent.test.ts
@@ -64,10 +64,42 @@ describe('resolveCanonicalAgentIdentity (#919 tier rule)', () => {
   });
 
   it('residue veto: a confirmed-dead same-slug screen read is not an agent', () => {
+    // No live hook backs the residue — the death edge expired the authority,
+    // so the strongest voice left is the detector's sticky banner.
     expect(
       resolveCanonicalAgentIdentity({
         proc: proc('claude', false),
-        auth: auth('claude', 30_000),
+        screenSlug: 'claude',
+      }),
+    ).toBeUndefined();
+    // A cwd-guessed authority cannot stand alone — and must not rescue the
+    // screen read from the veto either.
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('claude', false),
+        auth: auth('claude', 30_000, false),
+        screenSlug: 'claude',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('a fresh exact hook rescues the same-slug screen read from the veto (relaunch inside the arm backoff)', () => {
+    // GLM panel #919: same-slug relaunch within the 30s failure backoff —
+    // the tracker entry is stale-dead, but a live bridge just re-signaled
+    // from this exact ptyId. That is the relaunch, not residue; without the
+    // rescue the pane's label nulls for up to the backoff window.
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('claude', false),
+        auth: auth('claude', 5_000),
+        screenSlug: 'claude',
+      }),
+    ).toEqual({ slug: 'claude', source: 'hook' });
+    // Past IDENTITY_TTL the hook can no longer vouch: residue again.
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('claude', false),
+        auth: auth('claude', IDENTITY_TTL_MS + 1),
         screenSlug: 'claude',
       }),
     ).toBeUndefined();

--- a/src/daemon/__tests__/canonicalAgent.test.ts
+++ b/src/daemon/__tests__/canonicalAgent.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { IDENTITY_TTL_MS, resolveCanonicalAgentIdentity } from '../canonicalAgent';
+import type { AgentSlug } from '../../shared/agentIdentity';
+
+const proc = (slug: AgentSlug | undefined, alive: boolean) =>
+  slug === undefined ? { alive } : { slug, alive };
+const auth = (slug: AgentSlug, ageMs: number, exact = true) => ({ slug, ageMs, exact });
+
+describe('resolveCanonicalAgentIdentity (#919 tier rule)', () => {
+  it('a live DIFFERENT-slug process beats even a fresh hook — the #916 regression guard', () => {
+    // claude exited, codex banner re-armed the tracker; claude's authority is
+    // 30 seconds old and exactly routed. The label must still be codex.
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('codex', true),
+        auth: auth('claude', 30_000),
+        screenSlug: 'codex',
+      }),
+    ).toEqual({ slug: 'codex', source: 'process' });
+  });
+
+  it('an unarmed tracker + fresh exact-routed hook → hook wins', () => {
+    expect(
+      resolveCanonicalAgentIdentity({ auth: auth('claude', 30_000), screenSlug: 'grok' }),
+    ).toEqual({ slug: 'claude', source: 'hook' });
+  });
+
+  it('corroboration bypasses age and routing: a 25-min-old cwd-routed hook with a live same-slug process wins', () => {
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('claude', true),
+        auth: auth('claude', 25 * 60_000, false),
+      }),
+    ).toEqual({ slug: 'claude', source: 'hook' });
+  });
+
+  it('a non-exact (cwd-guessed) authority never stands alone', () => {
+    expect(
+      resolveCanonicalAgentIdentity({
+        auth: auth('claude', 30_000, false),
+        screenSlug: 'grok',
+      }),
+    ).toEqual({ slug: 'grok', source: 'screen' });
+  });
+
+  it('a dead slugless tracked pick does not contradict a stale hook → screen wins', () => {
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc(undefined, false),
+        auth: auth('claude', 10 * 60_000),
+        screenSlug: 'grok',
+      }),
+    ).toEqual({ slug: 'grok', source: 'screen' });
+  });
+
+  it('a stale hook for a dead process loses to the screen', () => {
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('claude', false),
+        auth: auth('claude', 10 * 60_000),
+        screenSlug: 'grok',
+      }),
+    ).toEqual({ slug: 'grok', source: 'screen' });
+  });
+
+  it('residue veto: a confirmed-dead same-slug screen read is not an agent', () => {
+    expect(
+      resolveCanonicalAgentIdentity({
+        proc: proc('claude', false),
+        auth: auth('claude', 30_000),
+        screenSlug: 'claude',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('no attribution at all → screen tier (remote/SSH pane); nothing → undefined', () => {
+    expect(resolveCanonicalAgentIdentity({ screenSlug: 'gemini' })).toEqual({
+      slug: 'gemini',
+      source: 'screen',
+    });
+    expect(resolveCanonicalAgentIdentity({})).toBeUndefined();
+  });
+
+  it('IDENTITY_TTL_MS is minutes, not the 30-min veto window', () => {
+    expect(IDENTITY_TTL_MS).toBe(120_000);
+    expect(
+      resolveCanonicalAgentIdentity({
+        auth: auth('claude', IDENTITY_TTL_MS + 1),
+        screenSlug: 'grok',
+      }),
+    ).toEqual({ slug: 'grok', source: 'screen' });
+  });
+});

--- a/src/daemon/canonicalAgent.ts
+++ b/src/daemon/canonicalAgent.ts
@@ -99,3 +99,26 @@ export function resolveCanonicalAgentIdentity(inputs: {
   if (screenSlug) return { slug: screenSlug, source: 'screen' };
   return undefined;
 }
+
+/**
+ * #919 — the suppression test shared by both detector-emission sites: a
+ * DETECTOR-origin event whose screen slug is contradicted by a tier-1/2
+ * (hook/process) canonical identity must not broadcast at all — a false
+ * detection should not notify, which also beats relabeling it. Screen-tier
+ * canonical (nothing stronger than the screen itself) and unconstrained
+ * events (canonical undefined) broadcast unchanged.
+ *
+ * An ABSENT screen slug is not a contradiction. A display name this build
+ * cannot map (a new agent, a renamed banner) says nothing about identity, and
+ * these events carry status and liveness as well as a label — suppressing them
+ * would cost the pane its running/idle updates over a name we merely failed to
+ * parse. resolveCanonicalAgentIdentity already treats an absent slug as "no
+ * constraint"; this test has to agree with it.
+ */
+export function detectorSuppressedBy(
+  canonical: CanonicalAgentIdentity | undefined,
+  screenSlug?: AgentSlug,
+): boolean {
+  if (screenSlug === undefined) return false;
+  return canonical !== undefined && canonical.source !== 'screen' && canonical.slug !== screenSlug;
+}

--- a/src/daemon/canonicalAgent.ts
+++ b/src/daemon/canonicalAgent.ts
@@ -1,0 +1,95 @@
+// Canonical pane-agent identity — the tier rule from issue #919.
+//
+// A pane's agent used to be decided by ONE signal: what the terminal printed
+// (AgentDetector's screen gates), which cannot tell an agent from a sentence
+// about an agent (#916: a Grok pane labelled Claude, twice). This module folds
+// the three available signals into one precedence:
+//
+//   hook self-report  >  process image truth  >  screen chrome
+//
+// The hook tier is NOT unconditional: a hook authority is a 30-minute map
+// entry, and letting it win on age alone reproduces #916 for half an hour
+// after the agent exits (the panel's top finding). A hook wins only when
+// CORROBORATED (a live same-slug process) or when FRESH and exactly routed
+// and uncontradicted. Process truth — a live attributed process — beats both
+// a stale hook and the screen. The screen stays the fallback for panes we
+// cannot attribute (remote/SSH), which is why AgentDetector is untouched.
+//
+// Pure on purpose: no tracker/router imports, no clock, no I/O — the daemon
+// reads its two maps and passes snapshots in, so every tier combination is
+// unit-testable without a process table.
+import type { AgentSlug } from '../shared/agentIdentity';
+
+/**
+ * How long an UNCORROBORATED hook authority may decide identity on its own.
+ * Deliberately NOT the 30-min veto TTL (HOOK_AUTHORITY_TTL_MS) — that window
+ * spans long quiet tool calls for notification suppression, but an identity
+ * claim riding a stale entry would mislabel the pane's next agent. Bridge
+ * hooks fire per tool use, so a live bridge re-signals well inside 2 minutes.
+ * Corroboration (a live same-slug process) bypasses age entirely.
+ */
+export const IDENTITY_TTL_MS = 2 * 60_000;
+
+/** What the tracker knows about the pane's attributed process, if any.
+ *  `slug` undefined = attributed a slugless pick (wrapper/direct child) —
+ *  its liveness still participates, its name does not. */
+export interface CanonicalProcessState {
+  slug?: AgentSlug;
+  alive: boolean;
+}
+
+/** What the hook authority map knows: the last bridge agent for this pane,
+ *  how recently it signaled, and whether the signal was routed by exact
+ *  ptyId (trusted to stand alone) or the cwd-prefix fallback (may only
+ *  corroborate — it can attach to a neighboring pane). */
+export interface CanonicalHookAuthority {
+  slug: AgentSlug;
+  ageMs: number;
+  exact: boolean;
+}
+
+export interface CanonicalAgentIdentity {
+  slug: AgentSlug;
+  source: 'hook' | 'process' | 'screen';
+}
+
+/**
+ * The tier rule. Rows, in order:
+ *
+ *  1. Residue veto — the tracked agent is CONFIRMED DEAD and the screen still
+ *     says the same slug: that is the detector's sticky residue, not a live
+ *     agent. No identity (a genuine relaunch re-arms the tracker first).
+ *  2. Corroborated hook — a live same-slug process backs the authority.
+ *     Age and routing are irrelevant here: the process IS the evidence.
+ *  3. Fresh exact-routed hook, uncontradicted — the bridge signaled within
+ *     IDENTITY_TTL and was routed by exact ptyId, and no live process of a
+ *     DIFFERENT slug contradicts it. A dead or slugless tracked process does
+ *     not contradict (the hook may be the relaunch; the pick may be the
+ *     wrapper the agent runs under).
+ *  4. Live process truth — an attributed, live process beats a stale hook
+ *     and the screen. This row is the #916 fix: after claude exits and codex
+ *     re-arms the tracker, claude's stale authority cannot win.
+ *  5. Screen — the fallback for unattributable panes (remote/SSH).
+ */
+export function resolveCanonicalAgentIdentity(inputs: {
+  proc?: CanonicalProcessState;
+  auth?: CanonicalHookAuthority;
+  screenSlug?: AgentSlug;
+  identityTtlMs?: number;
+}): CanonicalAgentIdentity | undefined {
+  const ttl = inputs.identityTtlMs ?? IDENTITY_TTL_MS;
+  const { proc, auth, screenSlug } = inputs;
+
+  if (proc?.slug && !proc.alive && proc.slug === screenSlug) return undefined;
+  if (auth && proc?.slug === auth.slug && proc.alive) {
+    return { slug: auth.slug, source: 'hook' };
+  }
+  const contradictedByLiveProcess =
+    proc?.slug !== undefined && proc.slug !== auth?.slug && proc.alive;
+  if (auth?.exact && auth.ageMs <= ttl && !contradictedByLiveProcess) {
+    return { slug: auth.slug, source: 'hook' };
+  }
+  if (proc?.slug && proc.alive) return { slug: proc.slug, source: 'process' };
+  if (screenSlug) return { slug: screenSlug, source: 'screen' };
+  return undefined;
+}

--- a/src/daemon/canonicalAgent.ts
+++ b/src/daemon/canonicalAgent.ts
@@ -58,7 +58,10 @@ export interface CanonicalAgentIdentity {
  *
  *  1. Residue veto — the tracked agent is CONFIRMED DEAD and the screen still
  *     says the same slug: that is the detector's sticky residue, not a live
- *     agent. No identity (a genuine relaunch re-arms the tracker first).
+ *     agent. No identity — UNLESS a fresh exact-routed hook backs the same
+ *     slug: that is the relaunch itself (a live bridge fired from this very
+ *     ptyId; the tracked entry is merely stale because the relaunch's arm()
+ *     can sit out the failure backoff), and row 3 must be allowed to answer.
  *  2. Corroborated hook — a live same-slug process backs the authority.
  *     Age and routing are irrelevant here: the process IS the evidence.
  *  3. Fresh exact-routed hook, uncontradicted — the bridge signaled within
@@ -80,7 +83,10 @@ export function resolveCanonicalAgentIdentity(inputs: {
   const ttl = inputs.identityTtlMs ?? IDENTITY_TTL_MS;
   const { proc, auth, screenSlug } = inputs;
 
-  if (proc?.slug && !proc.alive && proc.slug === screenSlug) return undefined;
+  if (
+    proc?.slug && !proc.alive && proc.slug === screenSlug
+    && !(auth?.exact && auth.ageMs <= ttl)
+  ) return undefined;
   if (auth && proc?.slug === auth.slug && proc.alive) {
     return { slug: auth.slug, source: 'hook' };
   }

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -53,6 +53,7 @@ import {
   agentSlugToDisplay,
   type AgentSignal,
   type AgentSignalKind,
+  type AgentSlug,
   type HookSignalResponse,
 } from '../../shared/hooks/signal-types';
 import { ENV_KEYS } from '../../shared/constants';
@@ -222,6 +223,17 @@ export interface HookIngestDeps {
    * Optional: only the daemon supplies it, and no hook behaviour depends on it.
    */
   emitDetectorEvent?: (sessionId: string, data: DetectorHeldEventData) => void;
+  /**
+   * #919 — fired after every resolved signal touches hook authority (both the
+   * `handle()` path and the permission-gate interceptor). Gives the daemon a
+   * single wiring point to ARM the process tracker for bannerless metadata
+   * hooks: a quiet claude mid-tool-call must not wait for a detector banner to
+   * become corroborable. The session is resolved; the callback owes the caller
+   * nothing back and its failure is non-fatal.
+   *
+   * Optional: only the daemon supplies it.
+   */
+  onAuthorityTouched?: (sessionId: string) => void;
 }
 
 /**
@@ -560,7 +572,13 @@ export class HookIngest {
     }
 
     // Touch authority on every gate signal — the bridge is alive on this pane.
-    this.router.touchAuthority(sessionId, signal.agent, this.now());
+    // `exact` (#919): only exact-ptyId routing may decide identity alone.
+    this.router.touchAuthority(sessionId, signal.agent, this.now(), signal.ptyId === sessionId);
+    try {
+      this.deps.onAuthorityTouched?.(sessionId);
+    } catch (err) {
+      this.deps.log?.('warn', `[hooks] authority-touch callback failed for ${sessionId}: ${String(err)}`);
+    }
 
     // Verdict-gate feed (R4): PreToolUse never reaches `handle()` — the RPC
     // interceptor routes awaiting_permission straight here — so this is the
@@ -682,8 +700,14 @@ export class HookIngest {
     // this agent, including the non-emit kinds (SessionStart, per-tool
     // activity) — freshness tracks "the bridge is alive on this pane", not
     // "a toast just fired". The detector-emission site consults
-    // isGovernedFor before fanning out its own notifications.
-    this.router.touchAuthority(sessionId, signal.agent, this.now());
+    // isGovernedFor before fanning out its own notifications. `exact` (#919):
+    // a cwd-prefix-resolved signal may corroborate identity but never stand alone.
+    this.router.touchAuthority(sessionId, signal.agent, this.now(), signal.ptyId === sessionId);
+    try {
+      this.deps.onAuthorityTouched?.(sessionId);
+    } catch (err) {
+      this.deps.log?.('warn', `[hooks] authority-touch callback failed for ${sessionId}: ${String(err)}`);
+    }
 
     // User answered a pending approval locally — no turn boundary, just expire the request.
     // The alarm is fed FIRST: an `answered` cue cancels a pending ATTENTION
@@ -995,6 +1019,30 @@ export class HookIngest {
     const outcome = this.alarm.observe(sessionId, slug, cue, resume);
     if (outcome === 'hold') return { source, decision: 'pending' };
     return { source, decision: 'internal' };
+  }
+
+  /**
+   * #919 — hook-tier identity input for the canonical tier rule. Thin delegate:
+   * the ingest owns the router; daemon/index.ts never touches it directly.
+   * Undefined when no authority is on record (or past the 30-min map TTL) —
+   * the caller applies the shorter IDENTITY_TTL and the `exact` gate on the
+   * uncorroborated path only.
+   */
+  authorityAgentFor(
+    sessionId: string,
+  ): { slug: AgentSlug; ageMs: number; exact: boolean } | undefined {
+    return this.router.authorityAgentFor(sessionId);
+  }
+
+  /**
+   * #919 — expire the pane's authority on CONFIRMED process death. The 30-min
+   * detector veto belongs to the dead launch's generation: left alone it keeps
+   * suppressing every completion of a relaunched same-slug agent whose hooks
+   * are broken. `onlyAgent` scopes the expiry so a death of process A never
+   * strips process B's authority.
+   */
+  expireAuthorityFor(sessionId: string, onlyAgent?: string): void {
+    this.router.expireAuthorityFor(sessionId, onlyAgent);
   }
 
   /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -4483,9 +4483,15 @@ function wireEvents(
     const activeCanonical = canonicalIdentityFor(agentProcessTracker, payload.sessionId, activeScreenSlug);
     if (!payload.likelyRepaint) hookIngest?.notePaneWorking(
       payload.sessionId,
+      // Canonical undefined + a mappable screen slug IS the residue veto
+      // (confirmed-dead same-slug read) — falling back to the persisted
+      // lastDetectedAgent there would feed the DEAD agent's slug to the
+      // alarm as if it were working (review #4). The legacy fallback only
+      // applies when the burst named no known agent at all.
       activeCanonical?.slug
-        ?? sessionManager.getSession(payload.sessionId)?.meta.lastDetectedAgent
-        ?? undefined,
+        ?? (activeScreenSlug ? undefined
+          : sessionManager.getSession(payload.sessionId)?.meta.lastDetectedAgent
+          ?? undefined),
     );
     const event: DaemonEvent = {
       type: 'activity.active',
@@ -4523,7 +4529,12 @@ function wireEvents(
       // stale "alive" state.
       if (managed) {
         const tracked = agentProcessTracker.identityFor(payload.sessionId);
-        if (tracked?.slug !== undefined && tracked.slug !== slug) {
+        // Only a LIVE conflicting pick needs the forced probe — a tracked
+        // pick that already DIED is exactly the case plain arm() handles
+        // (alive=false lets it re-probe), and rearm() would burn its 10s
+        // cooldown for nothing, potentially blocking the real launch probe
+        // moments later (review #3).
+        if (tracked?.slug !== undefined && tracked.slug !== slug && tracked.alive) {
           agentProcessTracker.rearm(payload.sessionId, managed.meta.pid);
         } else {
           agentProcessTracker.arm(payload.sessionId, managed.meta.pid);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -49,7 +49,7 @@ import { WorkTaskService } from './worktask/WorkTaskService';
 import { isTaskState, type Message } from '../shared/types';
 import { ProcessMonitor } from './ProcessMonitor';
 import { AgentProcessTracker } from './AgentProcessTracker';
-import { resolveCanonicalAgentIdentity, type CanonicalAgentIdentity } from './canonicalAgent';
+import { resolveCanonicalAgentIdentity, detectorSuppressedBy, type CanonicalAgentIdentity } from './canonicalAgent';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { isShutdownKillExit, SHUTDOWN_KILL_RECLASSIFY_MS } from './shutdownKill';
@@ -166,17 +166,8 @@ function canonicalIdentityFor(
   });
 }
 
-/**
- * #919 — the suppression test shared by both detector-emission sites: a
- * DETECTOR-origin event whose screen slug is contradicted by a tier-1/2
- * (hook/process) canonical identity must not broadcast at all — a false
- * detection should not notify, which also beats relabeling it. Screen-tier
- * canonical (nothing stronger than the screen itself) and unconstrained
- * events (canonical undefined) broadcast unchanged.
- */
-function detectorSuppressedBy(canonical: CanonicalAgentIdentity | undefined, screenSlug?: AgentSlug): boolean {
-  return canonical !== undefined && canonical.source !== 'screen' && canonical.slug !== screenSlug;
-}
+/* detectorSuppressedBy lives in canonicalAgent.ts beside the tier rule it
+   guards — it is pure, and that module is where the rule is unit tested. */
 
 /**
  * The one device roster in this process. A second instance would be a second

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -49,6 +49,7 @@ import { WorkTaskService } from './worktask/WorkTaskService';
 import { isTaskState, type Message } from '../shared/types';
 import { ProcessMonitor } from './ProcessMonitor';
 import { AgentProcessTracker } from './AgentProcessTracker';
+import { resolveCanonicalAgentIdentity, type CanonicalAgentIdentity } from './canonicalAgent';
 import { Watchdog } from './Watchdog';
 import { selectRecoverableSessions } from './recoverySelector';
 import { isShutdownKillExit, SHUTDOWN_KILL_RECLASSIFY_MS } from './shutdownKill';
@@ -136,6 +137,46 @@ let deviceStore: DeviceStore | null = null;
 // construction sites, one of which is a module-level function. Null until
 // registerRpcHandlers runs, which is before either site.
 let sessionLifecycle: WebSessionLifecycle | null = null;
+
+/**
+ * #919 — canonical pane-agent identity for one pane, right now. Folds the
+ * three signals (hook self-report, attributed process, screen chrome) through
+ * the tier rule in src/daemon/canonicalAgent.ts. EVERY raw emission/feed site
+ * routes through here — any site left reading the screen name directly
+ * re-asserts the mislabel this exists to fix (#916: a Grok pane labelled
+ * Claude by its own output text).
+ *
+ * Module-level like `hookIngest` because its two callers (registerRpcHandlers'
+ * detector re-emission, wireEvents' session handlers) live in separate
+ * functions; both also receive the tracker as a parameter. Both identity maps
+ * are boot-local (tracker state, hook authority), so nothing persisted can
+ * leak into this answer across a reboot.
+ */
+function canonicalIdentityFor(
+  agentProcessTracker: AgentProcessTracker,
+  sessionId: string,
+  screenSlug?: AgentSlug,
+): CanonicalAgentIdentity | undefined {
+  const proc = agentProcessTracker.identityFor(sessionId);
+  const auth = hookIngest?.authorityAgentFor(sessionId);
+  return resolveCanonicalAgentIdentity({
+    ...(proc ? { proc } : {}),
+    ...(auth ? { auth } : {}),
+    ...(screenSlug ? { screenSlug } : {}),
+  });
+}
+
+/**
+ * #919 — the suppression test shared by both detector-emission sites: a
+ * DETECTOR-origin event whose screen slug is contradicted by a tier-1/2
+ * (hook/process) canonical identity must not broadcast at all — a false
+ * detection should not notify, which also beats relabeling it. Screen-tier
+ * canonical (nothing stronger than the screen itself) and unconstrained
+ * events (canonical undefined) broadcast unchanged.
+ */
+function detectorSuppressedBy(canonical: CanonicalAgentIdentity | undefined, screenSlug?: AgentSlug): boolean {
+  return canonical !== undefined && canonical.source !== 'screen' && canonical.slug !== screenSlug;
+}
 
 /**
  * The one device roster in this process. A second instance would be a second
@@ -2937,10 +2978,25 @@ function registerRpcHandlers(
       // the handler performs, minus what already ran before arbitration
       // (lastDetectedAgent persistence, resume-chip arm).
       emitDetectorEvent: (sessionId, data) => {
+        // #919 — same canonical rule as the live `session:agent` site: a held
+        // completion contradicted by the pane's tier-1/2 identity must not
+        // broadcast (or drive phone liveness) when its window expires either.
+        const screenSlug = agentDisplayToSlug(data.agent);
+        if (detectorSuppressedBy(canonicalIdentityFor(agentProcessTracker, sessionId, screenSlug), screenSlug)) return;
         sessionManager.getSession(sessionId)?.bridge.noteAgentStatus(data.status as AgentEventStatus);
         const event: DaemonEvent = { type: 'agent.event', sessionId, data };
         pipeServer.broadcast(event);
         webTerminalServer?.emitAgentLiveness(deriveAgentLiveness(sessionId, data, Date.now()));
+      },
+      // #919 (Codex #8) — every resolved hook signal proves the bridge is
+      // alive on this pane RIGHT NOW, banner or not. Arming here means a quiet
+      // claude mid-tool-call (only PreToolUse/activity hooks firing) becomes
+      // process-corroborated without waiting for a detector banner. arm() is
+      // a no-op while a live agent is tracked and backoff-bounded otherwise,
+      // so the hot path stays cheap.
+      onAuthorityTouched: (sessionId) => {
+        const managed = sessionManager.getSession(sessionId);
+        if (managed) agentProcessTracker.arm(sessionId, managed.meta.pid);
       },
     });
   }
@@ -3097,7 +3153,20 @@ function registerRpcHandlers(
   pipeServer.onRpc('daemon.getAgentName', async (params) => {
     const id = typeof params['id'] === 'string' ? params['id'] : '';
     const session = id ? sessionManager.getSession(id) : undefined;
-    return { agentName: session?.bridge.getLastAgent() ?? null };
+    // #919 — answer canonically, not raw: the detector's getLastAgent is
+    // sticky screen truth, which mislabels exactly when this RPC is consulted
+    // (post-exit, agent swapped). Both canonical inputs are boot-local, so a
+    // rebooted daemon answers from the screen tier until evidence arrives —
+    // no persisted slug can claim a fresh shell. Canonical undefined WITH a
+    // mappable screen slug is the residue veto (confirmed-dead same slug):
+    // report no agent instead of resurrecting the label.
+    const rawName = session?.bridge.getLastAgent();
+    if (!session || !rawName) return { agentName: rawName ?? null };
+    const screenSlug = agentDisplayToSlug(rawName);
+    const canonical = canonicalIdentityFor(agentProcessTracker, id, screenSlug);
+    if (canonical) return { agentName: agentSlugToDisplay(canonical.slug) };
+    if (screenSlug) return { agentName: null };
+    return { agentName: rawName };
   });
 
   // daemon.readPromptEvents — read structured OSC 133 prompt/command events
@@ -4406,19 +4475,30 @@ function wireEvents(
     // DaemonPTYBridge already protects the detector dedup from). The loose
     // status-dot broadcast below still runs — only the strict alarm feed
     // skips repaint-flagged bursts.
+    // #919 — compute canonical identity ONCE for this burst and use it for
+    // both feeds below. Leaving either on the raw screen name would re-assert
+    // the detector's sticky label on every output burst, undoing whatever the
+    // canonical rule had corrected (Codex #5).
+    const activeScreenSlug = agentDisplayToSlug(payload.agentName ?? '');
+    const activeCanonical = canonicalIdentityFor(agentProcessTracker, payload.sessionId, activeScreenSlug);
     if (!payload.likelyRepaint) hookIngest?.notePaneWorking(
       payload.sessionId,
-      agentDisplayToSlug(payload.agentName ?? '')
+      activeCanonical?.slug
         ?? sessionManager.getSession(payload.sessionId)?.meta.lastDetectedAgent
         ?? undefined,
     );
     const event: DaemonEvent = {
       type: 'activity.active',
       sessionId: payload.sessionId,
-      // gate로 확정된 에이전트 이름을 data에 실어 main으로 전달한다(없으면 null).
-      // daemon mode running 상태에 agentName을 채우는 경로(local mode는
-      // PTYBridge가 getLastAgent로 직접 처리).
-      data: payload.agentName ?? null,
+      // Canonical agent name (or null) rides data to main — the daemon-mode
+      // path that fills running-state agentName (local mode stays on
+      // PTYBridge's getLastAgent). Undefined canonical with a mappable screen
+      // slug is the residue veto: null, not the dead agent's sticky label.
+      data: activeCanonical
+        ? agentSlugToDisplay(activeCanonical.slug)
+        : activeScreenSlug
+          ? null
+          : payload.agentName ?? null,
     };
     pipeServer.broadcast(event);
   });
@@ -4428,21 +4508,8 @@ function wireEvents(
     // reboot knows this interactive pane was an agent. agentDisplayToSlug maps
     // the AgentDetector display name ('Claude Code') → canonical slug ('claude').
     const slug = agentDisplayToSlug(payload.event.agent);
+    const managed = sessionManager.getSession(payload.sessionId);
     if (slug) {
-      const managed = sessionManager.getSession(payload.sessionId);
-      if (managed && managed.meta.lastDetectedAgent !== slug) {
-        managed.meta.lastDetectedAgent = slug;
-        // X6 ②: persist IMMEDIATELY, not debounced. lastDetectedAgent is the
-        // SOLE basis for the post-reboot resume offer (resumeOfferForRecovered
-        // reads it off the persisted session). A real OS reboot SIGKILLs the
-        // daemon — flush()/process.on('exit') never run — so a 30s debounce
-        // (or the periodic snapshot) can drop a fresh detection that has no
-        // other state-changing event to opportunistically flush it. The
-        // !== slug guard above bounds this to one sync write per agent
-        // transition (effectively once per idle agent pane), so the cost is
-        // negligible vs. the durability it buys.
-        stateWriter.saveImmediate(buildState(sessionManager));
-      }
       // The agent is live again → this pane is no longer a "resume me" shell.
       recoveredAgentShellIds.delete(payload.sessionId);
       recoveredResumeBindings.delete(payload.sessionId);
@@ -4450,7 +4517,39 @@ function wireEvents(
       // right now — attach the process watch so the chip can hide on process
       // truth and reappear exactly on the agent's exit edge. Covers codex,
       // which has no hooks (the setResumeBinding arm never fires for it).
-      if (managed) agentProcessTracker.arm(payload.sessionId, managed.meta.pid);
+      // #919: a banner naming a DIFFERENT slug than the tracked one is launch
+      // evidence — the old pick's death poll can lag a fresh launch by up to
+      // one monitor cadence, so force the probe instead of no-op'ing on the
+      // stale "alive" state.
+      if (managed) {
+        const tracked = agentProcessTracker.identityFor(payload.sessionId);
+        if (tracked?.slug !== undefined && tracked.slug !== slug) {
+          agentProcessTracker.rearm(payload.sessionId, managed.meta.pid);
+        } else {
+          agentProcessTracker.arm(payload.sessionId, managed.meta.pid);
+        }
+      }
+    }
+    // #919 — canonical identity decides what the pane IS. The screen tier
+    // (nothing stronger known) keeps today's behavior exactly: persist the
+    // detected slug. Hook/process tiers correct it; the residue veto
+    // (canonical undefined on a confirmed-dead same-slug read) persists
+    // nothing. arm() above is fire-and-forget, so the FIRST banner on an
+    // unarmed pane still resolves screen-tier — corrected on the tracker's
+    // attribution callback or the next event once the probe lands.
+    const canonical = canonicalIdentityFor(agentProcessTracker, payload.sessionId, slug);
+    if (canonical && managed && managed.meta.lastDetectedAgent !== canonical.slug) {
+      managed.meta.lastDetectedAgent = canonical.slug;
+      // X6 ②: persist IMMEDIATELY, not debounced. lastDetectedAgent is the
+      // SOLE basis for the post-reboot resume offer (resumeOfferForRecovered
+      // reads it off the persisted session). A real OS reboot SIGKILLs the
+      // daemon — flush()/process.on('exit') never run — so a 30s debounce
+      // (or the periodic snapshot) can drop a fresh detection that has no
+      // other state-changing event to opportunistically flush it. The
+      // !== slug guard above bounds this to one sync write per agent
+      // transition (effectively once per idle agent pane), so the cost is
+      // negligible vs. the durability it buys.
+      stateWriter.saveImmediate(buildState(sessionManager));
     }
     // M1: the daemon owns hook-vs-detector arbitration now — the hook lands
     // here, not in main, so main can no longer run it and reads the outcome
@@ -4466,10 +4565,21 @@ function wireEvents(
     // and stays: lastDetectedAgent persistence, resume-chip arm, the
     // recovered-set deletes.
     if (arbitration.decision === 'pending') return;
+    // #919 — a detector event contradicted by a tier-1/2 canonical identity
+    // is a false detection: suppress the broadcast entirely (data.agent is
+    // NEVER rewritten — main keys notification dedup off it and the
+    // arbitration stamp describes the raw detection).
+    if (detectorSuppressedBy(canonical, slug)) return;
     const event: DaemonEvent = {
       type: 'agent.event',
       sessionId: payload.sessionId,
-      data: { ...payload.event, ...arbitration },
+      data: {
+        ...payload.event,
+        ...arbitration,
+        // #919 — additive identity stamp for future consumers; main ignores
+        // unknown fields today.
+        ...(canonical ? { identity: { slug: canonical.slug, source: canonical.source } } : {}),
+      },
     };
     pipeServer.broadcast(event);
   });
@@ -5556,6 +5666,31 @@ async function main(): Promise<void> {
   // interactive panes so the chip can gate on process truth instead of the
   // decaying activity heuristic. Rides processMonitor's existing batch.
   const agentProcessTracker = new AgentProcessTracker(processMonitor);
+  // #919 — re-evaluate canonical identity OUTSIDE `session:agent`: the tier
+  // inputs change (attribution completes; a watched process dies) while no
+  // detector event is in flight, and a wrong label would otherwise sit in
+  // lastDetectedAgent until the next unrelated event. On the death edge the
+  // pane's hook authority ALSO expires — the 30-min detector veto belongs to
+  // the dead launch's generation, and left alone it would keep suppressing
+  // every completion of a relaunched same-slug agent whose hooks are broken
+  // (Codex #12). No identity-flip agent.event is fabricated (its lifecycle
+  // status semantics would invent completions); the label self-heals through
+  // activity.active / getAgentName on the next output burst.
+  agentProcessTracker.setStateChangeListener((sessionId, state) => {
+    if (!state.alive) hookIngest?.expireAuthorityFor(sessionId, state.slug);
+    const managed = sessionManager.getSession(sessionId);
+    if (!managed) return;
+    const screenSlug = managed.bridge.getLastAgent();
+    const canonical = canonicalIdentityFor(
+      agentProcessTracker,
+      sessionId,
+      screenSlug ? agentDisplayToSlug(screenSlug) : undefined,
+    );
+    if (canonical && managed.meta.lastDetectedAgent !== canonical.slug) {
+      managed.meta.lastDetectedAgent = canonical.slug;
+      stateWriter.saveImmediate(buildState(sessionManager));
+    }
+  });
 
   // LanLink PR-4 — the network surface. An ISOLATED net.Server (its OWN admission
   // counters, never the control pipe's = G1) bound to the configured NIC, with

--- a/src/shared/hooks/HookSignalRouter.ts
+++ b/src/shared/hooks/HookSignalRouter.ts
@@ -34,6 +34,7 @@ import type {
   AgentSignalKind,
   AgentSlug,
 } from './signal-types';
+import { isAgentSlug } from '../agentIdentity';
 import type { SignalLatencyMeter } from './SignalLatencyMeter';
 
 /** Default dedup window. 10s chosen by eng review 2026-05-22 after measuring
@@ -91,8 +92,14 @@ export class HookSignalRouter {
   private readonly windowMs: number;
   private readonly authorityTtlMs: number;
   /** ptyId → last bridge signal for that pane (any kind, incl. non-emit
-   *  SessionStart/activity). Drives the detector veto — see HOOK_AUTHORITY_TTL_MS. */
-  private readonly authority = new Map<string, { agent: string; lastSignalAt: number }>();
+   *  SessionStart/activity). Drives the detector veto — see HOOK_AUTHORITY_TTL_MS —
+   *  and (daemon-side, #919) the canonical identity tier. `exact` records
+   *  whether the signal was routed by exact ptyId or via the cwd-prefix
+   *  fallback: only exact-routed authority may decide identity alone. */
+  private readonly authority = new Map<
+    string,
+    { agent: string; lastSignalAt: number; exact: boolean }
+  >();
 
   constructor(deps: { latencyMeter: SignalLatencyMeter; dedupWindowMs?: number; authorityTtlMs?: number }) {
     this.latencyMeter = deps.latencyMeter;
@@ -105,9 +112,50 @@ export class HookSignalRouter {
    * Called by hooks.rpc on every resolved signal — including the non-emit
    * kinds (SessionStart, agent.activity) — so authority freshness tracks
    * "the bridge is alive for this pane", not "a toast just fired".
+   *
+   * `exact` (default true) marks signals routed by exact ptyId; the daemon's
+   * cwd-prefix fallback passes false — #919 lets only exact-routed authority
+   * decide identity uncorroborated, since a cwd guess can attach to a
+   * neighboring pane.
    */
-  touchAuthority(ptyId: string, agent: string, now: number = Date.now()): void {
-    this.authority.set(ptyId, { agent, lastSignalAt: now });
+  touchAuthority(
+    ptyId: string,
+    agent: string,
+    now: number = Date.now(),
+    exact = true,
+  ): void {
+    this.authority.set(ptyId, { agent, lastSignalAt: now, exact });
+  }
+
+  /**
+   * #919 — the pane's hook authority within the map TTL, as identity input:
+   * which agent's bridge signaled, how long ago, and with which routing
+   * provenance. Undefined past the 30-min TTL (the caller applies the much
+   * shorter identity TTL to `ageMs` on the uncorroborated path only).
+   */
+  authorityAgentFor(
+    ptyId: string,
+    now: number = Date.now(),
+  ): { slug: AgentSlug; ageMs: number; exact: boolean } | undefined {
+    const entry = this.authority.get(ptyId);
+    if (!entry || !isAgentSlug(entry.agent)) return undefined;
+    const ageMs = now - entry.lastSignalAt;
+    if (ageMs >= this.authorityTtlMs) return undefined;
+    return { slug: entry.agent, ageMs, exact: entry.exact };
+  }
+
+  /**
+   * #919 — expire the pane's authority on CONFIRMED process death. The 30-min
+   * veto belongs to the dead launch's generation: left alone it suppresses
+   * every detector completion of a relaunched same-slug agent whose hooks are
+   * broken. `onlyAgent` scopes the expiry to that agent's entry so a death of
+   * process A never strips process B's authority.
+   */
+  expireAuthorityFor(ptyId: string, onlyAgent?: string): void {
+    const entry = this.authority.get(ptyId);
+    if (!entry) return;
+    if (onlyAgent !== undefined && entry.agent !== onlyAgent) return;
+    this.authority.delete(ptyId);
   }
 
   /**

--- a/src/shared/hooks/__tests__/HookSignalRouter.test.ts
+++ b/src/shared/hooks/__tests__/HookSignalRouter.test.ts
@@ -251,5 +251,41 @@ describe('HookSignalRouter', () => {
       router.resetForTests();
       expect(router.isGovernedFor('p1', 'claude', 1100)).toBe(false);
     });
+
+    it('#919 authorityAgentFor reports slug, age and routing provenance', () => {
+      router.touchAuthority('p1', 'claude', 1000);
+      router.touchAuthority('p2', 'codex', 1000, false); // cwd-fallback routed
+      expect(router.authorityAgentFor('p1', 4000)).toEqual({ slug: 'claude', ageMs: 3000, exact: true });
+      expect(router.authorityAgentFor('p2', 4000)).toEqual({ slug: 'codex', ageMs: 3000, exact: false });
+      expect(router.authorityAgentFor('p3', 4000)).toBeUndefined();
+      // Non-slug agents (unknown future spellings) carry no identity weight.
+      expect(router.touchAuthority('p4', 'agent-nine', 1000)).toBeUndefined();
+      expect(router.authorityAgentFor('p4', 4000)).toBeUndefined();
+    });
+
+    it('#919 authorityAgentFor expires with the map TTL', () => {
+      router = new HookSignalRouter({ latencyMeter: meter, authorityTtlMs: 5_000 });
+      router.touchAuthority('p1', 'claude', 1000);
+      expect(router.authorityAgentFor('p1', 5_999)).toBeDefined();
+      expect(router.authorityAgentFor('p1', 6_000)).toBeUndefined();
+    });
+
+    it('#919 expireAuthorityFor clears the veto on confirmed process death', () => {
+      router.touchAuthority('p1', 'claude', 1000);
+      router.expireAuthorityFor('p1', 'claude');
+      // A relaunched same-slug agent with broken hooks must get its detector
+      // completions through — the veto died with the old launch.
+      expect(router.isGovernedFor('p1', 'claude', 1100)).toBe(false);
+      expect(router.authorityAgentFor('p1', 1100)).toBeUndefined();
+    });
+
+    it('#919 expireAuthorityFor scoped to another agent leaves the entry intact', () => {
+      router.touchAuthority('p1', 'codex', 1000);
+      router.expireAuthorityFor('p1', 'claude'); // claude's death, not codex's
+      expect(router.isGovernedFor('p1', 'codex', 1100)).toBe(true);
+      // Unscoped expiry (slugless pick) clears whatever is there.
+      router.expireAuthorityFor('p1');
+      expect(router.isGovernedFor('p1', 'codex', 1100)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## What

A pane's agent identity is no longer decided by what the terminal printed. It is folded from three signals into one precedence:

```
corroborated hook > fresh exact-routed hook (2-min TTL) > live attributed process > screen chrome
```

with a residue veto: a confirmed-dead same-slug screen read is sticky detector residue, not an agent — unless a fresh exact-routed hook backs the same slug, which is the relaunch itself.

Closes #919. Fixes the mislabel class from #916 (a Grok pane labelled Claude — twice) at the layer that actually caused it: the screen gates cannot tell an agent from a sentence about an agent, yet they were the only identity source.

## How

- **`src/daemon/canonicalAgent.ts` (new)** — the tier rule as a pure function. `IDENTITY_TTL_MS` (2 min) is deliberately not the 30-min hook-authority TTL: that window spans long quiet tool calls for notification suppression, but an identity claim riding a stale entry would mislabel the pane's next agent.
- **`AgentProcessTracker`** — the launch-edge process pick now also answers *which* agent: cmdline attribution with strict token discipline (quote-aware tokenizer; candidates are only the script token — `argv[1]`, or the first non-flag when the launcher prefixes runtime flags, in path form only so a bare `claude.js` is the user's own file — the non-flag after a package runner or `python -m`, and `node_modules/<pkg>` boundary segments; arbitrary ancestor directories never match). Pick = shallowest **attributed** by depth regardless of native-vs-runtime class; exact-depth different-slug ties drop the slug rather than guessing. Adds `rearm()` (forced probe when a banner names a different agent than the tracked one), a 30 s negative-result backoff so chatty banners can't re-run `ps` per event, and a state-change listener for attribution/death edges.
- **`HookSignalRouter`** — authority entries record routing provenance (`exact` vs cwd-guess); new `authorityAgentFor()` (identity input) and `expireAuthorityFor()` — the 30-min detector veto dies with the launch that earned it, so a relaunched same-slug agent with broken hooks gets its completions through.
- **`daemon/index.ts`** — every emission/feed site (`session:agent`, detector re-emission, `session:active`, `daemon.getAgentName`) resolves canonical identity. Detector events contradicted by a tier-1/2 identity are suppressed outright; **`data.agent` is never rewritten** (main's dedup keys off it). The pane label self-heals via `activity.active` / `getAgentName`; no fabricated lifecycle events. Hook signals arm the tracker so bannerless agents become corroborable; death edges expire authority and re-persist the corrected label.

`AgentDetector` gates are untouched — the screen stays the fallback for remote/SSH panes where no local process or hook exists.

## Cost

One process-table enumeration per agent **launch** per pane (arm/rearm), then a piggyback ride on the existing ProcessMonitor cadence. `ps -axo pid=,ppid=,args=` measures **0.01 s** wall on macOS (~600 processes); `identityFor`/`statusFor` are synchronous map reads. Windows rides the same single CIM query, now with `CommandLine`.

## Testing

- `canonicalAgent.test.ts` (new): all tier combinations including the #916 regression guard (live different-slug process beats even a fresh exact hook), the residue veto and its fresh-hook rescue, and non-exact routing never standing alone.
- `AgentProcessTracker.test.ts`: cmdline resolution real-world spellings and the false-positive guards (`node /work/claude/scratch.js`, `node demo.js claude`, `node claude.js` never resolve; `node --max-old-space-size=… cli.js` does), depth-regardless-of-class picking, rearm past a stale alive pick, queued-rearm replay behind an in-flight probe, backoff, listener edges, PID-reuse/stale-onDead/stale-batch guards.
- `HookSignalRouter.test.ts`: authority shape/TTL/provenance, death-scoped expiry.
- `ProcessMonitor.reuse.test.ts`: a stale monitor batch must not unwatch a replaced watch.

tsc clean, eslint clean on changed files; full `src/daemon` + `src/shared` suites pass (192 files / 3475 tests).

## Out of scope (deliberate)

- No `AgentDetector` pattern changes (screen tier must keep working for remote panes).
- No identity-flip `agent.event` fabrication — its lifecycle semantics would invent completions.
- No pgid/tty foreground enumeration; depth-first among attributed candidates approximates it.
- Main-process local mode (`PTYBridge`) identity paths untouched — daemon mode owns both detectors and ingest in one process.
- Follow-ups flagged by the pre-PR review panel, left for their own issues: (a) the desktop status label is not cleared when canonical `activity.active.data` goes null (tri-state `DaemonClient.onActive` plumbing — flicker-sensitive, needs its own change); (b) authority expiry on a **slugless** tracked death is pane-scoped, not pick-scoped (rare wrapper-orphan case; the exact fix needs a death timestamp the monitor edge does not carry today); (c) POSIX `kill(pid, 0)` liveness has no image identity check against PID reuse (pre-existing; this PR's `rearm()` at least recovers a stale-pick label on the next conflicting banner).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable agent identity detection across processes, hooks, runtimes, aliases, and scoped packages.
  * Agent events now include canonical identity information and its detection source.
  * Added support for refreshing process tracking and reporting live identity state changes.

* **Bug Fixes**
  * Prevented stale monitoring results from affecting replacement processes.
  * Improved handling of ambiguous, failed, terminated, and conflicting identity signals.
  * Added expiration and cleanup for outdated hook-based identity data.
  * Improved label recovery and suppressed contradictory identity notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->