### PR TITLE
Anchor the IME candidate window to the quiet caret while output streams

### DIFF
--- a/changelog.d/953.md
+++ b/changelog.d/953.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **Chinese IME candidate window no longer jumps to wherever a streaming
+  agent parked its cursor.** Typing Chinese (WeChat IME, Microsoft Pinyin)
+  while Claude Code streamed output anchored the candidate window to the
+  TUI's repaint cursor — a screen corner or an output row — because a cursor
+  that sat still for 32 ms was trusted as the caret, and a streaming TUI
+  parks its cursor between output bursts far longer than that. The anchor
+  now tracks output recency: while output is streaming, the composition
+  anchors to the cell the cursor held through the last output-quiet period —
+  the input line the TUI deliberately parked it on — instead of trusting
+  stillness alone. Ordinary typing into a quiet pane is unaffected, and the
+  IME diagnostic log (`ime-anchor3` → `ime-anchor4`) now records the output
+  gap and snapshot age so a follow-up report is self-diagnosing. (#951)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1127,7 +1127,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // field.
     const imeAnchorLogsLeft = { start: 20, mid: 20 };
     const imeAnchor = attachImeAnchor(terminal, {
-      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, outputGap, caretAge, selY, selX }) => {
+      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, outputGap, caretAge, edge, selY, selX }) => {
         const budget = phase === 'start' ? 'start' : 'mid';
         if (imeAnchorLogsLeft[budget] <= 0) return;
         imeAnchorLogsLeft[budget] -= 1;
@@ -1143,7 +1143,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // live composition-view correction.
         console.info(
           `[wmux:ime-anchor4] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
-          `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src} held=${held.toFixed(0)}ms ` +
+          `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src}${edge ? ' edge=1' : ''} held=${held.toFixed(0)}ms ` +
           `restAge=${restAge.toFixed(0)}ms gap=${outputGap.toFixed(0)}ms caretAge=${caretAge.toFixed(0)}ms ` +
           `cellHeight=${cellHeight.toFixed(2)} ` +
           `pin=(${dx.toFixed(1)},${dy.toFixed(1)}) preedit=(${preeditDx.toFixed(1)},${preeditDy.toFixed(1)})` +

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1127,23 +1127,26 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // field.
     const imeAnchorLogsLeft = { start: 20, mid: 20 };
     const imeAnchor = attachImeAnchor(terminal, {
-      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, selY, selX }) => {
+      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, outputGap, caretAge, selY, selX }) => {
         const budget = phase === 'start' ? 'start' : 'mid';
         if (imeAnchorLogsLeft[budget] <= 0) return;
         imeAnchorLogsLeft[budget] -= 1;
         // Mirrored into the main-side log file by src/main/index.ts's
-        // console-message listener, so the user can share it. The "3" in the
-        // tag marks the split-surface build so a shared log is unambiguous
-        // about which release produced it. src/held/restAge/sel are the
-        // cause-3 discriminator: src=resting means the composition started
-        // mid-repaint and the anchor used the last resting cell instead of
-        // the instantaneous cursor. pin= is the textarea correction,
-        // preedit= the live composition-view correction.
+        // console-message listener, so the user can share it. The "4" in the
+        // tag marks the quiet-caret build (#951) so a shared log is
+        // unambiguous about which release produced it. src/held/restAge/sel
+        // are the cause-3 discriminator: src=resting means the composition
+        // started mid-repaint and the anchor used the last resting cell;
+        // src=caret with gap= is the #951 discriminator: output was still
+        // flowing, so the anchor used the quiet-caret snapshot instead of
+        // any buffer cursor. pin= is the textarea correction, preedit= the
+        // live composition-view correction.
         console.info(
-          `[wmux:ime-anchor3] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
+          `[wmux:ime-anchor4] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
           `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src} held=${held.toFixed(0)}ms ` +
-          `restAge=${restAge.toFixed(0)}ms cellHeight=${cellHeight.toFixed(2)} pin=(${dx.toFixed(1)},${dy.toFixed(1)}) ` +
-          `preedit=(${preeditDx.toFixed(1)},${preeditDy.toFixed(1)})` +
+          `restAge=${restAge.toFixed(0)}ms gap=${outputGap.toFixed(0)}ms caretAge=${caretAge.toFixed(0)}ms ` +
+          `cellHeight=${cellHeight.toFixed(2)} ` +
+          `pin=(${dx.toFixed(1)},${dy.toFixed(1)}) preedit=(${preeditDx.toFixed(1)},${preeditDy.toFixed(1)})` +
           (imeAnchorLogsLeft[budget] === 0 ? ` (last ${budget} record, diagnostic capped)` : ''),
         );
       },

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -929,6 +929,17 @@ describe('#951 quiet-caret wiring', () => {
     });
     expect(translateOf(dom.textarea)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
     expect(translateOf(dom.textarea)?.dx).toBeCloseTo((5 - 127) * 10, 6);
+    // xterm re-anchors the inline preedit to the live cursor on every
+    // compositionupdate. A caret-sourced composition must pull it back onto
+    // the same frozen point as the textarea — the first quiet-caret build
+    // left it on the live cursor, and the field report showed the pinyin
+    // riding the agent's output rows while its candidate list sat at the
+    // input line (the two IME surfaces torn apart).
+    dom.compView.style.top = `${43 * 17.6}px`;
+    dom.compView.style.left = `${127 * 10}px`;
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(translateOf(dom.compView)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
+    expect(translateOf(dom.compView)?.dx).toBeCloseTo((5 - 127) * 10, 6);
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -21,6 +21,8 @@ import {
   computeImeAnchorCorrection,
   createRestingTracker,
   isUsableGeometry,
+  ANCHOR_CONTINUITY_MS,
+  noteCompositionAnchor,
   noteCursorMove,
   noteOutputParsed,
   OUTPUT_QUIET_MS,
@@ -869,36 +871,42 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting' });
   });
 
-  it('#953 case 1-2: a last-column park is rejected even when output is quiet', () => {
+  it('#953 case 1-2: a last-column park yields to the previous composition anchor', () => {
     // Claude Code idling with an empty input box parks its real cursor at
-    // the line end — (236,47) on a 237-col pane — and a 1.6s output gap then
+    // the line end — (236,47) on a 237-col pane — and a long output gap then
     // certified it as an at-rest caret, pushing the candidate window and the
     // pinyin off the right edge. A CJK composition can never sit on the last
-    // column, so the selection must fall back to the caret snapshot.
+    // column, so the selection reuses where the user last composed.
     const t = createRestingTracker(640, 5, 1000, 40);
-    noteOutputParsed(t, 1600, 237);        // snapshot: the input-line cell
-    noteCursorMove(t, 647, 236, 1700, 47); // TUI parks at the line end
-    noteOutputParsed(t, 1700, 237);
-    const sel = selectFreezeCell(t, 647, 236, 3400, { top: 600, rows: 48, cols: 237 }, 600);
-    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'caret', edge: true });
+    noteCompositionAnchor(t, 40, 12, 2000);  // previous composition anchored here
+    noteCursorMove(t, 647, 236, 2500, 47);   // TUI parks at the line end
+    const sel = selectFreezeCell(t, 647, 236, 4000, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 12, src: 'prev', edge: true });
+  });
+
+  it('#953: with no previous anchor a line-end park degrades to the instant cell', () => {
+    // Third field pass: every quiet cursor-derived fallback (the snapshot,
+    // the resting cell) wanders between inputs — a stable right-edge anchor
+    // read as better than an unpredictable one. Cold start keeps instant.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 647, 236, 1100, 47);
+    const sel = selectFreezeCell(t, 647, 236, 3000, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: false });
+  });
+
+  it('#953: an expired anchor no longer participates', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCompositionAnchor(t, 40, 12, 2000);
+    noteCursorMove(t, 647, 236, 2500, 47);
+    const late = 2000 + ANCHOR_CONTINUITY_MS + 1;
+    const sel = selectFreezeCell(t, 647, 236, late, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: false });
   });
 
   it('#953: line-end cells are never snapshotted as the caret', () => {
     const t = createRestingTracker(647, 236, 1000, 47);
     noteOutputParsed(t, 1600, 237); // spanning cell is a line-end park
     expect(t.hasCaret).toBe(false);
-    // …and with no snapshot and no resting cell, a last-column instant
-    // degrades to the pre-#953 selection instead of anchoring nowhere.
-    const sel = selectFreezeCell(t, 647, 236, 3000, { top: 600, rows: 48, cols: 237 }, 600);
-    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: false });
-  });
-
-  it('#953: without a snapshot, a last-column park falls back to the resting cell', () => {
-    const t = createRestingTracker(640, 5, 1000, 40);
-    noteCursorMove(t, 647, 236, 1100, 47); // promotes the input-line cell
-    const sel = selectFreezeCell(t, 647, 236, 2000, { top: 600, rows: 48, cols: 237 }, 600);
-    // held=900ms would have certified the line end; edge rejection wins.
-    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting', edge: true });
   });
 
   it('#953: a mid-line at-rest cursor keeps the instant selection (regression lock)', () => {
@@ -906,6 +914,28 @@ describe('#951 quiet-caret tracker (pure)', () => {
     noteOutputParsed(t, 1600, 237);
     const sel = selectFreezeCell(t, 640, 100, 3400, { top: 600, rows: 48, cols: 237 }, 600);
     expect(sel).toMatchObject({ absRow: 640, col: 100, src: 'instant', edge: false });
+  });
+
+  it('#953: consecutive streaming compositions reuse the previous anchor, not a re-taken snapshot', () => {
+    // The snapshot can be re-captured across mid-stream pauses and wander
+    // between inputs (field: rows 36 vs 43, cols 23-79). Once a composition
+    // has anchored, the next one lands at the same spot.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 643, 60, 2000, 43);
+    noteOutputParsed(t, 2000, 128);  // snapshot + epoch start
+    noteOutputParsed(t, 2300, 128);
+    noteOutputParsed(t, 2700, 128);
+    const first = selectFreezeCell(t, 643, 60, 2760, { top: 600, rows: 45, cols: 128 }, 600);
+    expect(first).toMatchObject({ src: 'caret', absRow: 640, col: 5 });
+    noteCompositionAnchor(t, first.absRow - 600, first.col, 2760);
+    // A mid-stream pause re-snapshots a DIFFERENT (wrong) cell…
+    noteCursorMove(t, 636, 79, 3200, 36);
+    noteOutputParsed(t, 3900, 128); // 1.2s pause ended — snapshot re-taken at (43,60)
+    noteOutputParsed(t, 4200, 128);
+    noteOutputParsed(t, 4650, 128);
+    const second = selectFreezeCell(t, 636, 79, 4700, { top: 600, rows: 45, cols: 128 }, 600);
+    // …but the previous anchor wins, so the candidate window does not wander.
+    expect(second).toMatchObject({ src: 'prev', absRow: 640, col: 5 });
   });
 
   it('a same-cell report still refreshes the screen row (scroll under a stationary cursor)', () => {
@@ -979,6 +1009,15 @@ describe('#951 quiet-caret wiring', () => {
     dom.textarea.dispatchEvent(new Event('compositionupdate'));
     expect(translateOf(dom.compView)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
     expect(translateOf(dom.compView)?.dx).toBeCloseTo((5 - 127) * 10, 6);
+    // The composition recorded its anchor; the next one mid-stream reuses it
+    // (src=prev) so the candidate window does not wander between inputs.
+    dom.textarea.dispatchEvent(new Event('compositionend'));
+    clock = 2900;
+    t.onWriteParsed.fire(undefined);
+    clock = 2950;
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    const last = diag.mock.calls[diag.mock.calls.length - 1][0];
+    expect(last).toMatchObject({ phase: 'start', src: 'prev', selY: 40, selX: 5 });
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -881,6 +881,32 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: true });
   });
 
+  it('#953: a line-end park defers to the snapshot while output is FLOWING', () => {
+    // The reported streaming failure. A token-paced stream pauses longer than
+    // OUTPUT_QUIET_MS between bursts, so `epochStart` keeps restarting and the
+    // sustain gate is never met — yet a perfectly good snapshot exists, and
+    // the live cursor is the TUI's line-end park. Anchoring there put the
+    // candidate window in the pane's bottom-right corner.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1600);             // quiet span ends -> caret at (40,5)
+    expect(t).toMatchObject({ hasCaret: true, caretCol: 5 });
+    noteCursorMove(t, 647, 236, 1650, 47); // TUI parks at the line end
+    noteOutputParsed(t, 1700);             // burst resumes; epoch is only 100ms old
+    const sel = selectFreezeCell(t, 647, 236, 1750, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'caret', edge: true });
+  });
+
+  it('#953: a mid-line cursor still waits out the sustain gate (commit echo)', () => {
+    // The gate's actual job: a committed syllable's echo is recent output too,
+    // and there the freshly moved cursor IS the caret. Nothing changes for it.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1600);
+    noteCursorMove(t, 640, 100, 1650, 40);
+    noteOutputParsed(t, 1700);
+    const sel = selectFreezeCell(t, 640, 100, 1750, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 100, src: 'instant', edge: false });
+  });
+
   it('#953: a line-end park is still snapshotted — the flag drives nothing', () => {
     // Withholding these cells from the snapshot was the last of three
     // generations of acting on `edge`, and the reporter measured it worse

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -642,7 +642,7 @@ describe('#874 resting-cell tracker (cause 3, pure)', () => {
     noteCursorMove(t, 49, 113, 1100); // caret promoted, cursor parked at 49,113
     // 5ms after the park: mid-burst -> resting cell.
     const midBurst = selectFreezeCell(t, 49, 113, 1105);
-    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5, outputGap: 105, caretAge: -1 });
+    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5, outputGap: 105, caretAge: -1, edge: false });
     // 100ms after the park: the parked cell is now at rest -> trusted as-is
     // (the documented cause-3 residual: dwell cannot tell a caret from a parked
     // cell — the diagnostic fields are the field-log discriminator).
@@ -867,6 +867,45 @@ describe('#951 quiet-caret tracker (pure)', () => {
     noteOutputParsed(t, 1100);             // gap 100ms < quiet -> no caret ever
     const sel = selectFreezeCell(t, 643, 127, 1105, { top: 600, rows: 45 }, 600);
     expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting' });
+  });
+
+  it('#953 case 1-2: a last-column park is rejected even when output is quiet', () => {
+    // Claude Code idling with an empty input box parks its real cursor at
+    // the line end — (236,47) on a 237-col pane — and a 1.6s output gap then
+    // certified it as an at-rest caret, pushing the candidate window and the
+    // pinyin off the right edge. A CJK composition can never sit on the last
+    // column, so the selection must fall back to the caret snapshot.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1600, 237);        // snapshot: the input-line cell
+    noteCursorMove(t, 647, 236, 1700, 47); // TUI parks at the line end
+    noteOutputParsed(t, 1700, 237);
+    const sel = selectFreezeCell(t, 647, 236, 3400, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'caret', edge: true });
+  });
+
+  it('#953: line-end cells are never snapshotted as the caret', () => {
+    const t = createRestingTracker(647, 236, 1000, 47);
+    noteOutputParsed(t, 1600, 237); // spanning cell is a line-end park
+    expect(t.hasCaret).toBe(false);
+    // …and with no snapshot and no resting cell, a last-column instant
+    // degrades to the pre-#953 selection instead of anchoring nowhere.
+    const sel = selectFreezeCell(t, 647, 236, 3000, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: false });
+  });
+
+  it('#953: without a snapshot, a last-column park falls back to the resting cell', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 647, 236, 1100, 47); // promotes the input-line cell
+    const sel = selectFreezeCell(t, 647, 236, 2000, { top: 600, rows: 48, cols: 237 }, 600);
+    // held=900ms would have certified the line end; edge rejection wins.
+    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting', edge: true });
+  });
+
+  it('#953: a mid-line at-rest cursor keeps the instant selection (regression lock)', () => {
+    const t = createRestingTracker(640, 100, 1000, 40);
+    noteOutputParsed(t, 1600, 237);
+    const sel = selectFreezeCell(t, 640, 100, 3400, { top: 600, rows: 48, cols: 237 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 100, src: 'instant', edge: false });
   });
 
   it('a same-cell report still refreshes the screen row (scroll under a stationary cursor)', () => {

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -21,8 +21,6 @@ import {
   computeImeAnchorCorrection,
   createRestingTracker,
   isUsableGeometry,
-  ANCHOR_CONTINUITY_MS,
-  noteCompositionAnchor,
   noteCursorMove,
   noteOutputParsed,
   OUTPUT_QUIET_MS,
@@ -871,36 +869,16 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting' });
   });
 
-  it('#953 case 1-2: a last-column park yields to the previous composition anchor', () => {
+  it('#953: a quiet line-end park is flagged edge=1 but NOT rerouted', () => {
     // Claude Code idling with an empty input box parks its real cursor at
-    // the line end — (236,47) on a 237-col pane — and a long output gap then
-    // certified it as an at-rest caret, pushing the candidate window and the
-    // pinyin off the right edge. A CJK composition can never sit on the last
-    // column, so the selection reuses where the user last composed.
-    const t = createRestingTracker(640, 5, 1000, 40);
-    noteCompositionAnchor(t, 40, 12, 2000);  // previous composition anchored here
-    noteCursorMove(t, 647, 236, 2500, 47);   // TUI parks at the line end
-    const sel = selectFreezeCell(t, 647, 236, 4000, { top: 600, rows: 48, cols: 237 }, 600);
-    expect(sel).toMatchObject({ absRow: 640, col: 12, src: 'prev', edge: true });
-  });
-
-  it('#953: with no previous anchor a line-end park degrades to the instant cell', () => {
-    // Third field pass: every quiet cursor-derived fallback (the snapshot,
-    // the resting cell) wanders between inputs — a stable right-edge anchor
-    // read as better than an unpredictable one. Cold start keeps instant.
+    // the line end — (236,47) on a 237-col pane. Two fallback generations
+    // (quiet snapshot, previous-composition anchor) both field-tested worse
+    // than leaving the selection alone, so the park is only flagged for the
+    // field log and the selection stays the instant cell.
     const t = createRestingTracker(640, 5, 1000, 40);
     noteCursorMove(t, 647, 236, 1100, 47);
     const sel = selectFreezeCell(t, 647, 236, 3000, { top: 600, rows: 48, cols: 237 }, 600);
-    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: false });
-  });
-
-  it('#953: an expired anchor no longer participates', () => {
-    const t = createRestingTracker(640, 5, 1000, 40);
-    noteCompositionAnchor(t, 40, 12, 2000);
-    noteCursorMove(t, 647, 236, 2500, 47);
-    const late = 2000 + ANCHOR_CONTINUITY_MS + 1;
-    const sel = selectFreezeCell(t, 647, 236, late, { top: 600, rows: 48, cols: 237 }, 600);
-    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: false });
+    expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: true });
   });
 
   it('#953: line-end cells are never snapshotted as the caret', () => {
@@ -909,33 +887,11 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(t.hasCaret).toBe(false);
   });
 
-  it('#953: a mid-line at-rest cursor keeps the instant selection (regression lock)', () => {
+  it('#953: a mid-line at-rest cursor keeps the instant selection, unflagged', () => {
     const t = createRestingTracker(640, 100, 1000, 40);
     noteOutputParsed(t, 1600, 237);
     const sel = selectFreezeCell(t, 640, 100, 3400, { top: 600, rows: 48, cols: 237 }, 600);
     expect(sel).toMatchObject({ absRow: 640, col: 100, src: 'instant', edge: false });
-  });
-
-  it('#953: consecutive streaming compositions reuse the previous anchor, not a re-taken snapshot', () => {
-    // The snapshot can be re-captured across mid-stream pauses and wander
-    // between inputs (field: rows 36 vs 43, cols 23-79). Once a composition
-    // has anchored, the next one lands at the same spot.
-    const t = createRestingTracker(640, 5, 1000, 40);
-    noteCursorMove(t, 643, 60, 2000, 43);
-    noteOutputParsed(t, 2000, 128);  // snapshot + epoch start
-    noteOutputParsed(t, 2300, 128);
-    noteOutputParsed(t, 2700, 128);
-    const first = selectFreezeCell(t, 643, 60, 2760, { top: 600, rows: 45, cols: 128 }, 600);
-    expect(first).toMatchObject({ src: 'caret', absRow: 640, col: 5 });
-    noteCompositionAnchor(t, first.absRow - 600, first.col, 2760);
-    // A mid-stream pause re-snapshots a DIFFERENT (wrong) cell…
-    noteCursorMove(t, 636, 79, 3200, 36);
-    noteOutputParsed(t, 3900, 128); // 1.2s pause ended — snapshot re-taken at (43,60)
-    noteOutputParsed(t, 4200, 128);
-    noteOutputParsed(t, 4650, 128);
-    const second = selectFreezeCell(t, 636, 79, 4700, { top: 600, rows: 45, cols: 128 }, 600);
-    // …but the previous anchor wins, so the candidate window does not wander.
-    expect(second).toMatchObject({ src: 'prev', absRow: 640, col: 5 });
   });
 
   it('a same-cell report still refreshes the screen row (scroll under a stationary cursor)', () => {
@@ -1009,15 +965,6 @@ describe('#951 quiet-caret wiring', () => {
     dom.textarea.dispatchEvent(new Event('compositionupdate'));
     expect(translateOf(dom.compView)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
     expect(translateOf(dom.compView)?.dx).toBeCloseTo((5 - 127) * 10, 6);
-    // The composition recorded its anchor; the next one mid-stream reuses it
-    // (src=prev) so the candidate window does not wander between inputs.
-    dom.textarea.dispatchEvent(new Event('compositionend'));
-    clock = 2900;
-    t.onWriteParsed.fire(undefined);
-    clock = 2950;
-    dom.textarea.dispatchEvent(new Event('compositionstart'));
-    const last = diag.mock.calls[diag.mock.calls.length - 1][0];
-    expect(last).toMatchObject({ phase: 'start', src: 'prev', selY: 40, selX: 5 });
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -869,6 +869,17 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting' });
   });
 
+  it('a same-cell report still refreshes the screen row (scroll under a stationary cursor)', () => {
+    // baseY up + cursorY down by the same amount keeps the absolute cell
+    // identical while the screen row moves; the snapshot records screen rows,
+    // so a quiet span after such a scroll must capture the fresh one.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 640, 5, 1010, 38); // same abs cell, screen row moved up 2
+    expect(t.currentSince).toBe(1000);   // dwell clock untouched
+    noteOutputParsed(t, 1600);
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 38, caretCol: 5 });
+  });
+
   it('resetRestingTracker drops the caret across a reflow boundary and re-seeds the quiet clock', () => {
     const t = createRestingTracker(640, 5, 1000, 40);
     noteOutputParsed(t, 1600);

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -22,6 +22,8 @@ import {
   createRestingTracker,
   isUsableGeometry,
   noteCursorMove,
+  noteOutputParsed,
+  OUTPUT_QUIET_MS,
   paintedCursorPosition,
   parsePxOrNull,
   pointFromCell,
@@ -172,6 +174,7 @@ function makeTerminal(dom: ReturnType<typeof buildTerminalDom>, rows = 39, cols 
   onScroll: FakeEmitter<unknown>;
   onResize: FakeEmitter<unknown>;
   onCursorMove: FakeEmitter<unknown>;
+  onWriteParsed: FakeEmitter<unknown>;
   onBufferChange: FakeEmitter<unknown>;
   state: ImeAnchorBufferState;
 } {
@@ -179,6 +182,7 @@ function makeTerminal(dom: ReturnType<typeof buildTerminalDom>, rows = 39, cols 
   const onScroll = new FakeEmitter<unknown>();
   const onResize = new FakeEmitter<unknown>();
   const onCursorMove = new FakeEmitter<unknown>();
+  const onWriteParsed = new FakeEmitter<unknown>();
   const onBufferChange = new FakeEmitter<unknown>();
   const state = buf();
   const terminal: ImeAnchorTerminal = {
@@ -190,8 +194,9 @@ function makeTerminal(dom: ReturnType<typeof buildTerminalDom>, rows = 39, cols 
     onScroll: onScroll.event,
     onResize: onResize.event,
     onCursorMove: onCursorMove.event,
+    onWriteParsed: onWriteParsed.event,
   };
-  return { terminal, onRender, onScroll, onResize, onCursorMove, onBufferChange, state };
+  return { terminal, onRender, onScroll, onResize, onCursorMove, onWriteParsed, onBufferChange, state };
 }
 
 describe('#874 attachImeAnchor', () => {
@@ -390,7 +395,7 @@ describe('#874 attachImeAnchor', () => {
 
   it('dispose unsubscribes everything and clears the transform', () => {
     const dom = buildTerminalDom();
-    const { terminal, onRender, onScroll, onResize, onCursorMove, onBufferChange, state } = makeTerminal(dom);
+    const { terminal, onRender, onScroll, onResize, onCursorMove, onWriteParsed, onBufferChange, state } = makeTerminal(dom);
     const handle = attachImeAnchor(terminal);
     Object.assign(state, { baseY: 10, viewportY: 5, cursorY: 4, cursorX: 0 });
     dom.textarea.style.top = `${4 * 17.6}px`;
@@ -405,6 +410,7 @@ describe('#874 attachImeAnchor', () => {
     expect(onScroll.size).toBe(0);
     expect(onResize.size).toBe(0);
     expect(onCursorMove.size).toBe(0);
+    expect(onWriteParsed.size).toBe(0);
     expect(onBufferChange.size).toBe(0);
     // A composition after dispose must not resurrect the transform.
     dom.textarea.dispatchEvent(new Event('compositionstart'));
@@ -422,6 +428,7 @@ describe('#874 attachImeAnchor', () => {
       onScroll: new FakeEmitter<unknown>().event,
       onResize: new FakeEmitter<unknown>().event,
       onCursorMove: new FakeEmitter<unknown>().event,
+      onWriteParsed: new FakeEmitter<unknown>().event,
     } as ImeAnchorTerminal;
     expect(() => attachImeAnchor(terminal).dispose()).not.toThrow();
   });
@@ -635,7 +642,7 @@ describe('#874 resting-cell tracker (cause 3, pure)', () => {
     noteCursorMove(t, 49, 113, 1100); // caret promoted, cursor parked at 49,113
     // 5ms after the park: mid-burst -> resting cell.
     const midBurst = selectFreezeCell(t, 49, 113, 1105);
-    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5 });
+    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5, outputGap: 105, caretAge: -1 });
     // 100ms after the park: the parked cell is now at rest -> trusted as-is
     // (the documented cause-3 residual: dwell cannot tell a caret from a parked
     // cell — the diagnostic fields are the field-log discriminator).
@@ -778,6 +785,139 @@ describe('#874 resting-cell wiring (cause 3)', () => {
     setClock(1105);
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     expect(diag.mock.calls[0][0]).toMatchObject({ src: 'scrolled_out', selY: 49, selX: 113 });
+    handle.dispose();
+  });
+});
+
+describe('#951 quiet-caret tracker (pure)', () => {
+  it('an output-free span promotes the spanning cell to the caret (no move yet this chunk)', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    // First chunk after 600ms of silence, onWriteParsed before any cursor
+    // move was reported: the current cell spanned the quiet period.
+    noteOutputParsed(t, 1000 + OUTPUT_QUIET_MS + 100);
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 40, caretCol: 5 });
+  });
+
+  it('covers the real xterm order too: cursor moves during the parse, writeParsed at batch end', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    // The batch's parse already parked the cursor elsewhere; the spanning cell
+    // was promoted to the resting slot inside this same batch.
+    noteCursorMove(t, 643, 127, 2000, 43);
+    noteOutputParsed(t, 2000);
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 40, caretCol: 5 });
+  });
+
+  it('sub-quiet gaps never snapshot a caret', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1000 + OUTPUT_QUIET_MS - 100);
+    expect(t.hasCaret).toBe(false);
+    // The clock still advanced — the next chunk measures from here.
+    noteOutputParsed(t, 1000 + OUTPUT_QUIET_MS + 200);
+    expect(t.hasCaret).toBe(false);
+  });
+
+  it('REGRESSION #951: a corner cell parked between stream bursts loses to the quiet caret', () => {
+    // The field log scenario: 128x45 pane, caret on the input line (row 40),
+    // Claude Code streaming. Between bursts the cursor sits on (127,43) far
+    // longer than RESTING_MS — pre-#951 that dwell made it src=instant.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 643, 127, 2000, 43); // stream's first parse parks the corner
+    noteOutputParsed(t, 2000);             // quiet span ended -> caret snapshot
+    noteOutputParsed(t, 2300);             // stream keeps flowing…
+    noteOutputParsed(t, 2700);             // …past the sustain threshold
+    const sel = selectFreezeCell(t, 643, 127, 2760, { top: 600, rows: 45 }, 600);
+    // held=760ms >= RESTING_MS would have certified the corner; output is only
+    // 60ms old and has streamed for 760ms, so the caret wins.
+    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'caret', outputGap: 60, caretAge: 760 });
+  });
+
+  it('an isolated echo burst keeps the freshly advanced cursor (fast-typist regression lock)', () => {
+    // Quiet shell, user commits a syllable: the echo advances the cursor 4
+    // cols. The echo IS recent output, but it is not a sustained stream — the
+    // next composition must anchor on the advanced cursor, not the snapshot
+    // taken before the word (which would drift further left every word).
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 640, 9, 3000, 40); // echo parse advances the caret
+    noteOutputParsed(t, 3000);           // snapshot exists, but epoch is fresh
+    const sel = selectFreezeCell(t, 640, 9, 3200, { top: 600, rows: 45 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 9, src: 'instant' });
+  });
+
+  it('the caret snapshot is a screen row: scrolled output rebases it onto the current ybase', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1600); // snapshot at screen row 40 while ybase=600
+    noteOutputParsed(t, 2000); // this output scrolled the buffer 10 rows on
+    noteOutputParsed(t, 2300);
+    const sel = selectFreezeCell(t, 655, 0, 2350, undefined, 610);
+    expect(sel).toMatchObject({ absRow: 650, col: 5, src: 'caret' });
+  });
+
+  it('quiet output keeps the pre-#951 selection (regression lock)', () => {
+    const t = createRestingTracker(30, 8, 1000, 30);
+    noteOutputParsed(t, 1600); // a snapshot exists…
+    // …but the last output is OUTPUT_QUIET_MS old: the parked cursor is the
+    // TUI's own final position — trust it exactly as before.
+    const sel = selectFreezeCell(t, 30, 8, 1600 + OUTPUT_QUIET_MS);
+    expect(sel).toMatchObject({ absRow: 30, col: 8, src: 'instant', outputGap: OUTPUT_QUIET_MS });
+  });
+
+  it('streaming without a snapshot degrades to the resting/instant selection', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteCursorMove(t, 643, 127, 1100, 43); // mid-burst from the very first chunk
+    noteOutputParsed(t, 1100);             // gap 100ms < quiet -> no caret ever
+    const sel = selectFreezeCell(t, 643, 127, 1105, { top: 600, rows: 45 }, 600);
+    expect(sel).toMatchObject({ absRow: 640, col: 5, src: 'resting' });
+  });
+
+  it('resetRestingTracker drops the caret across a reflow boundary and re-seeds the quiet clock', () => {
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1600);
+    expect(t.hasCaret).toBe(true);
+    resetRestingTracker(t, 320, 0, 1650, 20);
+    expect(t.hasCaret).toBe(false);
+    // The quiet clock restarts at the reset: only silence observed entirely
+    // in the new coordinate frame counts, AND the first post-reset quiet
+    // chunk must be able to take the current-cell branch (currentSince ===
+    // lastOutputAt) — preserving the old clock left `currentSince >
+    // lastOutputAt` forever and the snapshot could never re-form on a pane
+    // whose cursor stayed put (2-model panel finding).
+    expect(t.lastOutputAt).toBe(1650);
+    noteOutputParsed(t, 1650 + OUTPUT_QUIET_MS);
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 20, caretCol: 0 });
+  });
+});
+
+describe('#951 quiet-caret wiring', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('a composition mid-stream anchors the candidate window to the quiet caret', () => {
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    // Caret parked on the TUI's input line (screen row 40) while idle.
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const handle = attachImeAnchor(t.terminal, { now: () => clock, onCompositionDiagnostic: diag });
+    // Stream's first batch after 1s of silence, in xterm's real order: the
+    // parse parks the cursor on the corner, then onWriteParsed fires.
+    clock = 2000;
+    Object.assign(t.state, { cursorY: 43, cursorX: 127 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    // Stand in for xterm's own (instantaneous) anchoring of the textarea.
+    dom.textarea.style.top = `${43 * 17.6}px`;
+    dom.textarea.style.left = `${127 * 10}px`;
+    clock = 2400;
+    t.onWriteParsed.fire(undefined); // stream keeps flowing…
+    clock = 2750;
+    t.onWriteParsed.fire(undefined); // …past the sustain threshold
+    clock = 2800; // corner held 800ms >= RESTING_MS — dwell alone would trust it
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'caret', selY: 40, selX: 5, cursorY: 43, cursorX: 127, outputGap: 50, caretAge: 800,
+    });
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((5 - 127) * 10, 6);
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -881,15 +881,18 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(sel).toMatchObject({ absRow: 647, col: 236, src: 'instant', edge: true });
   });
 
-  it('#953: line-end cells are never snapshotted as the caret', () => {
+  it('#953: a line-end park is still snapshotted — the flag drives nothing', () => {
+    // Withholding these cells from the snapshot was the last of three
+    // generations of acting on `edge`, and the reporter measured it worse
+    // than the untouched baseline, so the tracker takes the cell as before.
     const t = createRestingTracker(647, 236, 1000, 47);
-    noteOutputParsed(t, 1600, 237); // spanning cell is a line-end park
-    expect(t.hasCaret).toBe(false);
+    noteOutputParsed(t, 1600); // spanning cell is a line-end park
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 47, caretCol: 236 });
   });
 
   it('#953: a mid-line at-rest cursor keeps the instant selection, unflagged', () => {
     const t = createRestingTracker(640, 100, 1000, 40);
-    noteOutputParsed(t, 1600, 237);
+    noteOutputParsed(t, 1600);
     const sel = selectFreezeCell(t, 640, 100, 3400, { top: 600, rows: 48, cols: 237 }, 600);
     expect(sel).toMatchObject({ absRow: 640, col: 100, src: 'instant', edge: false });
   });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -907,12 +907,26 @@ describe('#951 quiet-caret tracker (pure)', () => {
     expect(sel).toMatchObject({ absRow: 640, col: 100, src: 'instant', edge: false });
   });
 
-  it('#953: a line-end park is still snapshotted — the flag drives nothing', () => {
-    // Withholding these cells from the snapshot was the last of three
-    // generations of acting on `edge`, and the reporter measured it worse
-    // than the untouched baseline, so the tracker takes the cell as before.
+  it('#953: a line-end park is refused as a snapshot, keeping the last good one', () => {
+    // The field shape once the streaming path started using the snapshot:
+    // `cursor=(13,36) sel=(127,43) src=caret` — the live cursor mid-line while
+    // the snapshot pointed at the last column, so every composition anchored
+    // bottom-right. A quiet span that finds the TUI parked there must keep the
+    // caret the last real one recorded.
+    const t = createRestingTracker(640, 5, 1000, 40);
+    noteOutputParsed(t, 1600, 237);              // a real caret at (40,5)
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 40, caretCol: 5 });
+
+    noteCursorMove(t, 647, 236, 1700, 47);       // TUI parks at the line end
+    noteOutputParsed(t, 2300, 237);              // next quiet span spans it
+    expect(t).toMatchObject({ hasCaret: true, caretRelRow: 40, caretCol: 5 });
+  });
+
+  it('#953: without a column count the refusal is off, not wrongly bounded', () => {
+    // A caller with no geometry must keep the old behaviour rather than have
+    // the check silently pick a bound and drop legitimate caret cells.
     const t = createRestingTracker(647, 236, 1000, 47);
-    noteOutputParsed(t, 1600); // spanning cell is a line-end park
+    noteOutputParsed(t, 1600);
     expect(t).toMatchObject({ hasCaret: true, caretRelRow: 47, caretCol: 236 });
   });
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -113,11 +113,15 @@
  * (typing 대한민국 reads 대한국, #942). The composition ending cleared the
  * transform and the WebGL repaint restored the real cells, which is why the
  * buffer was never wrong, only the paint. So the pin applies to the textarea
- * alone, and the preedit gets the same anchor math against the live cursor,
- * never frozen — applied at xterm's own composition-event cadence (not per
- * render frame, see syncPreedit) so it lands on the painted caret when the
- * viewport is scrolled (cause 1 applies to it too) without chasing mid-repaint
- * transient cursors.
+ * alone, and the preedit gets the same anchor math against the live cursor —
+ * applied at xterm's own composition-event cadence (not per render frame, see
+ * syncPreedit) so it lands on the painted caret when the viewport is scrolled
+ * (cause 1 applies to it too) without chasing mid-repaint transient cursors.
+ * One exception (#951 field report on the first quiet-caret build): when the
+ * freeze cell came from the quiet caret, the live cursor is the streaming
+ * agent's repaint cursor, so the preedit pins to the same frozen point as the
+ * textarea — otherwise the pinyin rides the agent's output rows while its
+ * candidate list sits at the input line, and the two IME surfaces tear apart.
  *
  * The correction is computed as `desired - actual`, where `actual` is read back
  * from the styles xterm wrote rather than re-derived from the buffer. That
@@ -697,9 +701,21 @@ export function attachImeAnchor(
   };
 
   /**
-   * The preedit is NEVER pinned (#942): while composing it gets the same
-   * anchor math against the live cursor — the ydisp term xterm forgot —
-   * and outside a composition it carries no transform (xterm hides it).
+   * The preedit follows the live cursor in a quiet pane (#942): while
+   * composing it gets the same anchor math against the live cursor — the
+   * ydisp term xterm forgot — so a committed syllable's echo advances the
+   * composing syllable with the caret (Korean inline input). Outside a
+   * composition it carries no transform (xterm hides it).
+   *
+   * The one exception is a composition whose freeze cell came from the quiet
+   * caret (`src=caret`, #951/#953 field report): there the live cursor IS the
+   * streaming agent's repaint cursor, and following it split the two IME
+   * surfaces apart — the candidate window pinned at the input line while the
+   * inline pinyin chased the agent's output rows. Both surfaces must anchor
+   * to the same cell, so a caret-sourced composition pins the preedit to the
+   * same frozen point as the textarea. The quiet case is untouched: there the
+   * selection is instant/resting and the live follow stays (#942 stays
+   * fixed).
    *
    * Deliberately called only from the composition handlers, NOT from
    * onRender/onScroll: at a composition event xterm has just written the
@@ -720,7 +736,10 @@ export function attachImeAnchor(
     if (!isUsableGeometry(geometry)) return;
     const actualPreedit = readStyledPoint(compositionView);
     if (!actualPreedit) return;
-    const c = computeImeAnchorCorrection(paintedCursorPosition(bufferState(), geometry), actualPreedit);
+    const desired = frozen !== null && lastSel?.src === 'caret'
+      ? frozen
+      : paintedCursorPosition(bufferState(), geometry);
+    const c = computeImeAnchorCorrection(desired, actualPreedit);
     preeditTransform.set(c.dx, c.dy);
   };
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -79,13 +79,20 @@
  * the next composition onto the stale snapshot instead of the correctly
  * advanced cursor, and a fluid typist's candidate window would drift further
  * from the caret with every word (3-model panel finding on the first cut).
+ * Dwell has one more blind spot even when quiet (#953 field cases 1-3): a
+ * TUI with nothing to point at — empty input box, mid-edit redraw — parks
+ * its real cursor at the LAST column of the line it painted, and a long gap
+ * then certifies that placeholder. A CJK composition can never sit on the
+ * last column (the glyph alone is two cells wide), so a last-column cursor
+ * is rejected outright (`edge=1` in the diagnostic) in favor of the caret
+ * snapshot, and line-end cells are never snapshotted either.
  * Known residuals, all self-healing at the next quiet span and identifiable
  * in a field log via the src/gap/caretAge fields: a mid-stream pause longer
- * than OUTPUT_QUIET_MS with the cursor parked on repaint state re-snapshots
- * a wrong caret; a resize or clear mid-stream drops (resize) or strands
- * (clear — no reset event fires) the snapshot until output next goes quiet;
- * and a caret deliberately moved by the very chunk that ends a quiet span is
- * snapshotted at its pre-move cell.
+ * than OUTPUT_QUIET_MS with the cursor parked mid-line on repaint state
+ * re-snapshots a wrong caret; a resize or clear mid-stream drops (resize)
+ * or strands (clear — no reset event fires) the snapshot until output next
+ * goes quiet; and a caret deliberately moved by the very chunk that ends a
+ * quiet span is snapshotted at its pre-move cell.
  *
  * All of this lives in upstream xterm and this repo does not patch
  * node_modules, so the correction is applied downstream as a `transform` that
@@ -369,15 +376,23 @@ export function noteCursorMove(state: RestingTrackerState, absRow: number, col: 
  * exceeds RESTING_MS by construction) with a promotion clock inside this
  * chunk.
  */
-export function noteOutputParsed(state: RestingTrackerState, now: number): void {
+export function noteOutputParsed(state: RestingTrackerState, now: number, cols?: number): void {
   if (now - state.lastOutputAt >= OUTPUT_QUIET_MS) {
     state.epochStart = now;
+    // Line-end parks are never snapshotted (#953 field cases 1-2): a TUI
+    // idling with an empty input box parks its cursor at the last column,
+    // and a snapshot taken there would just relocate the mis-anchor from
+    // the instant path into the caret path.
+    const lastCol = cols !== undefined ? cols - 1 : Infinity;
     if (state.currentSince <= state.lastOutputAt) {
-      state.caretRelRow = state.currentRelRow;
-      state.caretCol = state.currentCol;
-      state.caretAt = now;
-      state.hasCaret = true;
-    } else if (state.hasResting && state.lastRestingAt > state.lastOutputAt) {
+      if (state.currentCol < lastCol) {
+        state.caretRelRow = state.currentRelRow;
+        state.caretCol = state.currentCol;
+        state.caretAt = now;
+        state.hasCaret = true;
+      }
+    } else if (state.hasResting && state.lastRestingAt > state.lastOutputAt
+      && state.lastRestingCol < lastCol) {
       state.caretRelRow = state.lastRestingRelRow;
       state.caretCol = state.lastRestingCol;
       state.caretAt = now;
@@ -430,6 +445,9 @@ export interface FreezeCellSelection {
   outputGap: number;
   /** Age of the caret snapshot at selection time; -1 when none exists. */
   caretAge: number;
+  /** True when the instantaneous cursor sat on the last column and was
+   *  rejected as a line-end park (#953 field cases 1-3). */
+  edge: boolean;
 }
 
 /**
@@ -466,7 +484,7 @@ export function selectFreezeCell(
   instAbsRow: number,
   instCol: number,
   now: number,
-  viewport?: { top: number; rows: number },
+  viewport?: { top: number; rows: number; cols?: number },
   baseY = 0,
 ): FreezeCellSelection {
   const held = now - state.currentSince;
@@ -478,17 +496,44 @@ export function selectFreezeCell(
     && state.hasCaret) {
     return {
       absRow: baseY + state.caretRelRow, col: state.caretCol,
-      src: 'caret', held, restAge, outputGap, caretAge,
+      src: 'caret', held, restAge, outputGap, caretAge, edge: false,
     };
   }
+  // Line-end park rejection (#953 field cases 1-3). A TUI that has nothing
+  // to point at — empty input box, mid-edit redraw, streaming repaint —
+  // parks its real cursor at the LAST column of the line it just painted
+  // ((236,47) on a 237-col pane, (127,43) on a 128-col one), and a long
+  // output gap then certifies that placeholder as an at-rest caret. A real
+  // CJK composition can never sit on the last column (the glyph alone is
+  // two cells wide), so a last-column cursor is rejected outright and the
+  // selection falls back to the caret snapshot — even when output is quiet —
+  // then to the resting cell. With neither available it degrades to the
+  // instant cell exactly as before.
+  const lastCol = viewport?.cols !== undefined ? viewport.cols - 1 : Infinity;
+  if (instCol >= lastCol) {
+    if (state.hasCaret) {
+      return {
+        absRow: baseY + state.caretRelRow, col: state.caretCol,
+        src: 'caret', held, restAge, outputGap, caretAge, edge: true,
+      };
+    }
+    if (state.hasResting && state.lastRestingCol < lastCol
+      && !(viewport && (state.lastRestingAbsRow < viewport.top
+        || state.lastRestingAbsRow >= viewport.top + viewport.rows))) {
+      return {
+        absRow: state.lastRestingAbsRow, col: state.lastRestingCol,
+        src: 'resting', held, restAge, outputGap, caretAge, edge: true,
+      };
+    }
+  }
   if (held >= RESTING_MS || !state.hasResting) {
-    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge };
+    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge: false };
   }
   if (viewport && (state.lastRestingAbsRow < viewport.top
     || state.lastRestingAbsRow >= viewport.top + viewport.rows)) {
-    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge };
+    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge, edge: false };
   }
-  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge };
+  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge, edge: false };
 }
 
 // ---------------------------------------------------------------------------
@@ -555,6 +600,9 @@ export interface ImeAnchorOptions {
      *  A large value on a src=caret record means the anchor came from a
      *  long-past quiet span — the stale-snapshot residual in action. */
     caretAge: number;
+    /** True when the cursor sat on the last column and was rejected as a
+     *  line-end park (#953 field cases 1-3). */
+    edge: boolean;
     /** Selected cell, ybase-relative like cursorY/cursorX. */
     selY: number;
     selX: number;
@@ -808,6 +856,7 @@ export function attachImeAnchor(
       restAge: lastSel.restAge,
       outputGap: lastSel.outputGap,
       caretAge: lastSel.caretAge,
+      edge: lastSel.edge,
       selY: lastSelRelY,
       selX: lastSel.col,
     });
@@ -825,6 +874,7 @@ export function attachImeAnchor(
     const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now(), {
       top: b.viewportY,
       rows: geometry.rows,
+      cols: geometry.cols,
     }, b.baseY);
     lastSel = sel;
     lastSelRelY = sel.absRow - b.baseY;
@@ -886,7 +936,7 @@ export function attachImeAnchor(
   // clock compare plus at most three number writes, so the streaming hot path
   // stays cold. noteOutputParsed tolerates either firing order relative to
   // onCursorMove within a chunk (see its doc comment).
-  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now()));
+  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now(), geometry.cols));
   // Normal <-> alt buffer switches change what an absolute row means.
   const bufferSub = terminal.buffer.onBufferChange(resetTracker);
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -332,7 +332,14 @@ export function createRestingTracker(absRow: number, col: number, now: number, r
 
 /** Record a cursor movement. Promotes the cell being left if it had rested. */
 export function noteCursorMove(state: RestingTrackerState, absRow: number, col: number, now: number, relRow: number = absRow): void {
-  if (absRow === state.currentAbsRow && col === state.currentCol) return;
+  if (absRow === state.currentAbsRow && col === state.currentCol) {
+    // Same buffer cell, so the dwell clock keeps running — but a scroll can
+    // move the screen row under a stationary absolute cell (baseY up, cursorY
+    // down by the same amount), and the caret snapshot records SCREEN rows,
+    // so the screen coordinate must stay fresh.
+    state.currentRelRow = relRow;
+    return;
+  }
   if (now - state.currentSince >= RESTING_MS) {
     state.lastRestingAbsRow = state.currentAbsRow;
     state.lastRestingCol = state.currentCol;

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -56,6 +56,37 @@
  * selected and why — the field log is the discriminator before any further
  * complexity is added.
  *
+ * That limit is exactly what #951 hit (field logs, WeChat IME + Microsoft
+ * Pinyin, Claude Code streaming into a 128x45 pane): `src=instant` selections
+ * at (127,43), (53,43), (127,38) — screen corners and output rows, never the
+ * user's input line. While an agent streams, output arrives in bursts with
+ * inter-burst gaps far above RESTING_MS (token pacing, network), and between
+ * bursts the cursor sits wherever the last write left it. Dwell time
+ * certifies that parked cursor as "at rest"; the resting fallback is derived
+ * from the same buffer cursor and is just as blind. The missing signal is
+ * output recency: a cell the cursor held through a period with NO parsed PTY
+ * output is where the TUI deliberately parked it — the caret at rest — while
+ * any cursor position observed with output still flowing is repaint state.
+ * So the tracker also records the last "quiet caret": the cell the cursor
+ * held across the most recent >= OUTPUT_QUIET_MS output-free span, stored
+ * ybase-RELATIVE (screen row), because a TUI addresses its input line by
+ * screen position and scrolling output changes that line's absolute row while
+ * its screen row stays put. A composition starting while output is recent
+ * AND has been flowing for STREAM_SUSTAIN_MS anchors there (`src=caret`)
+ * instead of trusting dwell. The sustain gate is what keeps the quiet-shell
+ * typing flow intact: a committed syllable's echo is also "recent output",
+ * but it is an isolated burst — without the gate, every commit would push
+ * the next composition onto the stale snapshot instead of the correctly
+ * advanced cursor, and a fluid typist's candidate window would drift further
+ * from the caret with every word (3-model panel finding on the first cut).
+ * Known residuals, all self-healing at the next quiet span and identifiable
+ * in a field log via the src/gap/caretAge fields: a mid-stream pause longer
+ * than OUTPUT_QUIET_MS with the cursor parked on repaint state re-snapshots
+ * a wrong caret; a resize or clear mid-stream drops (resize) or strands
+ * (clear — no reset event fires) the snapshot until output next goes quiet;
+ * and a caret deliberately moved by the very chunk that ends a quiet span is
+ * snapshotted at its pre-move cell.
+ *
  * All of this lives in upstream xterm and this repo does not patch
  * node_modules, so the correction is applied downstream as a `transform` that
  * composes with the `style.top` / `style.left` xterm keeps writing, instead of
@@ -213,6 +244,25 @@ export function parsePxOrNull(value: string | undefined | null): number | null {
 export const RESTING_MS = 32;
 
 /**
+ * Output silence required before the buffer cursor is trusted again (#951).
+ * Streaming agents keep their spinner/stream repaints under a few hundred ms
+ * apart, so mid-turn gaps stay below this; a pane whose agent has finished (or
+ * that never streamed) crosses it almost immediately. A cell the cursor held
+ * through a span this long with no parsed output is the TUI's parked caret.
+ */
+export const OUTPUT_QUIET_MS = 500;
+
+/**
+ * How long output must have been flowing (sub-quiet gaps, measured from the
+ * chunk that ended the last quiet span) before the quiet-caret snapshot
+ * outranks the live cursor. An isolated burst — a committed syllable's echo,
+ * a prompt redraw — stays well under this, so ordinary typing keeps trusting
+ * the freshly advanced cursor; an agent streaming output crosses it within
+ * the first second of its turn.
+ */
+export const STREAM_SUSTAIN_MS = 700;
+
+/**
  * Mutable tracker record. The transition functions below mutate it in place —
  * that is how "pure-function testability" and an allocation-free hot path
  * coexist: each function is deterministic in (state, args), returns scalars,
@@ -222,14 +272,35 @@ export interface RestingTrackerState {
   /** Cell the cursor is in right now (absolute row = ybase + buffer.y). */
   currentAbsRow: number;
   currentCol: number;
+  /** Screen row of the current cell at entry (xterm's `buffer.y`). */
+  currentRelRow: number;
   /** Clock reading when the current cell was entered. */
   currentSince: number;
   /** Last cell that was held for >= RESTING_MS before the cursor left it. */
   lastRestingAbsRow: number;
   lastRestingCol: number;
+  /** Screen row of the resting cell at its entry. */
+  lastRestingRelRow: number;
   /** Clock reading when the resting cell was promoted. */
   lastRestingAt: number;
   hasResting: boolean;
+  /** Clock reading of the last parsed PTY output (#951). */
+  lastOutputAt: number;
+  /** Clock reading of the chunk that ended the last quiet span — the start
+   *  of the current output epoch. Age >= STREAM_SUSTAIN_MS means the output
+   *  is a sustained stream, not an isolated echo burst. */
+  epochStart: number;
+  /**
+   * Cell the cursor held through the most recent >= OUTPUT_QUIET_MS
+   * output-free span — the TUI's parked caret. Screen-row coordinates: a TUI
+   * addresses its input line by screen position, so this survives the buffer
+   * scrolling underneath it, which an absolute row would not.
+   */
+  caretRelRow: number;
+  caretCol: number;
+  /** Clock reading when the caret snapshot was taken. */
+  caretAt: number;
+  hasCaret: boolean;
 }
 
 /**
@@ -237,48 +308,104 @@ export interface RestingTrackerState {
  * means an idle caret that never moves still reads as "at rest", so the
  * pre-first-move window has no hole where the selection could do nothing.
  */
-export function createRestingTracker(absRow: number, col: number, now: number): RestingTrackerState {
+export function createRestingTracker(absRow: number, col: number, now: number, relRow: number = absRow): RestingTrackerState {
   return {
     currentAbsRow: absRow,
     currentCol: col,
+    currentRelRow: relRow,
     currentSince: now,
     lastRestingAbsRow: 0,
     lastRestingCol: 0,
+    lastRestingRelRow: 0,
     lastRestingAt: 0,
     hasResting: false,
+    // Seeded with the creation clock: "no output since attach" reads as quiet,
+    // matching the seeded-at-rest semantics of the cell fields above.
+    lastOutputAt: now,
+    epochStart: now,
+    caretRelRow: 0,
+    caretCol: 0,
+    caretAt: 0,
+    hasCaret: false,
   };
 }
 
 /** Record a cursor movement. Promotes the cell being left if it had rested. */
-export function noteCursorMove(state: RestingTrackerState, absRow: number, col: number, now: number): void {
+export function noteCursorMove(state: RestingTrackerState, absRow: number, col: number, now: number, relRow: number = absRow): void {
   if (absRow === state.currentAbsRow && col === state.currentCol) return;
   if (now - state.currentSince >= RESTING_MS) {
     state.lastRestingAbsRow = state.currentAbsRow;
     state.lastRestingCol = state.currentCol;
+    state.lastRestingRelRow = state.currentRelRow;
     state.lastRestingAt = now;
     state.hasResting = true;
   }
   state.currentAbsRow = absRow;
   state.currentCol = col;
+  state.currentRelRow = relRow;
   state.currentSince = now;
 }
 
 /**
- * Invalidate everything and re-seed. Resize reflow and buffer switches
- * (alt-screen) change what an absolute row means, so a resting cell recorded
- * before either event must never be selected after it.
+ * Record a parsed PTY write (#951). When this chunk ends an output-free span
+ * of >= OUTPUT_QUIET_MS, the cell that held the cursor through that span is
+ * promoted to the quiet caret. Which tracker field holds that cell depends on
+ * event order inside the chunk, and both orders are covered: if the cursor
+ * has not (yet) been reported moved this chunk, the current cell still spans
+ * the quiet period (`currentSince <= lastOutputAt` — the cursor cannot move
+ * without output); if the move was already reported, the spanning cell was
+ * just promoted to the resting slot (its dwell covered the whole span, which
+ * exceeds RESTING_MS by construction) with a promotion clock inside this
+ * chunk.
  */
-export function resetRestingTracker(state: RestingTrackerState, absRow: number, col: number, now: number): void {
+export function noteOutputParsed(state: RestingTrackerState, now: number): void {
+  if (now - state.lastOutputAt >= OUTPUT_QUIET_MS) {
+    state.epochStart = now;
+    if (state.currentSince <= state.lastOutputAt) {
+      state.caretRelRow = state.currentRelRow;
+      state.caretCol = state.currentCol;
+      state.caretAt = now;
+      state.hasCaret = true;
+    } else if (state.hasResting && state.lastRestingAt > state.lastOutputAt) {
+      state.caretRelRow = state.lastRestingRelRow;
+      state.caretCol = state.lastRestingCol;
+      state.caretAt = now;
+      state.hasCaret = true;
+    }
+  }
+  state.lastOutputAt = now;
+}
+
+/**
+ * Invalidate everything and re-seed. Resize reflow and buffer switches
+ * (alt-screen) change what both an absolute and a screen row mean, so neither
+ * a resting cell nor a quiet caret recorded before either event may be
+ * selected after it. The output clock is re-seeded too: without that, the
+ * chunk ending the first post-reset quiet span would see
+ * `currentSince > lastOutputAt` (the reset stamped `currentSince`) and could
+ * never take the current-cell branch of noteOutputParsed, so a pane that
+ * kept streaming after a resize would not regain a caret snapshot until the
+ * cursor happened to move in exactly the right chunk (2-model panel
+ * finding). Re-seeding makes the quiet clock start fresh in the new
+ * coordinate frame, which is also the conservative reading: only silence
+ * observed entirely after the reflow counts toward a new snapshot.
+ */
+export function resetRestingTracker(state: RestingTrackerState, absRow: number, col: number, now: number, relRow: number = absRow): void {
   state.currentAbsRow = absRow;
   state.currentCol = col;
+  state.currentRelRow = relRow;
   state.currentSince = now;
   state.hasResting = false;
+  state.hasCaret = false;
+  state.lastOutputAt = now;
+  state.epochStart = now;
 }
 
 /** Where the freeze cell came from. `scrolled_out` is `instant` chosen because
  *  the resting cell had left the viewport — kept distinct so a field log can
- *  tell that rejection apart from a cursor that was simply at rest. */
-export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out';
+ *  tell that rejection apart from a cursor that was simply at rest. `caret` is
+ *  the quiet-caret snapshot, chosen because output was still flowing (#951). */
+export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret';
 
 export interface FreezeCellSelection {
   absRow: number;
@@ -288,13 +415,29 @@ export interface FreezeCellSelection {
   held: number;
   /** Age of the resting cell at selection time; -1 when none exists. */
   restAge: number;
+  /** Time since the last parsed PTY output when selection ran (#951). */
+  outputGap: number;
+  /** Age of the caret snapshot at selection time; -1 when none exists. */
+  caretAge: number;
 }
 
 /**
- * Pick the cell the composition should anchor to. A cursor that has held its
- * cell for RESTING_MS is at rest — trust it. A cursor that moved more recently
- * is mid-repaint, so fall back to the last cell that did rest. With no resting
- * cell recorded (fresh tracker), the instantaneous cursor is all there is.
+ * Pick the cell the composition should anchor to. When output has been quiet
+ * for OUTPUT_QUIET_MS the buffer cursor is where the TUI parked it — trust it
+ * when at rest (RESTING_MS), fall back to the resting cell mid-burst. While
+ * output is recent AND sustained (STREAM_SUSTAIN_MS since the current epoch
+ * began), dwell time certifies nothing (#951: a streaming agent parks its
+ * cursor on screen corners between bursts for far longer than RESTING_MS),
+ * so the quiet-caret snapshot wins over both. Recent-but-isolated output —
+ * a committed syllable's echo — keeps the normal dwell selection, because
+ * there the freshly moved cursor IS the caret and the snapshot is one word
+ * stale. The snapshot's
+ * screen row is rebased onto the CURRENT ybase: the TUI keeps its input line
+ * at a fixed screen position while output scrolls the buffer underneath.
+ * `pointFromCell` clamps the result into the viewport, which for a scrolled-up
+ * user pins the candidate window to the nearest visible edge — same contract
+ * as every other off-screen anchor here. With no snapshot (pane streamed from
+ * the moment it attached), selection degrades to the pre-#951 behavior.
  *
  * `viewport` guards the one case where the resting cell is the WORSE of the
  * two. A resting cell is by definition a past cell, so output that scrolls the
@@ -313,17 +456,28 @@ export function selectFreezeCell(
   instCol: number,
   now: number,
   viewport?: { top: number; rows: number },
+  baseY = 0,
 ): FreezeCellSelection {
   const held = now - state.currentSince;
   const restAge = state.hasResting ? now - state.lastRestingAt : -1;
+  const outputGap = now - state.lastOutputAt;
+  const caretAge = state.hasCaret ? now - state.caretAt : -1;
+  if (outputGap < OUTPUT_QUIET_MS
+    && now - state.epochStart >= STREAM_SUSTAIN_MS
+    && state.hasCaret) {
+    return {
+      absRow: baseY + state.caretRelRow, col: state.caretCol,
+      src: 'caret', held, restAge, outputGap, caretAge,
+    };
+  }
   if (held >= RESTING_MS || !state.hasResting) {
-    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge };
+    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge };
   }
   if (viewport && (state.lastRestingAbsRow < viewport.top
     || state.lastRestingAbsRow >= viewport.top + viewport.rows)) {
-    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge };
+    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge };
   }
-  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge };
+  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge };
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +507,8 @@ export interface ImeAnchorTerminal {
   onScroll: EventEmitterLike<unknown>;
   onResize: EventEmitterLike<unknown>;
   onCursorMove: EventEmitterLike<unknown>;
+  /** Fires after each PTY chunk is parsed — the output-recency signal (#951). */
+  onWriteParsed: EventEmitterLike<unknown>;
 }
 
 export interface ImeAnchorOptions {
@@ -382,6 +538,12 @@ export interface ImeAnchorOptions {
     src: FreezeCellSource;
     held: number;
     restAge: number;
+    /** Output silence at compositionstart — the #951 discriminator. */
+    outputGap: number;
+    /** Age of the caret snapshot at compositionstart; -1 when none existed.
+     *  A large value on a src=caret record means the anchor came from a
+     *  long-past quiet span — the stale-snapshot residual in action. */
+    caretAge: number;
     /** Selected cell, ybase-relative like cursorY/cursorX. */
     selY: number;
     selX: number;
@@ -457,6 +619,7 @@ export function attachImeAnchor(
     bufferState().baseY + bufferState().cursorY,
     bufferState().cursorX,
     now(),
+    bufferState().cursorY,
   );
 
   let frozen: ImeAnchorPoint | null = null;
@@ -556,7 +719,7 @@ export function attachImeAnchor(
 
   const resetTracker = (): void => {
     const b = bufferState();
-    resetRestingTracker(tracker, b.baseY + b.cursorY, b.cursorX, now());
+    resetRestingTracker(tracker, b.baseY + b.cursorY, b.cursorX, now(), b.cursorY);
   };
 
   const onRefreshGeometry = (): void => {
@@ -570,6 +733,11 @@ export function attachImeAnchor(
 
   // Freeze-cell selection of the current composition, for the diagnostic.
   let lastSel: FreezeCellSelection | null = null;
+  // Screen row of the selection, fixed at compositionstart: update/end records
+  // fire after the stream may have scrolled the buffer on, and re-deriving
+  // against the emission-time ybase would corrupt the very field the log
+  // exists to discriminate on (panel finding).
+  let lastSelRelY = 0;
   // Last corrections the diagnostic reported: update/end records fire only on
   // change, so a healthy composition costs one record and a developing offset
   // is captured the moment it develops (#942's field log was all
@@ -612,7 +780,9 @@ export function attachImeAnchor(
       src: lastSel.src,
       held: lastSel.held,
       restAge: lastSel.restAge,
-      selY: lastSel.absRow - b.baseY,
+      outputGap: lastSel.outputGap,
+      caretAge: lastSel.caretAge,
+      selY: lastSelRelY,
       selX: lastSel.col,
     });
   };
@@ -629,8 +799,9 @@ export function attachImeAnchor(
     const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now(), {
       top: b.viewportY,
       rows: geometry.rows,
-    });
+    }, b.baseY);
     lastSel = sel;
+    lastSelRelY = sel.absRow - b.baseY;
     frozen = isUsableGeometry(geometry)
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;
@@ -683,8 +854,13 @@ export function attachImeAnchor(
   // number writes, so the streaming hot path stays cold.
   const cursorSub = terminal.onCursorMove(() => {
     const b = bufferState();
-    noteCursorMove(tracker, b.baseY + b.cursorY, b.cursorX, now());
+    noteCursorMove(tracker, b.baseY + b.cursorY, b.cursorX, now(), b.cursorY);
   });
+  // Per parsed PTY chunk — the output-recency signal (#951). The handler is a
+  // clock compare plus at most three number writes, so the streaming hot path
+  // stays cold. noteOutputParsed tolerates either firing order relative to
+  // onCursorMove within a chunk (see its doc comment).
+  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now()));
   // Normal <-> alt buffer switches change what an absolute row means.
   const bufferSub = terminal.buffer.onBufferChange(resetTracker);
 
@@ -700,6 +876,7 @@ export function attachImeAnchor(
       scrollSub.dispose();
       resizeSub.dispose();
       cursorSub.dispose();
+      writeParsedSub.dispose();
       bufferSub.dispose();
       textarea.removeEventListener('compositionstart', onCompositionStart);
       textarea.removeEventListener('compositionupdate', onCompositionUpdate);

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -84,14 +84,17 @@
  * its real cursor at the LAST column of the line it painted, and a long gap
  * then certifies that placeholder. A CJK composition can never sit on the
  * last column (the glyph alone is two cells wide), so such a selection is
- * FLAGGED (`edge=1` in the diagnostic) and line-end cells are never taken
- * as quiet-caret snapshots — but the selection itself is NOT rerouted. Two
- * fallback generations were field-tested and both lost to this baseline:
- * re-selecting the quiet snapshot wandered between inputs (an idle TUI
- * keeps twitching its cursor, so consecutive quiet spans certify different
- * cells), and reusing the previous composition's anchor locked whatever
- * error the first anchor had for the whole session. The reporter ranked
- * the un-rerouted build best of the three, so the line-end miss stays a
+ * FLAGGED (`edge=1` in the diagnostic) and nothing else — the selection is
+ * NOT rerouted and the cell is still eligible as a quiet-caret snapshot.
+ * Three generations of acting on the flag were field-tested and all lost to
+ * this baseline: re-selecting the quiet snapshot wandered between inputs (an
+ * idle TUI keeps twitching its cursor, so consecutive quiet spans certify
+ * different cells); reusing the previous composition's anchor locked
+ * whatever error the first anchor had for the whole session; and merely
+ * withholding line-end cells from the snapshot — behaviourally invisible on
+ * paper, since it only ever drops a snapshot the streaming path would have
+ * used — still measured worse in the field, so the tracker takes the cell
+ * exactly as it did before the flag existed. The line-end miss stays a
  * KNOWN, flagged residual. Fixing it for real needs a different signal
  * class than the cursor — the ecosystem contract says the TUI must park
  * its cursor on the caret (Ink's useCursor exists; Claude Code has not
@@ -389,23 +392,15 @@ export function noteCursorMove(state: RestingTrackerState, absRow: number, col: 
  * exceeds RESTING_MS by construction) with a promotion clock inside this
  * chunk.
  */
-export function noteOutputParsed(state: RestingTrackerState, now: number, cols?: number): void {
+export function noteOutputParsed(state: RestingTrackerState, now: number): void {
   if (now - state.lastOutputAt >= OUTPUT_QUIET_MS) {
     state.epochStart = now;
-    // Line-end parks are never snapshotted (#953 field cases 1-2): a TUI
-    // idling with an empty input box parks its cursor at the last column,
-    // and a snapshot taken there would just relocate the mis-anchor from
-    // the instant path into the caret path.
-    const lastCol = cols !== undefined ? cols - 1 : Infinity;
     if (state.currentSince <= state.lastOutputAt) {
-      if (state.currentCol < lastCol) {
-        state.caretRelRow = state.currentRelRow;
-        state.caretCol = state.currentCol;
-        state.caretAt = now;
-        state.hasCaret = true;
-      }
-    } else if (state.hasResting && state.lastRestingAt > state.lastOutputAt
-      && state.lastRestingCol < lastCol) {
+      state.caretRelRow = state.currentRelRow;
+      state.caretCol = state.currentCol;
+      state.caretAt = now;
+      state.hasCaret = true;
+    } else if (state.hasResting && state.lastRestingAt > state.lastOutputAt) {
       state.caretRelRow = state.lastRestingRelRow;
       state.caretCol = state.lastRestingCol;
       state.caretAt = now;
@@ -505,9 +500,10 @@ export function selectFreezeCell(
   const outputGap = now - state.lastOutputAt;
   const caretAge = state.hasCaret ? now - state.caretAt : -1;
   // Diagnostic only (#953): a last-column cursor is a TUI line-end park, not
-  // a caret — but two generations of rerouting it (quiet snapshot, previous
-  // anchor) both field-tested worse than leaving it alone, so it is flagged
-  // and NOT redirected. See the header for the full account.
+  // a caret — but every generation of acting on it (reroute to the quiet
+  // snapshot, reuse the previous anchor, withhold the snapshot) field-tested
+  // worse than leaving it alone, so it is flagged and nothing more. See the
+  // header for the full account.
   const lastCol = viewport?.cols !== undefined ? viewport.cols - 1 : Infinity;
   const edge = instCol >= lastCol;
   if (outputGap < OUTPUT_QUIET_MS
@@ -928,7 +924,7 @@ export function attachImeAnchor(
   // clock compare plus at most three number writes, so the streaming hot path
   // stays cold. noteOutputParsed tolerates either firing order relative to
   // onCursorMove within a chunk (see its doc comment).
-  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now(), geometry.cols));
+  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now()));
   // Normal <-> alt buffer switches change what an absolute row means.
   const bufferSub = terminal.buffer.onBufferChange(resetTracker);
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -83,11 +83,24 @@
  * TUI with nothing to point at — empty input box, mid-edit redraw — parks
  * its real cursor at the LAST column of the line it painted, and a long gap
  * then certifies that placeholder. A CJK composition can never sit on the
- * last column (the glyph alone is two cells wide), so a last-column cursor
- * is rejected outright (`edge=1` in the diagnostic) in favor of the caret
- * snapshot, and line-end cells are never snapshotted either.
- * Known residuals, all self-healing at the next quiet span and identifiable
- * in a field log via the src/gap/caretAge fields: a mid-stream pause longer
+ * last column (the glyph alone is two cells wide), so such a selection is
+ * FLAGGED (`edge=1` in the diagnostic) and line-end cells are never taken
+ * as quiet-caret snapshots — but the selection itself is NOT rerouted. Two
+ * fallback generations were field-tested and both lost to this baseline:
+ * re-selecting the quiet snapshot wandered between inputs (an idle TUI
+ * keeps twitching its cursor, so consecutive quiet spans certify different
+ * cells), and reusing the previous composition's anchor locked whatever
+ * error the first anchor had for the whole session. The reporter ranked
+ * the un-rerouted build best of the three, so the line-end miss stays a
+ * KNOWN, flagged residual. Fixing it for real needs a different signal
+ * class than the cursor — the ecosystem contract says the TUI must park
+ * its cursor on the caret (Ink's useCursor exists; Claude Code has not
+ * shipped it, see anthropics/claude-code#25186), and the content-aware
+ * fallback proven by other terminals (detect the agent's input-line marker
+ * in the buffer, gated per known agent) is follow-up work, not another
+ * cursor heuristic.
+ * Known residuals, all identifiable in a field log via the src/gap/
+ * caretAge/edge fields: the line-end park above; a mid-stream pause longer
  * than OUTPUT_QUIET_MS with the cursor parked mid-line on repaint state
  * re-snapshots a wrong caret; a resize or clear mid-stream drops (resize)
  * or strands (clear — no reset event fires) the snapshot until output next
@@ -274,15 +287,6 @@ export const OUTPUT_QUIET_MS = 500;
 export const STREAM_SUSTAIN_MS = 700;
 
 /**
- * How long a previous composition's anchor stays the preferred fallback.
- * Long enough to survive the think-pauses of an ordinary typing session, so
- * consecutive compositions land at one consistent spot; short enough that an
- * abandoned session does not resurrect a long-dead anchor — and any quiet
- * non-edge composition refreshes it anyway.
- */
-export const ANCHOR_CONTINUITY_MS = 60_000;
-
-/**
  * Mutable tracker record. The transition functions below mutate it in place —
  * that is how "pure-function testability" and an allocation-free hot path
  * coexist: each function is deterministic in (state, args), returns scalars,
@@ -321,18 +325,6 @@ export interface RestingTrackerState {
   /** Clock reading when the caret snapshot was taken. */
   caretAt: number;
   hasCaret: boolean;
-  /**
-   * Anchor cell of the most recent composition whose selection was
-   * trustworthy (#953 third field pass). Consecutive compositions land at
-   * the same input line, so the previous anchor is the best predictor of
-   * the next one — and, unlike any cursor-derived cell, it is stable across
-   * inputs, which is precisely what the field reports asked for.
-   */
-  anchorRelRow: number;
-  anchorCol: number;
-  /** Clock reading when the anchor was recorded. */
-  anchorAt: number;
-  hasAnchor: boolean;
 }
 
 /**
@@ -359,10 +351,6 @@ export function createRestingTracker(absRow: number, col: number, now: number, r
     caretCol: 0,
     caretAt: 0,
     hasCaret: false,
-    anchorRelRow: 0,
-    anchorCol: 0,
-    anchorAt: 0,
-    hasAnchor: false,
   };
 }
 
@@ -428,19 +416,6 @@ export function noteOutputParsed(state: RestingTrackerState, now: number, cols?:
 }
 
 /**
- * Record where a composition actually anchored (#953). Called by the wiring
- * after each selection whose source is trustworthy — a quiet non-edge
- * instant cell, the quiet-caret snapshot, or a reused previous anchor —
- * never a line-end park or a mid-burst cell.
- */
-export function noteCompositionAnchor(state: RestingTrackerState, relRow: number, col: number, now: number): void {
-  state.anchorRelRow = relRow;
-  state.anchorCol = col;
-  state.anchorAt = now;
-  state.hasAnchor = true;
-}
-
-/**
  * Invalidate everything and re-seed. Resize reflow and buffer switches
  * (alt-screen) change what both an absolute and a screen row mean, so neither
  * a resting cell nor a quiet caret recorded before either event may be
@@ -461,7 +436,6 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
   state.currentSince = now;
   state.hasResting = false;
   state.hasCaret = false;
-  state.hasAnchor = false;
   state.lastOutputAt = now;
   state.epochStart = now;
 }
@@ -469,10 +443,8 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
 /** Where the freeze cell came from. `scrolled_out` is `instant` chosen because
  *  the resting cell had left the viewport — kept distinct so a field log can
  *  tell that rejection apart from a cursor that was simply at rest. `caret` is
- *  the quiet-caret snapshot, chosen because output was still flowing (#951).
- *  `prev` is the previous composition's anchor, reused for cross-input
- *  stability (#953 third field pass). */
-export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret' | 'prev';
+ *  the quiet-caret snapshot, chosen because output was still flowing (#951). */
+export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret';
 
 export interface FreezeCellSelection {
   absRow: number;
@@ -486,8 +458,8 @@ export interface FreezeCellSelection {
   outputGap: number;
   /** Age of the caret snapshot at selection time; -1 when none exists. */
   caretAge: number;
-  /** True when the instantaneous cursor sat on the last column and was
-   *  rejected as a line-end park (#953 field cases 1-3). */
+  /** True when the instantaneous cursor sat on the last column — a TUI
+   *  line-end park (#953). Diagnostic only; the selection is not rerouted. */
   edge: boolean;
 }
 
@@ -498,10 +470,10 @@ export interface FreezeCellSelection {
  * output is recent AND sustained (STREAM_SUSTAIN_MS since the current epoch
  * began), dwell time certifies nothing (#951: a streaming agent parks its
  * cursor on screen corners between bursts for far longer than RESTING_MS),
- * so the previous composition's anchor — then the quiet-caret snapshot —
- * wins over both. Recent-but-isolated output — a committed syllable's echo —
- * keeps the normal dwell selection, because there the freshly moved cursor
- * IS the caret and any remembered cell is one word stale. The snapshot's
+ * so the quiet-caret snapshot wins over both. Recent-but-isolated output —
+ * a committed syllable's echo — keeps the normal dwell selection, because
+ * there the freshly moved cursor IS the caret and the snapshot is one word
+ * stale. The snapshot's
  * screen row is rebased onto the CURRENT ybase: the TUI keeps its input line
  * at a fixed screen position while output scrolls the buffer underneath.
  * `pointFromCell` clamps the result into the viewport, which for a scrolled-up
@@ -532,53 +504,28 @@ export function selectFreezeCell(
   const restAge = state.hasResting ? now - state.lastRestingAt : -1;
   const outputGap = now - state.lastOutputAt;
   const caretAge = state.hasCaret ? now - state.caretAt : -1;
-  const anchorFresh = state.hasAnchor && now - state.anchorAt <= ANCHOR_CONTINUITY_MS;
-  // Streaming (recent AND sustained output): the buffer cursor is the
-  // agent's repaint state, so it never wins here. The previous composition's
-  // anchor is preferred over the quiet-caret snapshot — the snapshot can be
-  // re-taken across mid-stream pauses and wander between inputs (#953 third
-  // field pass), while the previous anchor is by construction where the user
-  // last composed.
-  if (outputGap < OUTPUT_QUIET_MS && now - state.epochStart >= STREAM_SUSTAIN_MS) {
-    if (anchorFresh) {
-      return {
-        absRow: baseY + state.anchorRelRow, col: state.anchorCol,
-        src: 'prev', held, restAge, outputGap, caretAge, edge: false,
-      };
-    }
-    if (state.hasCaret) {
-      return {
-        absRow: baseY + state.caretRelRow, col: state.caretCol,
-        src: 'caret', held, restAge, outputGap, caretAge, edge: false,
-      };
-    }
-  }
-  // Line-end park rejection (#953 field cases 1-3). A TUI that has nothing
-  // to point at — empty input box, mid-edit redraw — parks its real cursor
-  // at the LAST column of the line it just painted ((236,47) on a 237-col
-  // pane, (127,43) on a 128-col one), and a long output gap then certifies
-  // that placeholder as an at-rest caret. A real CJK composition can never
-  // sit on the last column (the glyph alone is two cells wide), so a
-  // last-column cursor yields to the previous composition's anchor when one
-  // is fresh. With no anchor it deliberately degrades to the instant cell:
-  // the third field pass showed every quiet cursor-derived fallback (the
-  // snapshot, the resting cell) wanders between inputs, and a stable
-  // right-edge anchor read as better than an unpredictable one.
+  // Diagnostic only (#953): a last-column cursor is a TUI line-end park, not
+  // a caret — but two generations of rerouting it (quiet snapshot, previous
+  // anchor) both field-tested worse than leaving it alone, so it is flagged
+  // and NOT redirected. See the header for the full account.
   const lastCol = viewport?.cols !== undefined ? viewport.cols - 1 : Infinity;
-  if (instCol >= lastCol && anchorFresh) {
+  const edge = instCol >= lastCol;
+  if (outputGap < OUTPUT_QUIET_MS
+    && now - state.epochStart >= STREAM_SUSTAIN_MS
+    && state.hasCaret) {
     return {
-      absRow: baseY + state.anchorRelRow, col: state.anchorCol,
-      src: 'prev', held, restAge, outputGap, caretAge, edge: true,
+      absRow: baseY + state.caretRelRow, col: state.caretCol,
+      src: 'caret', held, restAge, outputGap, caretAge, edge,
     };
   }
   if (held >= RESTING_MS || !state.hasResting) {
-    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge: false };
+    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge };
   }
   if (viewport && (state.lastRestingAbsRow < viewport.top
     || state.lastRestingAbsRow >= viewport.top + viewport.rows)) {
-    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge, edge: false };
+    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge, edge };
   }
-  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge, edge: false };
+  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge, edge };
 }
 
 // ---------------------------------------------------------------------------
@@ -645,8 +592,8 @@ export interface ImeAnchorOptions {
      *  A large value on a src=caret record means the anchor came from a
      *  long-past quiet span — the stale-snapshot residual in action. */
     caretAge: number;
-    /** True when the cursor sat on the last column and was rejected as a
-     *  line-end park (#953 field cases 1-3). */
+    /** True when the cursor sat on the last column — a TUI line-end park
+     *  (#953). Diagnostic only; the selection is not rerouted. */
     edge: boolean;
     /** Selected cell, ybase-relative like cursorY/cursorX. */
     selY: number;
@@ -800,15 +747,15 @@ export function attachImeAnchor(
    * composing syllable with the caret (Korean inline input). Outside a
    * composition it carries no transform (xterm hides it).
    *
-   * The one exception is a composition whose freeze cell did NOT come from
-   * the live cursor (`src=caret`/`src=prev`/edge-rejected, #951/#953 field
-   * reports): there the live cursor is the TUI's repaint or placeholder
-   * position, and following it split the two IME surfaces apart — the
-   * candidate window pinned at the input line while the inline pinyin chased
-   * the agent's output rows. Both surfaces must anchor to the same cell, so
-   * those compositions pin the preedit to the same frozen point as the
-   * textarea. The ordinary quiet case is untouched: there the selection is
-   * instant/resting and the live follow stays (#942 stays fixed).
+   * The one exception is a composition whose freeze cell came from the quiet
+   * caret (`src=caret`, #951/#953 field report): there the live cursor IS the
+   * streaming agent's repaint cursor, and following it split the two IME
+   * surfaces apart — the candidate window pinned at the input line while the
+   * inline pinyin chased the agent's output rows. Both surfaces must anchor
+   * to the same cell, so a caret-sourced composition pins the preedit to the
+   * same frozen point as the textarea. The quiet case is untouched: there the
+   * selection is instant/resting and the live follow stays (#942 stays
+   * fixed).
    *
    * Deliberately called only from the composition handlers, NOT from
    * onRender/onScroll: at a composition event xterm has just written the
@@ -829,7 +776,7 @@ export function attachImeAnchor(
     if (!isUsableGeometry(geometry)) return;
     const actualPreedit = readStyledPoint(compositionView);
     if (!actualPreedit) return;
-    const desired = frozen !== null && (lastSel?.src === 'caret' || lastSel?.src === 'prev' || lastSel?.edge)
+    const desired = frozen !== null && lastSel?.src === 'caret'
       ? frozen
       : paintedCursorPosition(bufferState(), geometry);
     const c = computeImeAnchorCorrection(desired, actualPreedit);
@@ -923,14 +870,6 @@ export function attachImeAnchor(
     }, b.baseY);
     lastSel = sel;
     lastSelRelY = sel.absRow - b.baseY;
-    // Remember trustworthy anchors for cross-input continuity (#953): a
-    // quiet non-edge instant cell, the quiet-caret snapshot, or a reused
-    // anchor (which refreshes its own lease). Line-end parks and mid-burst
-    // cells are never remembered.
-    if ((sel.src === 'instant' || sel.src === 'caret' || sel.src === 'prev')
-      && sel.col < geometry.cols - 1) {
-      noteCompositionAnchor(tracker, sel.absRow - b.baseY, sel.col, now());
-    }
     frozen = isUsableGeometry(geometry)
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -84,18 +84,22 @@
  * its real cursor at the LAST column of the line it painted, and a long gap
  * then certifies that placeholder. A CJK composition can never sit on the
  * last column (the glyph alone is two cells wide), so such a selection is
- * FLAGGED (`edge=1` in the diagnostic) and nothing else — the selection is
- * NOT rerouted and the cell is still eligible as a quiet-caret snapshot.
- * Three generations of acting on the flag were field-tested and all lost to
- * this baseline: re-selecting the quiet snapshot wandered between inputs (an
- * idle TUI keeps twitching its cursor, so consecutive quiet spans certify
- * different cells); reusing the previous composition's anchor locked
- * whatever error the first anchor had for the whole session; and merely
- * withholding line-end cells from the snapshot — behaviourally invisible on
- * paper, since it only ever drops a snapshot the streaming path would have
- * used — still measured worse in the field, so the tracker takes the cell
- * exactly as it did before the flag existed. The line-end miss stays a
- * KNOWN, flagged residual. Fixing it for real needs a different signal
+ * FLAGGED (`edge=1` in the diagnostic), and while output is FLOWING it also
+ * defers to the quiet-caret snapshot; the cell is still eligible as a snapshot
+ * itself, and while output is quiet the selection is NOT rerouted.
+ * That last split is the whole lesson of three earlier generations, all of
+ * which rerouted a line-end park in every condition and all of which lost to
+ * the untouched baseline: re-selecting the quiet snapshot wandered between
+ * inputs (an idle TUI keeps twitching its cursor, so consecutive quiet spans
+ * certify different cells); reusing the previous composition's anchor locked
+ * whatever error the first anchor had for the whole session; and withholding
+ * line-end cells from the snapshot measured worse too. What they had in
+ * common was acting while the pane was IDLE, which is exactly where dwell was
+ * already right. The streaming half was still broken after they were reverted
+ * (#953 field log, 2026-08-21: `gap=203ms caretAge=602ms src=instant edge=1`
+ * — a usable snapshot passed over, candidate window pinned to the pane's
+ * bottom-right corner), so the rule now fires only when output arrived within
+ * OUTPUT_QUIET_MS. The idle line-end miss stays a KNOWN, flagged residual. Fixing it for real needs a different signal
  * class than the cursor — the ecosystem contract says the TUI must park
  * its cursor on the caret (Ink's useCursor exists; Claude Code has not
  * shipped it, see anthropics/claude-code#25186), and the content-aware
@@ -506,8 +510,26 @@ export function selectFreezeCell(
   // header for the full account.
   const lastCol = viewport?.cols !== undefined ? viewport.cols - 1 : Infinity;
   const edge = instCol >= lastCol;
+  // The sustain gate exists to stop a COMMIT ECHO from pushing the next
+  // composition onto a stale snapshot — an echo is recent output too, and
+  // there the freshly moved cursor really is the caret. It has nothing to
+  // protect when the cursor is parked on the last column: a commit leaves the
+  // caret where the syllable landed, mid-line, and a CJK composition cannot
+  // sit on the last column at all (the glyph is two cells wide). So while
+  // output is flowing, a line-end park defers to the snapshot even before the
+  // epoch is old enough.
+  //
+  // This is narrower than the three generations the header records as losing.
+  // Each of those rerouted a line-end park in EVERY condition, idle included,
+  // and idle is exactly where dwell was right; this one cannot fire unless
+  // output arrived within OUTPUT_QUIET_MS. Field evidence for the distinction
+  // (#953, 2026-08-21): with idle confirmed good on 5ca90958, streaming still
+  // anchored bottom-right, and the log shows why — `gap=203ms caretAge=602ms
+  // src=instant edge=1`, a usable snapshot passed over because a token-paced
+  // stream pauses longer than OUTPUT_QUIET_MS between bursts, so `epochStart`
+  // kept restarting and never reached STREAM_SUSTAIN_MS.
   if (outputGap < OUTPUT_QUIET_MS
-    && now - state.epochStart >= STREAM_SUSTAIN_MS
+    && (now - state.epochStart >= STREAM_SUSTAIN_MS || edge)
     && state.hasCaret) {
     return {
       absRow: baseY + state.caretRelRow, col: state.caretCol,

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -85,8 +85,11 @@
  * then certifies that placeholder. A CJK composition can never sit on the
  * last column (the glyph alone is two cells wide), so such a selection is
  * FLAGGED (`edge=1` in the diagnostic), and while output is FLOWING it also
- * defers to the quiet-caret snapshot; the cell is still eligible as a snapshot
- * itself, and while output is quiet the selection is NOT rerouted.
+ * defers to the quiet-caret snapshot; while output is quiet the selection is
+ * NOT rerouted. Such a cell is also refused as a snapshot, so a quiet span
+ * that finds the TUI parked at the line end keeps the caret the last real one
+ * recorded instead of replacing it — without that, deferring to the snapshot
+ * just moves the same wrong cell one step earlier.
  * That last split is the whole lesson of three earlier generations, all of
  * which rerouted a line-end park in every condition and all of which lost to
  * the untouched baseline: re-selecting the quiet snapshot wandered between
@@ -396,19 +399,30 @@ export function noteCursorMove(state: RestingTrackerState, absRow: number, col: 
  * exceeds RESTING_MS by construction) with a promotion clock inside this
  * chunk.
  */
-export function noteOutputParsed(state: RestingTrackerState, now: number): void {
+export function noteOutputParsed(state: RestingTrackerState, now: number, cols?: number): void {
   if (now - state.lastOutputAt >= OUTPUT_QUIET_MS) {
     state.epochStart = now;
+    // A cell on the LAST column is the TUI's line-end park, never a caret: a
+    // CJK composition cannot sit there, since the glyph is two cells wide. It
+    // must not become the snapshot — and specifically must not REPLACE a good
+    // one, which is the shape the field log shows (#953, 2026-08-21):
+    // `cursor=(13,36) sel=(127,43) src=caret`, the live cursor mid-line while
+    // the snapshot points at column 127. Refusing keeps whatever caret the
+    // last real quiet span recorded. `cols` is optional so a caller with no
+    // geometry keeps the old behaviour rather than silently disabling the
+    // check with a wrong bound.
+    const lastCol = cols !== undefined ? cols - 1 : Infinity;
+    const promote = (relRow: number, col: number): void => {
+      if (col >= lastCol) return;
+      state.caretRelRow = relRow;
+      state.caretCol = col;
+      state.caretAt = now;
+      state.hasCaret = true;
+    };
     if (state.currentSince <= state.lastOutputAt) {
-      state.caretRelRow = state.currentRelRow;
-      state.caretCol = state.currentCol;
-      state.caretAt = now;
-      state.hasCaret = true;
+      promote(state.currentRelRow, state.currentCol);
     } else if (state.hasResting && state.lastRestingAt > state.lastOutputAt) {
-      state.caretRelRow = state.lastRestingRelRow;
-      state.caretCol = state.lastRestingCol;
-      state.caretAt = now;
-      state.hasCaret = true;
+      promote(state.lastRestingRelRow, state.lastRestingCol);
     }
   }
   state.lastOutputAt = now;
@@ -946,7 +960,7 @@ export function attachImeAnchor(
   // clock compare plus at most three number writes, so the streaming hot path
   // stays cold. noteOutputParsed tolerates either firing order relative to
   // onCursorMove within a chunk (see its doc comment).
-  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now()));
+  const writeParsedSub = terminal.onWriteParsed(() => noteOutputParsed(tracker, now(), terminal.cols));
   // Normal <-> alt buffer switches change what an absolute row means.
   const bufferSub = terminal.buffer.onBufferChange(resetTracker);
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -274,6 +274,15 @@ export const OUTPUT_QUIET_MS = 500;
 export const STREAM_SUSTAIN_MS = 700;
 
 /**
+ * How long a previous composition's anchor stays the preferred fallback.
+ * Long enough to survive the think-pauses of an ordinary typing session, so
+ * consecutive compositions land at one consistent spot; short enough that an
+ * abandoned session does not resurrect a long-dead anchor — and any quiet
+ * non-edge composition refreshes it anyway.
+ */
+export const ANCHOR_CONTINUITY_MS = 60_000;
+
+/**
  * Mutable tracker record. The transition functions below mutate it in place —
  * that is how "pure-function testability" and an allocation-free hot path
  * coexist: each function is deterministic in (state, args), returns scalars,
@@ -312,6 +321,18 @@ export interface RestingTrackerState {
   /** Clock reading when the caret snapshot was taken. */
   caretAt: number;
   hasCaret: boolean;
+  /**
+   * Anchor cell of the most recent composition whose selection was
+   * trustworthy (#953 third field pass). Consecutive compositions land at
+   * the same input line, so the previous anchor is the best predictor of
+   * the next one — and, unlike any cursor-derived cell, it is stable across
+   * inputs, which is precisely what the field reports asked for.
+   */
+  anchorRelRow: number;
+  anchorCol: number;
+  /** Clock reading when the anchor was recorded. */
+  anchorAt: number;
+  hasAnchor: boolean;
 }
 
 /**
@@ -338,6 +359,10 @@ export function createRestingTracker(absRow: number, col: number, now: number, r
     caretCol: 0,
     caretAt: 0,
     hasCaret: false,
+    anchorRelRow: 0,
+    anchorCol: 0,
+    anchorAt: 0,
+    hasAnchor: false,
   };
 }
 
@@ -403,6 +428,19 @@ export function noteOutputParsed(state: RestingTrackerState, now: number, cols?:
 }
 
 /**
+ * Record where a composition actually anchored (#953). Called by the wiring
+ * after each selection whose source is trustworthy — a quiet non-edge
+ * instant cell, the quiet-caret snapshot, or a reused previous anchor —
+ * never a line-end park or a mid-burst cell.
+ */
+export function noteCompositionAnchor(state: RestingTrackerState, relRow: number, col: number, now: number): void {
+  state.anchorRelRow = relRow;
+  state.anchorCol = col;
+  state.anchorAt = now;
+  state.hasAnchor = true;
+}
+
+/**
  * Invalidate everything and re-seed. Resize reflow and buffer switches
  * (alt-screen) change what both an absolute and a screen row mean, so neither
  * a resting cell nor a quiet caret recorded before either event may be
@@ -423,6 +461,7 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
   state.currentSince = now;
   state.hasResting = false;
   state.hasCaret = false;
+  state.hasAnchor = false;
   state.lastOutputAt = now;
   state.epochStart = now;
 }
@@ -430,8 +469,10 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
 /** Where the freeze cell came from. `scrolled_out` is `instant` chosen because
  *  the resting cell had left the viewport — kept distinct so a field log can
  *  tell that rejection apart from a cursor that was simply at rest. `caret` is
- *  the quiet-caret snapshot, chosen because output was still flowing (#951). */
-export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret';
+ *  the quiet-caret snapshot, chosen because output was still flowing (#951).
+ *  `prev` is the previous composition's anchor, reused for cross-input
+ *  stability (#953 third field pass). */
+export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret' | 'prev';
 
 export interface FreezeCellSelection {
   absRow: number;
@@ -457,10 +498,10 @@ export interface FreezeCellSelection {
  * output is recent AND sustained (STREAM_SUSTAIN_MS since the current epoch
  * began), dwell time certifies nothing (#951: a streaming agent parks its
  * cursor on screen corners between bursts for far longer than RESTING_MS),
- * so the quiet-caret snapshot wins over both. Recent-but-isolated output —
- * a committed syllable's echo — keeps the normal dwell selection, because
- * there the freshly moved cursor IS the caret and the snapshot is one word
- * stale. The snapshot's
+ * so the previous composition's anchor — then the quiet-caret snapshot —
+ * wins over both. Recent-but-isolated output — a committed syllable's echo —
+ * keeps the normal dwell selection, because there the freshly moved cursor
+ * IS the caret and any remembered cell is one word stale. The snapshot's
  * screen row is rebased onto the CURRENT ybase: the TUI keeps its input line
  * at a fixed screen position while output scrolls the buffer underneath.
  * `pointFromCell` clamps the result into the viewport, which for a scrolled-up
@@ -491,40 +532,44 @@ export function selectFreezeCell(
   const restAge = state.hasResting ? now - state.lastRestingAt : -1;
   const outputGap = now - state.lastOutputAt;
   const caretAge = state.hasCaret ? now - state.caretAt : -1;
-  if (outputGap < OUTPUT_QUIET_MS
-    && now - state.epochStart >= STREAM_SUSTAIN_MS
-    && state.hasCaret) {
-    return {
-      absRow: baseY + state.caretRelRow, col: state.caretCol,
-      src: 'caret', held, restAge, outputGap, caretAge, edge: false,
-    };
-  }
-  // Line-end park rejection (#953 field cases 1-3). A TUI that has nothing
-  // to point at — empty input box, mid-edit redraw, streaming repaint —
-  // parks its real cursor at the LAST column of the line it just painted
-  // ((236,47) on a 237-col pane, (127,43) on a 128-col one), and a long
-  // output gap then certifies that placeholder as an at-rest caret. A real
-  // CJK composition can never sit on the last column (the glyph alone is
-  // two cells wide), so a last-column cursor is rejected outright and the
-  // selection falls back to the caret snapshot — even when output is quiet —
-  // then to the resting cell. With neither available it degrades to the
-  // instant cell exactly as before.
-  const lastCol = viewport?.cols !== undefined ? viewport.cols - 1 : Infinity;
-  if (instCol >= lastCol) {
+  const anchorFresh = state.hasAnchor && now - state.anchorAt <= ANCHOR_CONTINUITY_MS;
+  // Streaming (recent AND sustained output): the buffer cursor is the
+  // agent's repaint state, so it never wins here. The previous composition's
+  // anchor is preferred over the quiet-caret snapshot — the snapshot can be
+  // re-taken across mid-stream pauses and wander between inputs (#953 third
+  // field pass), while the previous anchor is by construction where the user
+  // last composed.
+  if (outputGap < OUTPUT_QUIET_MS && now - state.epochStart >= STREAM_SUSTAIN_MS) {
+    if (anchorFresh) {
+      return {
+        absRow: baseY + state.anchorRelRow, col: state.anchorCol,
+        src: 'prev', held, restAge, outputGap, caretAge, edge: false,
+      };
+    }
     if (state.hasCaret) {
       return {
         absRow: baseY + state.caretRelRow, col: state.caretCol,
-        src: 'caret', held, restAge, outputGap, caretAge, edge: true,
+        src: 'caret', held, restAge, outputGap, caretAge, edge: false,
       };
     }
-    if (state.hasResting && state.lastRestingCol < lastCol
-      && !(viewport && (state.lastRestingAbsRow < viewport.top
-        || state.lastRestingAbsRow >= viewport.top + viewport.rows))) {
-      return {
-        absRow: state.lastRestingAbsRow, col: state.lastRestingCol,
-        src: 'resting', held, restAge, outputGap, caretAge, edge: true,
-      };
-    }
+  }
+  // Line-end park rejection (#953 field cases 1-3). A TUI that has nothing
+  // to point at — empty input box, mid-edit redraw — parks its real cursor
+  // at the LAST column of the line it just painted ((236,47) on a 237-col
+  // pane, (127,43) on a 128-col one), and a long output gap then certifies
+  // that placeholder as an at-rest caret. A real CJK composition can never
+  // sit on the last column (the glyph alone is two cells wide), so a
+  // last-column cursor yields to the previous composition's anchor when one
+  // is fresh. With no anchor it deliberately degrades to the instant cell:
+  // the third field pass showed every quiet cursor-derived fallback (the
+  // snapshot, the resting cell) wanders between inputs, and a stable
+  // right-edge anchor read as better than an unpredictable one.
+  const lastCol = viewport?.cols !== undefined ? viewport.cols - 1 : Infinity;
+  if (instCol >= lastCol && anchorFresh) {
+    return {
+      absRow: baseY + state.anchorRelRow, col: state.anchorCol,
+      src: 'prev', held, restAge, outputGap, caretAge, edge: true,
+    };
   }
   if (held >= RESTING_MS || !state.hasResting) {
     return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge: false };
@@ -755,15 +800,15 @@ export function attachImeAnchor(
    * composing syllable with the caret (Korean inline input). Outside a
    * composition it carries no transform (xterm hides it).
    *
-   * The one exception is a composition whose freeze cell came from the quiet
-   * caret (`src=caret`, #951/#953 field report): there the live cursor IS the
-   * streaming agent's repaint cursor, and following it split the two IME
-   * surfaces apart — the candidate window pinned at the input line while the
-   * inline pinyin chased the agent's output rows. Both surfaces must anchor
-   * to the same cell, so a caret-sourced composition pins the preedit to the
-   * same frozen point as the textarea. The quiet case is untouched: there the
-   * selection is instant/resting and the live follow stays (#942 stays
-   * fixed).
+   * The one exception is a composition whose freeze cell did NOT come from
+   * the live cursor (`src=caret`/`src=prev`/edge-rejected, #951/#953 field
+   * reports): there the live cursor is the TUI's repaint or placeholder
+   * position, and following it split the two IME surfaces apart — the
+   * candidate window pinned at the input line while the inline pinyin chased
+   * the agent's output rows. Both surfaces must anchor to the same cell, so
+   * those compositions pin the preedit to the same frozen point as the
+   * textarea. The ordinary quiet case is untouched: there the selection is
+   * instant/resting and the live follow stays (#942 stays fixed).
    *
    * Deliberately called only from the composition handlers, NOT from
    * onRender/onScroll: at a composition event xterm has just written the
@@ -784,7 +829,7 @@ export function attachImeAnchor(
     if (!isUsableGeometry(geometry)) return;
     const actualPreedit = readStyledPoint(compositionView);
     if (!actualPreedit) return;
-    const desired = frozen !== null && lastSel?.src === 'caret'
+    const desired = frozen !== null && (lastSel?.src === 'caret' || lastSel?.src === 'prev' || lastSel?.edge)
       ? frozen
       : paintedCursorPosition(bufferState(), geometry);
     const c = computeImeAnchorCorrection(desired, actualPreedit);
@@ -878,6 +923,14 @@ export function attachImeAnchor(
     }, b.baseY);
     lastSel = sel;
     lastSelRelY = sel.absRow - b.baseY;
+    // Remember trustworthy anchors for cross-input continuity (#953): a
+    // quiet non-edge instant cell, the quiet-caret snapshot, or a reused
+    // anchor (which refreshes its own lease). Line-end parks and mid-burst
+    // cells are never remembered.
+    if ((sel.src === 'instant' || sel.src === 'caret' || sel.src === 'prev')
+      && sel.col < geometry.cols - 1) {
+      noteCompositionAnchor(tracker, sel.absRow - b.baseY, sel.col, now());
+    }
     frozen = isUsableGeometry(geometry)
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;


### PR DESCRIPTION
Fixes #951.

## Problem

While an agent (Claude Code) streams output, a Chinese IME composition (WeChat IME, Microsoft Pinyin) anchors its candidate window to whatever cell the streaming TUI last parked its cursor on — a screen corner or an output row — instead of the user's input position. The #951 field logs show it directly: `src=instant` selections at `(127,43)`, `(53,43)`, `(127,38)` on a 128×45 pane.

## Root cause

`selectFreezeCell` trusted any buffer cursor that had held its cell for `RESTING_MS` (32 ms). That threshold was designed to reject sub-ms inter-chunk gaps inside one repaint frame, but a streaming agent's inter-burst gaps (token pacing, network) are far longer, so the dwell heuristic certified exactly the wrong cells. The `resting` fallback derives from the same buffer cursor and shares the blind spot. The missing signal is output recency: a cursor position observed while output is still flowing is repaint state, not a caret.

## Fix

- Track output recency via xterm's public `onWriteParsed`.
- Record a **quiet caret**: the cell the cursor held through the most recent ≥ `OUTPUT_QUIET_MS` (500 ms) output-free span — the position the TUI deliberately parked it on. Stored as a **screen row**, so output scrolling the buffer does not invalidate it (a TUI addresses its input line by screen position).
- At `compositionstart`, when output is recent **and sustained** (`STREAM_SUSTAIN_MS` = 700 ms since the burst epoch began), anchor to the quiet caret (`src=caret`) instead of trusting dwell. The sustain gate keeps ordinary typing intact: a committed syllable's echo is recent output too, but it is an isolated burst — without the gate, every commit would anchor the next composition on a one-word-stale snapshot (3-model review panel finding).
- Tracker resets (resize reflow, alt-screen switch) re-seed the output clock so a snapshot can re-form after a reflow (panel finding).
- Idle panes keep the exact pre-#951 selection, which the field reports as correct; with no snapshot the selection degrades to the previous behavior, never worse.

## Diagnostics

`ime-anchor3` → `ime-anchor4`: adds `gap=` (output silence at compositionstart), `caretAge=` (snapshot age), and the `caret` source; update/end records now emit the screen row fixed at selection time instead of re-deriving it against an ybase the stream has since advanced. A follow-up field log from the reporter can confirm the fix or identify the documented residuals (mid-stream pause re-snapshot, resize/clear stranding) without another instrumentation round.

## Tests

- Pure-tracker and DOM-wiring regression tests reproducing the field scenario (corner cell held ≥ 32 ms mid-stream loses to the caret; `src=caret` did not exist before, so both fail without the fix).
- Fast-typist regression lock: an isolated echo burst keeps the freshly advanced cursor.
- Screen-row rebase across scrolled output, reset re-seeding, snapshot formation in both intra-chunk event orders, sub-quiet gap rejection.
- Full suite: 11713 passed / typecheck clean.

## Field validation

No CJK IME or Windows box is available locally (same constraint as #875/#888/#945), so the anchor selection is validated by unit tests and the diagnostic is the field instrument. Requesting a log from @cnxiekun on the next build, as with previous rounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chinese IME candidate-window positioning during streamed terminal output.
  * Cursor anchoring now responds to recent output activity while preserving quiet-pane typing behavior.
  * Improved handling at terminal line ends, during scrolling, and when output continues without a recent cursor snapshot.
  * Inline preedit text now follows the live cursor except when anchored to a recent caret position.
* **Diagnostics**
  * Added output-gap, snapshot-age, and edge-condition details to IME diagnostics.
* **Tests**
  * Expanded coverage for streaming, scrolling, edge positions, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->