### PR TITLE
fix(rpc): stop reading the plugin host as the operator on private-event and channel reads

### DIFF
--- a/changelog.d/959.md
+++ b/changelog.d/959.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **An approved plugin can no longer read another workspace's private
+  activity by naming it.** The iframe plugin host dispatches through the same
+  trusted in-process channel as the app's own UI, and two read paths —
+  `events.poll` (private `a2a.task` / channel events) and the a2a channel /
+  mission reads — treated that shared channel as "the operator", so a plugin
+  granted an ordinary read capability could aim those reads at any workspace
+  by passing its id (or omitting one). Both paths now bind such a plugin to
+  the workspace it is actually hosted in, matching the scope its approval
+  implied; an unbound plugin read fails closed. This confines an approved
+  plugin — it is not a defense against hostile same-user code, and external
+  (non-plugin) callers are unchanged. (#959)

--- a/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.channel.rpc.test.ts
@@ -234,7 +234,7 @@ describe('a2a.channel.rpc — ws-human read scope is first-party only (W1)', () 
   );
 
   it.each(['a2a.channel.list', 'a2a.channel.getMessages'] as const)(
-    'first-party %s scoped to ws-human passes through (the renderer/plugin-host read path)',
+    'OPERATOR first-party %s scoped to ws-human passes through (the renderer read path; hosted callers are stamped to their binding instead — see the #922 suite)',
     async (method) => {
       const expected = { ok: true, value: [] };
       const daemon = makeFakeDaemon((m, params) => {
@@ -1061,5 +1061,84 @@ describe('a2a.channel.rpc — P5 create members[] cannot seed reserved identitie
       expect(r.error?.code).toBe('NOT_AUTHORIZED');
     }
     expect(daemon.rpc).not.toHaveBeenCalled();
+  });
+});
+
+// === #922 E — hosted (plugin-host) reads are bound to the hosted workspace ===
+//
+// The no-senderPtyId read path left the caller-supplied verifiedWorkspaceId in
+// place under process-boundary trust, written for the renderer and inherited by
+// the plugin host — so an approved plugin could read any channel a NAMED
+// workspace was a member of (a2a.channel.read, an ordinary declarable
+// capability), and task.mission.list answered for whatever workspace it named.
+// D5's own rule now applies: the server-derived binding is stamped over any
+// self-claim, and an unbound hosted caller fails closed.
+describe('a2a.channel.rpc — #922 hosted caller read binding', () => {
+  const PLUGIN_WS = 'ws-plugin';
+
+  it.each(['a2a.channel.list', 'a2a.channel.getMessages', 'task.mission.list'] as const)(
+    'hosted %s self-claiming a foreign workspace is answered for the BINDING',
+    async (method) => {
+      const expected = { ok: true, value: [] };
+      const daemon = makeFakeDaemon((m, params) => {
+        expect(m).toBe(method);
+        expect((params as Record<string, unknown>).verifiedWorkspaceId).toBe(PLUGIN_WS);
+        return expected;
+      });
+      const router = setupHandlerRouter(daemon);
+
+      const res = await router.dispatch(
+        {
+          id: `hosted-${method}`,
+          method,
+          params: { channelId: CHANNEL_ID, verifiedWorkspaceId: 'ws-victim', workspaceId: 'ws-victim' },
+          clientName: 'hello-panel',
+        },
+        { firstParty: true, hostedWorkspace: PLUGIN_WS },
+      );
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.result).toBe(expected);
+    },
+  );
+
+  it('hosted read self-claiming ws-human is stamped to the binding, not refused as human', async () => {
+    const daemon = makeFakeDaemon((_m, params) => {
+      expect((params as Record<string, unknown>).verifiedWorkspaceId).toBe(PLUGIN_WS);
+      return { ok: true, value: [] };
+    });
+    const router = setupHandlerRouter(daemon);
+    const res = await router.dispatch(
+      {
+        id: 'hosted-human',
+        method: 'a2a.channel.list',
+        params: { channelId: CHANNEL_ID, verifiedWorkspaceId: 'ws-human' },
+        clientName: 'hello-panel',
+      },
+      { firstParty: true, hostedWorkspace: PLUGIN_WS },
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it('an UNBOUND hosted caller (null binding) read is NOT_AUTHORIZED and never reaches the daemon', async () => {
+    const daemon = makeFakeDaemon(() => ({ ok: true, value: [] }));
+    const router = setupHandlerRouter(daemon);
+    const rpcSpy = (daemon as unknown as { rpc: ReturnType<typeof vi.fn> }).rpc;
+
+    const res = await router.dispatch(
+      {
+        id: 'hosted-unbound',
+        method: 'a2a.channel.list',
+        params: { channelId: CHANNEL_ID, verifiedWorkspaceId: 'ws-victim' },
+        clientName: 'hello-panel',
+      },
+      { firstParty: true, hostedWorkspace: null },
+    );
+    expect(res.ok).toBe(true); // transport envelope; the Result inside is the gate
+    if (res.ok) {
+      const r = res.result as { ok: boolean; error?: { code: string } };
+      expect(r.ok).toBe(false);
+      expect(r.error?.code).toBe('NOT_AUTHORIZED');
+    }
+    expect(rpcSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/main/pipe/handlers/__tests__/events.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/events.rpc.test.ts
@@ -1445,3 +1445,94 @@ describe('events.rpc — blocking poll cancellation', () => {
     if (res.ok) expect((res.result as { events: unknown[] }).events).toHaveLength(1);
   });
 });
+
+// === #922 E — hosted (plugin-host) callers are not the operator ===
+//
+// The renderer bridge and the plugin host both dispatch first-party, but only
+// the renderer is the operator. Before this suite's fix, `privateSet =
+// clientSet` keyed on bare firstParty, so an approved plugin could gate
+// another workspace's PRIVATE events (a2a.task, channel.*) by naming its id —
+// with `events.subscribe`, an ordinary declarable capability. The hosted rule
+// mirrors the B3 agent path: caller-supplied workspaceId is IGNORED for
+// private types; the scope is the server-derived binding on the context.
+describe('events.rpc — #922 hosted caller private-event scope', () => {
+  const VICTIM = 'ws-victim';
+  const OTHER = 'ws-other';
+  const PLUGIN_WS = 'ws-plugin';
+
+  beforeEach(() => {
+    eventBus.reset();
+  });
+
+  function seed(): void {
+    expect(
+      publishA2aTask({ type: 'a2a.task', from: VICTIM, to: OTHER, taskId: 'tv', state: 'submitted', kind: 'created' }),
+    ).toBe(true);
+    expect(
+      publishA2aTask({ type: 'a2a.task', from: PLUGIN_WS, to: OTHER, taskId: 'tp', state: 'submitted', kind: 'created' }),
+    ).toBe(true);
+    // A lifecycle event in the victim workspace — hosted callers keep the
+    // every-subscriber lifecycle semantics, so this must stay visible.
+    eventBus.emit({ type: 'pane.created', workspaceId: VICTIM, paneId: 'p-v' });
+  }
+
+  async function pollAs(
+    router: RpcRouter,
+    params: Record<string, unknown>,
+    opts: { firstParty: true; hostedWorkspace?: string | null },
+  ): Promise<Array<{ type: string; from?: string }>> {
+    const res = await router.dispatch({ id: 'hp', method: 'events.poll', params }, opts);
+    if (!res.ok) throw new Error('poll dispatch failed');
+    return (res.result as { events: Array<{ type: string; from?: string }> }).events;
+  }
+
+  it("a hosted caller naming the victim workspace gets its OWN events — the claim is ignored", async () => {
+    const router = setupRouter();
+    seed();
+    const events = await pollAs(
+      router,
+      { cursor: 0, workspaceId: VICTIM, types: ['a2a.task'] },
+      { firstParty: true, hostedWorkspace: PLUGIN_WS },
+    );
+    // The victim's private event is NOT returned; the binding scope is.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.from).toBe(PLUGIN_WS);
+  });
+
+  it("the same poll as the operator still works — the fix distinguishes, not narrows", async () => {
+    const router = setupRouter();
+    seed();
+    const events = await pollAs(router, { cursor: 0, workspaceId: VICTIM, types: ['a2a.task'] }, { firstParty: true });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.from).toBe(VICTIM);
+  });
+
+  it("a hosted caller that names nothing still resolves to its binding", async () => {
+    const router = setupRouter();
+    seed();
+    const own = await pollAs(
+      router,
+      { cursor: 0, types: ['a2a.task'] },
+      { firstParty: true, hostedWorkspace: PLUGIN_WS },
+    );
+    expect(own).toHaveLength(1);
+    expect(own[0]?.from).toBe(PLUGIN_WS);
+  });
+
+  it('an UNBOUND hosted caller (null binding) gets private types failed closed, lifecycle intact', async () => {
+    const router = setupRouter();
+    seed();
+    const priv = await pollAs(
+      router,
+      { cursor: 0, workspaceId: VICTIM, types: ['a2a.task'] },
+      { firstParty: true, hostedWorkspace: null },
+    );
+    expect(priv).toHaveLength(0);
+    const lifecycle = await pollAs(
+      router,
+      { cursor: 0, types: ['pane.created'] },
+      { firstParty: true, hostedWorkspace: null },
+    );
+    expect(lifecycle.some((e) => e.type === 'pane.created')).toBe(true);
+  });
+});

--- a/src/main/pipe/handlers/a2a.channel.rpc.ts
+++ b/src/main/pipe/handlers/a2a.channel.rpc.ts
@@ -49,6 +49,7 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import type { RpcContext } from '../../../shared/rpc';
+import { isHostedCaller, hostedBindingOf } from '../../../shared/rpc';
 import type { DaemonClient } from '../../DaemonClient';
 import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
@@ -223,6 +224,28 @@ export function registerA2aChannelRpc(
           },
         };
       }
+      // #922 E — a hosted (plugin-host) caller is first-party but NOT the
+      // operator. On this no-senderPtyId read path the caller-supplied
+      // `verifiedWorkspaceId` was left in place under process-boundary trust
+      // — written for the renderer, inherited by the plugin. For the one
+      // caller class whose workspace the host derives, apply D5's own rule:
+      // stamp the server-derived binding over any self-claim, so membership
+      // scoping and the owner-scoped reads below answer for the plugin's own
+      // workspace, not whichever one it named. An unbound hosted caller
+      // (`null` binding) fails closed — same rule as the browser hosted lane.
+      if (isHostedCaller(ctx)) {
+        const bound = hostedBindingOf(ctx);
+        if (!bound) {
+          return {
+            ok: false,
+            error: {
+              code: 'NOT_AUTHORIZED',
+              message: `${method} requires a workspace-bound caller (hosted caller has no workspace binding)`,
+            },
+          };
+        }
+        base.verifiedWorkspaceId = bound;
+      }
       if (ownerScoped && !ctx?.firstParty) {
         // An owner-scoped read off the wire with no resolvable senderPtyId
         // would answer for whatever workspace the caller named. The MCP
@@ -259,12 +282,20 @@ export function registerA2aChannelRpc(
       // above either. This also closes the PRE-W1 residual (wire reads of
       // human-member channels); other self-claimed workspace reads keep the
       // documented same-user residual (out of scope here).
-      if (base.verifiedWorkspaceId === HUMAN_WORKSPACE_ID && !ctx?.firstParty) {
+      // #922 E — the gate is OPERATOR-only, not firstParty-only: the plugin
+      // host also dispatches first-party, and a hosted caller must not read as
+      // ws-human (its binding can never be ws-human — the stamp above makes
+      // this unreachable for hosted callers — but the gate states the rule
+      // rather than relying on that).
+      if (
+        base.verifiedWorkspaceId === HUMAN_WORKSPACE_ID &&
+        !(ctx?.firstParty && !isHostedCaller(ctx))
+      ) {
         return {
           ok: false,
           error: {
             code: 'NOT_AUTHORIZED',
-            message: `reserved human workspace ('${HUMAN_WORKSPACE_ID}') reads are first-party only`,
+            message: `reserved human workspace ('${HUMAN_WORKSPACE_ID}') reads are operator-only`,
           },
         };
       }

--- a/src/main/pipe/handlers/events.rpc.ts
+++ b/src/main/pipe/handlers/events.rpc.ts
@@ -12,6 +12,7 @@ import {
   type ChannelCatalogEvent,
 } from '../../../shared/events';
 import type { PluginIdentityRecord } from '../../../shared/rpc';
+import { isHostedCaller, hostedBindingOf } from '../../../shared/rpc';
 import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 import { MAX_PIPE_CONNECTIONS } from '../PipeServer';
 
@@ -366,8 +367,22 @@ export function registerEventsRpc(
     // resolves server-side ('' ⇒ empty set ⇒ private types fail closed).
     const wantsPrivate = !types || types.some((t) => PRIVATE_EVENT_TYPES.has(t));
     let privateSet: Set<string>;
-    if (ctx?.firstParty) {
+    if (ctx?.firstParty && !isHostedCaller(ctx)) {
+      // The OPERATOR (renderer bridge): a human operates every local
+      // workspace, so the caller-supplied scope is trusted for private types.
       privateSet = clientSet;
+    } else if (isHostedCaller(ctx)) {
+      // #922 E — the plugin host also dispatches first-party, but it is NOT
+      // the operator (RpcContext.hostedWorkspace doc). Treating it as one let
+      // an approved plugin gate another workspace's a2a.task / channel.*
+      // events by simply naming its id. Same rule as the B3 agent path: the
+      // caller-supplied workspaceId is IGNORED for private types and the
+      // scope is the server-derived binding — the workspace the host is
+      // showing. An unbound hosted caller (`null`) resolves to the empty set,
+      // so private types fail closed exactly like an unresolvable agent;
+      // lifecycle types keep their every-subscriber semantics either way.
+      const bound = hostedBindingOf(ctx);
+      privateSet = bound ? new Set<string>([bound]) : new Set<string>();
     } else if (wantsPrivate) {
       const resolved = await resolveCallerWorkspace(getWindow, params);
       privateSet = resolved ? new Set<string>([resolved]) : new Set<string>();

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -213,6 +213,31 @@ export interface RpcContext {
   hostedWorkspace?: string | null;
 }
 
+/**
+ * #922 — is this context a plugin-host dispatch? Keyed on the PRESENCE of
+ * `hostedWorkspace` (its `null` state still means "hosted, unbound"), exactly
+ * like the browser `hosted` lane. `firstParty` alone cannot answer this: the
+ * renderer bridge and the plugin host both dispatch first-party, but only the
+ * former is the operator. Handlers that widen scope for "the operator" must
+ * use `firstParty && !isHostedCaller(ctx)`, never bare `firstParty`.
+ */
+export function isHostedCaller(ctx?: RpcContext): boolean {
+  return ctx !== undefined && ctx.hostedWorkspace !== undefined;
+}
+
+/**
+ * #922 — the hosted caller's server-derived workspace binding, or undefined
+ * when the host had no workspace to bind (`null`) or the context is not a
+ * hosted dispatch at all. Callers scoping on this must fail closed on
+ * undefined for a hosted context — never fall through to a caller-named
+ * workspace (see `RpcContext.hostedWorkspace`).
+ */
+export function hostedBindingOf(ctx?: RpcContext): string | undefined {
+  return typeof ctx?.hostedWorkspace === 'string' && ctx.hostedWorkspace.length > 0
+    ? ctx.hostedWorkspace
+    : undefined;
+}
+
 export type RpcResponse =
   | { id: string; ok: true; result: unknown }
   | { id: string; ok: false; error: string; rejection?: RpcRejection };


### PR DESCRIPTION
Part of #922.

## Scope — read this first

#922 has three tracks, and this PR is **not** the two the title of the issue names. Here is where it fits:

- **`declared` / `legacy` wire lanes** (the issue's headline): need the peer-credential primitive, deferred with the #113 grandfather clock. **Untouched here.**
- **PR1 — the `hosted` lane in `browser.rpc.ts`**: landed as #941. It derives the plugin host's workspace server-side and applies it to the `browser.*` table.
- **PR2 design pass** (snowyukitty, 2026-08-19): while enumerating the fallback family, its **section 5** found a separate, higher-value hole — `firstParty` is read as "the operator" at two read gates, and the plugin host is inside `firstParty` but is *not* the operator. The design pass explicitly asked (Q4) whether section 5 should be **its own change** rather than folded into the router work. **This PR is that change.**

So: this closes the `firstParty`-conflation leaks for the caller class whose workspace #941 already derives. The router-level mechanism (A–D: `pane.list`, `input.readScreen`, `browser.open` fallbacks) remains PR2's, unblocked by this.

## The two leaks

Both trusted bare `ctx.firstParty` as "a human operates every local workspace" — true for the renderer bridge, false for the iframe plugin host (`RpcContext`'s own doc: *"The iframe plugin host is also in-process but is NOT the operator."*).

**1. `events.poll` private-event scope** (`events.rpc.ts`). `privateSet = clientSet` on bare `firstParty`, so an approved plugin gated another workspace's PRIVATE events (`a2a.task`, `channel.*`) by naming its id. Cost: `events.subscribe`, which `hello-panel` declares. Repro from the design pass:
```
dispatch { method: 'events.poll', params: { workspaceId: 'ws-victim-a', types: ['a2a.task'] }, clientName: 'hello-panel' }
       as { firstParty: true, hostedWorkspace: 'ws-plugin' }
→ {"events":[{"type":"a2a.task","from":"ws-victim-a","to":"ws-victim-b","messagePreview":"PRIVATE"}]}
```

**2. `a2a.channel` reads** (`a2a.channel.rpc.ts`). The no-`senderPtyId` read path left the caller-supplied `verifiedWorkspaceId` in place under process-boundary trust. A plugin could read any channel a **named** workspace was a member of, clear the `ws-human` first-party gate into *every private channel with full history* (`a2a.channel.read`), and aim `task.mission.list` — titles, branches, absolute worktree paths, pane group ids — at any workspace.

## The fix

`isHostedCaller` / `hostedBindingOf` (`shared/rpc.ts`) key on the **presence** of `hostedWorkspace` (its `null` state still means "hosted, unbound"), mirroring #941's browser lane.

- **`events.poll`**: operator keeps the caller-supplied scope; a hosted caller's private scope **is** its server-derived binding (the claim is ignored, exactly the B3 agent-path rule); an unbound (`null`) hosted caller fails closed to the empty set. Lifecycle types keep every-subscriber semantics for everyone.
- **`a2a.channel` reads**: the binding is stamped over any self-claimed `verifiedWorkspaceId` (D5's rule, applied to this caller class); an unbound hosted read is refused before the daemon is reached; the `ws-human` gate is now **operator-only** rather than `firstParty`-only.

Plugin *mutations* were already refused on this path (no `senderPtyId`) — unchanged.

## Attacker model & ceiling

Threat closed: an **approved** plugin (same user, same machine) that names, or omits, a foreign `workspaceId` to read another workspace's private events / channels / missions. It controls neither half of its identity — `clientName` is stamped from the manifest, the workspace is derived by the host — so for this caller class the binding is a genuine server-side ownership fact, not a presence check.

Ceiling, per #941 and written into the changelog: this confines an approved plugin to the workspace hosting it. It is **not** containment of hostile same-user code, and it does **nothing** for the wire — external MCP callers keep landing in `declared` / `legacy` and still need the peer-credential primitive #922 is really about.

## Tests

`events.rpc.test.ts` (+4): hosted caller's claim ignored, operator unaffected (distinguishes, not narrows), unbound fails closed with lifecycle intact. `a2a.channel.rpc.test.ts` (+3, one renamed): hosted read stamped to binding across `list`/`getMessages`/`task.mission.list`, ws-human self-claim stamped not refused, unbound read `NOT_AUTHORIZED` before the daemon. `src/main/pipe` suite: 744 passed. tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7