### PR TITLE
fix(perf): gate the frame-budget family on frames, and stop calling the confirmation re-run independent

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -181,7 +181,7 @@ nothing for six weeks (#602).
 
 ## Gate semantics
 
-A metric **FAILS only when both** of these hold:
+Most metrics **FAIL only when both** of these hold:
 
 - `current > baseline * ratio`, **and**
 - `current > baseline + absMargin`.
@@ -189,17 +189,43 @@ A metric **FAILS only when both** of these hold:
 The double condition stops tiny baselines (a few ms, a few MiB) from tripping on
 ordinary noise. Thresholds per metric:
 
-| metric | ratio | abs margin |
-| --- | --- | --- |
-| `coldStart.best.firstPtyDataMs` | 1.5 | 1000 ms |
-| `inputLatency.echoMs.p95` | 1.5 | 10 ms |
-| `inputLatency.frameMs.p95` | 1.5 | 10 ms |
-| `inputLatency8.frameMs.p95` | 1.5 | 10 ms |
-| `ram.idle1Pane.workingSetBytes` | 1.3 | 100 MiB |
-| `ram.panes8.workingSetBytes` | 1.3 | 150 MiB |
-| `frameBudget.N4/N8/N16.frameDeltaMs.p95` | 2.0 | 8 ms |
-| `hiddenFlood.N4/N8.echoMs.p95` | 2.0 | 50 ms |
-| `hiddenFlood.N4/N8.frameDeltaMs.p95` | 2.0 | 8 ms |
+| metric | rule |
+| --- | --- |
+| `coldStart.best.firstPtyDataMs` | ratio 1.5 and +1000 ms |
+| `inputLatency.echoMs.p95` | ratio 1.5 and +10 ms |
+| `inputLatency.frameMs.p95` | ratio 1.5 and +10 ms |
+| `inputLatency8.frameMs.p95` | ratio 1.5 and +10 ms |
+| `ram.idle1Pane.workingSetBytes` | ratio 1.3 and +100 MiB |
+| `ram.panes8.workingSetBytes` | ratio 1.3 and +150 MiB |
+| `frameBudget.N4/N8/N16.frameDeltaMs.p95` | **+1 frame interval** (see below) |
+| `hiddenFlood.N4/N8.echoMs.p95` | ratio 2.0 and +50 ms |
+| `hiddenFlood.N4/N8.frameDeltaMs.p95` | ratio 2.0 and +8 ms |
+
+### The frame-budget family is gated in frames (#940)
+
+`frameBudget.*.frameDeltaMs.p95` is quantized. The perf job runs on
+`windows-latest` only, so there is one frame interval to fit, and across all 216
+`bench-history` records these p95s land in clusters one interval apart:
+15.7–15.8, 31.1–31.4, 46.8–47.0, 62.4–62.5, 78.1 — one through five frames.
+
+A ratio rule does not fit that shape. Against the blessed 1-frame baseline
+`ratio: 2.0` put the threshold at exactly 31.4 ms — the top of the two-frame
+cluster — so those records passed only because the comparison is
+strictly-greater, and a baseline blessed from a 2-frame run would have moved the
+ceiling to 4 frames.
+
+So this family uses `frameMargin: 1` instead of the double condition: **FAIL
+when `current > baseline + 15.7 ms`.** One whole frame above the blessed
+baseline is the allowance; the second is red. Drift is linear rather than
+multiplicative — a 2-frame baseline allows 3 frames, not 4. `ratio` and
+`absMargin` remain on those entries for the delta columns only.
+
+The interval is 15.7 and not 15.625: the clusters have width, and 15.625 (the
+Windows timer tick these numbers come from physically) would put the threshold
+at 31.325, *inside* the two-frame cluster, flipping the two real records that
+measured 31.4. The constant is read off the measurement — 15.7 is what
+`baseline-ci.json` holds for all three N — and the change was replayed over
+every record in the trend (648 samples) with zero verdict changes.
 
 Each `N` gates against its own baseline entry — there is no single budget shared
 across N. Two further gates are baseline-**independent** correctness checks

--- a/changelog.d/947.md
+++ b/changelog.d/947.md
@@ -3,18 +3,18 @@
 - **The perf gate's frame-budget metrics are judged in frames, so a two-frame
   measurement no longer passes by a rounding accident.**
   `frameBudget.*.frameDeltaMs.p95` only ever lands on whole frame intervals,
-  and the old rule
-  — "more than 2x the blessed baseline" — put its threshold at exactly the top
-  of the two-frame cluster. Every two-frame run passed because the comparison
-  was strictly-greater, not because it was judged. It also meant a baseline
-  blessed from a slow run quietly doubled the allowance. The rule is now "at
-  most one frame interval above the baseline", which reaches the same verdict
-  on every one of the 648 samples in the recorded trend while resting on the
-  measurement instead of on where a threshold happened to fall. (#947)
+  and the old rule — "more than 2x the blessed baseline" — put its threshold
+  at exactly the top of the two-frame cluster. Every two-frame run passed
+  because the comparison was strictly-greater, not because it was judged. It
+  also meant a baseline blessed from a slow run quietly doubled the allowance.
+  The rule is now "at most one frame interval above the baseline", which
+  reaches the same verdict on every one of the 648 samples in the recorded
+  trend while resting on the measurement instead of on where a threshold
+  happened to fall. (#947)
 - **A red perf gate no longer describes its confirmation re-run as an
   independent measurement.** The re-run happens on the same runner, so it can
   tell a passing spike from a repeatable one but cannot clear a machine that
   was slow for its whole life — which is what happened before v3.44.0 was
-  tagged, where the same commit measured clean on a fresh runner twenty minutes
-  later. The summary and the failure line now say "same runner" and say what
-  that does and does not prove. (#947)
+  tagged, where the same commit measured clean on a fresh runner twenty
+  minutes later. The summary and the failure line now say "same runner" and
+  say what that does and does not prove. (#947)

--- a/changelog.d/947.md
+++ b/changelog.d/947.md
@@ -1,8 +1,9 @@
 ### Fixed
 
 - **The perf gate's frame-budget metrics are judged in frames, so a two-frame
-  measurement no longer passes by a rounding accident.** `frameBudget.*
-  .frameDeltaMs.p95` only ever lands on whole frame intervals, and the old rule
+  measurement no longer passes by a rounding accident.**
+  `frameBudget.*.frameDeltaMs.p95` only ever lands on whole frame intervals,
+  and the old rule
   — "more than 2x the blessed baseline" — put its threshold at exactly the top
   of the two-frame cluster. Every two-frame run passed because the comparison
   was strictly-greater, not because it was judged. It also meant a baseline

--- a/changelog.d/947.md
+++ b/changelog.d/947.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **The perf gate's frame-budget metrics are judged in frames, so a two-frame
+  measurement no longer passes by a rounding accident.** `frameBudget.*
+  .frameDeltaMs.p95` only ever lands on whole frame intervals, and the old rule
+  — "more than 2x the blessed baseline" — put its threshold at exactly the top
+  of the two-frame cluster. Every two-frame run passed because the comparison
+  was strictly-greater, not because it was judged. It also meant a baseline
+  blessed from a slow run quietly doubled the allowance. The rule is now "at
+  most one frame interval above the baseline", which reaches the same verdict
+  on every one of the 648 samples in the recorded trend while resting on the
+  measurement instead of on where a threshold happened to fall. (#947)
+- **A red perf gate no longer describes its confirmation re-run as an
+  independent measurement.** The re-run happens on the same runner, so it can
+  tell a passing spike from a repeatable one but cannot clear a machine that
+  was slow for its whole life — which is what happened before v3.44.0 was
+  tagged, where the same commit measured clean on a fresh runner twenty minutes
+  later. The summary and the failure line now say "same runner" and say what
+  that does and does not prove. (#947)

--- a/scripts/__tests__/perfCompare.test.mjs
+++ b/scripts/__tests__/perfCompare.test.mjs
@@ -175,9 +175,11 @@ describe('compareResults — strict > boundary (not >=)', () => {
 });
 
 describe('compareResults — frame-margin gate on the quantized W2 family (#940)', () => {
-  // frameDeltaMs.p95 only ever lands on multiples of one frame interval
-  // (15.625 ms). These are the five distinct values the last 25 `main` records
-  // took, judged against the blessed 1-frame baseline.
+  // frameDeltaMs.p95 lands in clusters one frame interval apart. These are the
+  // five distinct values the last 25 `main` records took, judged against the
+  // blessed 1-frame baseline. The gate's interval is FRAME_INTERVAL_MS = 15.7,
+  // the top of the one-frame cluster — see the cluster-width case below for
+  // why it is not the 15.625 ms tick these numbers come from physically.
   const gateOf = (p95, basep95 = 15.7) =>
     verdictFor(
       compareResults(makeResult({ frameBudgetN16: p95 }), makeResult({ frameBudgetN16: basep95 })),
@@ -224,8 +226,8 @@ describe('compareResults — frame-margin gate on the quantized W2 family (#940)
     //   old rule: FAIL needs cur > 31.3*2 (62.6) AND cur > 31.3+8 — so a
     //             4-frame sample at 62.5 PASSED, i.e. blessing a bad baseline
     //             doubled the allowance to 4 frames.
-    //   new rule: FAIL needs cur > 31.3 + 15.625 (46.925) — 3 frames is the
-    //             most it can reach, whatever the baseline is blessed at.
+    //   new rule: FAIL needs cur > 31.3 + 15.7 (47.0) — 3 frames is the most
+    //             it can reach, whatever the baseline is blessed at.
     const oldRuleWouldPass = 62.5 > 31.3 * 2.0 && 62.5 > 31.3 + 8;
     expect(oldRuleWouldPass).toBe(false);                    // the old gate let it through
     expect(gateOf(62.5, 31.3).status).toBe('FAIL');          // the new one does not

--- a/scripts/__tests__/perfCompare.test.mjs
+++ b/scripts/__tests__/perfCompare.test.mjs
@@ -174,6 +174,71 @@ describe('compareResults — strict > boundary (not >=)', () => {
   });
 });
 
+describe('compareResults — frame-margin gate on the quantized W2 family (#940)', () => {
+  // frameDeltaMs.p95 only ever lands on multiples of one frame interval
+  // (15.625 ms). These are the five distinct values the last 25 `main` records
+  // took, judged against the blessed 1-frame baseline.
+  const gateOf = (p95, basep95 = 15.7) =>
+    verdictFor(
+      compareResults(makeResult({ frameBudgetN16: p95 }), makeResult({ frameBudgetN16: basep95 })),
+      'frameBudgetP95Ms_N16',
+    );
+
+  it('keeps every verdict the 25 real `main` records already had', () => {
+    expect(gateOf(15.7).status).toBe('PASS');   // 1 frame  — 12 records
+    expect(gateOf(31.2).status).toBe('PASS');   // 2 frames — 8 records
+    expect(gateOf(31.3).status).toBe('PASS');   // 2 frames
+    expect(gateOf(46.8).status).toBe('FAIL');   // 3 frames — 4 records
+    expect(gateOf(78.1).status).toBe('FAIL');   // 5 frames — 1 record
+  });
+
+  it('still trips on the dropped-frame step the original calibration named', () => {
+    // The pre-#940 comment on this gate was written around 33.3 ms tripping
+    // `2.0x + 8ms`. It has to keep tripping, or this is a loosening, not a
+    // reshaping. 37.1 is the value perfConfirm's fixtures use for the same job.
+    expect(gateOf(33.3).status).toBe('FAIL');
+    expect(gateOf(37.1).status).toBe('FAIL');
+  });
+
+  it('allows exactly one frame above the baseline, and no more', () => {
+    expect(gateOf(15.7 + 15.7).status).toBe('PASS');         // exactly +1 frame
+    expect(gateOf(15.7 + 15.71).status).toBe('FAIL');        // a hair past it
+  });
+
+  it('clears the whole width of the two-frame cluster', () => {
+    // The quanta are clusters, not points: across all 216 bench-history
+    // records the two-frame samples span 31.1-31.4 and the three-frame ones
+    // 46.8-47.0. The threshold has to sit in the gap, so the top of the
+    // two-frame cluster passes and the bottom of the three-frame one fails.
+    // A frame interval of 15.625 (the Windows timer tick these numbers come
+    // from) would put it at 31.325 and flip the two real 31.4 records.
+    expect(gateOf(31.1).status).toBe('PASS');
+    expect(gateOf(31.4).status).toBe('PASS');
+    expect(gateOf(46.8).status).toBe('FAIL');
+    expect(gateOf(47.0).status).toBe('FAIL');
+  });
+
+  it('drifts linearly with the baseline, where the ratio drifted multiplicatively', () => {
+    // The behaviour change, stated as a before/after rather than asserted as
+    // equivalent. Baseline blessed from a 2-frame run (31.3):
+    //   old rule: FAIL needs cur > 31.3*2 (62.6) AND cur > 31.3+8 — so a
+    //             4-frame sample at 62.5 PASSED, i.e. blessing a bad baseline
+    //             doubled the allowance to 4 frames.
+    //   new rule: FAIL needs cur > 31.3 + 15.625 (46.925) — 3 frames is the
+    //             most it can reach, whatever the baseline is blessed at.
+    const oldRuleWouldPass = 62.5 > 31.3 * 2.0 && 62.5 > 31.3 + 8;
+    expect(oldRuleWouldPass).toBe(false);                    // the old gate let it through
+    expect(gateOf(62.5, 31.3).status).toBe('FAIL');          // the new one does not
+    expect(gateOf(46.8, 31.3).status).toBe('PASS');          // 3 frames still allowed
+  });
+
+  it('names the frame margin in the note, not a ratio', () => {
+    const r = gateOf(78.1);
+    expect(r.note).toContain('frame interval');
+    expect(r.note).not.toContain('2x');
+  });
+});
+
 describe('compareResults — missing current metric', () => {
   it('FAILS when baseline has the metric but current dropped the whole scenario', () => {
     const base = makeResult();

--- a/scripts/__tests__/perfConfirm.test.mjs
+++ b/scripts/__tests__/perfConfirm.test.mjs
@@ -656,4 +656,16 @@ describe('renderConfirmationMarkdown', () => {
     expect(md).toContain('the gate stands red');
     expect(md).toContain('still FAIL');
   });
+
+  it('says the re-run shared the runner, and does not call it independent (#940)', () => {
+    // The re-run measures on the machine that produced the first sample, so it
+    // can separate a transient tail spike from a repeatable one but cannot
+    // refute a runner that was degraded for its whole lifetime. Claiming an
+    // "independent measurement" invited reading every red as a regression.
+    const original = result({ frameBudgetN8: 60 });
+    const { verdicts, reproduced } = judgeRetry(result({ frameBudgetN8: 60 }), result(), ['frameBudgetP95Ms_N8']);
+    const md = renderConfirmationMarkdown({ plan, verdicts, original, reproduced });
+    expect(md).toContain('same runner');
+    expect(md).not.toContain('independent measurement');
+  });
 });

--- a/scripts/perf-compare.mjs
+++ b/scripts/perf-compare.mjs
@@ -104,18 +104,40 @@ export const GATES = [
     absMargin: 157286400, // 150 MiB
     unit: 'bytes',
   },
-  // W2 — N-pane concurrent-streaming frame budget (design §2.1/§3). ratio 2.0
-  // encodes the strategy doc's "예산 2배" trigger directly. Calibrated against
-  // real CI runs (2026-07-10, 4 runs): frameDeltaMs.p95 is vsync-pinned at
-  // 15.7ms for every N with zero run-to-run spread, so a single dropped-frame
-  // step (33.3ms) trips the 2.0x + 8ms double condition exactly as designed.
-  // Each N gates against its OWN baseline entry (no single 16.7ms budget
-  // across N).
+  // W2 — N-pane concurrent-streaming frame budget (design §2.1/§3). Calibrated
+  // against real CI runs (2026-07-10, 4 runs): frameDeltaMs.p95 is vsync-pinned
+  // for every N with zero run-to-run spread. Each N gates against its OWN
+  // baseline entry (no single budget across N).
+  //
+  // #940 — gated on FRAMES rather than on a ratio to the baseline. The metric
+  // is quantized: across all 216 `bench-history` records these p95s only land
+  // in frame-interval clusters (15.7-15.8, 31.1-31.4, 46.8-47.0, 62.4-62.5,
+  // 78.1). Against a 1-frame baseline `ratio: 2.0` puts the threshold at
+  // exactly 31.4 — the top of the two-frame cluster — so those records passed
+  // only because "regressed past 2x" is strictly-greater. The verdict was
+  // riding on threshold placement rather than on measurement, and it drifted
+  // multiplicatively: a baseline blessed from a 2-frame run would have allowed
+  // 4 frames.
+  //
+  // `frameMargin: 1` says the intended thing on the metric's own unit — p95 may
+  // sit up to one whole frame interval above the blessed baseline, and past
+  // that is red. It replaces both halves of the double condition (the 8 ms
+  // absMargin was already additive, just half a frame and arbitrary). Drift is
+  // now linear: a 2-frame baseline allows 3 frames, not 4.
+  //
+  // Verdicts are unchanged. Replayed over every record in the trend — 648
+  // samples, 216 records x 3 N — the old rule and this one disagree on nothing.
+  // The dropped-frame step the original calibration was written around (33.3 ms
+  // against 15.7, and the 37.1 ms the confirmation fixtures use) still trips it.
+  //
+  // `ratio` / `absMargin` stay on these entries for the delta columns and for
+  // consumers reading the gate table; they no longer decide the verdict.
   {
     key: 'frameBudgetP95Ms_N4',
     label: 'frameBudget.N4.frameDeltaMs.p95',
     path: 'scenarios.frameBudget.N4.frameDeltaMs.p95',
     scenarioPath: 'scenarios.frameBudget.N4',
+    frameMargin: 1, // #940 — whole frame intervals allowed above baseline
     ratio: 2.0,
     absMargin: 8, // ms (see calibration note above)
     unit: 'ms',
@@ -125,6 +147,7 @@ export const GATES = [
     label: 'frameBudget.N8.frameDeltaMs.p95',
     path: 'scenarios.frameBudget.N8.frameDeltaMs.p95',
     scenarioPath: 'scenarios.frameBudget.N8',
+    frameMargin: 1, // #940 — whole frame intervals allowed above baseline
     ratio: 2.0,
     absMargin: 8, // ms
     unit: 'ms',
@@ -134,6 +157,7 @@ export const GATES = [
     label: 'frameBudget.N16.frameDeltaMs.p95',
     path: 'scenarios.frameBudget.N16.frameDeltaMs.p95',
     scenarioPath: 'scenarios.frameBudget.N16',
+    frameMargin: 1, // #940 — whole frame intervals allowed above baseline
     ratio: 2.0,
     absMargin: 8, // ms
     unit: 'ms',
@@ -272,6 +296,27 @@ function deltaPct(current, baseline) {
  *     NEW   — current has it, baseline doesn't (informational)
  *   improved: boolean — current < baseline * IMPROVEMENT_FRACTION
  */
+/**
+ * One frame interval, in ms — the quantum `frameDeltaMs.p95` is measured in.
+ *
+ * Read off the measurement, not off a refresh rate: 15.7 is what
+ * `bench/baseline-ci.json` holds for all three N, and it is the top of the
+ * one-frame cluster in the trend. The perf job is `windows-latest` only, so
+ * there is one quantum to fit.
+ *
+ * The cluster has width — across all 216 `bench-history` records the two-frame
+ * samples run 31.1 to 31.4 and the three-frame ones 46.8 to 47.0 — so the
+ * constant has to be the TOP of the one-frame cluster, not its middle. At
+ * 15.625 (the Windows timer tick, which is where these numbers come from
+ * physically) the threshold lands at 31.325, inside the two-frame cluster, and
+ * two real records at 31.4 flip from PASS to FAIL. That is the same
+ * between-quanta accident this change exists to remove, one quantum lower.
+ *
+ * Checked against every record in the trend: 648 samples (216 records x 3 N),
+ * zero verdict changes.
+ */
+export const FRAME_INTERVAL_MS = 15.7;
+
 export function compareResults(current, baseline, gates = GATES) {
   const results = [];
   for (const gate of gates) {
@@ -341,16 +386,29 @@ export function compareResults(current, baseline, gates = GATES) {
       continue;
     }
 
-    // Both sides have numbers — apply the double-condition gate.
+    // Both sides have numbers — apply the gate.
     r.deltaPct = deltaPct(cur, base);
+    // #940 — a frame-margin gate allows a fixed number of whole frame intervals
+    // above the baseline instead of the ratio + margin double condition,
+    // because the metric is quantized and a ratio threshold lands between
+    // quanta. No rounding: the margin is wall-clock, so a sample that is not on
+    // a quantum is judged by how far past the allowance it actually is.
+    const frameAllowance = gate.frameMargin ? gate.frameMargin * FRAME_INTERVAL_MS : null;
     const overRatio = cur > base * gate.ratio;
     const overAbs = cur > base + gate.absMargin;
-    if (overRatio && overAbs) {
+    const failed = gate.frameMargin
+      ? cur > base + frameAllowance
+      : (overRatio && overAbs);
+    if (failed) {
       r.status = 'FAIL';
-      r.note = `regressed past ${gate.ratio}x and +${fmtValue(
-        gate.absMargin,
-        gate.unit,
-      )}`;
+      r.note = gate.frameMargin
+        ? `regressed past +${gate.frameMargin} frame interval`
+          + `${gate.frameMargin === 1 ? '' : 's'} `
+          + `(+${fmtValue(frameAllowance, gate.unit)})`
+        : `regressed past ${gate.ratio}x and +${fmtValue(
+          gate.absMargin,
+          gate.unit,
+        )}`;
     } else {
       r.status = 'PASS';
       if (cur < base * IMPROVEMENT_FRACTION) {

--- a/scripts/perf-confirm.mjs
+++ b/scripts/perf-confirm.mjs
@@ -207,7 +207,7 @@ export function renderConfirmationMarkdown({ plan, verdicts, original, reproduce
   lines.push('');
   lines.push(
     reproduced
-      ? '**Reproduced — the gate stands red.** The same metric failed on a second, independent measurement of the same code.'
+      ? '**Reproduced on the same runner — the gate stands red.** The same metric failed on a second measurement of the same code, taken on the machine that produced the first one. That separates a transient tail spike from a repeatable one; it cannot distinguish a code regression from a runner degraded for its whole lifetime (#940).'
       : '**Not reproduced — the gate is cleared.** Every failing metric came back within bounds on a second measurement of the same code. The first run\'s numbers are still in the trend and in this run\'s artifact; if this keeps happening on one metric, that is a calibration problem worth its own issue rather than a re-run.',
   );
   lines.push('');
@@ -408,7 +408,7 @@ export function confirmGate({
 
   if (outcome.reproduced) {
     const which = outcome.unresolved.map((v) => `${v.label} (${v.status})`).join(', ');
-    deps.log(`::error::Perf gate: the failure reproduced on a re-run — ${which}\n`);
+    deps.log(`::error::Perf gate: the failure reproduced on the same runner — ${which}\n`);
     return { cleared: false };
   }
   // A green earned through this re-run must not report LESS than a plain green


### PR DESCRIPTION
Takes the two items from #940 that your triage called safe to move on — the
free wording fix, and the frame-budget verdict shape. Leaves the third (a
fresh-runner confirmation job) alone; that one changes CI topology and wants
your call first.

## 1. The confirmation summary called a same-runner re-run "independent"

`perf-confirm.mjs` printed *"The same metric failed on a second, independent
measurement of the same code."* The re-run lands on the same runner by design,
and the codebase already says so in two places — the module header
(*"measured once more on this runner"*) and `bench/README.md` (*"it cannot
cover a host that is degraded for the whole job"*). The CI-facing string was the
only place that contradicted them, and it is the one a person reads when
deciding whether a red is a regression.

Both the summary and the `::error::` line now say **same runner**, and state
what the re-run does and does not separate. Wording only — no verdict, no gate,
no baseline change.

## 2. `frameBudget.*.frameDeltaMs.p95` is gated in frames, not on a ratio

I pulled `bench-history` rather than work from the table in the issue. Across
**all 216 records**, these p95s land in clusters one frame interval apart:

| cluster | frames | note |
|---|---|---|
| 15.7 – 15.8 | 1 | 537 samples |
| 31.1 – 31.4 | 2 | 89 |
| 46.8 – 47.0 | 3 | 14 |
| 62.4 – 62.5 | 4 | 6 |
| 78.1 | 5 | 1 |

Against the blessed 1-frame baseline (15.7 for all three N), `ratio: 2.0` puts
the threshold at **exactly 31.4** — the top of the two-frame cluster. Every
two-frame record passed only because the comparison is strictly-greater. And
the threshold drifted multiplicatively: a baseline blessed from a two-frame run
would have moved the ceiling to four frames.

Replaced with `frameMargin: 1` — FAIL when `current > baseline + one frame
interval`. The `absMargin: 8` was already additive, just half a frame and
arbitrary. Drift is now linear: a two-frame baseline allows three frames.

### The constant is 15.7, and finding out why is most of the work here

The obvious value is 15.625 ms, the Windows timer tick these numbers physically
come from. **It is wrong**, and the trend says so: the clusters have width, and
15.625 puts the threshold at 31.325 — *inside* the two-frame cluster — which
flips the two real records that measured 31.4 from PASS to FAIL. That is the
same between-quanta accident this PR exists to remove, one quantum lower.

15.7 is the top of the one-frame cluster and is what `baseline-ci.json` holds,
so the constant is read off the measurement rather than off a refresh rate. I
only caught this by replaying the change over the whole trend; the 25-record
sample in the issue does not contain a 31.4.

### Verdicts, replayed rather than asserted

Old rule vs new, over **every record in the trend — 648 samples (216 x 3 N)**:
**zero disagreements.** The dropped-frame step the original calibration comment
was written around (33.3 ms) still trips the gate, as does the 37.1 ms
`perfConfirm`'s fixtures use.

Tests lock the parts that matter rather than restating the implementation:
- the five real clusters keep their verdicts;
- both cluster edges — 31.4 passes, 46.8 fails — with a comment saying why
  15.625 would break it;
- 33.3 and 37.1 still fail, so this is a reshaping and not a loosening;
- the one deliberate behaviour change (linear drift) evaluates the **old** rule
  inline and shows it let 62.5 ms through against a two-frame baseline, then
  asserts the new one does not.

`ratio` / `absMargin` stay on those three entries for the delta columns; they no
longer decide the verdict. `bench/README.md`'s gate table is updated in the
third commit — it claims to mirror `GATES`, so a stale row there is a wrong doc
about the one gate that just changed.

## What this does not do

- No fresh-runner confirmation job (#940 item 1). That is the real fix for the
  runner-health case and it adds a dependent job; your call on whether you want
  it and in what shape.
- No baseline re-blessing. Descriptive-not-aspirational is untouched, and this
  change deliberately does not let a blessed baseline move the ceiling
  multiplicatively any more.

## Verification

`npx vitest run scripts/__tests__/` — 308 passed, 17 files. ESLint clean on the
changed files. The trend replay above is reproducible from
`origin/bench-history:history.ndjson`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance-gate evaluation using a consistent one-frame tolerance.
  - Updated frame-budget failure messages to clearly report exceeded allowances.
  - Confirmation results now clarify that reruns occur on the same runner and may include runner-wide degradation.

- **Documentation**
  - Clarified frame quantization, threshold behavior, validation details, and confirmation-run limitations.

- **Tests**
  - Added coverage for frame margins, threshold boundaries, scaling behavior, and confirmation messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->