### PR TITLE
fix(restore): scroll the recovered screen into scrollback before the fresh process paints

### DIFF
--- a/changelog.d/955.md
+++ b/changelog.d/955.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Restored history no longer draws garbled after a restart.** When a pane
+  came back from a dead-process recovery (daemon restart or the local
+  scrollback cache), the restored screen stayed in the viewport while the
+  freshly spawned shell's coordinates started from row 1 — so typed input and
+  PSReadLine repaints landed on top of the restored text, overlapping it until
+  a `clear`. The restored screen now scrolls fully into scrollback before the
+  new prompt paints: the prompt starts on a clean viewport, and the history —
+  commands included — sits intact one wheel-notch above. (#955)

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -10,6 +10,7 @@ import { DaemonPTYBridge } from './DaemonPTYBridge';
 import { PromptEventLog } from './PromptEventLog';
 import { buildSpawnInjection, classifyShell } from './shell-integration';
 import { expandTilde } from '../shared/expandTilde';
+import { restoreSeam } from '../shared/restoreSeam';
 import { buildExecArgs } from './execWrapper';
 import { buildSafeChildEnv } from '../shared/envFilter';
 import { isMac, parseWindowsBuildNumber } from '../shared/platform';
@@ -524,6 +525,16 @@ export class DaemonSessionManager extends EventEmitter {
     // buffer — the exact garbling util/outputModeTracker.ts exists to prevent.
     if (params.scrollbackData && params.scrollbackData.length > 0) {
       ringBuffer.write(params.scrollbackData);
+      // #952: the dump repainted the DEAD process's screen, but the fresh
+      // process spawned above starts from an empty ConPTY whose absolute
+      // coordinates begin at row 1 — any restored rows left in the viewport
+      // get overdrawn by its first absolute repaint (PSReadLine, TUIs). The
+      // seam scrolls the restored screen fully into scrollback and homes the
+      // cursor, so the new prompt lands on the empty viewport both sides
+      // agree on. Written into the ring (not the PTY): it is display state
+      // for clients, and it must sit between the dump and the first live
+      // bytes on every future replay of this ring.
+      ringBuffer.write(Buffer.from(restoreSeam(rows), 'utf8'));
     }
 
     // Bridge: PTY data → RingBuffer + events

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -83,6 +83,7 @@ vi.mock('node-pty', () => ({
 
 // Import after mock is set up
 import { DaemonSessionManager } from '../DaemonSessionManager';
+import { restoreSeam } from '../../shared/restoreSeam';
 import { createDefaultConfig } from '../config';
 import { PWSH_EXIT_TAIL } from '../execWrapper';
 
@@ -554,7 +555,11 @@ describe('DaemonSessionManager', () => {
 
     const managed = manager.getSession('recover-1');
     const stored = managed?.ringBuffer.readAll().toString();
-    expect(stored).toBe('previous terminal output\r\n$ ls\r\nfile.txt');
+    // #952: the dump is followed by the restore seam, which scrolls the dead
+    // screen into scrollback so the fresh process paints on an empty viewport.
+    expect(stored).toBe(
+      'previous terminal output\r\n$ ls\r\nfile.txt' + restoreSeam(24),
+    );
     expect(session.id).toBe('recover-1');
   });
 
@@ -707,9 +712,9 @@ describe('DaemonSessionManager', () => {
         deferOutput: true,
       });
       const managed = manager.getSession('rec-2');
-      // Replay buffer was pre-filled.
+      // Replay buffer was pre-filled (dump + #952 restore seam).
       expect(managed?.ringBuffer.readAll().toString()).toBe(
-        'history-before-restart',
+        'history-before-restart' + restoreSeam(24),
       );
     });
 
@@ -729,16 +734,17 @@ describe('DaemonSessionManager', () => {
       });
       const managed = manager.getSession('rec-modes');
       const modes = managed?.bridge.outputModes;
-      expect(modes?.altScreen).toBe(true);
+      // #952: the restore seam appended after the dump leaves the alternate
+      // screen (`?1049l`) — the dead vim cannot own the fresh process's
+      // buffer, so the tracker's END state is normal-buffer…
+      expect(modes?.altScreen).toBe(false);
 
       const total = managed?.ringBuffer.totalBytesWritten ?? 0;
-      const alt = '\x1b[?1049h\x1b[2J\x1b[H';
-      // A window that still reaches the restored switch must NOT re-assert it
-      // (that would paint the scrollback ahead of it into the alt buffer)…
+      // …which means no window gets a stale alt-screen preamble: neither a
+      // full replay (the switch AND the seam's exit are both inside it) nor a
+      // tail window (the mode is no longer active at the end of the ring).
       expect(modes?.preamble(0)).toBe('');
-      // …and one that starts after it must.
-      expect(modes?.preamble(1)).toBe(alt);
-      expect(modes?.preamble(total - 16)).toBe(alt);
+      expect(modes?.preamble(total - 4)).toBe('');
     });
 
     it('unmutes after first resize plus the drain delay', () => {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -34,6 +34,7 @@ import { awaitParseBarrier } from '../terminal/parseBarrier';
 import { STALE_REPLAY_INPUT_MODE_RESETS, STALE_REPLAY_ALIVE_SHELL_RESETS, STALE_REPLAY_DISPLAY_RESETS, staleReplayResetLevel } from '../terminal/staleReplayModeReset';
 import { attachAltScreenWheel, PAGE_SCROLL_AGENTS } from '../terminal/altScreenWheel';
 import { RestingCursorGuard } from '../terminal/restingCursor';
+import { restoreSeam } from '../../shared/restoreSeam';
 import {
   writeTerminalOutput,
   flushTerminalOutput,
@@ -2077,15 +2078,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         const restored = isDaemonModeActive() ? null : content;
         if (restored) {
           terminal.write(restored);
-          // Whitespace + ANSI reset boundary so restored scrollback doesn't
-          // visually fuse with the fresh PTY prompt drawn moments later.
-          // \x1b[0m closes any attribute left open by restored content; the
-          // surrounding \r\n pair guards cursor placement when restored
-          // content doesn't end on a newline and gives the new prompt one
-          // blank line of headroom. No text label — Search/copy/vi-copy
-          // would otherwise treat a localized divider string as real shell
-          // output.
-          terminal.write('\r\n\x1b[0m\r\n');
+          // #952: the fresh PTY about to connect starts from an empty ConPTY
+          // whose absolute coordinates begin at row 1 — restored rows left in
+          // the viewport get overdrawn by its first absolute repaint
+          // (PSReadLine line editing, TUI redraws). The seam scrolls the
+          // restored screen fully into scrollback and homes the cursor so the
+          // new prompt lands on the empty viewport both sides agree on; the
+          // history sits intact one wheel-notch above. (Replaces the old
+          // \r\n divider, which left the restored screen in the viewport.)
+          terminal.write(restoreSeam(terminal.rows));
           fireFirstData();
           didRestoreTxt = true;
           // Arm the late-connect clear. If daemon mode activates after this

--- a/src/shared/__tests__/restoreSeam.test.ts
+++ b/src/shared/__tests__/restoreSeam.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { Terminal } from '@xterm/headless';
+import { restoreSeam } from '../restoreSeam';
+
+const write = (term: Terminal, data: string) =>
+  new Promise<void>((resolve) => term.write(data, resolve));
+
+const viewportText = (term: Terminal): string[] => {
+  const b = term.buffer.active;
+  const rows: string[] = [];
+  for (let y = 0; y < term.rows; y++) {
+    rows.push(b.getLine(b.baseY + y)?.translateToString(true) ?? '');
+  }
+  return rows;
+};
+
+describe('restoreSeam', () => {
+  it('scrolls the restored screen into scrollback and homes the cursor', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, scrollback: 1000, allowProposedApi: true });
+    for (let i = 1; i <= 30; i++) await write(term, `history line ${i}\r\n`);
+    await write(term, 'PS C:\\> '); // dead prompt, no trailing newline
+
+    await write(term, restoreSeam(term.rows));
+
+    const b = term.buffer.active;
+    // Cursor is home on an empty viewport…
+    expect(b.cursorX).toBe(0);
+    expect(b.cursorY).toBe(0);
+    expect(viewportText(term).every((row) => row === '')).toBe(true);
+    // …and every restored row survives in scrollback.
+    const scrollback: string[] = [];
+    for (let y = 0; y < b.baseY; y++) {
+      scrollback.push(b.getLine(y)?.translateToString(true) ?? '');
+    }
+    expect(scrollback.join('\n')).toContain('history line 1');
+    expect(scrollback.join('\n')).toContain('history line 30');
+    expect(scrollback.join('\n')).toContain('PS C:\\>');
+  });
+
+  it("aligns a fresh process's absolute repaints with its appended plain text", async () => {
+    // The #952 failure shape: after restore, plain-text output appended at the
+    // cursor and absolute-CUP repaints (PSReadLine) disagreed about where the
+    // prompt is. After the seam both land on viewport row 1.
+    const term = new Terminal({ cols: 80, rows: 24, scrollback: 1000, allowProposedApi: true });
+    for (let i = 1; i <= 30; i++) await write(term, `history line ${i}\r\n`);
+
+    await write(term, restoreSeam(term.rows));
+    await write(term, 'PS C:\\> ');            // fresh prompt, plain text
+    await write(term, '\x1b[1;9Hqweqwewqe');   // PSReadLine-style absolute repaint
+
+    const b = term.buffer.active;
+    const promptRow = b.getLine(b.baseY)?.translateToString(true) ?? '';
+    expect(promptRow).toBe('PS C:\\> qweqwewqe');
+    // No restored row was overdrawn (trailing scrollback rows are the old
+    // viewport's blank tail; the content sits just above them).
+    const tail: string[] = [];
+    for (let y = Math.max(0, b.baseY - term.rows); y < b.baseY; y++) {
+      tail.push(b.getLine(y)?.translateToString(true) ?? '');
+    }
+    expect(tail.join('\n')).toContain('history line 30');
+  });
+
+  it('exits the alternate screen in case the dump ended inside one', async () => {
+    const term = new Terminal({ cols: 80, rows: 24, scrollback: 100, allowProposedApi: true });
+    await write(term, 'normal content\r\n');
+    await write(term, '\x1b[?1049h'); // dump ended mid-vim
+    expect(term.buffer.active.type).toBe('alternate');
+
+    await write(term, restoreSeam(term.rows));
+    expect(term.buffer.active.type).toBe('normal');
+  });
+
+  it('clamps hostile row counts', () => {
+    expect(restoreSeam(0)).toBe(restoreSeam(1));
+    expect(restoreSeam(-5)).toBe(restoreSeam(1));
+    expect(restoreSeam(Number.NaN)).toBe(restoreSeam(1));
+    expect(restoreSeam(1e9).length).toBeLessThan(600);
+  });
+});

--- a/src/shared/restoreSeam.ts
+++ b/src/shared/restoreSeam.ts
@@ -1,0 +1,31 @@
+// Seam between restored terminal content and a freshly spawned process (#952).
+//
+// IMPORTANT: browser-safe, pure — imported by both the daemon
+// (DaemonSessionManager recovery) and the sandboxed renderer (useTerminal's
+// .txt restore path). No `process`, no Node imports.
+
+/**
+ * When a session is recovered after its process died, the restored bytes
+ * (ring dump or .txt cache) repaint the OLD screen into the emulator — but
+ * the freshly spawned shell's ConPTY starts from an empty screen model whose
+ * absolute coordinates begin at row 1. Anything left in the viewport is then
+ * doomed: plain-text output appends after the restored content (bottom) while
+ * absolute-CUP repaints (PSReadLine line editing, prediction lists, TUI
+ * redraws) land at the viewport TOP, overwriting restored rows — the
+ * "restored history draws garbled / text overlays each other" class.
+ *
+ * The seam aligns the two coordinate systems at their only common point: an
+ * empty viewport. It leaves the alternate screen in case the dump ended
+ * inside one, drops any dangling SGR attributes, parks the cursor on the
+ * bottom row, feeds one LF per viewport row so every restored row scrolls
+ * into scrollback (LF-driven scrolls are the only ones xterm preserves), and
+ * homes the cursor. The fresh prompt then paints at (1,1) of an empty
+ * viewport — exactly where its ConPTY believes it is — and the restored
+ * history sits intact one wheel-notch above.
+ */
+export function restoreSeam(rows: number): string {
+  // Clamp defensively: a hostile/corrupt rows value must not build a
+  // megabyte of newlines (bounds mirror what any real pane can be).
+  const r = Math.min(512, Math.max(1, Math.trunc(rows) || 1));
+  return `\x1b[?1049l\x1b[0m\x1b[${r};1H${'\n'.repeat(r)}\x1b[H`;
+}


### PR DESCRIPTION
Fixes #952.

## The bug, reproduced live

Kill the daemon with a pane full of history, relaunch, and type: the fresh pwsh's plain-text output appends after the restored content at the **bottom**, while PSReadLine's absolute-CUP repaints (Up-arrow recall, prediction lists) land at the viewport **top** — overwriting restored rows. Screenshot from the repro rig: pressing <kbd>Up</kbd> painted the recalled `echo …` line over the restored transcript's first row, with a doubled prompt at the bottom seam (`PS C:\…> PS C:\…>`). Exactly the reporter's video (typed text at top, prompt at bottom, self-overlapping), and exactly why `clear` repairs it — it is the first full repaint drawn purely from the fresh process's own coordinate model.

Root cause: the restored bytes repaint the **dead** process's screen, but the freshly spawned shell starts from an empty ConPTY whose absolute coordinates begin at row 1. Anything left in the viewport is doomed the moment the new process emits an absolute repaint.

## The fix — a restore seam (`src/shared/restoreSeam.ts`)

Align the two coordinate systems at their only common point: an empty viewport. After the restored bytes: leave the alt screen (in case the dump ended mid-vim), reset SGR, park at the bottom row, feed one LF per viewport row so every restored row scrolls into scrollback (LF-driven scrolls are the only ones xterm preserves), and home the cursor. The fresh prompt paints at (1,1) — where its ConPTY believes it is — and the history sits intact one wheel-notch above.

Applied at both restore seams:
- **daemon** (`DaemonSessionManager.createSession`): written into the ring right after the recovery dump, so every future replay of that ring carries it;
- **renderer** (`useTerminal` .txt path): replaces the old `\r\n` divider, which left the restored screen in the viewport.

## Verified live on the rig

After the fix, same kill-and-relaunch: prompt at (1,1) of an empty viewport; <kbd>Up</kbd> recall replaces the line **on the prompt row** (history from the previous life recalled correctly, no stray repaints anywhere); wheel-up shows the full restored transcript intact in scrollback, commands included.

## Tests

- `restoreSeam.test.ts` (headless xterm): restored screen scrolls fully into scrollback with cursor homed; a fresh process's plain text and absolute-CUP repaints agree on the prompt row; alt-screen dumps are exited; hostile row counts clamped.
- `DaemonSessionManager.test.ts`: ring pre-fill expectations now include the seam; the mid-vim mode-tracker test flips to assert the seam neutralizes the dangling alt screen (no client window gets a stale alt-screen preamble).

Known cosmetic tradeoff: content shorter than the viewport leaves that viewport's blank tail in scrollback between the history and the new prompt (same shape as a Windows Terminal <kbd>Ctrl+L</kbd>). Only on dead-process recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7