### PR TITLE
fix(pane): keep pane decoration rings under overlays and modals

### DIFF
--- a/changelog.d/956.md
+++ b/changelog.d/956.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **A pane's attention ring no longer draws on top of menus and modals.** The
+  green completed-blink ring, the notification pulse, and the pane flash sat
+  at overlay-level z-index without a containing stacking context, so a pane
+  that lit up could paint its ring straight across the new-workspace picker
+  (and the flash briefly over any modal). The decorations now sit above
+  everything inside their pane and below all app chrome. (#956)

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -479,7 +479,13 @@ select option {
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  z-index: 50;
+  /* #946: pane decorations must sit above pane content (toolbar caps the
+   * pane-local stack at z-30) but BELOW the --z-overlay(50) baseline. The
+   * pane root creates no stacking context, so these pseudo-elements compete
+   * document-wide: at 50 they tied with dropdowns/pickers and won on DOM
+   * order, painting the ring over the new-workspace picker. 40 keeps them
+   * over everything inside the pane and under every piece of app chrome. */
+  z-index: 40;
   /* Attention ring = warm accent (2-accent grammar: alive/attention is warm). */
   box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.3);
   animation: notification-ring-pulse 2s ease-in-out infinite;
@@ -511,7 +517,9 @@ select option {
   background: var(--accent);
   pointer-events: none;
   animation: pane-flash 0.5s ease-out forwards;
-  z-index: 100;
+  /* #946: below --z-overlay(50) — see .notification-ring::before. At 100 the
+   * 500ms flash painted over modals and dialogs. */
+  z-index: 40;
 }
 
 /* ─── T11: state-machine notification ring (DESIGN D3) ──────────────────────
@@ -581,7 +589,9 @@ select option {
   inset: 0;
   border-radius: inherit;
   pointer-events: none;
-  z-index: 50;
+  /* #946: below --z-overlay(50), above the toolbar (z-30) — see
+   * .notification-ring::before for the full stacking rationale. */
+  z-index: 40;
   box-shadow: 0 0 0 2px var(--accent-green) inset;
   animation: pane-complete-blink 1.2s ease-in-out infinite;
 }
@@ -594,7 +604,10 @@ select option {
   border-radius: 2px;
   background: var(--accent);
   box-shadow: none;
-  z-index: 100;
+  /* #946: same containment as the ring/blink — the flash is the same ::after
+   * element, so it needs no extra elevation to win over the blink rule, and
+   * at 100 it painted over modals/dialogs for its 500ms. */
+  z-index: 40;
   animation: pane-flash 0.5s ease-out forwards;
 }
 


### PR DESCRIPTION
Fixes #946.

The completed-blink ring (`.pane-complete-blink::after`), the notification ring (`.notification-ring::before`), and the pane flash (`.pane-flash::after`) are pseudo-elements at `z-index: 50`/`100` on a pane root that creates **no stacking context** — so they compete document-wide. At 50 they tied with the `--z-overlay` baseline (dropdowns, the new-workspace picker) and won on DOM order, drawing the green ring straight across the picker; at 100 the flash outranked even modals and dialogs for its 500 ms.

**Fix**: all three drop to `z-index: 40` — pane decorations only need to beat pane content, and the pane-local stack caps at the toolbar's `z-30`. 40 keeps them above everything inside the pane and below every piece of app chrome (`--z-overlay: 50` and up), slotting into the documented stacking scale beside `--z-cheatsheet: 40`.

**Why not `isolation: isolate` on the pane root** (the direction floated in triage): a stacking context on the pane would also trap pane-internal popovers (`AgentToolbar`'s RichInput is 30 rem wide) that legitimately overflow onto a neighboring pane — a later-DOM sibling pane would then paint over them. Lowering the decorations fixes the reported class without that regression, and without adding a new stacking context for future authors to reason about.

**Verified live**: injected the blink+notification ring on a pane, opened the new-workspace picker over its edge — the picker paints cleanly over the ring (before: the ring crossed the picker exactly as in the report's screenshot). Pane tests (130) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7