### PR TITLE
Stop the roster from reading a working pane as waiting

### DIFF
--- a/changelog.d/939.md
+++ b/changelog.d/939.md
@@ -13,3 +13,22 @@
   Note for anyone running a mixed pair: on the packaged daemon path the fix
   rides the daemon's own arbitration stamp, so an older daemon with a newer
   app does not get it until both are updated. (#935, #939)
+
+- **Claude Code panes are detected again.** The Claude gate needed its footer
+  spelled with literal spaces on a line of its own. The shipping product
+  (measured on v2.1.235) provides neither: spaces are cursor advances
+  (`ESC[1C`), so the footer strips to `bypasspermissionson`, and the whole
+  bottom region — input box, statusline, footer — arrives as one newline-free
+  run whose rows are placed with cursor-position escapes. The gate therefore
+  never opened on a real Claude pane, which quietly disabled every Claude
+  detector pattern, `waiting` and the approval `awaiting_input` regexes alike.
+  Whitespace is now optional in the footer fragments (the same treatment the
+  banner pattern already carried) and candidate lines are cut on row-position
+  escapes as well as newlines. (#935)
+
+- **A freshly launched agent no longer reads as busy.** Hook authority answers
+  "a bridge speaks for this pane", which is not the same as "the hook has
+  claimed this pane's lifecycle". A bridge that had sent only `SessionStart`
+  suppressed the detector's true "ready for input" read, leaving the pane on
+  the gate's one-shot `running` until its first turn ended. The status veto now
+  waits for the hook to actually take the lifecycle over. (#935)

--- a/changelog.d/939.md
+++ b/changelog.d/939.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **The roster no longer reads a working pane as waiting.** Claude Code's
+  `bypass permissions on` footer is on screen for the whole turn in
+  bypass-permissions mode, and the detector read every repaint of it as
+  "ready for input" — which put a false `waiting` on the pane's roster row
+  and inflated the "N need you" chip while the agent was still working. On a
+  pane with a live hook bridge the Stop signal now owns the lifecycle status
+  outright, on both the local and the packaged daemon path. Approval prompts
+  (`awaiting_input`) are unaffected, and a pane with no hook bridge keeps the
+  detector as its backstop. (#935, #939)

--- a/changelog.d/939.md
+++ b/changelog.d/939.md
@@ -8,4 +8,8 @@
   pane with a live hook bridge the Stop signal now owns the lifecycle status
   outright, on both the local and the packaged daemon path. Approval prompts
   (`awaiting_input`) are unaffected, and a pane with no hook bridge keeps the
-  detector as its backstop. (#935, #939)
+  detector as its backstop.
+
+  Note for anyone running a mixed pair: on the packaged daemon path the fix
+  rides the daemon's own arbitration stamp, so an older daemon with a newer
+  app does not get it until both are updated. (#935, #939)

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -98,10 +98,17 @@ export interface HookIngestSession {
  *   - 'emit'  → fan out the notification AND the `agent.lifecycle` tee
  *   - 'dedup' → the other source already covered this turn: lifecycle tee with
  *               `decision:'dedup'`, NO notification
- *   - 'veto'  → detector-only, hook-governed pane: metadata/status dot only,
+ *   - 'veto'  → detector-only, hook-governed pane: identity metadata only,
  *               no notification and no lifecycle tee (the hook is canonical
  *               here and the detector's always-visible footer would both
- *               re-fire mid-turn and poison the ledger against the real Stop)
+ *               re-fire mid-turn and poison the ledger against the real Stop).
+ *               #935: main also withholds the lifecycle STATUS on a veto —
+ *               that footer is what put a false 'waiting' on the roster row
+ *               and into "N need you". 'internal' does NOT share this (the
+ *               alarm's own judgement leaves the status live), so the two
+ *               verdicts are no longer interchangeable main-side.
+ *               `agent.awaiting_input` is never stamped 'veto' here, and main
+ *               enforces that locally too rather than trusting this process.
  *
  * `decision` is absent for DETECTOR statuses that are not emit-class (e.g.
  * 'running'): those never participated in dedup on either side.

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -580,7 +580,7 @@ export class HookIngest {
 
     // Touch authority on every gate signal — the bridge is alive on this pane.
     // `exact` (#919): only exact-ptyId routing may decide identity alone.
-    this.router.touchAuthority(sessionId, signal.agent, this.now(), signal.ptyId === sessionId);
+    this.router.touchAuthority(sessionId, signal.agent, this.now(), signal.ptyId === sessionId, signal.kind);
     try {
       this.deps.onAuthorityTouched?.(sessionId);
     } catch (err) {
@@ -709,7 +709,7 @@ export class HookIngest {
     // "a toast just fired". The detector-emission site consults
     // isGovernedFor before fanning out its own notifications. `exact` (#919):
     // a cwd-prefix-resolved signal may corroborate identity but never stand alone.
-    this.router.touchAuthority(sessionId, signal.agent, this.now(), signal.ptyId === sessionId);
+    this.router.touchAuthority(sessionId, signal.agent, this.now(), signal.ptyId === sessionId, signal.kind);
     try {
       this.deps.onAuthorityTouched?.(sessionId);
     } catch (err) {
@@ -993,7 +993,11 @@ export class HookIngest {
       if (cue) this.alarm.observe(sessionId, slug, cue);
       return { source };
     }
-    if (kind !== 'agent.awaiting_input' && this.router.isGovernedFor(sessionId, slug, this.now())) {
+    // #935 — one predicate, both processes. `governsDetectorStatus` already
+    // excludes `awaiting_input` (and every non-lifecycle status) and adds the
+    // turn-liveness scope that plain `isGovernedFor` lacks: a live bridge on an
+    // IDLE pane must not veto the detector's true "ready for input" read.
+    if (this.router.governsDetectorStatus(sessionId, slug, event.status, this.now())) {
       return { source, decision: 'veto' };
     }
     // Verdict gate (R1): the candidate holds a provisional window before it

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -709,14 +709,25 @@ export class DaemonNotificationRouter {
           return;
         }
 
+        // #935 — daemon-mode twin of the PTYBridge status gate. The lifecycle
+        // status is withheld when the pane's hook bridge owns it, or when the
+        // daemon already vetoed this detector event for that same reason
+        // (`decision: 'veto'`). Claude's bypass-mode footer is on screen for the
+        // whole turn, so an ungated broadcast wrote a false 'waiting' onto the
+        // roster row and into "N need you". Identity still rides every event.
+        const statusSlug = agentDisplayToSlug(ev.agent);
+        const statusRouter = this.getHookRouter?.() ?? null;
+        const withholdStatus =
+          arbitratedDecision(ev) === 'veto'
+          || statusRouter?.governsDetectorStatus(payload.sessionId, statusSlug, ev.status) === true;
         broadcastMetadataUpdate(win, {
           ptyId: payload.sessionId,
-          agentStatus: ev.status,
+          ...(withholdStatus ? {} : { agentStatus: ev.status }),
           agentName: ev.agent,
           // P2: carry the slug (daemon-mode path — the packaged production path)
           // so the renderer builds the pane auto-name `(<agent>)` suffix. ev.agent
           // is the display name; mirrors the PTYBridge local-mode broadcast.
-          agentSlug: agentDisplayToSlug(ev.agent) ?? null,
+          agentSlug: statusSlug ?? null,
         });
         // Cache the agent display name for any subsequent OSC 133
         // command_end on this PTY. Daemon mode has no direct equivalent
@@ -734,8 +745,10 @@ export class DaemonNotificationRouter {
           // hook Stop signal is canonical: the detector's footer heuristics
           // fire mid-turn (Claude's status footer is always visible) and
           // would pre-poison the dedup ledger so the real Stop lands as
-          // 'dedup' → silent completion. The metadata broadcast above
-          // (status dot) stays live either way.
+          // 'dedup' → silent completion. The metadata broadcast above rides
+          // the SAME rule now (#935) — it withholds the lifecycle status and
+          // carries identity only, so the roster stops showing a working pane
+          // as waiting.
           //
           // codex review catch (round 2): this must NOT cover
           // 'awaiting_input'. Claude's hooks.json wires PreToolUse ONLY for
@@ -764,8 +777,10 @@ export class DaemonNotificationRouter {
             // 'internal' is the daemon's CompletionAlarm rejecting the
             // candidate as not-a-real-turn-end (subagent stop, leftover
             // background work, turn-gate miss, already announced, or a
-            // rebutted window). Same treatment either way: the status dot
-            // (broadcast above) stays live; nothing else fires.
+            // rebutted window). Nothing else fires either way. They differ
+            // only in the status dot: 'veto' means the hook owns the
+            // lifecycle, so the broadcast above withheld the status (#935);
+            // 'internal' is the alarm's own judgement and leaves it live.
             if (decision === 'veto' || decision === 'internal') return;
           } else if (
             ev.status !== 'awaiting_input'

--- a/src/main/notification/DaemonNotificationRouter.ts
+++ b/src/main/notification/DaemonNotificationRouter.ts
@@ -709,17 +709,37 @@ export class DaemonNotificationRouter {
           return;
         }
 
-        // #935 — daemon-mode twin of the PTYBridge status gate. The lifecycle
-        // status is withheld when the pane's hook bridge owns it, or when the
-        // daemon already vetoed this detector event for that same reason
-        // (`decision: 'veto'`). Claude's bypass-mode footer is on screen for the
-        // whole turn, so an ungated broadcast wrote a false 'waiting' onto the
-        // roster row and into "N need you". Identity still rides every event.
+        // #935 — daemon-mode twin of the PTYBridge status gate. Claude's
+        // bypass-mode footer is on screen for the whole turn, so an ungated
+        // broadcast wrote a false 'waiting' onto the roster row and into
+        // "N need you". Identity still rides every event; only the lifecycle
+        // status is withheld.
+        //
+        // The two arms mirror the notification veto's own split below, and for
+        // the same reason — an arbitrated event already carries the daemon's
+        // judgement, so main must not re-run its own authority on top of it:
+        //
+        //   arbitrated  → trust the stamp. Withhold on 'veto' (the daemon
+        //                 applied exactly this rule) and nothing else. Note
+        //                 M1 makes this the ONLY live arm: `hooks.rpc` returns
+        //                 at the daemon relay, above its `touchAuthority`
+        //                 call, so main's router never gains authority over a
+        //                 daemon-served pane.
+        //   otherwise   → the pre-M1 fallback, where main's own authority is
+        //                 the only thing that knows.
+        //
+        // `awaiting_input` is excluded on BOTH arms. The daemon already
+        // refuses to stamp 'veto' on it (HookIngest), but that guarantee lives
+        // in another process: an older daemon paired with this main would
+        // otherwise hide a real approval prompt for the full authority TTL,
+        // which is worse than the bug this fixes. Cheap to enforce locally.
         const statusSlug = agentDisplayToSlug(ev.agent);
         const statusRouter = this.getHookRouter?.() ?? null;
-        const withholdStatus =
-          arbitratedDecision(ev) === 'veto'
-          || statusRouter?.governsDetectorStatus(payload.sessionId, statusSlug, ev.status) === true;
+        const withholdStatus = ev.status !== 'awaiting_input' && (
+          arbitratedSource(ev)
+            ? arbitratedDecision(ev) === 'veto'
+            : statusRouter?.governsDetectorStatus(payload.sessionId, statusSlug, ev.status) === true
+        );
         broadcastMetadataUpdate(win, {
           ptyId: payload.sessionId,
           ...(withholdStatus ? {} : { agentStatus: ev.status }),

--- a/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
@@ -224,11 +224,50 @@ describe('DaemonNotificationRouter — detector lifecycle tee (awaiting_input)',
     }
   });
 
-  it('#935 REGRESSION: a governed pane never gets a detector "waiting" onto agentStatus', async () => {
-    // Daemon-mode twin of the PTYBridge #935 test, and the path the packaged
-    // Windows build actually takes. Claude's `bypass permissions on` footer is
-    // on screen for the whole turn, so an ungated status broadcast marked a
-    // working pane 'waiting' and inflated the "N need you" chip.
+  it('#935 REGRESSION (M1 production arm): a daemon-vetoed detector "waiting" never reaches agentStatus', async () => {
+    // THE path the packaged build takes. `hooks.rpc` returns at the daemon
+    // relay, ABOVE its own `touchAuthority` call, so main's router never gains
+    // authority over a daemon-served pane — `governsDetectorStatus` is false
+    // here and the daemon's `decision: 'veto'` stamp is the whole mechanism.
+    // Stubbing the router to true instead would pass while testing a branch
+    // production never takes (team review catch).
+    //
+    // Claude's `bypass permissions on` footer is on screen for the whole turn,
+    // so an ungated status broadcast marked a working pane 'waiting' and
+    // inflated the "N need you" chip.
+    const hookRouter = stubHookRouter('emit'); // governsDetectorStatus → false
+    const { router: nr, captured } = makeRouter({ hookRouter });
+    try {
+      broadcastMetadataUpdateMock.mockClear();
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: {
+          agent: 'Claude Code',
+          status: 'waiting',
+          message: 'Ready for input',
+          source: 'detector',
+          decision: 'veto',
+        },
+      });
+      await flushMicrotasks();
+
+      const statusCalls = broadcastMetadataUpdateMock.mock.calls.filter(
+        (c) => (c[1] as { agentStatus?: string }).agentStatus === 'waiting',
+      );
+      expect(statusCalls).toHaveLength(0);
+      expect(broadcastMetadataUpdateMock.mock.calls[0][1]).toMatchObject({
+        ptyId: 'pty-a',
+        agentName: 'Claude Code',
+        agentSlug: 'claude',
+      });
+    } finally {
+      nr.stop();
+    }
+  });
+
+  it('#935 pre-M1 fallback arm: an UNARBITRATED detector "waiting" on a governed pane is withheld', async () => {
+    // No `source` stamp means an older daemon (or the local fallback), where
+    // main's own authority is the only thing that knows.
     const hookRouter = {
       recordDetector: vi.fn(),
       recordHook: vi.fn(),
@@ -250,10 +289,70 @@ describe('DaemonNotificationRouter — detector lifecycle tee (awaiting_input)',
         (c) => (c[1] as { agentStatus?: string }).agentStatus === 'waiting',
       );
       expect(statusCalls).toHaveLength(0);
+    } finally {
+      nr.stop();
+    }
+  });
+
+  it('#935 an ARBITRATED hook event keeps its status — main must not re-run its own authority on the daemon\'s judgement', async () => {
+    // The pane IS governed (by this very signal). Applying main's authority to
+    // a hook-sourced event would withhold the hook's own completion status,
+    // leaving the roster to depend entirely on the later boundary re-broadcast.
+    const hookRouter = {
+      recordDetector: vi.fn(),
+      recordHook: vi.fn(),
+      touchAuthority: vi.fn(),
+      isGovernedFor: vi.fn().mockReturnValue(true),
+      governsDetectorStatus: vi.fn().mockReturnValue(true),
+    } as unknown as HookSignalRouter;
+    const { router: nr, captured } = makeRouter({ hookRouter });
+    try {
+      broadcastMetadataUpdateMock.mockClear();
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: {
+          agent: 'Claude Code',
+          status: 'complete',
+          message: 'Task finished',
+          source: 'hook',
+          hookKind: 'agent.stop',
+          decision: 'emit',
+        },
+      });
+      await flushMicrotasks();
+
       expect(broadcastMetadataUpdateMock.mock.calls[0][1]).toMatchObject({
         ptyId: 'pty-a',
-        agentName: 'Claude Code',
-        agentSlug: 'claude',
+        agentStatus: 'complete',
+      });
+    } finally {
+      nr.stop();
+    }
+  });
+
+  it('#935 a "veto" stamped on awaiting_input is refused locally — daemon-skew defence', async () => {
+    // Today the daemon never stamps 'veto' on awaiting_input (HookIngest), but
+    // that guarantee lives in another process. An older daemon paired with this
+    // main must not be able to hide a real approval prompt for the authority TTL.
+    const hookRouter = stubHookRouter('emit');
+    const { router: nr, captured } = makeRouter({ hookRouter });
+    try {
+      broadcastMetadataUpdateMock.mockClear();
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: {
+          agent: 'Claude Code',
+          status: 'awaiting_input',
+          message: 'Approval requested',
+          source: 'detector',
+          decision: 'veto',
+        },
+      });
+      await flushMicrotasks();
+
+      expect(broadcastMetadataUpdateMock.mock.calls[0][1]).toMatchObject({
+        ptyId: 'pty-a',
+        agentStatus: 'awaiting_input',
       });
     } finally {
       nr.stop();

--- a/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
+++ b/src/main/notification/__tests__/DaemonNotificationRouter.lifecycle.test.ts
@@ -105,6 +105,7 @@ function stubHookRouter(decision: 'emit' | 'dedup'): HookSignalRouter {
     touchAuthority: vi.fn(),
     // Tests here exercise the detector tee — no pane is hook-governed.
     isGovernedFor: vi.fn().mockReturnValue(false),
+    governsDetectorStatus: vi.fn().mockReturnValue(false),
   } as unknown as HookSignalRouter;
 }
 
@@ -201,6 +202,11 @@ describe('DaemonNotificationRouter — detector lifecycle tee (awaiting_input)',
       recordHook: vi.fn(),
       touchAuthority: vi.fn(),
       isGovernedFor: vi.fn().mockReturnValue(true),
+      // #935: the status broadcast rides the same authority as the veto.
+      governsDetectorStatus: vi.fn(
+        (_p: string, slug: string | null | undefined, status: string) =>
+          !!slug && (status === 'waiting' || status === 'complete'),
+      ),
     } as unknown as HookSignalRouter;
     const { router: nr, captured } = makeRouter({ hookRouter });
     try {
@@ -218,6 +224,42 @@ describe('DaemonNotificationRouter — detector lifecycle tee (awaiting_input)',
     }
   });
 
+  it('#935 REGRESSION: a governed pane never gets a detector "waiting" onto agentStatus', async () => {
+    // Daemon-mode twin of the PTYBridge #935 test, and the path the packaged
+    // Windows build actually takes. Claude's `bypass permissions on` footer is
+    // on screen for the whole turn, so an ungated status broadcast marked a
+    // working pane 'waiting' and inflated the "N need you" chip.
+    const hookRouter = {
+      recordDetector: vi.fn(),
+      recordHook: vi.fn(),
+      touchAuthority: vi.fn(),
+      isGovernedFor: vi.fn().mockReturnValue(true),
+      governsDetectorStatus: vi.fn().mockReturnValue(true),
+    } as unknown as HookSignalRouter;
+    const { router: nr, captured } = makeRouter({ hookRouter });
+    try {
+      broadcastMetadataUpdateMock.mockClear();
+      captured.agent!({
+        sessionId: 'pty-a',
+        event: { agent: 'Claude Code', status: 'waiting', message: 'Ready for input' },
+      });
+      await flushMicrotasks();
+
+      expect(vi.mocked(hookRouter.governsDetectorStatus)).toHaveBeenCalledWith('pty-a', 'claude', 'waiting');
+      const statusCalls = broadcastMetadataUpdateMock.mock.calls.filter(
+        (c) => (c[1] as { agentStatus?: string }).agentStatus === 'waiting',
+      );
+      expect(statusCalls).toHaveLength(0);
+      expect(broadcastMetadataUpdateMock.mock.calls[0][1]).toMatchObject({
+        ptyId: 'pty-a',
+        agentName: 'Claude Code',
+        agentSlug: 'claude',
+      });
+    } finally {
+      nr.stop();
+    }
+  });
+
   it('codex review catch (round 2): the veto does NOT cover awaiting_input — daemon-mode twin of the PTYBridge exemption test', async () => {
     // Same rationale as the PTYBridge test: Claude's hooks.json only wires
     // PreToolUse for AskUserQuestion — generic approval prompts ("Do you
@@ -228,6 +270,11 @@ describe('DaemonNotificationRouter — detector lifecycle tee (awaiting_input)',
       recordHook: vi.fn(),
       touchAuthority: vi.fn(),
       isGovernedFor: vi.fn().mockReturnValue(true),
+      // #935: the status broadcast rides the same authority as the veto.
+      governsDetectorStatus: vi.fn(
+        (_p: string, slug: string | null | undefined, status: string) =>
+          !!slug && (status === 'waiting' || status === 'complete'),
+      ),
     } as unknown as HookSignalRouter;
     const { router: nr, captured } = makeRouter({ hookRouter });
     try {
@@ -258,6 +305,11 @@ describe('DaemonNotificationRouter — M1 daemon-arbitrated events (source field
       recordHook: vi.fn(),
       touchAuthority: vi.fn(),
       isGovernedFor: vi.fn().mockReturnValue(true),
+      // #935: the status broadcast rides the same authority as the veto.
+      governsDetectorStatus: vi.fn(
+        (_p: string, slug: string | null | undefined, status: string) =>
+          !!slug && (status === 'waiting' || status === 'complete'),
+      ),
     } as unknown as HookSignalRouter;
     const { router: nr, captured } = makeRouter({ hookRouter });
     try {
@@ -325,8 +377,12 @@ describe('DaemonNotificationRouter — M1 daemon-arbitrated events (source field
     }
   });
 
-  it('decision:"veto" updates the status dot only — no toast, no tee', async () => {
+  it('#935 decision:"veto" withholds the lifecycle status too — no dot, no toast, no tee', async () => {
     // The daemon applied the hook-authority rule main used to apply locally.
+    // It used to leave the status dot live, which put the detector's reading
+    // of Claude's always-visible bypass footer onto the roster row and into
+    // "N need you" while the agent was still working. The hook owns lifecycle
+    // on a vetoed event; identity still rides the broadcast.
     const hookRouter = stubHookRouter('emit');
     const { router: nr, captured } = makeRouter({ hookRouter });
     try {
@@ -344,7 +400,15 @@ describe('DaemonNotificationRouter — M1 daemon-arbitrated events (source field
       });
       await flushMicrotasks();
 
-      expect(broadcastMetadataUpdateMock).toHaveBeenCalled(); // dot stays live
+      // Identity still broadcast, lifecycle status withheld.
+      expect(broadcastMetadataUpdateMock.mock.calls[0][1]).toMatchObject({
+        ptyId: 'pty-a',
+        agentName: 'Claude Code',
+      });
+      const statusCalls = broadcastMetadataUpdateMock.mock.calls.filter(
+        (c) => (c[1] as { agentStatus?: string }).agentStatus !== undefined,
+      );
+      expect(statusCalls).toHaveLength(0);
       expect(dispatchNotificationMock).not.toHaveBeenCalled();
       expect(pollLifecycle()).toHaveLength(0);
       expect(hookRouter.recordDetector).not.toHaveBeenCalled();
@@ -431,6 +495,11 @@ describe('DaemonNotificationRouter — M1 daemon-arbitrated events (source field
       recordHook: vi.fn(),
       touchAuthority: vi.fn(),
       isGovernedFor: vi.fn().mockReturnValue(true),
+      // #935: the status broadcast rides the same authority as the veto.
+      governsDetectorStatus: vi.fn(
+        (_p: string, slug: string | null | undefined, status: string) =>
+          !!slug && (status === 'waiting' || status === 'complete'),
+      ),
     } as unknown as HookSignalRouter;
     const { router: nr, captured } = makeRouter({ hookRouter });
     try {

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.alarm.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.alarm.test.ts
@@ -56,6 +56,7 @@ function stubHookRouter() {
     recordDetector: vi.fn(),
     touchAuthority: vi.fn(),
     isGovernedFor: vi.fn().mockReturnValue(false),
+    governsDetectorStatus: vi.fn().mockReturnValue(false),
     getLatencyMeter: () => ({
       recordSignal: vi.fn(),
       recordWorkspaceMatch: vi.fn(),

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
@@ -71,6 +71,7 @@ function stubHookRouter(): StubRouter {
     recordDetector: vi.fn(),
     touchAuthority: vi.fn(),
     isGovernedFor: vi.fn().mockReturnValue(false),
+    governsDetectorStatus: vi.fn().mockReturnValue(false),
     getLatencyMeter: () => ({
       recordSignal: vi.fn(),
       recordWorkspaceMatch: vi.fn(),

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.mirror.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.mirror.test.ts
@@ -189,6 +189,7 @@ function stubHookRouter(): HookSignalRouter {
     recordDetector: vi.fn(),
     touchAuthority: vi.fn(),
     isGovernedFor: vi.fn().mockReturnValue(false),
+    governsDetectorStatus: vi.fn().mockReturnValue(false),
     getLatencyMeter: () => ({
       recordSignal: vi.fn(),
       recordWorkspaceMatch: vi.fn(),

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.relay.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.relay.test.ts
@@ -46,6 +46,7 @@ function stubHookRouter() {
     recordDetector: vi.fn(),
     touchAuthority,
     isGovernedFor: vi.fn().mockReturnValue(false),
+    governsDetectorStatus: vi.fn().mockReturnValue(false),
     getLatencyMeter: () => ({
       recordSignal: vi.fn(),
       recordWorkspaceMatch: vi.fn(),

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.relay.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.relay.test.ts
@@ -164,7 +164,9 @@ describe('hooks.signal — daemon relay', () => {
     expect(res.result).toEqual({ ok: true });
     expect(daemon.rpc).not.toHaveBeenCalled();
     expect(recordHook).toHaveBeenCalledTimes(1);
-    expect(touchAuthority).toHaveBeenCalledWith('pty-1', 'claude');
+    // The signal kind rides along (#935): it is what tells the router whether
+    // the hook has taken this pane's lifecycle over from the detector.
+    expect(touchAuthority).toHaveBeenCalledWith('pty-1', 'claude', expect.any(Number), true, 'agent.stop');
     expect(dispatchNotificationMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -576,7 +576,7 @@ export function registerHooksRpc(
     // mid-turn and pre-poison the dedup ledger against the real Stop) are
     // notification-suppressed. Detector metadata/status broadcasts are
     // unaffected. See HOOK_AUTHORITY_TTL_MS for staleness.
-    hookRouter.touchAuthority(ptyId, signal.agent);
+    hookRouter.touchAuthority(ptyId, signal.agent, Date.now(), true, signal.kind);
 
     // X6 ③: persist the resume binding for session-LIFECYCLE kinds. This runs
     // BEFORE the isEmitKind gate below, which drops SessionStart for the

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -122,7 +122,16 @@ const KIRO_PROMPT_LINE = /^[▸>❯]?\s*ask\s*a\s*question\s*or\s*describe\s*a\s
 // `shift+tab to cycle` from source; treating the blob as one string opened
 // the gate on a live Grok pane (2026-08-16).
 // Signal B (prompt): the same fragments, but only as TUI footer chrome.
-const CLAUDE_PROMPT_RE = /bypass permissions on|shift\+tab to cycle/;
+//
+// \s* — same treatment CLAUDE_BANNER_RE already carries, and for the same
+// reason. Claude Code (measured on v2.1.235) paints its footer by advancing
+// the cursor instead of writing spaces: the wire carries
+// `⏵⏵ESC[1Cbypass ESC[1Cpermissions ESC[1Con ESC[1C(shift+tab...`, which
+// strips to `bypasspermissionson(shift+tabtocycle)`. The space-bearing form
+// could never match a live pane, so the compound gate never closed its second
+// half and the whole Claude pattern block — waiting AND the approval
+// awaiting_input regexes — was dead code against the real product.
+const CLAUDE_PROMPT_RE = /bypass\s*permissions\s*on|shift\+tab\s*to\s*cycle/;
 // Cheap `ap.gate` hint only — checkGates does not use this on the 4 KB
 // probe. Line-level `isClaudeBannerChrome` is the real banner signal.
 const CLAUDE_BANNER_RE = /(?<!Open)(?<!Open\s)Claude\s*Code|claude-code/;
@@ -159,8 +168,8 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // appears while a response is in flight (hint that the user can ESC to
       // cancel), not when the agent is idle. Including it produced
       // false-positive "waiting" notifications mid-turn. Removed.
-      { regex: /bypass permissions on/,          status: 'waiting',          message: 'Ready for input' },
-      { regex: /shift\+tab to cycle/,            status: 'waiting',          message: 'Ready for input' },
+      { regex: /bypass\s*permissions\s*on/,      status: 'waiting',          message: 'Ready for input' },
+      { regex: /shift\+tab\s*to\s*cycle/,        status: 'waiting',          message: 'Ready for input' },
       // Approval prompts — Claude Code is paused mid-turn waiting for the user
       // to pick an option. Orchestrators can react to 'awaiting_input' to feed
       // pre-approved answers without waiting for the full turn to end.
@@ -378,10 +387,26 @@ const MAX_BUFFER = 16 * 1024;
 // eslint-disable-next-line no-control-regex
 const ANSI_STRIP = /\x1b(?:\[[0-9;?<=>]*[a-zA-Z@]|\][^\x07]*\x07|\([A-Z])/g;
 
+/**
+ * Row boundaries as a full-screen TUI actually draws them.
+ *
+ * Newlines are only half the story. Claude repaints its whole bottom region —
+ * input box, statusline, mode footer — as ONE run with no newline in it,
+ * positioning each visual row with a CUP escape (`ESC[<row>;<col>H`). Splitting
+ * on newlines alone therefore hands the chrome tests a single ~900-char blob,
+ * and `isClaudePromptChrome` then rejects the footer via SOURCE_LINE_RE because
+ * something ELSE in that blob looks like code. Measured on a live pane: the
+ * user's own echoed prompt (`sleep 8; echo s1`) and an env var in a Claude
+ * warning (`CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1`) each supplied the `;`/`=`
+ * that killed the gate. Cutting on CUP restores the row the TUI meant to draw,
+ * `bypasspermissionson(shift+tabtocycle)`, which reads as chrome cleanly.
+ */
+// eslint-disable-next-line no-control-regex
+const ROW_BREAK_RE = /\r\n|\n|\r|\u001b\[[0-9]{0,4}(?:;[0-9]{0,4})?[Hf]/;
 /** Complete lines in `text`, or `[text]` itself when it is still a tail. */
 function candidateLines(text: string): string[] {
-  if (!/[\r\n]/.test(text)) return [text];
-  return text.split(/\r\n|\n|\r/).filter((l) => l.length > 0);
+  if (!ROW_BREAK_RE.test(text)) return [text];
+  return text.split(new RegExp(ROW_BREAK_RE.source, 'g')).filter((l) => l.length > 0);
 }
 
 function stripAnsi(line: string): string {
@@ -618,7 +643,10 @@ export class AgentDetector {
         probe.includes('Claude') || probe.includes('claude')
       );
       const mayContainPrompt = !this.claudePromptSeen && (
-        probe.includes('bypass permissions') || probe.includes('shift+tab')
+        // Both spellings: the cursor-drawn footer collapses to
+        // `bypasspermissionson` after the strip (see CLAUDE_PROMPT_RE), and
+        // this prefilter runs on the stripped probe as well as the raw one.
+        probe.includes('bypass permissions') || probe.includes('bypasspermissions') || probe.includes('shift+tab')
       );
 
       if (mayContainBanner || mayContainPrompt) {

--- a/src/main/pty/PTYBridge.ts
+++ b/src/main/pty/PTYBridge.ts
@@ -429,9 +429,18 @@ export class PTYBridge {
       try {
         const win = this.getWindow();
         const status = agentEvent.status as AgentStatus;
+        const slug = agentDisplayToSlug(agentEvent.agent);
+        const hookRouter = this.getHookRouter?.() ?? null;
+        // #935: the status broadcast is governed by the same hook authority as
+        // the notification veto below. Claude's bypass-mode footer is on screen
+        // for the WHOLE turn, so leaving the metadata ungated wrote a false
+        // 'waiting' onto a working pane's roster row and into "N need you".
+        // Identity (name/slug) still rides every event — only the lifecycle
+        // status is withheld.
+        const withholdStatus = hookRouter?.governsDetectorStatus(ptyId, slug, status) === true;
         broadcastMetadataUpdate(win, {
           ptyId,
-          agentStatus: status,
+          ...(withholdStatus ? {} : { agentStatus: status }),
           agentName: agentEvent.agent,
           // P2: carry the slug so the renderer builds the `(<agent>)` auto-name
           // suffix without importing the main-only display→slug map.
@@ -442,7 +451,6 @@ export class PTYBridge {
         // arms the turn gate on an ungoverned pane and clears `announced`
         // after a confirmed completion (the next turn's boundary). Keyed to
         // the detected slug; an agent-less running event has nothing to arm.
-        const slug = agentDisplayToSlug(agentEvent.agent);
         const alarm = this.getAlarm?.() ?? null;
         if (status === 'running' && alarm && slug) {
           alarm.observe(ptyId, slug, { class: 'working' });
@@ -461,8 +469,10 @@ export class PTYBridge {
           // hook lands as 'dedup' → the true completion goes silent.
           // Skipping recordDetector + the EventBus tee here is the point:
           // the hook path emits the one canonical lifecycle event. The
-          // metadata broadcast above (status dot) is intentionally NOT
-          // gated — visual state stays live either way.
+          // metadata broadcast above rides the SAME rule now (#935) —
+          // `governsDetectorStatus` withholds the lifecycle status while
+          // still carrying identity, so the roster stops showing a working
+          // pane as waiting.
           //
           // codex review catch (round 2): must NOT cover 'awaiting_input'.
           // Claude's hooks.json wires PreToolUse ONLY for the
@@ -473,8 +483,11 @@ export class PTYBridge {
           // `status`) are the ONLY signal source for those. Vetoing here
           // would leave an agent blocked on a real approval prompt
           // completely silent for the full authority TTL (30 minutes).
-          const hookRouter = this.getHookRouter?.() ?? null;
-          if (status !== 'awaiting_input' && slug && hookRouter?.isGovernedFor(ptyId, slug)) {
+          // Same predicate the status broadcast above used — one expression of
+          // the rule, so the two cannot drift apart. Inside this block the
+          // status set is {waiting, complete, awaiting_input}, and
+          // `governsDetectorStatus` covers exactly the first two.
+          if (withholdStatus) {
             return;
           }
 

--- a/src/main/pty/__tests__/AgentDetector.test.ts
+++ b/src/main/pty/__tests__/AgentDetector.test.ts
@@ -45,6 +45,57 @@ describe('AgentDetector', () => {
       expect(det.getLastAgent()).toBe('Claude Code');
     });
 
+    // ── #935: the gate against the wire, not against a hand-typed fixture ──
+    //
+    // Every fixture above spells the footer with literal spaces on its own
+    // line. Claude Code does neither. Captured from a live pane (v2.1.235):
+    // spaces are cursor advances, and the whole bottom region arrives as one
+    // newline-free run whose rows are placed with CUP escapes. Both of those
+    // kept the compound gate shut on every real Claude pane, which made the
+    // detector's entire Claude block — waiting AND the approval awaiting_input
+    // regexes — dead code against the shipping product.
+    const ESC = String.fromCharCode(27);
+    /** Join with cursor-forward-1 where the TUI would have written a space. */
+    const cuf = (...words: string[]) => words.join(`${ESC}[1C`);
+    /** Position the following text at a screen row, as a full-screen TUI does. */
+    const at = (row: number) => `${ESC}[${row};3H`;
+    const FOOTER_WIRE = `⏵⏵${ESC}[1C${cuf('bypass', 'permissions', 'on', '(shift+tab', 'to', 'cycle)')}`;
+
+    it('#935 opens the gate on the wire form Claude emits (cursor-drawn spaces)', () => {
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code v2.1.235\n');
+      expect(cb).not.toHaveBeenCalled();
+      det.feed(`${FOOTER_WIRE}\n`);
+      expect(det.getLastAgent()).toBe('Claude Code');
+      const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
+      expect(statuses).toContain('running');
+      expect(statuses).toContain('waiting');
+    });
+
+    it('#935 opens the gate when the footer shares one cursor-addressed blob', () => {
+      // The real bottom region: a Claude warning carrying `=`, the mode footer,
+      // and the user's own echoed prompt carrying `;`. No newline anywhere in
+      // it. Split on newlines alone this is ONE ~900-char "line", and
+      // SOURCE_LINE_RE rejects it as source because of characters that belong
+      // to neither the footer nor any code.
+      const det = new AgentDetector();
+      const cb = vi.fn();
+      det.onEvent(cb);
+      det.feed('Claude Code v2.1.235\n');
+      const blob = [
+        at(44) + cuf('Transcript', 'saving', 'is', 'off', '-', 'restart', 'with', 'CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1'),
+        at(46) + FOOTER_WIRE,
+        at(48) + cuf('Opus', '5', '(high)'),
+        at(50) + '> Run `sleep 8; echo s1`, then `sleep 8; echo s2`.',
+      ].join('');
+      det.feed(`${blob}\n`);
+      expect(det.getLastAgent()).toBe('Claude Code');
+      const statuses = cb.mock.calls.map((c: unknown[]) => (c[0] as { status: string }).status);
+      expect(statuses).toContain('waiting');
+    });
+
     it('emits "waiting" for "shift+tab to cycle" Claude prompt', () => {
       const { det, cb } = claudeGated();
       det.feed('  shift+tab to cycle modes\n');

--- a/src/main/pty/__tests__/PTYBridge.alarm.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.alarm.test.ts
@@ -70,6 +70,7 @@ function stubHookRouter(decision: 'emit' | 'dedup' = 'emit'): HookSignalRouter {
     recordHook: vi.fn().mockReturnValue('emit'),
     touchAuthority: vi.fn(),
     isGovernedFor: vi.fn().mockReturnValue(false),
+    governsDetectorStatus: vi.fn().mockReturnValue(false),
   } as unknown as HookSignalRouter;
 }
 

--- a/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
+++ b/src/main/pty/__tests__/PTYBridge.lifecycle.test.ts
@@ -95,11 +95,19 @@ function stubHookRouter(
   decision: 'emit' | 'dedup',
   opts: { governed?: boolean } = {},
 ): HookSignalRouter {
+  const governed = opts.governed ?? false;
   return {
     recordDetector: vi.fn().mockReturnValue(decision),
     recordHook: vi.fn().mockReturnValue('emit'),
     touchAuthority: vi.fn(),
-    isGovernedFor: vi.fn().mockReturnValue(opts.governed ?? false),
+    isGovernedFor: vi.fn().mockReturnValue(governed),
+    // Mirrors the real predicate: only the two statuses the Stop hook speaks
+    // for, and only on a governed pane. Stubbing it as a flat `governed`
+    // would wrongly withhold 'awaiting_input' too.
+    governsDetectorStatus: vi.fn(
+      (_ptyId: string, slug: string | null | undefined, status: string) =>
+        governed && !!slug && (status === 'waiting' || status === 'complete'),
+    ),
   } as unknown as HookSignalRouter;
 }
 
@@ -188,13 +196,12 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     expect(pollLifecycle().length).toBeGreaterThanOrEqual(1);
   });
 
-  it('hook-authority veto: governed (ptyId, slug) suppresses detector notification, ledger write and tee — status dot stays', () => {
+  it('hook-authority veto: governed (ptyId, slug) suppresses detector notification, ledger write and tee', () => {
     // While the pane's hook bridge is fresh for the SAME agent, the
     // detector's footer heuristics must go fully silent on the
     // notification path: no sendNotification, no recordDetector (a ledger
     // write here would make the REAL Stop hook land as 'dedup' → silent
-    // completion), no lifecycle tee (the hook path emits the canonical
-    // one). Metadata/status broadcasts are NOT gated.
+    // completion), no lifecycle tee (the hook path emits the canonical one).
     const router = stubHookRouter('emit', { governed: true });
     const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
 
@@ -203,11 +210,48 @@ describe('PTYBridge — agent.lifecycle EventBus tee (detector source)', () => {
     proc.emitData('  shift+tab to cycle\n');
     flush();
 
-    expect(router.isGovernedFor).toHaveBeenCalledWith('pty-1', 'claude');
     expect(mocks.sendNotification).not.toHaveBeenCalled();
     expect(router.recordDetector).not.toHaveBeenCalled();
     expect(pollLifecycle()).toHaveLength(0);
-    // Sidebar dot still updated (agentStatus broadcast precedes the veto).
+  });
+
+  it('#935 REGRESSION: a governed pane never gets a detector "waiting" onto agentStatus — Claude\'s bypass footer is on screen the WHOLE turn', () => {
+    // The bug: the status broadcast ran BEFORE the veto and was deliberately
+    // ungated, so `bypass permissions on` — permanent chrome in
+    // bypass-permissions mode, not a turn boundary — wrote 'waiting' onto a
+    // working pane's roster row. selectors/fleet.ts counts 'waiting' toward
+    // the "N need you" chip, so every mid-turn repaint became a false
+    // attention badge. The hook's Stop signal owns lifecycle on this pane;
+    // the detector must not contradict it on the status either.
+    const router = stubHookRouter('emit', { governed: true });
+    const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('  bypass permissions on\n');
+    proc.emitData('  shift+tab to cycle\n');
+    flush();
+
+    expect(router.governsDetectorStatus).toHaveBeenCalledWith('pty-1', 'claude', 'waiting');
+    const statusCalls = mocks.broadcastMetadataUpdate.mock.calls.filter(
+      (c) => (c[1] as { agentStatus?: string }).agentStatus === 'waiting',
+    );
+    expect(statusCalls).toHaveLength(0);
+    // Identity still rides the same broadcast — withholding the status must
+    // not cost the pane its `(Claude Code)` auto-name.
+    expect(mocks.broadcastMetadataUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ptyId: 'pty-1', agentName: 'Claude Code', agentSlug: 'claude' }),
+    );
+  });
+
+  it('#935: an UNGOVERNED pane keeps the detector status — no hook bridge means the detector is still the backstop', () => {
+    const router = stubHookRouter('emit', { governed: false });
+    const { proc } = makeBridge({ workspaceId: 'ws-a', hookRouter: router });
+
+    proc.emitData('Claude Code\n');
+    proc.emitData('  shift+tab to cycle\n');
+    flush();
+
     expect(mocks.broadcastMetadataUpdate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ ptyId: 'pty-1', agentStatus: 'waiting' }),

--- a/src/shared/hooks/HookSignalRouter.ts
+++ b/src/shared/hooks/HookSignalRouter.ts
@@ -176,6 +176,43 @@ export class HookSignalRouter {
   }
 
   /**
+   * True when the pane's live hook bridge owns this detector-sourced status,
+   * so the caller must withhold it from `metadata.agentStatus` as well as from
+   * the notification.
+   *
+   * `waiting` and `complete` are the two statuses the bridge's Stop signal
+   * speaks for. They are also the two the detector infers from ALWAYS-VISIBLE
+   * TUI chrome: Claude Code's footer reads `bypass permissions on` /
+   * `shift+tab to cycle` for the whole turn in bypass-permissions mode, so
+   * every repaint re-asserts "ready for input" while the agent is working.
+   * The notification veto (`isGovernedFor`) has always covered the toast, but
+   * the status broadcast ran BEFORE it and was deliberately left ungated —
+   * which put the false read straight onto the roster row and into the
+   * "N need you" roll-up, the one signal that must never cry wolf (#935).
+   *
+   * Deliberately NOT covered:
+   *   - `awaiting_input` — Claude's hooks wire PreToolUse only for
+   *     AskUserQuestion, so the ordinary approval prompts have no hook at all
+   *     and the detector is their only source. Same carve-out the notification
+   *     veto makes, and for the same reason.
+   *   - `running` — a working cue, not a turn boundary; nothing about it
+   *     competes with the Stop signal.
+   *
+   * An ungoverned pane (no bridge, or a bridge gone quiet past the authority
+   * TTL) is unaffected: the detector stays the backstop it has always been.
+   */
+  governsDetectorStatus(
+    ptyId: string,
+    slug: string | null | undefined,
+    status: string,
+    now: number = Date.now(),
+  ): boolean {
+    if (status !== 'waiting' && status !== 'complete') return false;
+    if (!slug) return false;
+    return this.isGovernedFor(ptyId, slug, now);
+  }
+
+  /**
    * Record a hook-bridge signal. Returns `emit` when the caller should
    * proceed to fan-out, `dedup` when a recent detector emission already
    * covered the same (slug, ptyId, kind) tuple.

--- a/src/shared/hooks/HookSignalRouter.ts
+++ b/src/shared/hooks/HookSignalRouter.ts
@@ -200,6 +200,18 @@ export class HookSignalRouter {
    *
    * An ungoverned pane (no bridge, or a bridge gone quiet past the authority
    * TTL) is unaffected: the detector stays the backstop it has always been.
+   *
+   * Accepted cost, stated because a reviewer will ask: this rides the same
+   * 30-minute authority TTL as the notification veto, so a bridge that stops
+   * speaking while its agent process is still alive leaves the status stale
+   * until the TTL expires. That is deliberately symmetric — the notification
+   * veto has always accepted exactly that window on the LOUDER surface, and
+   * making the status less trusting than the toast would be the odd choice.
+   * A shorter TTL is not the answer either: a single turn can run past twenty
+   * minutes with no bridge traffic at all on a turn-boundary-only hook install
+   * (the #935 report measured 21m), so a short window would simply restore the
+   * bug it fixes. Confirmed process death already releases authority ahead of
+   * the TTL (`expireAuthorityFor`, wired to the daemon's liveness poll).
    */
   governsDetectorStatus(
     ptyId: string,

--- a/src/shared/hooks/HookSignalRouter.ts
+++ b/src/shared/hooks/HookSignalRouter.ts
@@ -73,6 +73,34 @@ interface LedgerEntry {
 export type RouteDecision = 'emit' | 'dedup';
 
 /**
+ * Has the pane's hook bridge taken over its lifecycle yet?
+ *
+ * `isGovernedFor` answers "a bridge speaks for this pane". That is the right
+ * question for the notification veto but a subtly wrong one for the status
+ * broadcast, and the gap has a name: a bridge that has said `SessionStart` and
+ * nothing else is alive but has never written a lifecycle status. Withholding
+ * the detector's read there leaves the roster showing whatever it had —
+ * the gate's one-shot `running` — so a freshly launched agent sitting at its
+ * prompt reads as busy until its first turn ends. Live-measured at 30+ seconds
+ * per launch.
+ *
+ * So: `agent.session_start` (and only it) hands the lifecycle BACK to the
+ * detector, because it is the one signal that says "this pane's hook history
+ * starts here, and nothing has been claimed yet". A relaunch in the same pane
+ * resets ownership for the same reason.
+ *
+ * Every other kind — work, turn ends, subagent stops, permission-gate state —
+ * means the bridge is speaking for the turn, so the hook owns the lifecycle
+ * and the detector's always-visible footer must not overwrite it.
+ *
+ * An absent kind also means owned: a caller that does not name its signal gets
+ * the pre-#935 behavior, which is the conservative direction here.
+ */
+function hookOwnsLifecycleAfter(kind: AgentSignalKind | undefined): boolean {
+  return kind !== 'agent.session_start';
+}
+
+/**
  * Wiring: one instance per process. In main it is constructed in
  * main/index.ts and shared across:
  *   - `src/main/pipe/handlers/hooks.rpc.ts` (calls recordHook on every
@@ -98,7 +126,7 @@ export class HookSignalRouter {
    *  fallback: only exact-routed authority may decide identity alone. */
   private readonly authority = new Map<
     string,
-    { agent: string; lastSignalAt: number; exact: boolean }
+    { agent: string; lastSignalAt: number; exact: boolean; lifecycleOwned: boolean }
   >();
 
   constructor(deps: { latencyMeter: SignalLatencyMeter; dedupWindowMs?: number; authorityTtlMs?: number }) {
@@ -117,14 +145,23 @@ export class HookSignalRouter {
    * cwd-prefix fallback passes false — #919 lets only exact-routed authority
    * decide identity uncorroborated, since a cwd guess can attach to a
    * neighboring pane.
+   *
+   * `kind` sets the pane's lifecycle-ownership latch that
+   * `governsDetectorStatus` reads — see `hookOwnsLifecycleAfter`.
    */
   touchAuthority(
     ptyId: string,
     agent: string,
     now: number = Date.now(),
     exact = true,
+    kind?: AgentSignalKind,
   ): void {
-    this.authority.set(ptyId, { agent, lastSignalAt: now, exact });
+    this.authority.set(ptyId, {
+      agent,
+      lastSignalAt: now,
+      exact,
+      lifecycleOwned: hookOwnsLifecycleAfter(kind),
+    });
   }
 
   /**
@@ -197,6 +234,13 @@ export class HookSignalRouter {
    *     veto makes, and for the same reason.
    *   - `running` — a working cue, not a turn boundary; nothing about it
    *     competes with the Stop signal.
+   *   - a pane whose bridge has said `SessionStart` and nothing since. It is
+   *     governed, but the hook has not written a lifecycle status yet, so
+   *     withholding the detector's read leaves the roster on the gate's
+   *     one-shot `running` — a launched-but-idle agent reading as busy, live-
+   *     measured at 30+ seconds per launch. See `hookOwnsLifecycleAfter`. Once
+   *     any other kind arrives the hook owns the lifecycle and this returns
+   *     true again, so the post-Stop double-toast veto is unaffected.
    *
    * An ungoverned pane (no bridge, or a bridge gone quiet past the authority
    * TTL) is unaffected: the detector stays the backstop it has always been.
@@ -221,7 +265,8 @@ export class HookSignalRouter {
   ): boolean {
     if (status !== 'waiting' && status !== 'complete') return false;
     if (!slug) return false;
-    return this.isGovernedFor(ptyId, slug, now);
+    if (!this.isGovernedFor(ptyId, slug, now)) return false;
+    return this.authority.get(ptyId)?.lifecycleOwned === true;
   }
 
   /**

--- a/src/shared/hooks/__tests__/HookSignalRouter.test.ts
+++ b/src/shared/hooks/__tests__/HookSignalRouter.test.ts
@@ -246,6 +246,34 @@ describe('HookSignalRouter', () => {
       expect(router.governsDetectorStatus('p1', 'claude', 'complete', 2000)).toBe(true);
     });
 
+    it('#935 SessionStart alone does not hand the lifecycle to the hook', () => {
+      // The bridge is alive but has never written a lifecycle status, so the
+      // detector's read is all the roster has. Withholding it left a freshly
+      // launched agent showing the gate's one-shot `running` while it sat at
+      // its prompt — live-measured at 30+ seconds per launch.
+      router.touchAuthority('p1', 'claude', 1000, true, 'agent.session_start');
+      expect(router.isGovernedFor('p1', 'claude', 2000)).toBe(true);
+      expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 2000)).toBe(false);
+    });
+
+    it('#935 any signal after SessionStart hands the lifecycle back to the hook', () => {
+      // Including the turn END: the post-Stop veto is what stops a detector
+      // repaint from double-toasting a completion the hook already announced.
+      for (const kind of ['agent.activity', 'agent.stop', 'agent.subagent_stop'] as const) {
+        router.resetForTests();
+        router.touchAuthority('p1', 'claude', 1000, true, 'agent.session_start');
+        router.touchAuthority('p1', 'claude', 2000, true, kind);
+        expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 2100)).toBe(true);
+      }
+    });
+
+    it('#935 a relaunch in the same pane returns the lifecycle to the detector', () => {
+      router.touchAuthority('p1', 'claude', 1000, true, 'agent.stop');
+      expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 1100)).toBe(true);
+      router.touchAuthority('p1', 'claude', 2000, true, 'agent.session_start');
+      expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 2100)).toBe(false);
+    });
+
     it('#935 governsDetectorStatus spares awaiting_input and running', () => {
       router.touchAuthority('p1', 'claude', 1000);
       // Approval prompts have no hook (PreToolUse is wired for AskUserQuestion

--- a/src/shared/hooks/__tests__/HookSignalRouter.test.ts
+++ b/src/shared/hooks/__tests__/HookSignalRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { HookSignalRouter, DEFAULT_DEDUP_WINDOW_MS } from '../HookSignalRouter';
+import { HookSignalRouter, DEFAULT_DEDUP_WINDOW_MS, HOOK_AUTHORITY_TTL_MS } from '../HookSignalRouter';
 import { SignalLatencyMeter } from '../SignalLatencyMeter';
 import type { AgentSignal } from '../signal-types';
 
@@ -238,6 +238,33 @@ describe('HookSignalRouter', () => {
       router.touchAuthority('p1', 'codex', 2000);
       expect(router.isGovernedFor('p1', 'claude', 2100)).toBe(false);
       expect(router.isGovernedFor('p1', 'codex', 2100)).toBe(true);
+    });
+
+    it('#935 governsDetectorStatus covers waiting/complete on a governed pane', () => {
+      router.touchAuthority('p1', 'claude', 1000);
+      expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 2000)).toBe(true);
+      expect(router.governsDetectorStatus('p1', 'claude', 'complete', 2000)).toBe(true);
+    });
+
+    it('#935 governsDetectorStatus spares awaiting_input and running', () => {
+      router.touchAuthority('p1', 'claude', 1000);
+      // Approval prompts have no hook (PreToolUse is wired for AskUserQuestion
+      // only), so the detector is their sole source — withholding this status
+      // would leave a blocked pane looking idle for the full authority TTL.
+      expect(router.governsDetectorStatus('p1', 'claude', 'awaiting_input', 2000)).toBe(false);
+      // 'running' is a working cue, not a turn boundary.
+      expect(router.governsDetectorStatus('p1', 'claude', 'running', 2000)).toBe(false);
+    });
+
+    it('#935 governsDetectorStatus is false without authority, slug, or a matching agent', () => {
+      expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 2000)).toBe(false);
+      router.touchAuthority('p1', 'claude', 1000);
+      expect(router.governsDetectorStatus('p1', null, 'waiting', 2000)).toBe(false);
+      expect(router.governsDetectorStatus('p1', undefined, 'waiting', 2000)).toBe(false);
+      // A different agent on the same pane is a genuinely distinct source.
+      expect(router.governsDetectorStatus('p1', 'codex', 'waiting', 2000)).toBe(false);
+      // Past the authority TTL the detector is the backstop again.
+      expect(router.governsDetectorStatus('p1', 'claude', 'waiting', 1000 + HOOK_AUTHORITY_TTL_MS)).toBe(false);
     });
 
     it('dropPty releases authority immediately (pane disposal)', () => {


### PR DESCRIPTION
Claude Code's footer says `bypass permissions on` for the whole turn in bypass-permissions mode. It is chrome, not a turn boundary. `AgentDetector` maps it to `waiting`, and the hook-authority veto that exists for exactly this reason only covered the notification — the status broadcast ran *before* it and was deliberately left ungated. So every mid-turn repaint wrote `waiting` onto the pane's roster row, and because `countNeedsAttention` counts `waiting`, each false read also inflated the "N need you" chip. That chip is the one signal that must never cry wolf.

## What changed

The rule now lives in one place. `HookSignalRouter.governsDetectorStatus` answers whether the pane's live hook bridge owns a given detector status, and both emission sites withhold the lifecycle status when it does:

- `PTYBridge` — local panes
- `DaemonNotificationRouter` — the packaged daemon path, which is what the report was running

On the daemon path a `decision: 'veto'` event is withheld too; the daemon already applied the same rule upstream.

## What is deliberately *not* withheld

- **Identity.** `agentName` / `agentSlug` still ride every broadcast, so a pane keeps its `(Claude Code)` auto-name.
- **`awaiting_input`.** Claude wires `PreToolUse` for `AskUserQuestion` alone, so the detector is the only source for ordinary approval prompts. Gating it would leave a pane blocked on a real prompt looking idle for the full 30-minute authority TTL.
- **`running`.** A working cue, not a turn boundary.
- **Ungoverned panes.** No hook bridge, or one gone quiet past the TTL, means the detector is still the backstop it has always been.

Prior art worth naming: OpenClaude already carried this exclusion in a comment — it re-renders its status bar every frame, so `bypass permissions on` was never wired to waiting for it. Claude Code in bypass mode has the same property; the exclusion just never reached it.

## Scope — two directions from #935 are NOT fixed here

The report showed three disagreements. This closes the false-alarm one. The other two are staleness with a different root and need their own change:

- a Stop hook's `complete` survives into the next turn
- a finished pane can read `running`

Both trace to `ActivityMonitor.onActive` being edge-triggered and re-armed only after five seconds of byte silence (`IDLE_DELAY_MS`), which a TUI painting a live timer never gives. Fixing it needs `ActivityMonitor` reachable from the hook path in both main and the daemon, so it is not a rider on this PR.

## Tests

- `HookSignalRouter` — the predicate: covers `waiting`/`complete`, spares `awaiting_input`/`running`, false without authority / slug / matching agent / past TTL
- `PTYBridge.lifecycle` — governed pane gets no `waiting` status but keeps identity; ungoverned pane still gets it
- `DaemonNotificationRouter.lifecycle` — same pair on the daemon path, plus `decision: 'veto'` now withholding the status

Both regression tests were confirmed to fail with the fix disabled. Two existing tests that pinned the old "status dot stays live" behaviour were updated rather than deleted.

Full suite: 11818 passed, 0 failed. `tsc` clean on the app, daemon and mcp projects.

Closes part of #935.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude Code pane and prompt detection for cursor-rendered text and omitted whitespace.
  * Hook-controlled panes now suppress detector-generated waiting and completion statuses while preserving agent identity information.
  * Approval prompts and `awaiting_input` statuses remain unaffected.
  * Panes without active hooks continue using detector-based status behavior until lifecycle control is established.
  * Vetoed lifecycle statuses are suppressed while identity metadata remains available.

* **Documentation**
  * Added guidance to update both app and daemon components when using mixed versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->