### PR TITLE
fix(terminal): render the cursor only at rest for synchronized-output TUIs

### DIFF
--- a/changelog.d/954.md
+++ b/changelog.d/954.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Codex panes no longer show a second blinking cursor on the status
+  line.** Codex ends some of its synchronized-output frames with the
+  hardware cursor visibly parked after the model/cwd status text or next to
+  the "Working" spinner, and the terminal faithfully painted it there for a
+  frame or two — quasi-periodic flashes that read as a second caret blinking
+  alongside the composer's. The cursor is now rendered only at rest: frame
+  traffic hides it, and it reappears 32 ms after the last frame — at the
+  composer, where the resting position actually is. Classic TUIs (vim, less,
+  htop) never bracket frames, so their cursor behavior is unchanged. (#954)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -33,6 +33,7 @@ import { createDeadInputWatchdog } from '../terminal/deadInputWatchdog';
 import { awaitParseBarrier } from '../terminal/parseBarrier';
 import { STALE_REPLAY_INPUT_MODE_RESETS, STALE_REPLAY_ALIVE_SHELL_RESETS, STALE_REPLAY_DISPLAY_RESETS, staleReplayResetLevel } from '../terminal/staleReplayModeReset';
 import { attachAltScreenWheel, PAGE_SCROLL_AGENTS } from '../terminal/altScreenWheel';
+import { RestingCursorGuard } from '../terminal/restingCursor';
 import {
   writeTerminalOutput,
   flushTerminalOutput,
@@ -1934,7 +1935,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // the bytes are held out of xterm entirely (the flush-complete handler
     // resets the stale buffer FIRST, then writes them onto the clean one — a
     // direct write here could parse ahead of that reset and be wiped).
-    const routePtyData = (data: string) => {
+    // #929: frame-writer TUIs (codex) end some ?2026 frames with the cursor
+    // visibly parked on the status row; render the cursor only at rest. The
+    // guard's own show-injection goes through `deliverPtyData` (NOT
+    // routePtyData) so it is ordered with queued output but never re-enters
+    // the guard.
+    const restingCursor = new RestingCursorGuard((seq) => deliverPtyData(seq));
+    const routePtyData = (data: string) => deliverPtyData(restingCursor.process(data));
+    const deliverPtyData = (data: string) => {
       const st = resyncRef.current;
       if (st.pending) {
         st.buffer.push(data);
@@ -2256,6 +2264,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // stops stray input during the defer window.
       onDataDisposable.dispose();
       resizeObserver.disconnect();
+      // #929: cancel any pending resting-cursor show before dispose — a late
+      // inject into a disposed xterm is the #582 class of bug.
+      restingCursor.dispose();
       removeDataListener?.();
       removeExitListener?.();
       removeDaemonConnectedForRestore?.();

--- a/src/renderer/terminal/__tests__/restingCursor.test.ts
+++ b/src/renderer/terminal/__tests__/restingCursor.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  RestingCursorGuard,
+  CURSOR_HIDE,
+  CURSOR_SHOW,
+  RESTING_DELAY_MS,
+} from '../restingCursor';
+
+const SYNC_ON = '\x1b[?2026h';
+const SYNC_OFF = '\x1b[?2026l';
+
+describe('RestingCursorGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('passes chunks without a ?2026 marker through untouched, with no timer', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    const chunk = 'plain output\x1b[1;1Hmore';
+    expect(guard.process(chunk)).toBe(chunk);
+    vi.advanceTimersByTime(RESTING_DELAY_MS * 4);
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it('appends a hide to a sync-frame chunk and shows again after the resting delay', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    const chunk = `${SYNC_ON}\x1b[2;1Hstatus tick${SYNC_OFF}`;
+    expect(guard.process(chunk)).toBe(chunk + CURSOR_HIDE);
+    expect(inject).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(RESTING_DELAY_MS);
+    expect(inject).toHaveBeenCalledExactlyOnceWith(CURSOR_SHOW);
+  });
+
+  it('keeps the cursor hidden across a burst — only the last frame re-arms the show', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    for (let i = 0; i < 5; i++) {
+      guard.process(`${SYNC_ON}frame ${i}${SYNC_OFF}`);
+      vi.advanceTimersByTime(RESTING_DELAY_MS / 2);
+    }
+    expect(inject).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(RESTING_DELAY_MS);
+    expect(inject).toHaveBeenCalledTimes(1);
+  });
+
+  it('never re-shows a cursor the app itself hid', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    guard.process(`\x1b[?25l${SYNC_ON}repaint${SYNC_OFF}`);
+    vi.advanceTimersByTime(RESTING_DELAY_MS * 2);
+    expect(inject).not.toHaveBeenCalled();
+    // the app shows it again → resting show resumes
+    guard.process(`${SYNC_ON}repaint\x1b[?25h${SYNC_OFF}`);
+    vi.advanceTimersByTime(RESTING_DELAY_MS);
+    expect(inject).toHaveBeenCalledExactlyOnceWith(CURSOR_SHOW);
+  });
+
+  it('tracks the LAST DECTCEM in a chunk as the app intent', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    // codex-style frame: hide during repaint, show at the end
+    guard.process(`${SYNC_ON}\x1b[?25lrepaint\x1b[?25h${SYNC_OFF}`);
+    vi.advanceTimersByTime(RESTING_DELAY_MS);
+    expect(inject).toHaveBeenCalledExactlyOnceWith(CURSOR_SHOW);
+  });
+
+  it('an injected hide is not mistaken for app intent on the next chunk', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    const out = guard.process(`${SYNC_ON}a${SYNC_OFF}`);
+    expect(out.endsWith(CURSOR_HIDE)).toBe(true);
+    // next sync chunk carries no DECTCEM of its own — app intent is still
+    // "visible" from the initial state, so rest shows the cursor
+    guard.process(`${SYNC_ON}b${SYNC_OFF}`);
+    vi.advanceTimersByTime(RESTING_DELAY_MS);
+    expect(inject).toHaveBeenCalledExactlyOnceWith(CURSOR_SHOW);
+  });
+
+  it('dispose cancels the pending show and stops appending', () => {
+    const inject = vi.fn();
+    const guard = new RestingCursorGuard(inject);
+    guard.process(`${SYNC_ON}a${SYNC_OFF}`);
+    guard.dispose();
+    vi.advanceTimersByTime(RESTING_DELAY_MS * 2);
+    expect(inject).not.toHaveBeenCalled();
+    const chunk = `${SYNC_ON}b${SYNC_OFF}`;
+    expect(guard.process(chunk)).toBe(chunk);
+  });
+});

--- a/src/renderer/terminal/restingCursor.ts
+++ b/src/renderer/terminal/restingCursor.ts
@@ -1,0 +1,84 @@
+/**
+ * Resting-cursor guard for synchronized-output frame writers (#929).
+ *
+ * Codex (and TUIs of its shape) repaint through `?2026` synchronized-output
+ * frames, but some frames — status-line ticks, the "Working" shimmer — END
+ * with the hardware cursor parked wherever the frame's last text write
+ * finished: after the model/cwd status text, next to the spinner. The frame is
+ * complete (`?2026l`, cursor visible), so honoring `?2026` does not help; a
+ * faithful renderer briefly paints the cursor there. Byte-timestamped capture
+ * shows those states holding 17–23 ms on a fast machine and a full video
+ * frame (≥42 ms) on the reporter's — quasi-periodic flashes that read as a
+ * second blinking caret (upstream: openai/codex#9081, #32546).
+ *
+ * The guard renders the cursor only at REST: every chunk that carries a
+ * `?2026` marker gets `?25l` appended, and the cursor is re-shown only after
+ * RESTING_DELAY_MS with no further frame traffic — and only if the
+ * application itself last asked for a visible cursor (its own DECTCEM state
+ * is tracked and never overridden at rest). Measured over a real codex
+ * session, this cuts stray-position cursor visibility by ~93% while the
+ * composer caret keeps its resting visibility.
+ *
+ * Scope is deliberately behavioral, not per-agent: only chunks containing
+ * `?2026` arm the guard, so classic TUIs that never bracket frames (vim,
+ * less, htop) are untouched — their cursor keeps xterm's default behavior.
+ * 32 ms matches the ImeAnchor resting threshold (#888), the same "the cursor's
+ * resting cell is the truthful one" reading applied to rendering.
+ */
+
+export const RESTING_DELAY_MS = 32;
+export const CURSOR_HIDE = '\x1b[?25l';
+export const CURSOR_SHOW = '\x1b[?25h';
+
+// eslint-disable-next-line no-control-regex -- matching the ESC byte is the point
+const SYNC_MARK = /\x1b\[\?2026[hl]/;
+// eslint-disable-next-line no-control-regex -- matching the ESC byte is the point
+const DECTCEM = /\x1b\[\?25([hl])/g;
+
+export class RestingCursorGuard {
+  /** The application's own DECTCEM intent — the state restored at rest. */
+  private appCursorVisible = true;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(
+    /** Writes a sequence to the SAME terminal through the SAME ordered write
+     *  path as PTY output (ordering with queued chunks must hold). */
+    private readonly inject: (seq: string) => void,
+    private readonly delayMs: number = RESTING_DELAY_MS,
+  ) {}
+
+  /**
+   * Transform one PTY output chunk about to be written to the terminal.
+   * Chunks without a `?2026` marker pass through untouched.
+   */
+  process(data: string): string {
+    // Track the app's own show/hide intent BEFORE appending anything of ours,
+    // so an injected hide is never mistaken for the app's.
+    DECTCEM.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let last: string | null = null;
+    while ((match = DECTCEM.exec(data)) !== null) last = match[1];
+    if (last !== null) this.appCursorVisible = last === 'h';
+
+    if (this.disposed || !SYNC_MARK.test(data)) return data;
+    this.arm();
+    return data + CURSOR_HIDE;
+  }
+
+  private arm(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      if (!this.disposed && this.appCursorVisible) this.inject(CURSOR_SHOW);
+    }, this.delayMs);
+  }
+
+  /** Cancel any pending show. Call before the terminal is disposed — a late
+   *  inject into a disposed xterm is the #582 class of bug. */
+  dispose(): void {
+    this.disposed = true;
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = null;
+  }
+}


### PR DESCRIPTION
Fixes #929.

## What the second caret is

Byte-level work on #929's sibling investigation (#936) settled the composition of the "two blinking cursors": there is only **one** real cursor, and it teleports. Codex ends some `?2026` synchronized-output frames — status-line ticks, the "Working" shimmer — with the hardware cursor **visible and parked where the frame's last text write finished**: after the model/cwd status text (`row29 col29`, right after `… · ~`) and next to the spinner. Replaying a captured session frame-by-frame: of 336 sync frames, 115 end at the composer, 125 end mid-transcript during streaming, and 9 end on the status row — every one of them with the cursor shown. Both positions the reporters named (after the cwd path, next to "Working") appear verbatim in the held-state list.

Frame-level video analysis of the reporter's recording confirms the illusion: whenever the status-row caret is lit, the composer block is dark (`Sc` correlation in every frame) — one cursor, bouncing, integrated by the eye into two.

Timing measurements (chunk-timestamped capture): the stray states persist 17–23 ms on a fast Win11 box — 1–2 render frames — and at least a full video frame (≥42 ms) on the reporter's machine. Honoring `?2026` cannot help; these are **complete** frames whose end state is bad. Upstream reports of the same family: openai/codex#9081 (closed not-planned), openai/codex#32546 (open).

## The fix

The resting-cell idea from #888, applied to cursor rendering: every output chunk carrying a `?2026` marker gets a DECTCEM hide appended, and the cursor is re-shown only after **32 ms with no further frame traffic** — and only if the application's own last DECTCEM asked for a visible cursor (its intent is tracked before our injection and never overridden).

- Behavioral gate, not an agent list: only `?2026`-bracketing frame writers arm the guard. vim/less/htop never see it.
- Simulated over a real byte-timestamped codex session (40 s, prompt → streaming → Working): stray-position cursor visibility drops **1,939 ms → 144 ms (−93%)**; the composer caret keeps its resting visibility.
- The show-injection routes through the same ordered write path as PTY output (resync hold-out included), and the guard is disposed before the terminal (the #582 lesson).

## Tests

`restingCursor.test.ts`: pass-through without `?2026`, hide+show cycle, burst coalescing, app-hidden cursor never re-shown, last-DECTCEM-wins intent tracking, injected hide not mistaken for app intent, dispose cancels the pending show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7