### PR TITLE
fix(browser): scope a plugin's browser calls to the workspace hosting it

### DIFF
--- a/changelog.d/941.md
+++ b/changelog.d/941.md
@@ -1,0 +1,15 @@
+### Security
+
+- **A UI plugin's browser calls now stay in the workspace you are looking at.**
+  An approved iframe plugin could already only *watch* the active workspace —
+  its event feed has been scoped since #719 — but its own `browser.*` calls
+  were forwarded with whatever workspace id the plugin chose, so it could drive
+  a browser surface in a workspace you were not in. The workspace the plugin
+  host is showing now travels with each request on its own channel, out of the
+  plugin's reach, and a browser call that names a different workspace is
+  refused; one that names none resolves to the workspace hosting the plugin
+  instead of being rejected as unresolved. A plugin whose host has no active
+  workspace is refused rather than falling back to naming its own. This
+  confines an approved plugin to the scope its approval implied — it is not a
+  defence against hostile code already running as your user, and callers on the
+  local RPC wire are unchanged. (#941)

--- a/changelog.d/941.md
+++ b/changelog.d/941.md
@@ -1,15 +1,18 @@
 ### Security
 
-- **A UI plugin's browser calls now stay in the workspace you are looking at.**
-  An approved iframe plugin could already only *watch* the active workspace —
-  its event feed has been scoped since #719 — but its own `browser.*` calls
-  were forwarded with whatever workspace id the plugin chose, so it could drive
-  a browser surface in a workspace you were not in. The workspace the plugin
-  host is showing now travels with each request on its own channel, out of the
-  plugin's reach, and a browser call that names a different workspace is
-  refused; one that names none resolves to the workspace hosting the plugin
-  instead of being rejected as unresolved. A plugin whose host has no active
-  workspace is refused rather than falling back to naming its own. This
-  confines an approved plugin to the scope its approval implied — it is not a
-  defence against hostile code already running as your user, and callers on the
-  local RPC wire are unchanged. (#941)
+- **A UI plugin can no longer drive a browser surface in a workspace you are not
+  in.** An approved iframe plugin could already only *watch* the active
+  workspace — its event feed has been scoped since #719 — but its own
+  `browser.*` calls were forwarded with whatever workspace id the plugin chose.
+  The workspace the plugin host is showing now travels with each request on its
+  own channel, out of the plugin's reach: a browser call that names a different
+  workspace is refused, one that names none resolves to the workspace hosting
+  the plugin instead of being rejected as unresolved, and a plugin whose host
+  has no active workspace is refused rather than falling back to naming its own.
+  This covers the browser methods that resolve a target — navigation,
+  evaluation, extraction, input, capture and the rest. Opening and closing
+  browser surfaces (`browser.open`, `browser.close`) resolve their workspace on
+  a different path and are **not** covered yet; that is the next step on #922.
+  Either way this confines an approved plugin to the scope its approval implied
+  — it is not a defence against hostile code already running as your user, and
+  callers on the local RPC wire are unchanged. (#941)

--- a/src/main/audit/shadowRejectionLog.ts
+++ b/src/main/audit/shadowRejectionLog.ts
@@ -82,6 +82,7 @@ export type BrowserScopeShadowReason =
   | 'pinned-source-unqualified'
   | 'pinned-workspace-mismatch'
   | 'hosted-source-unqualified'
+  | 'hosted-workspace-unbound'
   | 'hosted-workspace-mismatch'
   | 'workspace-unresolved';
 

--- a/src/main/audit/shadowRejectionLog.ts
+++ b/src/main/audit/shadowRejectionLog.ts
@@ -81,6 +81,8 @@ export type BrowserScopeShadowReason =
   | 'caller-origin-unsupported'
   | 'pinned-source-unqualified'
   | 'pinned-workspace-mismatch'
+  | 'hosted-source-unqualified'
+  | 'hosted-workspace-mismatch'
   | 'workspace-unresolved';
 
 /**
@@ -95,6 +97,12 @@ export interface BrowserScopeShadowEntry {
   reason: BrowserScopeShadowReason;
   requestedWorkspaceId?: string;
   pinnedWorkspaceId?: string;
+  /**
+   * #922 — the workspace the plugin host derived for the caller. Recorded for
+   * the same reason as `pinnedWorkspaceId`: this is a local operator-owned
+   * audit file, so it may hold what a refusal message must never disclose.
+   */
+  hostedWorkspaceId?: string;
 }
 
 export type BrowserScopeShadowInput = Omit<BrowserScopeShadowEntry, 'entryKind' | 'ts'>;

--- a/src/main/ipc/handlers/__tests__/pluginHost.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/pluginHost.handler.test.ts
@@ -73,13 +73,16 @@ describe('plugins:rpc host workspace binding', () => {
     expect(request.params).toEqual({ hostedWorkspace: 'ws-forged' });
   });
 
-  it('omits the option when the host has no workspace yet', async () => {
+  it.each([undefined, '', '   '])('says "hosted, unbound" rather than going quiet (%p)', async (value) => {
     const rpc = setup();
 
-    await rpc({}, 'demo', 'workspace.current', {}, undefined);
+    await rpc({}, 'demo', 'workspace.current', {}, value);
 
     const [, opts] = dispatch.mock.calls[0] as DispatchArgs;
-    expect(opts).toEqual({ firstParty: true });
+    // The key is present with a null value. Omitting it would make this
+    // indistinguishable from a caller that is not the plugin host at all, and
+    // the browser lane would then let the plugin name its own workspace.
+    expect(opts).toEqual({ firstParty: true, hostedWorkspace: null });
   });
 
   it('refuses a non-string host workspace instead of coercing it', async () => {

--- a/src/main/ipc/handlers/__tests__/pluginHost.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/pluginHost.handler.test.ts
@@ -1,0 +1,92 @@
+// #922 — the plugin-host IPC seam.
+//
+// This is the one place a plugin's workspace binding is established: the host
+// component passes the workspace it is SHOWING as its own argument, and this
+// handler turns it into a dispatch option that no request envelope can reach.
+// The tests below pin that seam from both sides — what reaches the router when
+// the host supplies a workspace, and what reaches it when the argument is
+// malformed or absent.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { IPC } from '../../../../shared/constants';
+import type { RpcRequest, RpcResponse } from '../../../../shared/rpc';
+import type { RpcRouter } from '../../../pipe/RpcRouter';
+import { registerPluginHostHandlers } from '../pluginHost.handler';
+
+const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    removeHandler: vi.fn(),
+    handle: vi.fn((channel: string, fn: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, fn);
+    }),
+  },
+}));
+
+type DispatchArgs = [RpcRequest, Record<string, unknown> | undefined];
+
+let dispatch: ReturnType<typeof vi.fn>;
+
+function setup() {
+  handlers.clear();
+  dispatch = vi.fn(async (): Promise<RpcResponse> => ({ id: 'x', ok: true, result: {} }));
+  const router = { dispatch } as unknown as RpcRouter;
+  const loader = {
+    get: (name: string) =>
+      name === 'demo' ? { manifest: { name: 'demo', version: '1.0.0' } } : undefined,
+  };
+  registerPluginHostHandlers(router, () => loader as never);
+  const rpc = handlers.get(IPC.PLUGINS_RPC);
+  expect(rpc, 'plugins:rpc handler was never registered').toBeDefined();
+  return rpc!;
+}
+
+// NOT `beforeEach(setup)`: setup returns the handler, and vitest treats a
+// function returned from a hook as its teardown callback — it would then be
+// invoked with no arguments after every test.
+beforeEach(() => { setup(); });
+
+describe('plugins:rpc host workspace binding', () => {
+  it('forwards the host workspace as a dispatch option, not as a param', async () => {
+    const rpc = setup();
+
+    await rpc({}, 'demo', 'browser.navigate', { url: 'https://example.test' }, 'ws-host');
+
+    const [request, opts] = dispatch.mock.calls[0] as DispatchArgs;
+    expect(opts).toEqual({ firstParty: true, hostedWorkspace: 'ws-host' });
+    // The params are forwarded verbatim: the binding is carried beside them, so
+    // main can compare what the plugin asked for against where it lives.
+    expect(request.params).toEqual({ url: 'https://example.test' });
+    expect(request.clientName).toBe('demo');
+  });
+
+  it('keeps the plugin from naming its own binding through params', async () => {
+    const rpc = setup();
+
+    await rpc({}, 'demo', 'browser.navigate', { hostedWorkspace: 'ws-forged' }, 'ws-host');
+
+    const [request, opts] = dispatch.mock.calls[0] as DispatchArgs;
+    expect(opts).toEqual({ firstParty: true, hostedWorkspace: 'ws-host' });
+    // Still present in params — the router does not read it there, and
+    // stripping it would hide a hostile plugin from the audit trail.
+    expect(request.params).toEqual({ hostedWorkspace: 'ws-forged' });
+  });
+
+  it('omits the option when the host has no workspace yet', async () => {
+    const rpc = setup();
+
+    await rpc({}, 'demo', 'workspace.current', {}, undefined);
+
+    const [, opts] = dispatch.mock.calls[0] as DispatchArgs;
+    expect(opts).toEqual({ firstParty: true });
+  });
+
+  it('refuses a non-string host workspace instead of coercing it', async () => {
+    const rpc = setup();
+
+    await expect(rpc({}, 'demo', 'workspace.current', {}, { id: 'ws-host' }))
+      .rejects.toThrow(/host workspace/i);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/ipc/handlers/pluginHost.handler.ts
+++ b/src/main/ipc/handlers/pluginHost.handler.ts
@@ -46,6 +46,7 @@ export function registerPluginHostHandlers(
     pluginName: unknown,
     method: unknown,
     params: unknown,
+    hostWorkspaceId: unknown,
   ): Promise<RpcResponse> => {
     if (typeof pluginName !== 'string' || typeof method !== 'string'
       || method.length === 0 || method.length > MAX_METHOD_LEN) {
@@ -53,6 +54,14 @@ export function registerPluginHostHandlers(
     }
     if (params !== undefined && (typeof params !== 'object' || params === null || Array.isArray(params))) {
       throw new Error('Invalid plugin RPC params');
+    }
+    // #922 — the workspace the HOST is showing, passed as its own argument by
+    // the host component, never taken from the plugin's own params. The preload
+    // signature makes the position mandatory so a new call site cannot forget
+    // it; the value may still be absent before any workspace exists, and a
+    // hosted caller without one simply lands in the lane it lands in today.
+    if (hostWorkspaceId !== undefined && typeof hostWorkspaceId !== 'string') {
+      throw new Error('Invalid plugin RPC host workspace');
     }
     const loader = getLoader();
     const plugin = loader?.get(pluginName);
@@ -75,7 +84,15 @@ export function registerPluginHostHandlers(
       params: (params ?? {}) as Record<string, unknown>,
       clientName: plugin.manifest.name,
       clientVersion: plugin.manifest.version,
-    }, { firstParty: true });
+    }, {
+      firstParty: true,
+      // Both halves of this caller's identity are derived main-side or
+      // host-side: the name from the manifest just above, the workspace from
+      // the host component that owns the iframe. Neither is readable from the
+      // bridge envelope, which is what lets `browser.rpc.ts` treat the pair as
+      // an ownership claim instead of a declaration (#922).
+      ...(hostWorkspaceId ? { hostedWorkspace: hostWorkspaceId } : {}),
+    });
   }));
 
   // Renderer-initiated approval for an unconfirmed plugin. Breaks the UI

--- a/src/main/ipc/handlers/pluginHost.handler.ts
+++ b/src/main/ipc/handlers/pluginHost.handler.ts
@@ -58,8 +58,8 @@ export function registerPluginHostHandlers(
     // #922 — the workspace the HOST is showing, passed as its own argument by
     // the host component, never taken from the plugin's own params. The preload
     // signature makes the position mandatory so a new call site cannot forget
-    // it; the value may still be absent before any workspace exists, and a
-    // hosted caller without one simply lands in the lane it lands in today.
+    // it; the value may still be absent before any workspace exists, which is
+    // forwarded as an explicit `null` rather than as an omission.
     if (hostWorkspaceId !== undefined && typeof hostWorkspaceId !== 'string') {
       throw new Error('Invalid plugin RPC host workspace');
     }
@@ -91,7 +91,12 @@ export function registerPluginHostHandlers(
       // the host component that owns the iframe. Neither is readable from the
       // bridge envelope, which is what lets `browser.rpc.ts` treat the pair as
       // an ownership claim instead of a declaration (#922).
-      ...(hostWorkspaceId ? { hostedWorkspace: hostWorkspaceId } : {}),
+      // Sent on EVERY call, `null` included: presence is what tells main this
+      // is a plugin-host caller. A host with no active workspace yet says so
+      // explicitly rather than looking like a caller that may name its own.
+      hostedWorkspace: typeof hostWorkspaceId === 'string' && hostWorkspaceId.trim().length > 0
+        ? hostWorkspaceId.trim()
+        : null,
     });
   }));
 

--- a/src/main/mcp/__tests__/wireProvenance.test.ts
+++ b/src/main/mcp/__tests__/wireProvenance.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { isLocalExternalWireContext } from '../wireProvenance';
+
+const MAIN_DIR = path.resolve(__dirname, '..', '..');
+
+function collectProductionTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__') continue;
+      out.push(...collectProductionTsFiles(full));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function writesExternalWireTrue(file: string): boolean {
+  const source = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) &&
+      node.name.text === 'externalWire' &&
+      node.initializer.kind === ts.SyntaxKind.TrueKeyword
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
+}
+
+describe('local external-wire provenance', () => {
+  it('requires the positive PipeServer marker and excludes other sources', () => {
+    expect(
+      isLocalExternalWireContext({ origin: 'local', externalWire: true }),
+    ).toBe(true);
+    expect(isLocalExternalWireContext({ origin: 'local' })).toBe(false);
+    expect(
+      isLocalExternalWireContext({ origin: 'remote', externalWire: true }),
+    ).toBe(false);
+    expect(
+      isLocalExternalWireContext({
+        origin: 'local',
+        externalWire: true,
+        firstParty: true,
+      }),
+    ).toBe(false);
+    expect(
+      isLocalExternalWireContext({
+        origin: 'local',
+        externalWire: true,
+        operator: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps PipeServer as the only production writer of externalWire authority', () => {
+    const writers = collectProductionTsFiles(MAIN_DIR)
+      .filter(writesExternalWireTrue)
+      .map((file) => path.relative(MAIN_DIR, file).replaceAll('\\', '/'))
+      .sort();
+
+    expect(writers).toEqual(['pipe/PipeServer.ts']);
+  });
+});

--- a/src/main/mcp/wireProvenance.ts
+++ b/src/main/mcp/wireProvenance.ts
@@ -1,0 +1,29 @@
+// Provenance gate for client identities that are meaningful only on wmux's
+// machine-local external RPC wire (named pipe / Unix socket / loopback TCP).
+
+import type { RpcContext } from '../../shared/rpc';
+
+export type LocalExternalWireContext = RpcContext & {
+  origin: 'local';
+  externalWire: true;
+  firstParty?: false;
+  operator?: false;
+};
+
+/**
+ * True only when PipeServer positively classified this request as external and
+ * local. `externalWire` is a dispatch option rather than a request-envelope
+ * field, so a wire caller cannot forge it. Requiring the literal `true` is
+ * deliberately fail-closed for every in-process or future dispatch source;
+ * `firstParty` is also excluded defensively if contradictory options appear.
+ */
+export function isLocalExternalWireContext(
+  ctx: RpcContext | undefined,
+): ctx is LocalExternalWireContext {
+  return (
+    ctx?.origin === 'local' &&
+    ctx.externalWire === true &&
+    ctx.firstParty !== true &&
+    ctx.operator !== true
+  );
+}

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -75,11 +75,18 @@ const IDENTITY_OWN_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
  * dispatch(). No marker is accepted from the RpcRequest envelope. `operator`
  * is the renderer bridge; `firstParty` is the in-process plugin host;
  * `externalWire` is the authenticated PipeServer boundary.
+ *
+ * #922 — `hostedWorkspace` rides on the `firstParty` variant alone, because the
+ * plugin host is the only dispatch source that DERIVES its caller's workspace
+ * instead of being told it. The other two declare it `never`: the operator may
+ * act across workspaces by design, and a wire caller has no host to derive
+ * anything. Supplying it elsewhere is an internal provenance failure, caught by
+ * the type here and by a runtime guard in dispatch for JS/casted call sites.
  */
 type RpcDispatchOptions = (
-  | { operator: true; firstParty?: never; externalWire?: never }
-  | { firstParty: true; operator?: never; externalWire?: never }
-  | { externalWire: true; operator?: never; firstParty?: never }
+  | { operator: true; firstParty?: never; externalWire?: never; hostedWorkspace?: never }
+  | { firstParty: true; operator?: never; externalWire?: never; hostedWorkspace?: string }
+  | { externalWire: true; operator?: never; firstParty?: never; hostedWorkspace?: never }
 ) & {
   /**
    * Cancellation for handlers that WAIT (see RpcContext.signal). Supplied by
@@ -223,6 +230,25 @@ export class RpcRouter {
     }
     const firstParty = operator || inProcessFirstParty;
 
+    // Host-derived workspace (#922). Accepted ONLY from the in-process plugin
+    // host lane. A non-firstParty caller that supplies it is the same class of
+    // internal provenance failure as a conflicting trust marker, so it fails
+    // the same way — loudly, before any handler runs — rather than being
+    // dropped into a context that then looks merely unscoped.
+    const hostedWorkspaceOpt = typeof opts?.hostedWorkspace === 'string'
+      ? opts.hostedWorkspace.trim()
+      : undefined;
+    if (hostedWorkspaceOpt !== undefined && !inProcessFirstParty) {
+      return {
+        id: request.id,
+        ok: false,
+        error: 'Invalid RPC dispatch provenance',
+      };
+    }
+    const hostedWorkspace = hostedWorkspaceOpt && hostedWorkspaceOpt.length > 0
+      ? hostedWorkspaceOpt
+      : undefined;
+
     const handler = this.handlers.get(request.method);
 
     if (!handler) {
@@ -253,6 +279,9 @@ export class RpcRouter {
       // Positive local-wire provenance. Never inferred from request JSON,
       // origin, or the absence of firstParty; only PipeServer supplies it.
       externalWire: externalWire ? true : undefined,
+      // The workspace the plugin host derived for this caller (#922). Absent
+      // for every other dispatch source, and never readable from the envelope.
+      ...(hostedWorkspace && { hostedWorkspace }),
       clientName:
         typeof request.clientName === 'string' && request.clientName.trim().length > 0
           ? request.clientName.trim()

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -82,10 +82,16 @@ const IDENTITY_OWN_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
  * act across workspaces by design, and a wire caller has no host to derive
  * anything. Supplying it elsewhere is an internal provenance failure, caught by
  * the type here and by a runtime guard in dispatch for JS/casted call sites.
+ *
+ * The plugin host passes the key on EVERY dispatch, `null` included. Presence
+ * is what marks the caller class; the value is only the binding. Omitting the
+ * key when there is no workspace would erase the one fact a scoping handler
+ * needs — that this is a hosted caller — and leave it indistinguishable from a
+ * caller free to name its own workspace.
  */
 type RpcDispatchOptions = (
   | { operator: true; firstParty?: never; externalWire?: never; hostedWorkspace?: never }
-  | { firstParty: true; operator?: never; externalWire?: never; hostedWorkspace?: string }
+  | { firstParty: true; operator?: never; externalWire?: never; hostedWorkspace?: string | null }
   | { externalWire: true; operator?: never; firstParty?: never; hostedWorkspace?: never }
 ) & {
   /**
@@ -235,18 +241,23 @@ export class RpcRouter {
     // internal provenance failure as a conflicting trust marker, so it fails
     // the same way — loudly, before any handler runs — rather than being
     // dropped into a context that then looks merely unscoped.
-    const hostedWorkspaceOpt = typeof opts?.hostedWorkspace === 'string'
-      ? opts.hostedWorkspace.trim()
-      : undefined;
-    if (hostedWorkspaceOpt !== undefined && !inProcessFirstParty) {
+    const hostedDispatch = opts !== undefined && 'hostedWorkspace' in opts;
+    if (hostedDispatch && !inProcessFirstParty) {
       return {
         id: request.id,
         ok: false,
         error: 'Invalid RPC dispatch provenance',
       };
     }
-    const hostedWorkspace = hostedWorkspaceOpt && hostedWorkspaceOpt.length > 0
-      ? hostedWorkspaceOpt
+    // A blank or whitespace-only binding normalises to `null`, NOT to absent:
+    // the caller is still the plugin host, it just has no workspace to bind to.
+    // Collapsing the two would hand an unbound hosted call to a lane that lets
+    // it name its own workspace, which is the hole this exists to close.
+    const hostedTrimmed = typeof opts?.hostedWorkspace === 'string'
+      ? opts.hostedWorkspace.trim()
+      : '';
+    const hostedWorkspace: string | null | undefined = hostedDispatch
+      ? (hostedTrimmed.length > 0 ? hostedTrimmed : null)
       : undefined;
 
     const handler = this.handlers.get(request.method);
@@ -279,9 +290,10 @@ export class RpcRouter {
       // Positive local-wire provenance. Never inferred from request JSON,
       // origin, or the absence of firstParty; only PipeServer supplies it.
       externalWire: externalWire ? true : undefined,
-      // The workspace the plugin host derived for this caller (#922). Absent
-      // for every other dispatch source, and never readable from the envelope.
-      ...(hostedWorkspace && { hostedWorkspace }),
+      // The workspace the plugin host derived for this caller (#922). `null`
+      // means "hosted, but nothing to bind to"; the key is absent for every
+      // other dispatch source, and never readable from the envelope.
+      ...(hostedWorkspace !== undefined && { hostedWorkspace }),
       clientName:
         typeof request.clientName === 'string' && request.clientName.trim().length > 0
           ? request.clientName.trim()

--- a/src/main/pipe/__tests__/RpcRouter.dispatchProvenance.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.dispatchProvenance.test.ts
@@ -251,27 +251,67 @@ describe('RpcRouter dispatch provenance', () => {
   });
 
   it('never lets a request envelope populate the host workspace (#922)', async () => {
-    let seen: RpcContext | undefined;
+    const seen: (RpcContext | undefined)[] = [];
     router.register('system.identify', async (_params, ctx) => {
-      seen = ctx;
+      seen.push(ctx);
       return { name: 'wmux' };
     });
 
-    const response = await router.dispatch(
+    // Positive control first, so this test cannot pass with the feature
+    // removed: the OPTION sets the binding even while the envelope and the
+    // params both name something else.
+    await router.dispatch(
+      {
+        id: 'option-wins',
+        method: 'system.identify',
+        params: { hostedWorkspace: 'ws-forged' },
+        clientName: 'hello-panel',
+        ...({ hostedWorkspace: 'ws-forged' } as Record<string, unknown>),
+      } as RpcRequest,
+      { firstParty: true, hostedWorkspace: 'ws-host' },
+    );
+    expect(seen[0]?.hostedWorkspace).toBe('ws-host');
+
+    // Same envelope, no option: a wire client is free to put the field on the
+    // request, and the router still does not read it.
+    await router.dispatch(
       {
         id: 'forged',
         method: 'system.identify',
         params: { hostedWorkspace: 'ws-forged' },
         clientName: 'hello-panel',
-        // A wire client is free to put this on the envelope; it is not a
-        // field the router reads.
         ...({ hostedWorkspace: 'ws-forged' } as Record<string, unknown>),
       } as RpcRequest,
       { externalWire: true },
     );
+    expect(seen[1]?.hostedWorkspace).toBeUndefined();
+  });
 
-    expect(response.ok).toBe(true);
-    expect(seen?.hostedWorkspace).toBeUndefined();
+  it('keeps an unbound plugin-host dispatch distinguishable from a non-hosted one (#922)', async () => {
+    const seen: (RpcContext | undefined)[] = [];
+    router.register('system.identify', async (_params, ctx) => {
+      seen.push(ctx);
+      return { name: 'wmux' };
+    });
+
+    for (const value of [null, '', '   '] as const) {
+      await router.dispatch(
+        { id: `unbound-${String(value)}`, method: 'system.identify', params: {}, clientName: 'hello-panel' },
+        { firstParty: true, hostedWorkspace: value },
+      );
+    }
+    // null, not undefined: the caller IS the plugin host, it just has no
+    // workspace to bind to. Collapsing the two is what let an unbound plugin
+    // fall through to a lane that accepts its own workspaceId.
+    expect(seen.map((c) => c?.hostedWorkspace)).toEqual([null, null, null]);
+    expect(seen.every((c) => c !== undefined && 'hostedWorkspace' in c)).toBe(true);
+
+    // A plain first-party dispatch that is not the plugin host stays absent.
+    await router.dispatch(
+      { id: 'not-hosted', method: 'system.identify', params: {}, clientName: 'hello-panel' },
+      { firstParty: true },
+    );
+    expect(seen[3]?.hostedWorkspace).toBeUndefined();
   });
 
   it('rejects a host workspace supplied off the plugin-host lane (#922)', async () => {

--- a/src/main/pipe/__tests__/RpcRouter.dispatchProvenance.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.dispatchProvenance.test.ts
@@ -224,6 +224,79 @@ describe('RpcRouter dispatch provenance', () => {
     expect(systemIdentifyHandler).not.toHaveBeenCalled();
   });
 
+  it('threads the plugin host workspace onto the context it dispatches (#922)', async () => {
+    let seen: RpcContext | undefined;
+    router.register('system.identify', async (_params, ctx) => {
+      seen = ctx;
+      return { name: 'wmux' };
+    });
+
+    const response = await router.dispatch(
+      {
+        id: 'hosted',
+        method: 'system.identify',
+        params: { workspaceId: 'ws-other' },
+        clientName: 'hello-panel',
+      },
+      { firstParty: true, hostedWorkspace: 'ws-host' },
+    );
+
+    expect(response.ok).toBe(true);
+    // The option wins over anything the request carried: the params still say
+    // 'ws-other' and the context says 'ws-host'. Keeping both visible is the
+    // point — the handler decides, and it can only decide if it can tell them
+    // apart.
+    expect(seen?.hostedWorkspace).toBe('ws-host');
+    expect(seen?.firstParty).toBe(true);
+  });
+
+  it('never lets a request envelope populate the host workspace (#922)', async () => {
+    let seen: RpcContext | undefined;
+    router.register('system.identify', async (_params, ctx) => {
+      seen = ctx;
+      return { name: 'wmux' };
+    });
+
+    const response = await router.dispatch(
+      {
+        id: 'forged',
+        method: 'system.identify',
+        params: { hostedWorkspace: 'ws-forged' },
+        clientName: 'hello-panel',
+        // A wire client is free to put this on the envelope; it is not a
+        // field the router reads.
+        ...({ hostedWorkspace: 'ws-forged' } as Record<string, unknown>),
+      } as RpcRequest,
+      { externalWire: true },
+    );
+
+    expect(response.ok).toBe(true);
+    expect(seen?.hostedWorkspace).toBeUndefined();
+  });
+
+  it('rejects a host workspace supplied off the plugin-host lane (#922)', async () => {
+    for (const lane of [{ externalWire: true }, { operator: true }] as const) {
+      const response = await router.dispatch(
+        {
+          id: 'hosted-off-lane',
+          method: 'system.identify',
+          params: {},
+          clientName: 'claude-code',
+        },
+        { ...lane, hostedWorkspace: 'ws-host' } as unknown as DispatchOptions,
+      );
+
+      // Loud, not lenient: dropping the field would leave a context that reads
+      // as merely unscoped, which is the state this lane exists to end.
+      expect(response).toEqual({
+        id: 'hosted-off-lane',
+        ok: false,
+        error: 'Invalid RPC dispatch provenance',
+      });
+    }
+    expect(systemIdentifyHandler).not.toHaveBeenCalled();
+  });
+
   it('does not inherit external-wire provenance into an unmarked nested dispatch', async () => {
     records.set('claude-code', approved('claude-code'));
     router.register('system.identify', async () =>

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -156,6 +156,91 @@ describe('callerScope shadow decision (#810)', () => {
       },
     ],
     [
+      // #922 — the plugin host derives both halves of this identity, so an
+      // omitted workspaceId resolves instead of being refused. Contrast the
+      // `declared` cases below: those callers name their own scope.
+      'hosted plugin omitting its scope resolves to the host workspace',
+      {
+        origin: 'local',
+        firstParty: true,
+        clientName: 'hello-panel',
+        hostedWorkspace: 'ws-host',
+      },
+      {},
+      { kind: 'scoped', lane: 'hosted', workspaceId: 'ws-host' },
+    ],
+    [
+      'hosted plugin naming its own workspace',
+      {
+        origin: 'local',
+        firstParty: true,
+        clientName: 'hello-panel',
+        hostedWorkspace: 'ws-host',
+      },
+      { workspaceId: 'ws-host' },
+      { kind: 'scoped', lane: 'hosted', workspaceId: 'ws-host' },
+    ],
+    [
+      // THE defect #922 describes: before this lane the same call landed in
+      // `declared` and was scoped to 'ws-other' — a foreign workspace, on one
+      // approval, from a plugin that #719 already forbids from WATCHING it.
+      'hosted plugin naming a foreign workspace is refused',
+      {
+        origin: 'local',
+        firstParty: true,
+        clientName: 'hello-panel',
+        hostedWorkspace: 'ws-host',
+      },
+      { workspaceId: 'ws-other' },
+      {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-workspace-mismatch',
+        requestedWorkspaceId: 'ws-other',
+        hostedWorkspaceId: 'ws-host',
+      },
+    ],
+    [
+      // Provenance, not payload: dispatch already refuses the option off the
+      // firstParty lane, so a wire context carrying one is malformed. It is
+      // refused rather than quietly demoted to `declared`, which would let a
+      // malformed context buy the OLD behaviour back.
+      'wire caller carrying a host workspace is refused',
+      {
+        origin: 'local',
+        externalWire: true,
+        clientName: 'approved-plugin',
+        hostedWorkspace: 'ws-host',
+      },
+      { workspaceId: 'ws-other' },
+      {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-source-unqualified',
+        requestedWorkspaceId: 'ws-other',
+        hostedWorkspaceId: 'ws-host',
+      },
+    ],
+    [
+      // The pinned lane is checked first and stays first: a forged commander
+      // pin is refused before the hosted lane can rescue the same caller.
+      'hosted plugin forging a server pin is still refused as pinned',
+      {
+        origin: 'local',
+        firstParty: true,
+        clientName: 'hello-panel',
+        hostedWorkspace: 'ws-host',
+        commanderWorkspace: 'ws-forged',
+      },
+      {},
+      {
+        kind: 'rejected',
+        lane: 'pinned',
+        reason: 'pinned-source-unqualified',
+        pinnedWorkspaceId: 'ws-forged',
+      },
+    ],
+    [
       'identified caller declaring a scope',
       { origin: 'local', externalWire: true, clientName: 'approved-plugin' },
       { workspaceId: 'ws-declared' },

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -222,6 +222,41 @@ describe('callerScope shadow decision (#810)', () => {
       },
     ],
     [
+      // The host had no active workspace, so there is nothing to bind to. This
+      // must NOT fall through to `declared`, which would accept the plugin's
+      // own workspaceId — an unbound plugin would end up less confined than a
+      // bound one.
+      'hosted plugin with no binding is refused, not demoted',
+      {
+        origin: 'local',
+        firstParty: true,
+        clientName: 'hello-panel',
+        hostedWorkspace: null,
+      },
+      { workspaceId: 'ws-other' },
+      {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-workspace-unbound',
+        requestedWorkspaceId: 'ws-other',
+      },
+    ],
+    [
+      'hosted plugin with a blank binding is refused the same way',
+      {
+        origin: 'local',
+        firstParty: true,
+        clientName: 'hello-panel',
+        hostedWorkspace: '',
+      },
+      {},
+      {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-workspace-unbound',
+      },
+    ],
+    [
       // The pinned lane is checked first and stays first: a forged commander
       // pin is refused before the hosted lane can rescue the same caller.
       'hosted plugin forging a server pin is still refused as pinned',
@@ -745,6 +780,76 @@ describe('registerBrowserRpc', () => {
   // options or a request field. Its decisions are covered pure-functionally in
   // the `callerScope` describe above; `scopeFor` funnels every rejected lane
   // through one branch, exercised by the unresolved cases here.
+
+  // The hosted lane, unlike pinned, IS reachable from here: `hostedWorkspace`
+  // comes from the dispatch options the plugin host supplies, so these drive
+  // the real handler chain rather than the decision function alone.
+  it('resolves a hosted plugin that omits its workspace to the host binding', async () => {
+    const router = register(() => null, undefined, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-hosted-omitted',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1' },
+      clientName: 'hello-panel',
+    }, { firstParty: true, hostedWorkspace: 'ws-host' });
+
+    expect(response.ok).toBe(true);
+    // The binding, not the absent request field, is what the lookup receives.
+    expect(cdpOf(router).getTarget).toHaveBeenCalledWith(undefined, 'ws-host');
+  });
+
+  it('refuses a hosted plugin that names another workspace, before any lookup', async () => {
+    const shadowSink = vi.fn();
+    const router = register(() => null, shadowSink, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-hosted-mismatch',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1', workspaceId: 'ws-other' },
+      clientName: 'hello-panel',
+    }, { firstParty: true, hostedWorkspace: 'ws-host' });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) {
+      expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+      expect(response.error).toContain('omit workspaceId');
+    }
+    expect(cdpOf(router).getTarget).not.toHaveBeenCalled();
+    expect(cdpOf(router).ensureAwake).not.toHaveBeenCalled();
+    expect(mockWebContents.debugger.sendCommand).not.toHaveBeenCalled();
+    expect(shadowSink).toHaveBeenCalledWith({
+      clientName: 'hello-panel',
+      method: 'browser.evaluate',
+      reason: 'hosted-workspace-mismatch',
+      requestedWorkspaceId: 'ws-other',
+      hostedWorkspaceId: 'ws-host',
+    });
+  });
+
+  it('refuses an unbound hosted plugin instead of accepting the workspace it names', async () => {
+    const shadowSink = vi.fn();
+    const router = register(() => null, shadowSink, 'enforce');
+
+    const response = await router.dispatch({
+      id: 'scope-enforce-hosted-unbound',
+      method: 'browser.evaluate',
+      params: { expression: '1 + 1', workspaceId: 'ws-other' },
+      clientName: 'hello-panel',
+    }, { firstParty: true, hostedWorkspace: null });
+
+    expect(response.ok).toBe(false);
+    if (!response.ok) expect(response.error).toContain('BROWSER_SCOPE_REFUSED');
+    // The regression this guards: before the lane keyed on presence, this call
+    // landed in `declared` and was scoped to 'ws-other'.
+    expect(cdpOf(router).getTarget).not.toHaveBeenCalled();
+    expect(shadowSink).toHaveBeenCalledWith({
+      clientName: 'hello-panel',
+      method: 'browser.evaluate',
+      reason: 'hosted-workspace-unbound',
+      requestedWorkspaceId: 'ws-other',
+    });
+  });
 
   it('hands the decided workspace to the lookup, not the raw request field', async () => {
     const router = register(() => null, undefined, 'enforce');

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -115,11 +115,15 @@ function requestedWorkspaceId(params: Record<string, unknown>): string | undefin
  *           lookup; it is refused. This is the caller #810 describes.
  *   closes  a pinned commander can no longer name a workspace other than the
  *           one its validated token is bound to.
- *   closes  (#922) an approved IFRAME PLUGIN can no longer act on a workspace
- *           other than the one the user is in. It used to reach `declared` and
- *           receive whatever workspace it named, while #719 already held it to
- *           the active workspace for OBSERVATION — "may watch here, may act
- *           anywhere" was an asymmetry, not a decision.
+ *   closes  (#922) an approved IFRAME PLUGIN can no longer point a browser
+ *           target lookup — every `browser.*` method that resolves through
+ *           `scopeFor` — at a workspace other than the one hosting it. It used
+ *           to reach `declared` and receive whatever workspace it named, while
+ *           #719 already held it to the active workspace for OBSERVATION:
+ *           "may watch here, may act anywhere" was an asymmetry, not a
+ *           decision. Confined to THIS table: the renderer's own fallbacks
+ *           (`pane.list`, `browser.open` in `useRpcBridge.ts`) resolve a
+ *           workspace without ever reaching here and are not covered.
  *   OPEN    the `declared` lane checks that `workspaceId` is PRESENT, not that
  *           it is the caller's own. For a WIRE caller nothing in the main
  *           process binds a clientName to a workspace — `mcp.claimWorkspace`
@@ -199,24 +203,41 @@ export function callerScope(
   // readable from the bridge envelope, so unlike `declared` this is an
   // ownership fact rather than a claim, and it is applied with the pinned
   // lane's exact rules: omitted resolves to it, a mismatch is refused.
-  const hostedWorkspaceId =
-    typeof ctx.hostedWorkspace === 'string' && ctx.hostedWorkspace.length > 0
-      ? ctx.hostedWorkspace
-      : undefined;
-  if (hostedWorkspaceId) {
+  //
+  // The lane is keyed on the PRESENCE of the field, not on it holding a
+  // workspace. A hosted caller with `null` — the host had no active workspace
+  // to bind to — is refused here. Falling through on the empty case would send
+  // exactly the caller this lane exists for into `declared`, where its own
+  // `workspaceId` is accepted: an unbound plugin would be strictly less
+  // confined than a bound one.
+  if (ctx.hostedWorkspace !== undefined) {
+    const hostedWorkspaceId =
+      typeof ctx.hostedWorkspace === 'string' && ctx.hostedWorkspace.length > 0
+        ? ctx.hostedWorkspace
+        : undefined;
     // Mirror of the pinned lane's source check, pointed the other way: pinned
-    // must arrive on the local wire, hosted must arrive in-process. RpcRouter
-    // already refuses the option off the firstParty lane, so this is the
-    // fail-closed second reading rather than the only one. The operator is not
-    // tested here because it returns above — it may act across workspaces by
-    // design, and dispatch rejects operator + hostedWorkspace outright.
+    // must arrive on the local wire, hosted must arrive in-process. This is an
+    // invariant backstop, not production telemetry — RpcRouter rejects the
+    // option off the firstParty lane before a context is ever built, so the
+    // only way here is a hand-built context (tests, a future context
+    // constructor). It stays because the lane must fail closed for those too.
+    // The operator is not tested: it returns above, may act across workspaces
+    // by design, and dispatch refuses operator + hostedWorkspace outright.
     if (ctx.firstParty !== true || ctx.externalWire === true) {
       return {
         kind: 'rejected',
         lane: 'hosted',
         reason: 'hosted-source-unqualified',
         ...(requested && { requestedWorkspaceId: requested }),
-        hostedWorkspaceId,
+        ...(hostedWorkspaceId && { hostedWorkspaceId }),
+      };
+    }
+    if (!hostedWorkspaceId) {
+      return {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-workspace-unbound',
+        ...(requested && { requestedWorkspaceId: requested }),
       };
     }
     if (requested && requested !== hostedWorkspaceId) {
@@ -291,6 +312,8 @@ const SCOPE_REFUSAL_REMEDY: Record<BrowserScopeShadowReason, string> = {
     'address a surface in the workspace your token is bound to',
   'hosted-source-unqualified':
     'a host-bound caller must arrive through the in-process plugin host',
+  'hosted-workspace-unbound':
+    'the plugin host has no active workspace to resolve this call against',
   'hosted-workspace-mismatch':
     'omit workspaceId and this resolves to the workspace you are hosted in',
   'workspace-unresolved':

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -70,15 +70,16 @@ export type BrowserCallerScopeDecision =
     }
   | {
       kind: 'scoped';
-      lane: 'pinned' | 'declared';
+      lane: 'pinned' | 'hosted' | 'declared';
       workspaceId: string;
     }
   | {
       kind: 'rejected';
-      lane: 'context' | 'pinned' | 'declared';
+      lane: 'context' | 'pinned' | 'hosted' | 'declared';
       reason: BrowserScopeShadowReason;
       requestedWorkspaceId?: string;
       pinnedWorkspaceId?: string;
+      hostedWorkspaceId?: string;
     };
 
 function requestedWorkspaceId(params: Record<string, unknown>): string | undefined {
@@ -114,17 +115,28 @@ function requestedWorkspaceId(params: Record<string, unknown>): string | undefin
  *           lookup; it is refused. This is the caller #810 describes.
  *   closes  a pinned commander can no longer name a workspace other than the
  *           one its validated token is bound to.
+ *   closes  (#922) an approved IFRAME PLUGIN can no longer act on a workspace
+ *           other than the one the user is in. It used to reach `declared` and
+ *           receive whatever workspace it named, while #719 already held it to
+ *           the active workspace for OBSERVATION — "may watch here, may act
+ *           anywhere" was an asymmetry, not a decision.
  *   OPEN    the `declared` lane checks that `workspaceId` is PRESENT, not that
- *           it is the caller's own. Nothing in the main process binds a
- *           clientName to a workspace — `mcp.claimWorkspace` forwards to the
- *           renderer and records no server-side association — so a caller that
- *           names a foreign workspace is still accepted here, exactly as before.
+ *           it is the caller's own. For a WIRE caller nothing in the main
+ *           process binds a clientName to a workspace — `mcp.claimWorkspace`
+ *           forwards to the renderer and records no server-side association —
+ *           so one that names a foreign workspace is still accepted here.
  *   OPEN    the `legacy` lane (no `clientName`) stays allowed and unscoped, and
  *           `PermissionEnforcer` grandfathers the same callers. Dropping the
  *           identity envelope therefore still bypasses this.
  *
- * Both OPEN items need a caller-identity binding that does not exist yet; they
- * are tracked on #810 rather than papered over here.
+ * The hosted lane closes one caller CLASS, not the general problem: it works
+ * only because the plugin host derives both halves of the identity itself.
+ * Both OPEN items are wire callers, still need the peer-credential primitive
+ * that does not exist yet, and are tracked on #922.
+ *
+ * Ceiling, stated so the lane is not read as more than it is: this confines an
+ * APPROVED plugin to the scope its approval implied. It is not a defence
+ * against hostile code already running as the user.
  */
 export function callerScope(
   ctx: RpcContext | undefined,
@@ -179,6 +191,44 @@ export function callerScope(
       };
     }
     return { kind: 'scoped', lane: 'pinned', workspaceId: pinnedWorkspaceId };
+  }
+
+  // #922 — the hosted lane. The plugin host derives BOTH halves of this
+  // caller's identity: `clientName` is stamped from the manifest and
+  // `hostedWorkspace` is the workspace the host is showing. Neither is
+  // readable from the bridge envelope, so unlike `declared` this is an
+  // ownership fact rather than a claim, and it is applied with the pinned
+  // lane's exact rules: omitted resolves to it, a mismatch is refused.
+  const hostedWorkspaceId =
+    typeof ctx.hostedWorkspace === 'string' && ctx.hostedWorkspace.length > 0
+      ? ctx.hostedWorkspace
+      : undefined;
+  if (hostedWorkspaceId) {
+    // Mirror of the pinned lane's source check, pointed the other way: pinned
+    // must arrive on the local wire, hosted must arrive in-process. RpcRouter
+    // already refuses the option off the firstParty lane, so this is the
+    // fail-closed second reading rather than the only one. The operator is not
+    // tested here because it returns above — it may act across workspaces by
+    // design, and dispatch rejects operator + hostedWorkspace outright.
+    if (ctx.firstParty !== true || ctx.externalWire === true) {
+      return {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-source-unqualified',
+        ...(requested && { requestedWorkspaceId: requested }),
+        hostedWorkspaceId,
+      };
+    }
+    if (requested && requested !== hostedWorkspaceId) {
+      return {
+        kind: 'rejected',
+        lane: 'hosted',
+        reason: 'hosted-workspace-mismatch',
+        requestedWorkspaceId: requested,
+        hostedWorkspaceId,
+      };
+    }
+    return { kind: 'scoped', lane: 'hosted', workspaceId: hostedWorkspaceId };
   }
 
   if (!ctx.clientName) {
@@ -239,6 +289,10 @@ const SCOPE_REFUSAL_REMEDY: Record<BrowserScopeShadowReason, string> = {
     'a workspace-pinned caller must arrive on the local wmux wire',
   'pinned-workspace-mismatch':
     'address a surface in the workspace your token is bound to',
+  'hosted-source-unqualified':
+    'a host-bound caller must arrive through the in-process plugin host',
+  'hosted-workspace-mismatch':
+    'omit workspaceId and this resolves to the workspace you are hosted in',
   'workspace-unresolved':
     'send the workspaceId of the workspace you are calling from',
 };
@@ -366,6 +420,9 @@ export function registerBrowserRpc(
             }),
             ...(decision.pinnedWorkspaceId && {
               pinnedWorkspaceId: decision.pinnedWorkspaceId,
+            }),
+            ...(decision.hostedWorkspaceId && {
+              hostedWorkspaceId: decision.hostedWorkspaceId,
             }),
           });
         } catch {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -847,8 +847,17 @@ const electronAPI = {
       plugins: unknown[];
       failures: Array<{ name: string; errors: string[] }>;
     }>,
-    rpc: (pluginName: string, method: string, params?: Record<string, unknown>) =>
-      ipcRenderer.invoke(IPC.PLUGINS_RPC, pluginName, method, params) as Promise<unknown>,
+    // `hostWorkspaceId` is the workspace the HOST is showing (#922) — a
+    // mandatory position with a nullable value, so a future call site cannot
+    // silently omit the binding, while a host that genuinely has no workspace
+    // yet can still say so.
+    rpc: (
+      pluginName: string,
+      method: string,
+      params: Record<string, unknown> | undefined,
+      hostWorkspaceId: string | undefined,
+    ) =>
+      ipcRenderer.invoke(IPC.PLUGINS_RPC, pluginName, method, params, hostWorkspaceId) as Promise<unknown>,
     requestApproval: (pluginName: string) =>
       ipcRenderer.invoke(IPC.PLUGINS_REQUEST_APPROVAL, pluginName) as Promise<{ approved: boolean }>,
     onPaneDecoration: (callback: (decoration: {

--- a/src/renderer/plugins/PluginFrame.tsx
+++ b/src/renderer/plugins/PluginFrame.tsx
@@ -112,7 +112,12 @@ export default function PluginFrame({
         const req = parseBridgeRequest(e.data);
         if (!req || disposed) return;
         window.electronAPI.plugins
-          .rpc(pluginName, req.method, req.params)
+          // #922: the workspace the host is showing rides alongside the
+          // request, never inside it, so main can tell what this plugin IS
+          // from what it ASKED for. Read at request time on purpose — making
+          // it a dependency of this effect would tear the port down on every
+          // workspace switch, which is exactly what #928 fixed.
+          .rpc(pluginName, req.method, req.params, useStore.getState().activeWorkspaceId)
           .then((raw) => {
             const resp = raw as { ok?: boolean; result?: unknown; error?: string } | null;
             if (resp && resp.ok === true) {
@@ -182,9 +187,18 @@ export default function PluginFrame({
       if (stopped || inFlight) return;
       inFlight = true;
       window.electronAPI.plugins
-        .rpc(pluginName, 'events.poll', cursor === null
-          ? { workspaceId: activeWorkspaceId }
-          : { cursor, workspaceId: activeWorkspaceId })
+        .rpc(
+          pluginName,
+          'events.poll',
+          cursor === null
+            ? { workspaceId: activeWorkspaceId }
+            : { cursor, workspaceId: activeWorkspaceId },
+          // Same value the params carry here (this effect re-runs on a
+          // workspace switch), passed on the host channel as well so every
+          // plugin-host dispatch states the host's binding, not just the
+          // methods that read it today.
+          activeWorkspaceId,
+        )
         .then((raw) => {
           const resp = raw as { ok?: boolean; result?: { events?: unknown[]; nextCursor?: number } } | null;
           if (!resp || resp.ok !== true || !resp.result) {

--- a/src/renderer/plugins/__tests__/PluginFrame.bridge.dynamic.test.tsx
+++ b/src/renderer/plugins/__tests__/PluginFrame.bridge.dynamic.test.tsx
@@ -114,6 +114,41 @@ describe('PluginFrame — bridge lifetime across a workspace switch', () => {
       .toMatchObject({ kind: 'response', id: 'after' });
   });
 
+  // #922 — every plugin request carries the workspace the HOST is showing, on
+  // its own channel, so main can tell what this caller IS from what it ASKED
+  // for. Read at request time rather than captured at load: the same port must
+  // report ws-2 after the user switches, without the bridge being rebuilt
+  // (making it an effect dependency is what #928 fixed).
+  it('sends the host workspace with each request and follows a switch', async () => {
+    act(() => {
+      root.render(React.createElement(PluginFrame, {
+        pluginName: 'demo',
+        entry: 'index.html',
+        forwardEvents: false,
+      }));
+    });
+
+    const iframe = container.querySelector('iframe')!;
+    const framePostMessage = vi.fn();
+    Object.defineProperty(iframe, 'contentWindow', {
+      configurable: true,
+      get: () => ({ postMessage: framePostMessage }),
+    });
+
+    await act(async () => { iframe.dispatchEvent(new Event('load')); });
+    const port = pluginPort(framePostMessage);
+    port.start();
+
+    await settledOrTimedOut(request(port, 'before', 'browser.navigate'));
+    expect(rpc).toHaveBeenLastCalledWith('demo', 'browser.navigate', {}, 'ws-1');
+
+    await act(async () => { useStore.setState({ activeWorkspaceId: 'ws-2' }); });
+
+    // Same port, no reload, no re-render of the bridge — only the store moved.
+    await settledOrTimedOut(request(port, 'after', 'browser.navigate'));
+    expect(rpc).toHaveBeenLastCalledWith('demo', 'browser.navigate', {}, 'ws-2');
+  });
+
   // A response belongs to the document that ASKED. The reload window is what
   // makes that observable: an rpc started on the old port resolves after the
   // new one exists, and answering on the current port hands the fresh document
@@ -203,12 +238,12 @@ describe('PluginFrame — bridge lifetime across a workspace switch', () => {
       await act(async () => { iframe.dispatchEvent(new Event('load')); });
       await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
 
-      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-1' });
+      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-1' }, 'ws-1');
 
       await act(async () => { useStore.setState({ activeWorkspaceId: 'ws-2' }); });
       await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
 
-      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-2' });
+      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-2' }, 'ws-2');
       // ...and never keeps polling the workspace the user left.
       const pollsAfterSwitch = rpc.mock.calls
         .slice(rpc.mock.calls.findIndex((c) => c[2]?.workspaceId === 'ws-2'))
@@ -243,7 +278,7 @@ describe('PluginFrame — bridge lifetime across a workspace switch', () => {
 
       await act(async () => { iframe.dispatchEvent(new Event('load')); });
       await act(async () => { await vi.advanceTimersByTimeAsync(1000); });
-      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-1' });
+      expect(rpc).toHaveBeenCalledWith('demo', 'events.poll', { workspaceId: 'ws-1' }, 'ws-1');
 
       // Swap the plugin: the bridge effect tears down and the new frame has
       // not loaded yet, so there is no port.

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -189,6 +189,20 @@ export interface RpcContext {
    * envelope field — validation is the only writer.
    */
   commanderWorkspace?: string;
+  /**
+   * #922 — the workspace the PLUGIN HOST derived for this caller, not one the
+   * caller named. Set by RpcRouter only from the `hostedWorkspace` dispatch
+   * option, and only on the in-process `firstParty` lane; a request envelope
+   * can never populate it and the external wire never carries it.
+   *
+   * The iframe plugin surface is the one caller class where neither half of the
+   * identity is caller-supplied: `clientName` is stamped from the loaded
+   * manifest, and this is the workspace the host is showing. Handlers may
+   * therefore treat it as the caller's own workspace — which `browser.rpc.ts`
+   * does in its `hosted` lane — where `declared` can only check that some
+   * workspaceId is present.
+   */
+  hostedWorkspace?: string;
 }
 
 export type RpcResponse =

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -201,8 +201,16 @@ export interface RpcContext {
    * therefore treat it as the caller's own workspace — which `browser.rpc.ts`
    * does in its `hosted` lane — where `declared` can only check that some
    * workspaceId is present.
+   *
+   * Three states, and the difference between the last two is load-bearing:
+   *   `string`     the host is showing this workspace; bind the call to it.
+   *   `null`       the plugin host dispatched this and had NO workspace to
+   *                bind it to. Still a hosted caller — a handler that scopes
+   *                on this must refuse, never fall through to a lane that lets
+   *                the caller name its own workspace.
+   *   `undefined`  not a plugin-host dispatch at all.
    */
-  hostedWorkspace?: string;
+  hostedWorkspace?: string | null;
 }
 
 export type RpcResponse =


### PR DESCRIPTION
PR1 of the two-PR split agreed on #922
([comment](https://github.com/openwong2kim/wmux/issues/922#issuecomment-5337705295)).
Built on current `main`, since #928 moved these lines.

## The asymmetry this closes

The iframe plugin surface is the one caller class where **neither half of the
identity is supplied by the caller**:

- `clientName` is stamped main-side from the loaded manifest
  (`pluginHost.handler.ts`), never read from the bridge envelope;
- the workspace is derived by the host component that owns the frame —
  `PluginFrame.tsx` reads `activeWorkspaceId` from the store.

#719 already used that derivation on one side: `events.poll` is scoped, so a
plugin may not **observe** another workspace's lifecycle events. But a plugin's
own requests were forwarded with their params untouched, so `browser.*` landed
in the `declared` lane and got whatever workspace it named. The live rule was
*may watch only where the user is, may act anywhere* — which reads as an
oversight rather than a decision.

## What it does

- `RpcContext.hostedWorkspace`, written only by `RpcRouter.dispatch` from a new
  dispatch option next to `firstParty`. The plugin-host IPC handler is the sole
  call site that supplies it. A request envelope cannot reach it.
- The option is typed onto the `firstParty` variant alone and declared `never`
  on the other two; the runtime guard in `dispatch` rejects it off that lane as
  an internal provenance failure rather than dropping it into a context that
  would then read as merely unscoped.
- **Presence marks the caller class; the value is only the binding.** `string`
  binds, `null` means *the plugin host dispatched this and has no workspace to
  bind to*, absent means *not a plugin-host dispatch*. The host sends the key on
  every call.
- A `hosted` lane in `callerScope`, above `declared`, with the `pinned` lane's
  exact semantics — omitted `workspaceId` resolves to the binding, a mismatch is
  refused — plus two of its own: the mirror of `pinned`'s source check (`pinned`
  must arrive on the local wire, `hosted` must arrive in-process), and a refusal
  for the unbound case.
- Refusal copy follows the existing rule: name the refusal, never name another
  workspace. The audit entry may carry the ids; the message may not.

Because both halves are derived, this lane is an ownership fact where `declared`
can only be a claim.

## Deliberately not in this PR

- Moving the binding up to dispatch, and the `useRpcBridge.ts` renderer
  fallbacks (`pane.list`, `browser.open`) — that is PR2, and it gets its own
  design pass.
- The wire lanes. `declared` and `legacy` are untouched.

## One non-change worth flagging

`PluginFrame.tsx` reads the workspace **at request time** rather than taking it
as a dependency of the bridge effect. Making it a dependency is precisely what
broke the bridge in #928: the effect's cleanup closes the `MessagePort`, and
`load` never fires again for an unchanged `src`.

## Ceiling

This confines an **approved** plugin to the scope its approval implied. It is
not a defence against hostile code already running as the user, and it does not
touch the wire lanes, which still need the peer-credential primitive. The
binding is only as strong as the host's own derivation — not cryptographic
identity.

## Effect on shipped code

None. The bundled reference plugin (`examples/plugins/hello-panel`) calls
`workspace.list` and `pane.list` only — neither is in the browser lane table.
For any other plugin: omitting `workspaceId` on a `browser.*` call now
**resolves**, where `declared` previously refused it as `workspace-unresolved`;
naming a foreign workspace is refused where it previously succeeded.
Enforcement rides the existing `mcp.mode` gate (packaged `enforce`, dev
`shadow`), so there is no new mode or rollback switch.

## Review

Second commit is the result of an independent review (codex, `gpt-5.6-sol`,
read-only) that caught the lane **fail-open on its own empty case**: with the
binding omitted when the host had no active workspace, the context was
indistinguishable from any other in-process caller and the plugin fell through
to `declared`, where its own `workspaceId` is accepted — an unbound plugin would
have been *less* confined than a bound one. That is what the tri-state above
fixes. The same review narrowed two over-broad comments and flagged the source
check as an invariant backstop rather than production telemetry; both are in.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — clean. `eslint` on the changed files —
  clean.
- `vitest run src/main/pipe src/renderer/plugins src/main/ipc/handlers/__tests__/pluginHost.handler.test.ts`
  — 36 files, 755 tests, green.
- Wider sweep `vitest run src/main src/shared src/preload` — 4658 passed. Three
  files fail on this machine (`logSink`, `cliShim`, `mergeSession`); `logSink`
  fails identically on a clean `origin/main` checkout here and the other two
  pass in isolation, so they are load/environment noise, not this change.
- The unbound test was run against the pre-fix implementation: it fails there
  with `expected true to be false` — the call succeeded and was scoped to the
  workspace the plugin named — and passes here.

New coverage:

- `browser.rpc.test.ts` — seven lane-table cases (resolve-on-omit, accept-own,
  **refuse-foreign**, unbound, blank, wire-context-carrying-the-field, and
  pinned-before-hosted precedence) plus three enforce-path cases through the
  registered handler, asserting the refusals land **before** any target lookup,
  wake, or lease, and that the audit entry is written.
- `RpcRouter.dispatchProvenance.test.ts` — the option reaches the context (with
  a positive control so the test cannot pass with the feature removed), an
  envelope field never does, `null`/`''`/whitespace all normalise to `null`
  while staying distinguishable from absent, and off-lane cases hard-reject.
- `pluginHost.handler.test.ts` (new file) — the IPC seam: forwarded as an option
  not a param, params left verbatim, absent/blank host workspace forwarded as an
  explicit `null`, non-string refused.
- `PluginFrame.bridge.dynamic.test.tsx` — mounted: the same port reports `ws-1`
  then `ws-2` across a switch with no reload, pinning both the binding and the
  #928 invariant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted hosted plugin browser requests to the host’s active workspace.
  - Rejected requests with missing, mismatched, or invalid workspace context.
  - Prevented untrusted request data from overriding the host workspace.

- **Bug Fixes**
  - Preserved correct workspace binding when switching workspaces.
  - Improved audit details for rejected hosted plugin requests.

- **Tests**
  - Added coverage for workspace inheritance, rejection scenarios, provenance validation, and workspace switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->