### PR TITLE
feat(pane): make the unread-glow dim level user-tunable

### DIFF
--- a/changelog.d/960.md
+++ b/changelog.d/960.md
@@ -1,0 +1,9 @@
+### Added
+
+- **The unread-glow dim is now adjustable.** A pane holding an unvisited
+  notification used to drop to 60% opacity — "the inactive terminal is
+  shadowed" — which made a session you were monitoring harder to read at the
+  exact moment it produced output. Settings → Notifications now has an
+  "Unread pane brightness" slider: 100% removes the shadowing entirely (the
+  colored border glow still marks the unread pane), 60% keeps the classic
+  look, and the default is unchanged. (#960)

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -289,6 +289,10 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
   // so the new visual is on by default until the user disables it.
   const ringState = useStore((s) => s.paneNotificationRing[pane.id]);
   const paneRingEnabled = useStore((s) => s.paneRingEnabled);
+  // #949: user-tunable glow dim. Fed to CSS as a custom property so the
+  // .pane-ring-glow rule stays the single owner of the visual; 1 turns the
+  // shadowing off while keeping the border-color glow as the unread cue.
+  const paneGlowOpacity = useStore((s) => s.paneGlowOpacity);
 
   // ─── B8: completed-terminal blink ────────────────────────────────────────
   // The pane's active surface ptyId drives the border blink. When that
@@ -482,6 +486,10 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     <div
       className={composePaneClassName({ hasUnread, ringState, paneRingEnabled, flashing, completeBlink })}
       style={{
+        // #949: dim level for the unread glow — consumed by .pane-ring-glow's
+        // `opacity: var(--pane-glow-opacity, 0.6)`. Set unconditionally so a
+        // glow that arrives without a re-render still reads the current value.
+        ['--pane-glow-opacity' as string]: String(paneGlowOpacity),
         // Design-system cohesion: panes keep a QUIET hairline in both states —
         // focus is signaled by the amber underline on the tab strip (mock's
         // .pane.focused .pane-head treatment), not a loud full border box.

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -3734,6 +3734,9 @@ export interface NotificationsViewProps {
   // T12 — 4 new toggles
   paneRingEnabled: boolean;
   onChangePaneRingEnabled: (v: boolean) => void;
+  // #949 — unread-glow dim level (1 = no dimming, 0.6 = historical look)
+  paneGlowOpacity: number;
+  onChangePaneGlowOpacity: (v: number) => void;
   paneFlashEnabled: boolean;
   onChangePaneFlashEnabled: (v: boolean) => void;
   taskbarFlashEnabled: boolean;
@@ -3767,6 +3770,7 @@ export function NotificationsView(props: NotificationsViewProps) {
     toastEnabled, onChangeToastEnabled,
     notificationRingEnabled, onChangeNotificationRingEnabled,
     paneRingEnabled, onChangePaneRingEnabled,
+    paneGlowOpacity, onChangePaneGlowOpacity,
     paneFlashEnabled, onChangePaneFlashEnabled,
     taskbarFlashEnabled, onChangeTaskbarFlashEnabled,
     notificationSoundChoice, onChangeNotificationSoundChoice,
@@ -3809,6 +3813,27 @@ export function NotificationsView(props: NotificationsViewProps) {
             onChange={onChangePaneRingEnabled}
             label={t('settings.paneRing')}
           />
+        </SettingRow>
+
+        {/* #949 — Unread-glow dim level. A slider rather than a toggle so users
+            can land anywhere between "no shadowing" (100%) and the historical
+            look (60%). Disabled alongside the pane ring: with the ring off the
+            glow never renders, so the dim has nothing to act on. */}
+        <SettingRow label={t('settings.paneGlowDim')} description={t('settings.paneGlowDimDesc')}>
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={60}
+              max={100}
+              step={5}
+              value={Math.round(paneGlowOpacity * 100)}
+              onChange={(e) => onChangePaneGlowOpacity(Number(e.target.value) / 100)}
+              disabled={!paneRingEnabled}
+              aria-label={t('settings.paneGlowDim')}
+              className="w-24 accent-[color:var(--accent-blue)] disabled:opacity-40"
+            />
+            <span className="text-xs font-mono tabular-nums text-[color:var(--text-sub)] w-9 text-right">{Math.round(paneGlowOpacity * 100)}%</span>
+          </div>
         </SettingRow>
 
         {/* T12 — Pane flash */}
@@ -3980,6 +4005,8 @@ function TabNotifications() {
   // T12 fields
   const paneRingEnabled          = useStore((s) => s.paneRingEnabled);
   const setPaneRingEnabled       = useStore((s) => s.setPaneRingEnabled);
+  const paneGlowOpacity          = useStore((s) => s.paneGlowOpacity);
+  const setPaneGlowOpacity       = useStore((s) => s.setPaneGlowOpacity);
   const paneFlashEnabled         = useStore((s) => s.paneFlashEnabled);
   const setPaneFlashEnabled      = useStore((s) => s.setPaneFlashEnabled);
   const taskbarFlashEnabled      = useStore((s) => s.taskbarFlashEnabled);
@@ -4016,6 +4043,8 @@ function TabNotifications() {
       onChangeNotificationRingEnabled={setNotificationRingEnabled}
       paneRingEnabled={paneRingEnabled}
       onChangePaneRingEnabled={setPaneRingEnabled}
+      paneGlowOpacity={paneGlowOpacity}
+      onChangePaneGlowOpacity={setPaneGlowOpacity}
       paneFlashEnabled={paneFlashEnabled}
       onChangePaneFlashEnabled={setPaneFlashEnabled}
       taskbarFlashEnabled={taskbarFlashEnabled}

--- a/src/renderer/components/Settings/__tests__/SettingsPanel.notifications.test.tsx
+++ b/src/renderer/components/Settings/__tests__/SettingsPanel.notifications.test.tsx
@@ -25,6 +25,7 @@ import { NotificationsView, type NotificationsViewProps, type NotificationsViewW
 
 const noop = (): void => undefined;
 const noopBool = (_: boolean): void => undefined;
+const noopNum = (_v: number) => {};
 const noopChoice = (_: 'default' | 'none'): void => undefined;
 const noopMute = (_id: string, _muted: boolean): void => undefined;
 
@@ -51,6 +52,8 @@ function makeProps(overrides: Partial<NotificationsViewProps> = {}): Notificatio
     onChangeCategoryMuted: noop,
     paneRingEnabled: true,
     onChangePaneRingEnabled: noopBool,
+    paneGlowOpacity: 0.6,
+    onChangePaneGlowOpacity: noopNum,
     paneFlashEnabled: true,
     onChangePaneFlashEnabled: noopBool,
     taskbarFlashEnabled: true,

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -872,6 +872,8 @@ export const en = {
   // Notification system expansion (T12)
   'settings.paneRing': 'Pane border ring on new notifications',
   'settings.paneRingDesc': 'Highlights the pane that received a notification with a blue border.',
+  'settings.paneGlowDim': 'Unread pane brightness',
+  'settings.paneGlowDimDesc': 'How bright a pane stays while it holds an unread glow. 100% disables the shadowing so inactive sessions remain fully readable; 60% is the classic dimmed look.',
   'settings.paneFlash': 'Flash effect on new notification ring',
   'settings.paneFlashDesc': 'Plays a 500ms flash before the steady glow. Skips flash if disabled (goes straight to glow).',
   'settings.taskbarFlash': 'Flash taskbar when window is unfocused',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -1053,6 +1053,8 @@ export const zh = {
   'settings.paneActionsVisibleDesc': '在每个面板的标签栏中显示新建终端、分割和新建浏览器按钮。',
   'settings.paneRing': '新通知的面板边框光环',
   'settings.paneRingDesc': '用蓝色边框高亮收到通知的面板。',
+  'settings.paneGlowDim': '未读面板亮度',
+  'settings.paneGlowDimDesc': '面板处于未读高亮状态时保持的亮度。100% 关闭变暗效果，让非活动会话始终清晰可读；60% 为经典的变暗外观。',
   'settings.paneFlash': '新通知光环的闪烁效果',
   'settings.paneFlashDesc': '在常亮辉光之前播放 500ms 闪烁。禁用则跳过闪烁（直接进入辉光）。',
   'settings.taskbarFlash': '窗口未聚焦时闪烁任务栏',

--- a/src/renderer/stores/slices/__tests__/uiSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/uiSlice.test.ts
@@ -203,6 +203,12 @@ describe('UISlice — notification surface toggles (T5)', () => {
     expect(store.getState().taskbarFlashEnabled).toBe(true);
   });
 
+  // #949 — the unread-glow dim ships at the historical 0.6 so existing
+  // installs see no visual change until they move the slider.
+  it('paneGlowOpacity defaults to 0.6', () => {
+    expect(store.getState().paneGlowOpacity).toBe(0.6);
+  });
+
   it('notificationSoundChoice defaults to \'default\'', () => {
     expect(store.getState().notificationSoundChoice).toBe('default');
   });
@@ -213,6 +219,20 @@ describe('UISlice — notification surface toggles (T5)', () => {
   it('setPaneRingEnabled(false) flips paneRingEnabled to false', () => {
     store.getState().setPaneRingEnabled(false);
     expect(store.getState().paneRingEnabled).toBe(false);
+  });
+
+  // #949 — slider round-trip plus the clamp: 1 must be reachable (that IS the
+  // "disable shadowing" position) and out-of-range writes must land on the
+  // nearest legal value rather than making panes dimmer than they ever were.
+  it('setPaneGlowOpacity stores the value and clamps to [0.6, 1]', () => {
+    store.getState().setPaneGlowOpacity(1);
+    expect(store.getState().paneGlowOpacity).toBe(1);
+    store.getState().setPaneGlowOpacity(0.8);
+    expect(store.getState().paneGlowOpacity).toBe(0.8);
+    store.getState().setPaneGlowOpacity(0.2);
+    expect(store.getState().paneGlowOpacity).toBe(0.6);
+    store.getState().setPaneGlowOpacity(3);
+    expect(store.getState().paneGlowOpacity).toBe(1);
   });
 
   it('setPaneFlashEnabled(false) flips paneFlashEnabled to false', () => {

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -387,6 +387,16 @@ export interface UISlice {
   paneFlashEnabled: boolean;
   setPaneFlashEnabled: (enabled: boolean) => void;
 
+  // paneGlowOpacity (#949): opacity applied to a pane while it holds the
+  //   steady unread glow (.pane-ring-glow). The glow used to hard-code 0.6,
+  //   which reads as "the pane is shadowed" and makes an inactive session
+  //   hard to monitor. 1 disables the dimming entirely (the border-color
+  //   glow stays); 0.6 is the historical look. Clamped to [0.6, 1] — below
+  //   0.6 would only make the readability complaint worse. Same
+  //   non-persisting family as paneRingEnabled above.
+  paneGlowOpacity: number;
+  setPaneGlowOpacity: (opacity: number) => void;
+
   taskbarFlashEnabled: boolean;
   setTaskbarFlashEnabled: (enabled: boolean) => void;
 
@@ -1212,6 +1222,15 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
 
   setPaneFlashEnabled: (enabled) => set((state) => {
     state.paneFlashEnabled = enabled;
+  }),
+
+  paneGlowOpacity: 0.6,
+
+  setPaneGlowOpacity: (opacity) => set((state) => {
+    // Clamp instead of reject: the slider is the only writer today, but a
+    // future caller (or a corrupt restore) must not be able to push the pane
+    // below the historical dim or above full opacity.
+    state.paneGlowOpacity = Math.min(1, Math.max(0.6, opacity));
   }),
 
   taskbarFlashEnabled: true,

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -543,7 +543,10 @@ select option {
 
 .pane-ring-glow {
   border-color: var(--accent) !important;
-  opacity: 0.6;
+  /* #949: the dim is user-tunable (Settings → Notifications). Pane.tsx sets
+   * --pane-glow-opacity on the pane root; 1 = no shadowing (border glow only),
+   * 0.6 = the historical look and the fallback when the var is absent. */
+  opacity: var(--pane-glow-opacity, 0.6);
 }
 
 /* Reduced motion: drop the transition so the border flip is instant. The


### PR DESCRIPTION
Fixes #949.

## What the "shadowing" is

The reported shadow on inactive terminals is the unread glow: `.pane-ring-glow` drops the **whole pane** to a hard-coded `opacity: 0.6` while a notification sits unvisited. For the reporter's exact workflow — monitoring two Claude sessions side by side — that is backwards: the pane that just produced output becomes the hardest one to read.

## The knob

Per the triage direction, a **range rather than a binary toggle**: `paneGlowOpacity` (default `0.6`, clamped to `[0.6, 1]`) feeds the pane root's `--pane-glow-opacity` custom property, and `.pane-ring-glow` consumes it with the historical `0.6` as fallback — so existing installs see no change until they move the slider.

- **100%** = shadowing off; the border-color glow keeps carrying the unread cue.
- **60%** = the classic look (default).
- Below 60% is unreachable — it would only worsen the readability complaint the issue is about.
- The slider sits in Settings → Notifications beside the pane-ring toggle and disables with it (ring off → no glow → nothing to dim).
- Same non-persisting family as `paneRingEnabled` / `paneFlashEnabled` (per that family's documented convention); if the family ever gains persistence this rides along.

## Verification

- Unit: store default + clamp round-trip (1 reachable, 0.2→0.6, 3→1); settings-view factory extended; all Pane/Settings/uiSlice suites green (210 tests), `tsc` clean, eslint clean on touched files.
- **Live end-to-end**: pane root carries `--pane-glow-opacity: 0.6` by default and a glow pane computes `opacity: 0.6`; driving the real settings slider to 100% flips the same pane's computed opacity to `1` with the glow class still applied.

i18n: `en` + `zh` (the two locales that carry the sibling pane-ring keys; the rest fall back to `en`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7