### PR TITLE
Pin only the textarea during IME composition, never the inline preedit

### DIFF
--- a/changelog.d/945.md
+++ b/changelog.d/945.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Korean IME no longer paints the composing syllable over the one just
+  committed.** Since v3.42.0, typing Korean showed syllables disappearing as
+  you typed (`대한민국` read `대한국` until the composition ended) — the
+  candidate-window pin introduced for Chinese/Japanese IMEs dragged the whole
+  helper container, inline preedit included, back onto committed cells. The
+  pin now holds only the hidden textarea that anchors the candidate window,
+  while the visible inline preedit stays on the live cursor, so Korean input
+  reads correctly keystroke by keystroke and the Chinese/Japanese
+  candidate-window behavior is unchanged. The IME diagnostic log (now
+  `ime-anchor2` → `ime-anchor3`) also records mid-composition and
+  composition-end corrections when they change, so a future report of this
+  family is self-diagnosing. (#945)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1120,13 +1120,17 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // (#942's field log was all zeros because the drag developed after the
     // start-only diagnostic had fired). Capped: the first few are all anyone
     // needs to diagnose, and the cap keeps it from filling main-*.log for the
-    // rest of the session. Remove the whole diagnostic once #874/#942 are
-    // confirmed fixed in the field.
-    let imeAnchorLogsLeft = 20;
+    // rest of the session. Budgeted per phase so one long composition's
+    // update/end records cannot burn the start budget (or vice versa) and
+    // silence the diagnostic for the rest of the session.
+    // Remove the whole diagnostic once #874/#942 are confirmed fixed in the
+    // field.
+    const imeAnchorLogsLeft = { start: 20, mid: 20 };
     const imeAnchor = attachImeAnchor(terminal, {
       onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, selY, selX }) => {
-        if (imeAnchorLogsLeft <= 0) return;
-        imeAnchorLogsLeft -= 1;
+        const budget = phase === 'start' ? 'start' : 'mid';
+        if (imeAnchorLogsLeft[budget] <= 0) return;
+        imeAnchorLogsLeft[budget] -= 1;
         // Mirrored into the main-side log file by src/main/index.ts's
         // console-message listener, so the user can share it. The "3" in the
         // tag marks the split-surface build so a shared log is unambiguous
@@ -1140,7 +1144,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src} held=${held.toFixed(0)}ms ` +
           `restAge=${restAge.toFixed(0)}ms cellHeight=${cellHeight.toFixed(2)} pin=(${dx.toFixed(1)},${dy.toFixed(1)}) ` +
           `preedit=(${preeditDx.toFixed(1)},${preeditDy.toFixed(1)})` +
-          (imeAnchorLogsLeft === 0 ? ' (last one, diagnostic capped)' : ''),
+          (imeAnchorLogsLeft[budget] === 0 ? ` (last ${budget} record, diagnostic capped)` : ''),
         );
       },
     });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1104,34 +1104,42 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       },
     });
 
-    // #874: keep the IME candidate window on the cursor. xterm anchors its
-    // hidden helper textarea at the ybase-relative cursor row while the
+    // #874/#942: keep the IME candidate window on the cursor. xterm anchors
+    // its hidden helper textarea at the ybase-relative cursor row while the
     // renderer paints the cursor at the ydisp-relative one, so a scrolled-up
     // viewport offsets the candidate window by exactly that many rows, and the
     // composition path re-anchors on every keystroke so the window chases the
-    // TUI's cursor while an agent streams. See terminal/imeAnchor.ts.
-    // #874 could not be reproduced locally (no CJK IME on the dev boxes), so
-    // the anchor reports what it corrected and a reporter's log tells us
-    // whether any offset survives. A CJK user starts a composition per word,
-    // so this is capped: the first few are all anyone needs to diagnose, and
-    // the cap keeps it from filling main-*.log for the rest of the session.
-    // Remove the whole diagnostic once #874 is confirmed fixed in the field.
+    // TUI's cursor while an agent streams. The pin covers the textarea only;
+    // the inline preedit box follows the live cursor (#942, Korean IME draws
+    // its composition inline with no candidate window). See
+    // terminal/imeAnchor.ts.
+    // Neither issue could be reproduced locally (no CJK IME on the dev boxes),
+    // so the anchor reports what it corrected and a reporter's log tells us
+    // whether any offset survives. Start records fire per composition;
+    // update/end records only when a correction changed mid-composition
+    // (#942's field log was all zeros because the drag developed after the
+    // start-only diagnostic had fired). Capped: the first few are all anyone
+    // needs to diagnose, and the cap keeps it from filling main-*.log for the
+    // rest of the session. Remove the whole diagnostic once #874/#942 are
+    // confirmed fixed in the field.
     let imeAnchorLogsLeft = 20;
     const imeAnchor = attachImeAnchor(terminal, {
-      onCompositionDiagnostic: ({ baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, src, held, restAge, selY, selX }) => {
+      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, selY, selX }) => {
         if (imeAnchorLogsLeft <= 0) return;
         imeAnchorLogsLeft -= 1;
         // Mirrored into the main-side log file by src/main/index.ts's
-        // console-message listener, so the user can share it. The "2" in the
-        // tag marks the resting-cell build so a shared log is unambiguous
+        // console-message listener, so the user can share it. The "3" in the
+        // tag marks the split-surface build so a shared log is unambiguous
         // about which release produced it. src/held/restAge/sel are the
         // cause-3 discriminator: src=resting means the composition started
         // mid-repaint and the anchor used the last resting cell instead of
-        // the instantaneous cursor.
+        // the instantaneous cursor. pin= is the textarea correction,
+        // preedit= the live composition-view correction.
         console.info(
-          `[wmux:ime-anchor2] pty=${ptyIdRef.current} compositionstart ybase=${baseY} ydisp=${viewportY} ` +
+          `[wmux:ime-anchor3] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
           `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src} held=${held.toFixed(0)}ms ` +
-          `restAge=${restAge.toFixed(0)}ms cellHeight=${cellHeight.toFixed(2)} correction=(${dx.toFixed(1)},${dy.toFixed(1)})` +
+          `restAge=${restAge.toFixed(0)}ms cellHeight=${cellHeight.toFixed(2)} pin=(${dx.toFixed(1)},${dy.toFixed(1)}) ` +
+          `preedit=(${preeditDx.toFixed(1)},${preeditDy.toFixed(1)})` +
           (imeAnchorLogsLeft === 0 ? ' (last one, diagnostic capped)' : ''),
         );
       },

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -468,12 +468,14 @@ describe('#942 inline preedit (Korean IME) — the pin never drags the preedit',
     expect(dom.textarea.style.transform).toBe('');
     expect(dom.compView.style.transform).toBe('');
 
-    // Echo arrives: cursor advances past the pinned cell, cells repaint.
+    // Echo arrives: cursor advances past the pinned cell, cells repaint. The
+    // render-path correction touches only the textarea; the preedit stays
+    // where xterm put it until the next composition event, exactly like stock
+    // xterm (following the per-frame cursor would chase mid-repaint
+    // transients — see syncPreedit).
     Object.assign(t.state, { cursorX: 25 });
     t.onRender.fire(undefined);
-    // The preedit is corrected forward onto the live caret even before xterm's
-    // next reposition; the pinned textarea has nothing to move yet.
-    expect(translateOf(dom.compView)?.dx).toBeCloseTo(2 * 10, 6);
+    expect(dom.compView.style.transform).toBe('');
     expect(dom.textarea.style.transform).toBe('');
 
     // Next compositionupdate: xterm re-anchors both children to the live caret.
@@ -520,29 +522,49 @@ describe('#942 inline preedit (Korean IME) — the pin never drags the preedit',
     expect(diag).toHaveBeenCalledTimes(1);
     expect(diag.mock.calls[0][0]).toMatchObject({ phase: 'start', dx: 0, dy: 0, preeditDx: 0, preeditDy: 0 });
 
+    // The echo alone changes nothing observable (the pin holds, the preedit
+    // waits for the next composition event) — no record burned.
     Object.assign(t.state, { cursorX: 25 });
     t.onRender.fire(undefined);
-    expect(diag).toHaveBeenCalledTimes(2);
-    expect(diag.mock.calls[1][0]).toMatchObject({ phase: 'update', dx: 0 });
-    expect(diag.mock.calls[1][0].preeditDx).toBeCloseTo(2 * 10, 6);
+    expect(diag).toHaveBeenCalledTimes(1);
 
+    // The compositionupdate that follows develops the pin offset — recorded.
     positionChildren(30, 25);
     dom.textarea.dispatchEvent(new Event('compositionupdate'));
-    expect(diag).toHaveBeenCalledTimes(3);
-    expect(diag.mock.calls[2][0]).toMatchObject({ phase: 'update', preeditDx: 0 });
-    expect(diag.mock.calls[2][0].dx).toBeCloseTo(-2 * 10, 6);
+    expect(diag).toHaveBeenCalledTimes(2);
+    expect(diag.mock.calls[1][0]).toMatchObject({ phase: 'update', preeditDx: 0 });
+    expect(diag.mock.calls[1][0].dx).toBeCloseTo(-2 * 10, 6);
 
     // A quiet frame adds no record.
     t.onRender.fire(undefined);
-    expect(diag).toHaveBeenCalledTimes(3);
+    expect(diag).toHaveBeenCalledTimes(2);
 
     dom.textarea.dispatchEvent(new Event('compositionend'));
-    expect(diag).toHaveBeenCalledTimes(4);
-    expect(diag.mock.calls[3][0]).toMatchObject({ phase: 'end', dx: 0, dy: 0, preeditDx: 0, preeditDy: 0 });
+    expect(diag).toHaveBeenCalledTimes(3);
+    expect(diag.mock.calls[2][0]).toMatchObject({ phase: 'end', dx: 0, dy: 0, preeditDx: 0, preeditDy: 0 });
 
     // Post-composition renders never report.
     t.onRender.fire(undefined);
-    expect(diag).toHaveBeenCalledTimes(4);
+    expect(diag).toHaveBeenCalledTimes(3);
+    handle.dispose();
+  });
+
+  it('an agent streaming mid-composition never drags the preedit to transient cursors', () => {
+    // The 2-model panel finding on the first cut of this fix: a per-frame
+    // preedit follow re-opens cause 3 for the preedit. While a TUI repaints,
+    // the buffer cursor parks mid-frame on real JS turns; renders during a
+    // composition must leave the preedit where xterm put it.
+    const { dom, t, handle, positionChildren } = composeAt(30, 23);
+    positionChildren(30, 23);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(dom.compView.style.transform).toBe('');
+    // TUI repaint parks the cursor far away for a frame, then puts it back.
+    Object.assign(t.state, { cursorY: 5, cursorX: 100 });
+    t.onRender.fire(undefined);
+    expect(dom.compView.style.transform).toBe('');
+    Object.assign(t.state, { cursorY: 30, cursorX: 23 });
+    t.onRender.fire(undefined);
+    expect(dom.compView.style.transform).toBe('');
     handle.dispose();
   });
 

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 /**
- * #874 — IME candidate-window anchoring.
+ * #874 — IME candidate-window anchoring; #942 — the composition pin is split
+ * per child (textarea pinned, inline preedit live) so Korean inline
+ * composition is never dragged onto committed cells.
  *
  * Three layers, because each catches a class the others cannot:
  *   1. Pure math, including a regression lock on the live-measured drift.
@@ -141,6 +143,7 @@ function translateOf(el: HTMLElement): { dx: number; dy: number } | null {
 
 function buildTerminalDom(cellWidth = 10, cellHeight = 17.6, rows = 39, cols = 142): {
   root: HTMLElement; screen: HTMLElement; helpers: HTMLElement; textarea: HTMLTextAreaElement;
+  compView: HTMLElement;
 } {
   const root = document.createElement('div');
   root.className = 'xterm';
@@ -150,14 +153,17 @@ function buildTerminalDom(cellWidth = 10, cellHeight = 17.6, rows = 39, cols = 1
   helpers.className = 'xterm-helpers';
   const textarea = document.createElement('textarea');
   textarea.className = 'xterm-helper-textarea';
+  const compView = document.createElement('div');
+  compView.className = 'composition-view';
   helpers.appendChild(textarea);
+  helpers.appendChild(compView);
   screen.appendChild(helpers);
   root.appendChild(screen);
   document.body.appendChild(root);
   // jsdom has no layout; stand in for the measured cell grid.
   Object.defineProperty(screen, 'clientWidth', { value: cellWidth * cols, configurable: true });
   Object.defineProperty(screen, 'clientHeight', { value: cellHeight * rows, configurable: true });
-  return { root, screen, helpers, textarea };
+  return { root, screen, helpers, textarea, compView };
 }
 
 function makeTerminal(dom: ReturnType<typeof buildTerminalDom>, rows = 39, cols = 142): {
@@ -197,7 +203,7 @@ describe('#874 attachImeAnchor', () => {
     const handle = attachImeAnchor(terminal);
     onRender.fire(undefined);
     // style.left is still xterm's -9999em stylesheet default.
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
     handle.dispose();
   });
 
@@ -209,8 +215,8 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = `${38 * 17.6}px`;
     dom.textarea.style.left = `${12 * 10}px`;
     onRender.fire(undefined);
-    expect(translateOf(dom.helpers)?.dx).toBe(0);
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(8 * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dx).toBe(0);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(8 * 17.6, 6);
     handle.dispose();
   });
 
@@ -222,11 +228,11 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = `${38 * 17.6}px`;
     dom.textarea.style.left = '0px';
     onScroll.fire(undefined);
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
     // User wheels up 4 rows. xterm leaves style.top alone; we absorb it.
     state.viewportY = 18;
     onScroll.fire(undefined);
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(4 * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(4 * 17.6, 6);
     handle.dispose();
   });
 
@@ -238,7 +244,7 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = `${5 * 17.6}px`;
     dom.textarea.style.left = '20px';
     onRender.fire(undefined);
-    const spy = vi.spyOn(dom.helpers.style, 'transform', 'set');
+    const spy = vi.spyOn(dom.textarea.style, 'transform', 'set');
     for (let i = 0; i < 60; i++) onRender.fire(undefined);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
@@ -253,7 +259,7 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = `${30 * 17.6}px`;
     dom.textarea.style.left = '80px';
     onRender.fire(undefined);
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
 
     dom.textarea.dispatchEvent(new Event('compositionstart'));
 
@@ -265,12 +271,16 @@ describe('#874 attachImeAnchor', () => {
     onRender.fire(undefined);
 
     // Candidate window must stay on row 30 / col 8 where the user started.
-    expect(translateOf(dom.helpers)?.dx).toBeCloseTo(40, 6);
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(12 * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo(40, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(12 * 17.6, 6);
+    // The pin covers the textarea only — the inline preedit is never dragged
+    // by it (#942; xterm has not positioned the preedit here, so no live
+    // correction exists either).
+    expect(dom.compView.style.transform).toBe('');
 
     dom.textarea.dispatchEvent(new Event('compositionend'));
     onRender.fire(undefined);
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
     handle.dispose();
   });
 
@@ -287,7 +297,7 @@ describe('#874 attachImeAnchor', () => {
     // Simulate xterm's deferred updateCompositionElements(true) moving it.
     dom.textarea.style.top = `${6 * 17.6}px`;
     await new Promise((r) => setTimeout(r, 1));
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(14 * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(14 * 17.6, 6);
     handle.dispose();
   });
 
@@ -299,14 +309,14 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = `${4 * 17.6}px`;
     dom.textarea.style.left = '0px';
     onRender.fire(undefined);
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(2 * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(2 * 17.6, 6);
     // Font size bumped: cells get taller, and xterm re-anchors at the new
     // metrics. Our correction must track the new cell height, which it only
     // learns about from onResize (never from a per-frame layout read).
     Object.defineProperty(dom.screen, 'clientHeight', { value: 20 * 39, configurable: true });
     dom.textarea.style.top = `${4 * 20}px`;
     onResize.fire(undefined);
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(2 * 20, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(2 * 20, 6);
     handle.dispose();
   });
 
@@ -323,7 +333,7 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.height = '16px'; // what _syncTextArea writes
     onRender.fire(undefined);
     // Exactly two cells of drift at xterm's 16px, not 2 * 17.59.
-    expect(translateOf(dom.helpers)?.dy).toBe(32);
+    expect(translateOf(dom.textarea)?.dy).toBe(32);
     handle.dispose();
   });
 
@@ -336,14 +346,14 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.left = '0px';
     dom.textarea.style.height = '16px';
     onRender.fire(undefined);
-    expect(translateOf(dom.helpers)?.dy).toBe(32);
+    expect(translateOf(dom.textarea)?.dy).toBe(32);
 
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     // xterm now writes the preedit box height here, not a cell height.
     dom.textarea.style.height = '48px';
     onRender.fire(undefined);
     // Frozen at the composition-start row, and still using the 16px cell.
-    expect(translateOf(dom.helpers)?.dy).toBe(32);
+    expect(translateOf(dom.textarea)?.dy).toBe(32);
     handle.dispose();
   });
 
@@ -355,11 +365,11 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = '0px';
     dom.textarea.style.left = '0px';
     onRender.fire(undefined);
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
     handle.dispose();
   });
 
-  it('reports the composition diagnostic once per composition', () => {
+  it('reports a start diagnostic per composition and stays quiet while nothing changes', () => {
     const dom = buildTerminalDom(10, 17.6, 47);
     const { terminal, state } = makeTerminal(dom, 47);
     const diag = vi.fn();
@@ -369,8 +379,10 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.left = '120px';
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     expect(diag).toHaveBeenCalledTimes(1);
-    expect(diag.mock.calls[0][0]).toMatchObject({ baseY: 22, viewportY: 14, cursorY: 38, cursorX: 12 });
+    expect(diag.mock.calls[0][0]).toMatchObject({ phase: 'start', baseY: 22, viewportY: 14, cursorY: 38, cursorX: 12 });
     expect(diag.mock.calls[0][0].dy).toBeCloseTo(140.8, 6);
+    // An update with no correction change is change-gated out (#942 made the
+    // diagnostic fire mid-composition, but only when there is news).
     dom.textarea.dispatchEvent(new Event('compositionupdate'));
     expect(diag).toHaveBeenCalledTimes(1);
     handle.dispose();
@@ -384,10 +396,11 @@ describe('#874 attachImeAnchor', () => {
     dom.textarea.style.top = `${4 * 17.6}px`;
     dom.textarea.style.left = '0px';
     onRender.fire(undefined);
-    expect(dom.helpers.style.transform).not.toBe('');
+    expect(dom.textarea.style.transform).not.toBe('');
 
     handle.dispose();
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
+    expect(dom.compView.style.transform).toBe('');
     expect(onRender.size).toBe(0);
     expect(onScroll.size).toBe(0);
     expect(onResize.size).toBe(0);
@@ -396,7 +409,7 @@ describe('#874 attachImeAnchor', () => {
     // A composition after dispose must not resurrect the transform.
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     onRender.fire(undefined);
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
   });
 
   it('is a no-op when the helper container is missing', () => {
@@ -411,6 +424,141 @@ describe('#874 attachImeAnchor', () => {
       onCursorMove: new FakeEmitter<unknown>().event,
     } as ImeAnchorTerminal;
     expect(() => attachImeAnchor(terminal).dispose()).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('#942 inline preedit (Korean IME) — the pin never drags the preedit', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  /** Typing at an idle prompt: caret at (row, col), both children positioned
+   *  there by xterm, then a composition starts. */
+  function composeAt(row: number, col: number): {
+    dom: ReturnType<typeof buildTerminalDom>;
+    t: ReturnType<typeof makeTerminal>;
+    handle: { dispose(): void };
+    diag: ReturnType<typeof vi.fn>;
+    positionChildren: (r: number, c: number) => void;
+  } {
+    const dom = buildTerminalDom();
+    const t = makeTerminal(dom);
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 0, viewportY: 0, cursorY: row, cursorX: col });
+    const positionChildren = (r: number, c: number): void => {
+      dom.textarea.style.top = `${r * 17.6}px`;
+      dom.textarea.style.left = `${c * 10}px`;
+      dom.compView.style.top = `${r * 17.6}px`;
+      dom.compView.style.left = `${c * 10}px`;
+    };
+    positionChildren(row, col);
+    const handle = attachImeAnchor(t.terminal, { onCompositionDiagnostic: diag });
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    return { dom, t, handle, diag, positionChildren };
+  }
+
+  it('a committed syllable\'s echo advances the caret: preedit follows, textarea stays pinned', () => {
+    // 대한민국 on Korean Microsoft IME: 민 is composing at col 23 when the echo
+    // of the committed 한 lands. The buffer cursor advances two cells and xterm
+    // re-anchors BOTH children to the live caret on the next compositionupdate.
+    // The candidate-window pin must hold the textarea at the start cell — and
+    // must NOT haul the visible preedit back onto the syllable that just
+    // committed (the #942 symptom: 대한민국 reads 대한국 while typing).
+    const { dom, t, handle, positionChildren } = composeAt(30, 23);
+    expect(dom.textarea.style.transform).toBe('');
+    expect(dom.compView.style.transform).toBe('');
+
+    // Echo arrives: cursor advances past the pinned cell, cells repaint.
+    Object.assign(t.state, { cursorX: 25 });
+    t.onRender.fire(undefined);
+    // The preedit is corrected forward onto the live caret even before xterm's
+    // next reposition; the pinned textarea has nothing to move yet.
+    expect(translateOf(dom.compView)?.dx).toBeCloseTo(2 * 10, 6);
+    expect(dom.textarea.style.transform).toBe('');
+
+    // Next compositionupdate: xterm re-anchors both children to the live caret.
+    positionChildren(30, 25);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    // Textarea pinned back to the start cell (candidate-window anchor stays
+    // where the user started typing)…
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo(-2 * 10, 6);
+    // …while the preedit stays on the live caret: zero correction. Under the
+    // #875 container transform both children were dragged back to col 23,
+    // painting the composing syllable over the committed one.
+    expect(dom.compView.style.transform).toBe('');
+
+    dom.textarea.dispatchEvent(new Event('compositionend'));
+    // Composition over: xterm hides the preedit, the pin dissolves, the real
+    // cells repaint — nothing left to correct on either child.
+    expect(dom.textarea.style.transform).toBe('');
+    expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
+  });
+
+  it('while composing scrolled up, the preedit gets the same ydisp correction as the textarea', () => {
+    // Cause 1 applies to the preedit too: xterm anchors it ybase-relative while
+    // the renderer paints ydisp-relative. The split must not lose that.
+    const dom = buildTerminalDom(10, 17.6, 47);
+    const t = makeTerminal(dom, 47);
+    const handle = attachImeAnchor(t.terminal);
+    Object.assign(t.state, { baseY: 22, viewportY: 14, cursorY: 38, cursorX: 12 });
+    dom.textarea.style.top = `${38 * 17.6}px`;
+    dom.textarea.style.left = '120px';
+    dom.compView.style.top = `${38 * 17.6}px`;
+    dom.compView.style.left = '120px';
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(8 * 17.6, 6);
+    expect(translateOf(dom.compView)?.dy).toBeCloseTo(8 * 17.6, 6);
+    handle.dispose();
+  });
+
+  it('diagnostic: change-gated update/end records capture a mid-composition offset', () => {
+    // #942's field log was 40/41 correction=(0,0): the start-only diagnostic
+    // fired before the committed syllable's echo moved anything. The update
+    // and end phases exist so this class of report is self-diagnosing.
+    const { dom, t, handle, diag, positionChildren } = composeAt(30, 23);
+    expect(diag).toHaveBeenCalledTimes(1);
+    expect(diag.mock.calls[0][0]).toMatchObject({ phase: 'start', dx: 0, dy: 0, preeditDx: 0, preeditDy: 0 });
+
+    Object.assign(t.state, { cursorX: 25 });
+    t.onRender.fire(undefined);
+    expect(diag).toHaveBeenCalledTimes(2);
+    expect(diag.mock.calls[1][0]).toMatchObject({ phase: 'update', dx: 0 });
+    expect(diag.mock.calls[1][0].preeditDx).toBeCloseTo(2 * 10, 6);
+
+    positionChildren(30, 25);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(diag).toHaveBeenCalledTimes(3);
+    expect(diag.mock.calls[2][0]).toMatchObject({ phase: 'update', preeditDx: 0 });
+    expect(diag.mock.calls[2][0].dx).toBeCloseTo(-2 * 10, 6);
+
+    // A quiet frame adds no record.
+    t.onRender.fire(undefined);
+    expect(diag).toHaveBeenCalledTimes(3);
+
+    dom.textarea.dispatchEvent(new Event('compositionend'));
+    expect(diag).toHaveBeenCalledTimes(4);
+    expect(diag.mock.calls[3][0]).toMatchObject({ phase: 'end', dx: 0, dy: 0, preeditDx: 0, preeditDy: 0 });
+
+    // Post-composition renders never report.
+    t.onRender.fire(undefined);
+    expect(diag).toHaveBeenCalledTimes(4);
+    handle.dispose();
+  });
+
+  it('a missing .composition-view degrades to stock preedit behavior, not a crash', () => {
+    const dom = buildTerminalDom();
+    dom.compView.remove();
+    const t = makeTerminal(dom);
+    const handle = attachImeAnchor(t.terminal);
+    Object.assign(t.state, { cursorY: 30, cursorX: 23 });
+    dom.textarea.style.top = `${30 * 17.6}px`;
+    dom.textarea.style.left = '230px';
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    Object.assign(t.state, { cursorX: 25 });
+    expect(() => t.onRender.fire(undefined)).not.toThrow();
+    expect(dom.textarea.style.transform).toBe('');
+    handle.dispose();
   });
 });
 
@@ -553,8 +701,8 @@ describe('#874 resting-cell wiring (cause 3)', () => {
     setClock(1105);        // 5ms later — inside the burst window
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     // Anchor must land on the caret cell (30, 8): correction = desired - actual.
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo((30 - 49) * 17.6, 6);
-    expect(translateOf(dom.helpers)?.dx).toBeCloseTo((8 - 113) * 10, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo((30 - 49) * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((8 - 113) * 10, 6);
     expect(diag.mock.calls[0][0]).toMatchObject({
       src: 'resting', held: 5, restAge: 5, selY: 30, selX: 8, cursorY: 49, cursorX: 113,
     });
@@ -570,7 +718,7 @@ describe('#874 resting-cell wiring (cause 3)', () => {
     setClock(1200); // held 200ms >= RESTING_MS
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     // Pinned at bottom, cursor at rest: nothing to correct, no transform.
-    expect(dom.helpers.style.transform).toBe('');
+    expect(dom.textarea.style.transform).toBe('');
     expect(diag.mock.calls[0][0]).toMatchObject({ src: 'instant', selY: 30, selX: 8 });
     handle.dispose();
   });
@@ -648,6 +796,10 @@ describe('#874 upstream contracts', () => {
       expect(helpers).not.toBeNull();
       expect(helpers!.parentElement).toBe(screen);
       expect(helpers!.querySelector('.xterm-helper-textarea')).not.toBeNull();
+      // #942 splits the correction across the two children, so the preedit box
+      // must still live here under this class — if an upgrade renames it, the
+      // preedit silently loses its ydisp correction (degrades, not breaks).
+      expect(helpers!.querySelector('.composition-view')).not.toBeNull();
       // Not yet positioned — the -9999em parking spot parsePxOrNull rejects.
       expect(parsePxOrNull((term.textarea as HTMLTextAreaElement).style.top)).toBeNull();
     } finally {
@@ -677,7 +829,7 @@ describe('#874 upstream contracts', () => {
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     expect(order).toEqual(['xterm', 'ours']);
     // 4 rows of scrollback offset, read against the value xterm just wrote.
-    expect(translateOf(dom.helpers)?.dy).toBeCloseTo(4 * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(4 * 17.6, 6);
     handle.dispose();
   });
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -83,9 +83,10 @@
  * transform and the WebGL repaint restored the real cells, which is why the
  * buffer was never wrong, only the paint. So the pin applies to the textarea
  * alone, and the preedit gets the same anchor math against the live cursor,
- * never frozen — it still lands on the painted caret when the viewport is
- * scrolled (cause 1 applies to it too), and it follows the caret as commits
- * echo back mid-composition.
+ * never frozen — applied at xterm's own composition-event cadence (not per
+ * render frame, see syncPreedit) so it lands on the painted caret when the
+ * viewport is scrolled (cause 1 applies to it too) without chasing mid-repaint
+ * transient cursors.
  *
  * The correction is computed as `desired - actual`, where `actual` is read back
  * from the styles xterm wrote rather than re-derived from the buffer. That
@@ -478,8 +479,13 @@ export function attachImeAnchor(
   };
 
   /** Write-elided transform setter. #942 split the correction per child, so
-   *  each child carries its own last-applied pair. */
-  const makeTransformApplier = (el: HTMLElement): { set(dx: number, dy: number): void } => {
+   *  each child carries its own last-applied pair; `get` exposes it so the
+   *  diagnostic reports what is actually on the element, not a recomputed
+   *  value that may be zero while a stale transform persists. */
+  const makeTransformApplier = (el: HTMLElement): {
+    set(dx: number, dy: number): void;
+    get(): ImeAnchorCorrection;
+  } => {
     let lastDx = 0;
     let lastDy = 0;
     return {
@@ -489,13 +495,13 @@ export function attachImeAnchor(
         lastDy = dy;
         el.style.transform = dx === 0 && dy === 0 ? '' : `translate(${dx}px, ${dy}px)`;
       },
+      get(): ImeAnchorCorrection {
+        return { dx: lastDx, dy: lastDy };
+      },
     };
   };
   const textareaTransform = makeTransformApplier(textarea);
   const preeditTransform = compositionView ? makeTransformApplier(compositionView) : null;
-  // Last preedit correction actually applied, for the diagnostic.
-  let preeditDx = 0;
-  let preeditDy = 0;
 
   const sync = (): ImeAnchorCorrection | null => {
     if (!composing) {
@@ -509,34 +515,43 @@ export function attachImeAnchor(
       }
     }
     if (!isUsableGeometry(geometry)) return null;
-    const live = paintedCursorPosition(bufferState(), geometry);
-    // The preedit is NEVER pinned (#942): while composing it gets the same
-    // anchor math against the live cursor — the ydisp term xterm forgot plus
-    // whatever the caret did since xterm last wrote its styles — and outside a
-    // composition it carries no transform at all (xterm hides it anyway).
-    if (preeditTransform && compositionView) {
-      if (composing) {
-        const actualPreedit = readStyledPoint(compositionView);
-        if (actualPreedit) {
-          const c = computeImeAnchorCorrection(live, actualPreedit);
-          preeditDx = c.dx;
-          preeditDy = c.dy;
-          preeditTransform.set(c.dx, c.dy);
-        }
-      } else {
-        preeditDx = 0;
-        preeditDy = 0;
-        preeditTransform.set(0, 0);
-      }
-    }
     const actual = readStyledPoint(textarea);
     // xterm has not positioned the textarea yet (stylesheet default
     // `left: -9999em`). Nothing to correct against, and forcing a transform
     // now would only move the off-screen parking spot around.
     if (!actual) return null;
-    const correction = computeImeAnchorCorrection(frozen ?? live, actual);
+    const desired = frozen ?? paintedCursorPosition(bufferState(), geometry);
+    const correction = computeImeAnchorCorrection(desired, actual);
     textareaTransform.set(correction.dx, correction.dy);
     return correction;
+  };
+
+  /**
+   * The preedit is NEVER pinned (#942): while composing it gets the same
+   * anchor math against the live cursor — the ydisp term xterm forgot —
+   * and outside a composition it carries no transform (xterm hides it).
+   *
+   * Deliberately called only from the composition handlers, NOT from
+   * onRender/onScroll: at a composition event xterm has just written the
+   * preedit's styles from the same instantaneous cursor this reads, so the
+   * correction reduces to the ydisp term and the preedit's motion profile
+   * stays exactly stock xterm's. Following the cursor per render frame would
+   * re-open the cause-3 hole for the preedit — an agent streaming into the
+   * pane parks the cursor mid-repaint on real JS turns, and a per-frame
+   * follow would drag the composing syllable around the screen (2-model
+   * panel finding on the first cut of this fix).
+   */
+  const syncPreedit = (): void => {
+    if (!preeditTransform || !compositionView) return;
+    if (!composing) {
+      preeditTransform.set(0, 0);
+      return;
+    }
+    if (!isUsableGeometry(geometry)) return;
+    const actualPreedit = readStyledPoint(compositionView);
+    if (!actualPreedit) return;
+    const c = computeImeAnchorCorrection(paintedCursorPosition(bufferState(), geometry), actualPreedit);
+    preeditTransform.set(c.dx, c.dy);
   };
 
   const resetTracker = (): void => {
@@ -565,19 +580,23 @@ export function attachImeAnchor(
   let reportedPreeditDx = 0;
   let reportedPreeditDy = 0;
 
-  const emitDiagnostic = (phase: 'start' | 'update' | 'end', correction: ImeAnchorCorrection | null): void => {
+  const emitDiagnostic = (phase: 'start' | 'update' | 'end'): void => {
     if (!options.onCompositionDiagnostic || lastSel === null) return;
-    const dx = correction?.dx ?? 0;
-    const dy = correction?.dy ?? 0;
+    // Report what is actually applied to the elements, not the last computed
+    // correction — when sync() bails (unusable geometry, unpositioned
+    // textarea) a previous transform is still live, and reporting zeros there
+    // would recreate the all-zeros-log misdiagnosis #942 was filed with.
+    const { dx, dy } = textareaTransform.get();
+    const preedit = preeditTransform?.get() ?? { dx: 0, dy: 0 };
     if (phase !== 'start'
       && dx === reportedDx && dy === reportedDy
-      && preeditDx === reportedPreeditDx && preeditDy === reportedPreeditDy) {
+      && preedit.dx === reportedPreeditDx && preedit.dy === reportedPreeditDy) {
       return;
     }
     reportedDx = dx;
     reportedDy = dy;
-    reportedPreeditDx = preeditDx;
-    reportedPreeditDy = preeditDy;
+    reportedPreeditDx = preedit.dx;
+    reportedPreeditDy = preedit.dy;
     const b = bufferState();
     options.onCompositionDiagnostic({
       phase,
@@ -588,8 +607,8 @@ export function attachImeAnchor(
       cellHeight: geometry.cellHeight,
       dx,
       dy,
-      preeditDx,
-      preeditDy,
+      preeditDx: preedit.dx,
+      preeditDy: preedit.dy,
       src: lastSel.src,
       held: lastSel.held,
       restAge: lastSel.restAge,
@@ -615,43 +634,50 @@ export function attachImeAnchor(
     frozen = isUsableGeometry(geometry)
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;
-    emitDiagnostic('start', sync());
+    sync();
+    syncPreedit();
+    emitDiagnostic('start');
   };
 
   const onCompositionUpdate = (): void => {
     // xterm's own compositionupdate handler already ran (it registered first)
     // and re-anchored the children; correct on top of that. It also queues a
     // setTimeout(0) re-run of the same repositioning, so queue one behind it.
-    emitDiagnostic('update', sync());
+    sync();
+    syncPreedit();
+    emitDiagnostic('update');
     if (pendingCompositionSync !== null) clearTimeout(pendingCompositionSync);
     pendingCompositionSync = setTimeout(() => {
       pendingCompositionSync = null;
-      emitDiagnostic('update', sync());
+      sync();
+      syncPreedit();
+      emitDiagnostic('update');
     }, 0);
   };
 
   const onCompositionEnd = (): void => {
     composing = false;
     frozen = null;
-    emitDiagnostic('end', sync());
+    // A deferred update-sync from this composition must not straddle into the
+    // next one and report against its selection.
+    if (pendingCompositionSync !== null) {
+      clearTimeout(pendingCompositionSync);
+      pendingCompositionSync = null;
+    }
+    sync();
+    syncPreedit();
+    emitDiagnostic('end');
     lastSel = null;
   };
 
   // onRender fires after xterm has written the child styles for the frame, so
-  // reading them here never sees a half-updated position. Mid-composition this
-  // is also where a committed syllable's PTY echo lands (cursor advances, cells
-  // repaint), so the diagnostic samples here too — change-gated, so a quiet
-  // frame costs a few compares and no record.
-  const renderSub = terminal.onRender(() => {
-    const correction = sync();
-    if (composing) emitDiagnostic('update', correction);
-  });
+  // reading them here never sees a half-updated position. Only the textarea is
+  // corrected here — see syncPreedit for why the preedit must not follow the
+  // per-frame cursor.
+  const renderSub = terminal.onRender(() => sync());
   // xterm does NOT re-sync the textarea on scroll — that omission is half of
   // #874 — so this is where the scrolled-viewport correction actually lands.
-  const scrollSub = terminal.onScroll(() => {
-    const correction = sync();
-    if (composing) emitDiagnostic('update', correction);
-  });
+  const scrollSub = terminal.onScroll(() => sync());
   const resizeSub = terminal.onResize(onRefreshGeometry);
   // Coalesced per parse batch by xterm; the handler is a compare plus a few
   // number writes, so the streaming hot path stays cold.

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -57,17 +57,35 @@
  * complexity is added.
  *
  * All of this lives in upstream xterm and this repo does not patch
- * node_modules, so the correction is applied downstream: one `transform` on
- * the `.xterm-helpers` container, which holds the textarea and the visible
- * preedit box. xterm keeps writing `style.top` / `style.left` on those
- * children; a transform on their parent composes with that instead of
- * fighting it.
+ * node_modules, so the correction is applied downstream as a `transform` that
+ * composes with the `style.top` / `style.left` xterm keeps writing, instead of
+ * fighting it. #875 put that transform on the `.xterm-helpers` container;
+ * #942 showed the container is the wrong unit, because its two children have
+ * opposite requirements while a composition is live:
  *
  *   .xterm-screen  (position: relative, origin for everything below)
- *     +-- .xterm-helpers                 <- transform: translate(dx, dy)  [ours]
- *     |     +-- textarea                 <- style.top / left              [xterm]
- *     |     +-- .composition-view        <- style.top / left              [xterm]
- *     +-- canvas                         <- painted cursor                [webgl]
+ *     +-- .xterm-helpers
+ *     |     +-- textarea            <- style.top/left [xterm] + transform [ours: pinned]
+ *     |     +-- .composition-view   <- style.top/left [xterm] + transform [ours: live]
+ *     +-- canvas                    <- painted cursor                     [webgl]
+ *
+ * The textarea is what Chromium reports the caret rect from, so it is what a
+ * floating candidate window (Chinese/Japanese) follows — pinning it for the
+ * whole composition is the point of the freeze. The `.composition-view` is
+ * the visible inline preedit, and `CompositionHelper.updateCompositionElements`
+ * deliberately re-anchors it to the live cursor on every `compositionupdate`.
+ * Korean Microsoft IME draws no candidate window at all: the preedit rendered
+ * inline at the caret IS the text the user is watching. Freezing the shared
+ * parent turned every committed syllable's echo into a backwards drag — the
+ * caret advances past the pinned point, `frozen - actual` goes negative, and
+ * the composing syllable is painted on top of the one that just committed
+ * (typing 대한민국 reads 대한국, #942). The composition ending cleared the
+ * transform and the WebGL repaint restored the real cells, which is why the
+ * buffer was never wrong, only the paint. So the pin applies to the textarea
+ * alone, and the preedit gets the same anchor math against the live cursor,
+ * never frozen — it still lands on the painted caret when the viewport is
+ * scrolled (cause 1 applies to it too), and it follows the caret as commits
+ * echo back mid-composition.
  *
  * The correction is computed as `desired - actual`, where `actual` is read back
  * from the styles xterm wrote rather than re-derived from the buffer. That
@@ -338,18 +356,27 @@ export interface ImeAnchorTerminal {
 
 export interface ImeAnchorOptions {
   /**
-   * Called once per composition start with the coordinates that produced the
-   * correction. #874 could not be reproduced locally (no CJK IME here), so this
-   * is how a reporter's log tells us whether any offset survives the fix.
+   * Called with the coordinates that produced the correction. #874/#942 could
+   * not be reproduced locally (no CJK IME here), so this is how a reporter's
+   * log tells us whether any offset survives the fix. Fires on every
+   * `compositionstart`, and again mid-composition (`update`) or at
+   * `compositionend` ONLY when a correction changed since the last report —
+   * #942's log was all `correction=(0,0)` precisely because the drag developed
+   * after the start-only diagnostic had already fired.
    */
   onCompositionDiagnostic?: (info: {
+    phase: 'start' | 'update' | 'end';
     baseY: number;
     viewportY: number;
     cursorY: number;
     cursorX: number;
     cellHeight: number;
+    /** Correction applied to the textarea (the pinned candidate-window anchor). */
     dx: number;
     dy: number;
+    /** Live correction applied to the inline preedit box; 0,0 when none. */
+    preeditDx: number;
+    preeditDy: number;
     /** Which cell the anchor froze to (cause 3 discriminator). */
     src: FreezeCellSource;
     held: number;
@@ -374,6 +401,10 @@ export function attachImeAnchor(
   if (!textarea || !screen || !helpers) {
     return NO_OP;
   }
+  // The inline preedit box (#942). Optional on purpose: if an xterm upgrade
+  // renames it, the preedit stays on xterm's own live positioning — the
+  // pre-#875 behavior Korean reporters describe as clean — instead of breaking.
+  const compositionView = helpers.querySelector<HTMLElement>('.composition-view');
 
   const now = options.now ?? ((): number => performance.now());
 
@@ -428,31 +459,46 @@ export function attachImeAnchor(
   );
 
   let frozen: ImeAnchorPoint | null = null;
-  let lastDx = 0;
-  let lastDy = 0;
+  // Tracked separately from `frozen`: unusable geometry at compositionstart
+  // leaves `frozen` null while a composition IS live, and both the cell-height
+  // sampling gate and the preedit correction key off the composition itself.
+  let composing = false;
   let pendingCompositionSync: ReturnType<typeof setTimeout> | null = null;
 
   /**
-   * Where xterm currently has the children, in screen-local pixels, with our
-   * own transform excluded. Read from the inline styles xterm wrote rather than
+   * Where xterm currently has a child, in screen-local pixels, with our own
+   * transform excluded. Read from the inline styles xterm wrote rather than
    * from `offsetTop`, so the hot path stays layout-read-free.
    */
-  const readActual = (): ImeAnchorPoint | null => {
-    const top = parsePxOrNull(textarea.style.top);
-    const left = parsePxOrNull(textarea.style.left);
+  const readStyledPoint = (el: HTMLElement): ImeAnchorPoint | null => {
+    const top = parsePxOrNull(el.style.top);
+    const left = parsePxOrNull(el.style.left);
     if (top === null || left === null) return null;
     return { left: helpersOrigin.left + left, top: helpersOrigin.top + top };
   };
 
-  const apply = (dx: number, dy: number): void => {
-    if (dx === lastDx && dy === lastDy) return;
-    lastDx = dx;
-    lastDy = dy;
-    helpers.style.transform = dx === 0 && dy === 0 ? '' : `translate(${dx}px, ${dy}px)`;
+  /** Write-elided transform setter. #942 split the correction per child, so
+   *  each child carries its own last-applied pair. */
+  const makeTransformApplier = (el: HTMLElement): { set(dx: number, dy: number): void } => {
+    let lastDx = 0;
+    let lastDy = 0;
+    return {
+      set(dx: number, dy: number): void {
+        if (dx === lastDx && dy === lastDy) return;
+        lastDx = dx;
+        lastDy = dy;
+        el.style.transform = dx === 0 && dy === 0 ? '' : `translate(${dx}px, ${dy}px)`;
+      },
+    };
   };
+  const textareaTransform = makeTransformApplier(textarea);
+  const preeditTransform = compositionView ? makeTransformApplier(compositionView) : null;
+  // Last preedit correction actually applied, for the diagnostic.
+  let preeditDx = 0;
+  let preeditDy = 0;
 
   const sync = (): ImeAnchorCorrection | null => {
-    if (frozen === null) {
+    if (!composing) {
       // Not composing, so `style.height` is still the cell height xterm wrote
       // in _syncTextArea (during a composition it holds the preedit box size
       // instead, which is why this only samples outside one).
@@ -463,14 +509,33 @@ export function attachImeAnchor(
       }
     }
     if (!isUsableGeometry(geometry)) return null;
-    const actual = readActual();
+    const live = paintedCursorPosition(bufferState(), geometry);
+    // The preedit is NEVER pinned (#942): while composing it gets the same
+    // anchor math against the live cursor — the ydisp term xterm forgot plus
+    // whatever the caret did since xterm last wrote its styles — and outside a
+    // composition it carries no transform at all (xterm hides it anyway).
+    if (preeditTransform && compositionView) {
+      if (composing) {
+        const actualPreedit = readStyledPoint(compositionView);
+        if (actualPreedit) {
+          const c = computeImeAnchorCorrection(live, actualPreedit);
+          preeditDx = c.dx;
+          preeditDy = c.dy;
+          preeditTransform.set(c.dx, c.dy);
+        }
+      } else {
+        preeditDx = 0;
+        preeditDy = 0;
+        preeditTransform.set(0, 0);
+      }
+    }
+    const actual = readStyledPoint(textarea);
     // xterm has not positioned the textarea yet (stylesheet default
     // `left: -9999em`). Nothing to correct against, and forcing a transform
     // now would only move the off-screen parking spot around.
     if (!actual) return null;
-    const desired = frozen ?? paintedCursorPosition(bufferState(), geometry);
-    const correction = computeImeAnchorCorrection(desired, actual);
-    apply(correction.dx, correction.dy);
+    const correction = computeImeAnchorCorrection(frozen ?? live, actual);
+    textareaTransform.set(correction.dx, correction.dy);
     return correction;
   };
 
@@ -488,63 +553,105 @@ export function attachImeAnchor(
     sync();
   };
 
+  // Freeze-cell selection of the current composition, for the diagnostic.
+  let lastSel: FreezeCellSelection | null = null;
+  // Last corrections the diagnostic reported: update/end records fire only on
+  // change, so a healthy composition costs one record and a developing offset
+  // is captured the moment it develops (#942's field log was all
+  // `correction=(0,0)` because the start-only diagnostic fired before the
+  // committed syllable's echo moved anything).
+  let reportedDx = 0;
+  let reportedDy = 0;
+  let reportedPreeditDx = 0;
+  let reportedPreeditDy = 0;
+
+  const emitDiagnostic = (phase: 'start' | 'update' | 'end', correction: ImeAnchorCorrection | null): void => {
+    if (!options.onCompositionDiagnostic || lastSel === null) return;
+    const dx = correction?.dx ?? 0;
+    const dy = correction?.dy ?? 0;
+    if (phase !== 'start'
+      && dx === reportedDx && dy === reportedDy
+      && preeditDx === reportedPreeditDx && preeditDy === reportedPreeditDy) {
+      return;
+    }
+    reportedDx = dx;
+    reportedDy = dy;
+    reportedPreeditDx = preeditDx;
+    reportedPreeditDy = preeditDy;
+    const b = bufferState();
+    options.onCompositionDiagnostic({
+      phase,
+      baseY: b.baseY,
+      viewportY: b.viewportY,
+      cursorY: b.cursorY,
+      cursorX: b.cursorX,
+      cellHeight: geometry.cellHeight,
+      dx,
+      dy,
+      preeditDx,
+      preeditDy,
+      src: lastSel.src,
+      held: lastSel.held,
+      restAge: lastSel.restAge,
+      selY: lastSel.absRow - b.baseY,
+      selX: lastSel.col,
+    });
+  };
+
   const onCompositionStart = (): void => {
-    // Pin the anchor for the whole composition. The buffer cursor keeps moving
-    // while the agent streams, but the candidate window belongs where the user
-    // started typing, not wherever the TUI's redraw last left the cursor. The
-    // cell it pins to is the resting-tracker selection: the instantaneous
-    // cursor when it is at rest, the last resting cell when the composition
-    // starts inside a repaint burst (cause 3).
+    // Pin the textarea anchor for the whole composition. The buffer cursor
+    // keeps moving while the agent streams, but the candidate window belongs
+    // where the user started typing, not wherever the TUI's redraw last left
+    // the cursor. The cell it pins to is the resting-tracker selection: the
+    // instantaneous cursor when it is at rest, the last resting cell when the
+    // composition starts inside a repaint burst (cause 3).
+    composing = true;
     const b = bufferState();
     const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now(), {
       top: b.viewportY,
       rows: geometry.rows,
     });
+    lastSel = sel;
     frozen = isUsableGeometry(geometry)
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;
-    const correction = sync();
-    if (options.onCompositionDiagnostic) {
-      options.onCompositionDiagnostic({
-        baseY: b.baseY,
-        viewportY: b.viewportY,
-        cursorY: b.cursorY,
-        cursorX: b.cursorX,
-        cellHeight: geometry.cellHeight,
-        dx: correction?.dx ?? 0,
-        dy: correction?.dy ?? 0,
-        src: sel.src,
-        held: sel.held,
-        restAge: sel.restAge,
-        selY: sel.absRow - b.baseY,
-        selX: sel.col,
-      });
-    }
+    emitDiagnostic('start', sync());
   };
 
   const onCompositionUpdate = (): void => {
     // xterm's own compositionupdate handler already ran (it registered first)
     // and re-anchored the children; correct on top of that. It also queues a
     // setTimeout(0) re-run of the same repositioning, so queue one behind it.
-    sync();
+    emitDiagnostic('update', sync());
     if (pendingCompositionSync !== null) clearTimeout(pendingCompositionSync);
     pendingCompositionSync = setTimeout(() => {
       pendingCompositionSync = null;
-      sync();
+      emitDiagnostic('update', sync());
     }, 0);
   };
 
   const onCompositionEnd = (): void => {
+    composing = false;
     frozen = null;
-    sync();
+    emitDiagnostic('end', sync());
+    lastSel = null;
   };
 
   // onRender fires after xterm has written the child styles for the frame, so
-  // reading them here never sees a half-updated position.
-  const renderSub = terminal.onRender(() => sync());
+  // reading them here never sees a half-updated position. Mid-composition this
+  // is also where a committed syllable's PTY echo lands (cursor advances, cells
+  // repaint), so the diagnostic samples here too — change-gated, so a quiet
+  // frame costs a few compares and no record.
+  const renderSub = terminal.onRender(() => {
+    const correction = sync();
+    if (composing) emitDiagnostic('update', correction);
+  });
   // xterm does NOT re-sync the textarea on scroll — that omission is half of
   // #874 — so this is where the scrolled-viewport correction actually lands.
-  const scrollSub = terminal.onScroll(() => sync());
+  const scrollSub = terminal.onScroll(() => {
+    const correction = sync();
+    if (composing) emitDiagnostic('update', correction);
+  });
   const resizeSub = terminal.onResize(onRefreshGeometry);
   // Coalesced per parse batch by xterm; the handler is a compare plus a few
   // number writes, so the streaming hot path stays cold.
@@ -572,7 +679,8 @@ export function attachImeAnchor(
       textarea.removeEventListener('compositionupdate', onCompositionUpdate);
       textarea.removeEventListener('compositionend', onCompositionEnd);
       if (pendingCompositionSync !== null) clearTimeout(pendingCompositionSync);
-      helpers.style.transform = '';
+      textarea.style.transform = '';
+      if (compositionView) compositionView.style.transform = '';
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixes #942 — on Korean Microsoft IME, the composing syllable was painted on top of the syllable that just committed (typing `대한민국` read `대한국`), a display-only regression introduced by the #875 composition-anchor pin.

### Root cause

The pin applied its correction as a single `transform` on `.xterm-helpers`, a container holding two surfaces with opposite requirements during a composition:

- the hidden **textarea** — the caret rect Chromium reports, i.e. the candidate-window anchor, which SHOULD stay pinned where the user started typing (#874/#875/#888);
- **`.composition-view`** — the visible inline preedit, which xterm deliberately re-anchors to the live cursor on every `compositionupdate`.

Korean IME draws no candidate window: the inline preedit IS the text the user watches. When a committed syllable's echo advanced the caret, `frozen − actual` went negative and dragged the preedit back onto the committed cell. The buffer was always correct, which is why ending the composition restored the text — exactly as reported.

### Fix

Split the correction per child:

- **textarea**: keeps the composition pin (preserves the Chinese/Japanese candidate-window behavior from #874/#875/#888);
- **`.composition-view`**: never frozen; gets the same anchor math against the live cursor (so it still receives the ydisp scroll correction xterm forgets), applied only at xterm's own composition-event cadence — not per render frame — so it cannot chase mid-repaint transient cursors while an agent streams (cause-3 protection, a 3-model review-panel finding on the first cut).

### Diagnostics

The `ime-anchor` diagnostic is retagged `ime-anchor3` and now also fires on `compositionupdate`/`compositionend` when a correction changes — #942's field log was 40/41 `correction=(0,0)` precisely because the drag developed after the start-only diagnostic had fired. Records report the transforms actually applied (not recomputed values), and the log budget is split per phase (20 start + 20 update/end) so one long composition cannot silence the diagnostic.

## Testing

- New `#942` regression suite: the committed-syllable-echo scenario (verified to fail on the previous code), scrolled-viewport preedit parity, streaming-jitter protection, change-gated diagnostic phases, missing-`.composition-view` degradation.
- Upstream-contract test now also locks `.composition-view`'s place in `.xterm-helpers`.
- Full suite: 11,659 passed / 27 skipped. `tsc --noEmit` clean.
- Reviewed by a 3-model panel (Claude / Codex / GLM); all four findings addressed in the second commit. Field verification on a real Korean Windows setup is pending — the reporter offered to verify any candidate build (they are pinned to v3.41.1 meanwhile).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Korean IME composition rendering by keeping inline preedit text aligned with the live cursor.
  - Corrected candidate-window positioning without disrupting visible composition text.
  - Preserved existing Chinese and Japanese IME behavior.
  - Improved cleanup and scrolling behavior during and after text composition.

- **Diagnostics**
  - Enhanced IME diagnostics to report composition updates, completion corrections, and preedit positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->