### PR TITLE
Let a turn the agent starts by itself report that it is running

### DIFF
--- a/changelog.d/965.md
+++ b/changelog.d/965.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **A pane reports that it is working when the agent starts a turn by itself.**
+  A background task finishes, the agent picks up and works for a minute — and
+  the pane kept wearing the previous turn's `complete` for the whole thing,
+  because the only two things that could start a turn were you pressing Enter
+  and a hook that a plugin-less install does not wire. Byte activity now counts
+  while a pane is settled, held back by a cool-down after the turn end, by your
+  own keystrokes still echoing, and by a resize still repainting. A pane waiting
+  on an approval is left alone: only answering it retires a question.

--- a/scripts/autonomous-turn-status-dogfood.mjs
+++ b/scripts/autonomous-turn-status-dogfood.mjs
@@ -1,0 +1,264 @@
+// Dogfood #935 direction 2: does a turn the agent starts BY ITSELF report
+// `running`, or does it wear the previous turn's `complete` for its whole
+// length?
+//
+// Unit tests cannot answer this. The first attempt at this fix (#943) passed
+// its own tests and was inert in production, because the thing that decides is
+// the interaction between three live parts: the real Stop hook's arrival time,
+// the real TUI's byte pattern, and the daemon's status gate. So this drives all
+// three for real.
+//
+// Isolation: the daemon runs under a private WMUX_DATA_SUFFIX, so its control
+// pipe name and its `~/.wmux<suffix>/daemon-pipe` hint file are its own. The
+// pane inherits that suffix (DaemonSessionManager stamps it), so the hook
+// bridge inside the pane resolves the private pipe. HOME stays real — Claude
+// Code needs its credentials and its ORDINARY hook settings, which on this
+// machine are already the plugin-less shape the report describes (Stop,
+// SubagentStop, SessionStart, and the AskUserQuestion pair; no wide
+// PostToolUse). The production daemon is never addressed.
+//
+// Usage: node scripts/autonomous-turn-status-dogfood.mjs
+import net from 'node:net';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const REPO = process.cwd();
+const DAEMON = path.join(REPO, 'dist', 'daemon-bundle', 'index.js');
+const TAG = Math.random().toString(36).slice(2, 8);
+const SUFFIX = `-935dog-${TAG}`;
+const DAEMON_DIR = path.join(os.homedir(), `.wmux${SUFFIX}`);
+const PTY_ID = `dog935-${TAG}`;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const readPipeName = () => fs.readFileSync(path.join(DAEMON_DIR, 'daemon-pipe'), 'utf8').trim();
+const readToken = () => fs.readFileSync(path.join(DAEMON_DIR, 'daemon-auth-token'), 'utf8').trim();
+
+function rpc(method, params = {}) {
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  return new Promise((resolve, reject) => {
+    const s = net.createConnection(readPipeName());
+    let buf = '';
+    const t = setTimeout(() => { s.destroy(); reject(new Error(`rpc timeout: ${method}`)); }, 20000);
+    s.on('connect', () => s.write(`${JSON.stringify({ id, token: readToken(), method, params })}\n`));
+    s.on('data', (d) => {
+      buf += d.toString();
+      let nl;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (!line.trim()) continue;
+        let msg; try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id !== id) continue;
+        clearTimeout(t); s.end();
+        return msg.ok ? resolve(msg.result) : reject(new Error(String(msg.error)));
+      }
+    });
+    s.on('error', (e) => { clearTimeout(t); reject(e); });
+  });
+}
+
+async function dumpScreen(label) {
+  try {
+    const text = await rpc('daemon.readSessionText', { id: PTY_ID, scrollback: 0 });
+    const rows = (text?.rows ?? []).map((r) => (typeof r === 'string' ? r : r.text ?? ''));
+    const meat = rows.filter((r) => r.trim().length > 0);
+    console.log(`\n--- screen: ${label} (${meat.length} non-empty rows) ---`);
+    for (const r of meat.slice(-14)) console.log('  |', r.slice(0, 150));
+  } catch (e) { console.log(`[warn] screen read (${label}) failed:`, e.message); }
+}
+
+/** Long-lived listener: every status-bearing frame, stamped. */
+function statusListener(t0) {
+  const events = [];
+  const s = net.createConnection(readPipeName());
+  let buf = '';
+  s.on('connect', () => {
+    // Pushed events are first-party gated (#659): identify, THEN subscribe on
+    // the same connection. Subscribing without the identify silently returns
+    // ok:false and the stream stays empty.
+    s.write(`${JSON.stringify({ id: `id-${TAG}`, token: readToken(), method: 'daemon.client.identify', params: { role: 'main' } })}\n`);
+    setTimeout(() => {
+      s.write(`${JSON.stringify({ id: `sub-${TAG}`, token: readToken(), method: 'daemon.events.subscribe', params: {} })}\n`);
+    }, 300);
+  });
+  s.on('data', (d) => {
+    buf += d.toString();
+    let nl;
+    while ((nl = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      if (!line.trim()) continue;
+      let f; try { f = JSON.parse(line); } catch { continue; }
+      if (f.sessionId && f.sessionId !== PTY_ID) continue;
+      const at = ((Date.now() - t0) / 1000).toFixed(1);
+      if (f.type === 'agent.event') {
+        events.push({ at, kind: `agent.event ${f.data?.status}`, detail: `${f.data?.source ?? '?'}/${f.data?.hookKind ?? f.data?.message ?? ''}` });
+      } else if (f.type === 'activity.active') {
+        // `data` is the canonical agent name (or null); the repaint flag is
+        // consumed daemon-side and does not ride the broadcast.
+        events.push({ at, kind: 'activity.active (byte burst)', detail: f.data ?? '' });
+      } else if (f.type === 'activity.idle') {
+        events.push({ at, kind: 'activity.idle (byte silence)', detail: '' });
+      }
+    }
+  });
+  s.on('error', () => {});
+  return { events, close: () => { try { s.destroy(); } catch {} } };
+}
+
+let daemonPid = null;
+let sub = null;
+let failed = false;
+
+try {
+  console.log(`[setup] bundle mtime=${fs.statSync(DAEMON).mtime.toISOString()}`);
+  console.log(`[setup] private instance suffix=${SUFFIX} (production ~/.wmux untouched)`);
+
+  // Scrub the agent env before it reaches the daemon — the pane inherits from
+  // here, and a nested Claude Code that sees CLAUDE_CODE_CHILD_SESSION turns
+  // transcript persistence off and comes up degraded, which is not the product
+  // this is supposed to be measuring.
+  const daemonEnv = { WMUX_DATA_SUFFIX: SUFFIX };
+  for (const [k, v] of Object.entries(process.env)) {
+    if (/^(CLAUDE|ANTHROPIC|AI_AGENT)/i.test(k)) continue;
+    daemonEnv[k] = v;
+  }
+  const child = spawn(process.execPath, [DAEMON], {
+    env: daemonEnv, detached: true, stdio: 'ignore',
+  });
+  child.unref();
+  daemonPid = child.pid;
+
+  const deadline = Date.now() + 30000;
+  let ready = false;
+  while (Date.now() < deadline && !ready) {
+    if (fs.existsSync(path.join(DAEMON_DIR, 'daemon-pipe')) && fs.existsSync(path.join(DAEMON_DIR, 'daemon-auth-token'))) {
+      try { await rpc('daemon.listSessions'); ready = true; break; } catch { /* booting */ }
+    }
+    await sleep(400);
+  }
+  if (!ready) throw new Error('daemon never became ready');
+  console.log(`[setup] daemon pid=${daemonPid} pipe=${readPipeName()}`);
+
+  const t0 = Date.now();
+  sub = statusListener(t0);
+  await sleep(500);
+
+  // An ordinary interactive shell pane, then launch the agent by typing —
+  // exactly how a wmux pane gets an agent in it.
+  await rpc('daemon.createSession', {
+    id: PTY_ID,
+    cmd: process.env.SHELL || '/bin/zsh',
+    cwd: os.homedir(),
+    cols: 140,
+    rows: 41,
+  });
+  console.log(`[setup] pane=${PTY_ID} (interactive shell)`);
+
+  // Input rides the SESSION pipe, the way a real client sends keystrokes —
+  // that is the path `bridge.noteInput` sits on, so both the submitted-turn
+  // boundary and the typing-echo stamp are exercised for real.
+  await rpc('daemon.attachSession', { id: PTY_ID });
+  const sessionSock = path.join(DAEMON_DIR, `session-${PTY_ID}.sock`);
+  const inputSock = await new Promise((resolve, reject) => {
+    const c = net.createConnection(sessionSock);
+    const t = setTimeout(() => reject(new Error('session pipe connect timeout')), 15000);
+    c.on('connect', () => { clearTimeout(t); c.write(`${readToken()}\n`); resolve(c); });
+    c.on('error', (e) => { clearTimeout(t); reject(e); });
+  });
+  inputSock.on('data', () => {});   // drain the output flush
+  const write = async (data) => { inputSock.write(data); await sleep(120); };
+
+  await sleep(2500);
+  console.log('[setup] launching claude in the pane');
+  // Pin the model: this machine's personal config selects one this account
+  // cannot reach, and an errored turn ends without the Stop hook that the
+  // scenario is built around.
+  await write('claude --dangerously-skip-permissions --model sonnet\r');
+  // Let the TUI boot and the SessionStart hook land.
+  await sleep(20000);
+  await dumpScreen('after boot');
+
+  // ── The scenario ────────────────────────────────────────────────────────
+  // Ask for a background task that finishes AFTER the turn ends, so the
+  // completion resumes the agent with no submitted input behind it.
+  console.log('[drive] submitting the turn that will resume itself');
+  await write(
+    'Run this in the background and then END YOUR TURN immediately without waiting: '
+    + 'sleep 45 && echo WOKEUP. Do not comment. When the task completes later, '
+    + 'read its output and reply with one short sentence about it.',
+  );
+  await sleep(1200);
+  await write('\r');
+
+  console.log('[drive] waiting out the submitted turn + the autonomous turn');
+  for (let i = 0; i < 18; i++) {
+    await sleep(10000);
+    if ((i + 1) % 6 === 0) await dumpScreen(`t+${(i + 1) * 10}s`);
+    else process.stdout.write(`  ..${(i + 1) * 10}s`);
+  }
+  console.log('');
+
+  // ── The guard ───────────────────────────────────────────────────────────
+  // Letting bytes promote a settled pane costs nothing only if the pane's own
+  // echo of the user's typing is excluded. Compose a long draft, slowly, with
+  // no Enter: the pane must stay settled for all of it.
+  const beforeTyping = sub.events.length;
+  console.log('\n[drive] typing a draft with no Enter (the echo guard)');
+  for (let i = 0; i < 60; i++) {
+    await write('abcdefghij'[i % 10]);
+    await sleep(150);
+  }
+  await sleep(3000);
+  const duringTyping = sub.events.slice(beforeTyping)
+    .filter((e) => e.kind === 'activity.active (byte burst)');
+  console.log(`[drive] draft typed; active bursts during it: ${duringTyping.length}`);
+
+  await write('\x15');   // ctrl-U, discard the draft
+  await sleep(1500);
+
+  await dumpScreen('final');
+
+  console.log('\n=== status timeline (t=0 at daemon subscribe) ===');
+  for (const e of sub.events) console.log(`  ${e.at.padStart(6)}s  ${e.kind.padEnd(28)} ${e.detail}`);
+
+  // ── The verdict ─────────────────────────────────────────────────────────
+  // The bug: after the FIRST turn-ending `complete`, nothing reports running
+  // again for the autonomous turn. So look for any running-class evidence
+  // strictly after the first complete.
+  const firstComplete = sub.events.findIndex((e) => e.kind === 'agent.event complete');
+  const after = firstComplete >= 0 ? sub.events.slice(firstComplete + 1) : [];
+  const resumed = after.filter((e) => e.kind === 'activity.active (byte burst)');
+
+  console.log('\n=== verdict ===');
+  if (duringTyping.length > 0) {
+    failed = true;
+    console.log(`FAIL (echo guard): typing a draft produced ${duringTyping.length} running burst(s)`);
+  } else {
+    console.log('PASS (echo guard): a draft typed into a settled pane never reported running');
+  }
+  if (firstComplete < 0) {
+    failed = true;
+    console.log('INCONCLUSIVE: no turn-ending `complete` was ever observed — the Stop hook did not land.');
+  } else if (resumed.length > 0) {
+    console.log(`PASS: the autonomous turn reported running — ${resumed.length} burst(s) after the turn-ending complete`);
+    console.log(`      first at t=${resumed[0].at}s`);
+  } else {
+    failed = true;
+    console.log('FAIL: the pane stayed settled through the autonomous turn (#935 direction 2 still present)');
+  }
+} catch (err) {
+  failed = true;
+  console.error('[error]', err?.message ?? err);
+} finally {
+  sub?.close();
+  try { await rpc('daemon.destroySession', { id: PTY_ID }); } catch {}
+  await sleep(500);
+  if (daemonPid) { try { process.kill(daemonPid, 'SIGTERM'); } catch {} }
+  await sleep(1000);
+  try { fs.rmSync(DAEMON_DIR, { recursive: true, force: true }); } catch {}
+  console.log('[teardown] private daemon stopped, its data dir removed');
+  process.exit(failed ? 1 : 0);
+}

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -110,7 +110,46 @@ export class DaemonPTYBridge extends EventEmitter {
    * the separation from depending on one agent's repaint economy.
    */
   private lastInputAt = 0;
-  private static readonly INPUT_ECHO_QUIET_MS = 1500;
+  /**
+   * At least one full activity window. A shorter one would let bytes banked
+   * before a keystroke combine, inside the same 3 s measurement window, with
+   * the echo that followed it — the guard has to outlast what it is guarding.
+   */
+  private static readonly INPUT_ECHO_QUIET_MS = 3000;
+
+  /**
+   * When the current settle was recorded, and how long a burst must wait
+   * before it may contradict it.
+   *
+   * A turn does not stop painting the moment it ends: the summary line, the
+   * footer and the cursor restore all land after the Stop hook. Promoting on
+   * that tail would be wrong twice over — it reports a finished pane as
+   * running, and it feeds `notePaneWorking`, whose whole job is to rebut an
+   * open completion window, so a real "turn finished" alarm would die
+   * silently (the failure #907 exists to prevent).
+   *
+   * The length is set by a SECOND constraint, which is the tighter one. The
+   * status a promotion writes is cleared by the byte-silence idle that follows
+   * it, and main drops that idle when it lands within 10 s of the pane's last
+   * lifecycle event (`AGENT_EVENT_SUPPRESSION_MS` in DaemonNotificationRouter,
+   * mirrored from PTYBridge). The idle cannot arrive sooner than
+   * IDLE_DELAY_MS (5 s) after the promoting burst, so a cool-down under 5 s
+   * leaves a window where a SHORT autonomous burst is promoted and then has
+   * its clearing idle swallowed — a pane stuck reporting `running` after it
+   * finished, which is the other half of the very bug this fixes. Six seconds
+   * clears 10 s with both delays counted, and is still short next to any turn
+   * worth reporting.
+   */
+  private settledAtMs = 0;
+  private static readonly SETTLE_COOLDOWN_MS = 6000;
+
+  /**
+   * A pane that has been blocked on a human since its last submitted input or
+   * running edge. `settledStatus` alone is not enough: the Claude footer under
+   * an approval box still matches the detector's idle-prompt patterns, and that
+   * `waiting` would otherwise overwrite the `awaiting_input` that must stay.
+   */
+  private awaitingHuman = false;
 
   /** Track bracketed-paste input so newlines inside a pasted draft are not
    * mistaken for Enter. The closing marker and the later CR are separate writes
@@ -157,6 +196,7 @@ export class DaemonPTYBridge extends EventEmitter {
 
     this.explicitTerminalStatus = false;
     this.settledStatus = null;
+    this.awaitingHuman = false;
     this.submittedTurnPending = true;
     if (this.resizeGuardTimer) {
       clearTimeout(this.resizeGuardTimer);
@@ -177,10 +217,18 @@ export class DaemonPTYBridge extends EventEmitter {
     if (status === 'running') {
       this.explicitTerminalStatus = false;
       this.settledStatus = null;
+      // `awaitingHuman` deliberately survives. HookIngest projects
+      // `agent.subagent_stop` and every metadata kind (activity, tool_started,
+      // session_start) as `running`, so a subagent finishing behind an
+      // unanswered approval would otherwise retire the question nobody
+      // answered. Only `noteInput` — a human, including the forceSubmitted
+      // approval controls — clears it.
       return;
     }
     this.explicitTerminalStatus = true;
     this.settledStatus = status;
+    if (status === 'awaiting_input') this.awaitingHuman = true;
+    this.settledAtMs = Date.now();
     this.submittedTurnPending = false;
     if (this.resizeGuardTimer) {
       clearTimeout(this.resizeGuardTimer);
@@ -273,6 +321,8 @@ export class DaemonPTYBridge extends EventEmitter {
     this.inputInBracketedPaste = false;
     this.lastInputAt = 0;
     this.settledStatus = null;
+    this.settledAtMs = 0;
+    this.awaitingHuman = false;
 
     const activityMonitor = new ActivityMonitor();
     this.activityMonitor = activityMonitor;
@@ -295,18 +345,30 @@ export class DaemonPTYBridge extends EventEmitter {
       let likelyRepaint = false;
 
       if (this.explicitTerminalStatus) {
-        // `awaiting_input` is the one settle bytes may never retire — a pane
-        // holding a question stays in the "needs you" count until a human
-        // answers it, however much a subagent paints behind the prompt.
-        if (this.settledStatus === 'awaiting_input') return;
+        // A pane blocked on a human is never retired by bytes — it stays in
+        // the "needs you" count until a person answers, however much a
+        // subagent paints behind the prompt. Read from the sticky flag rather
+        // than `settledStatus`, which a later detector `waiting` off the footer
+        // under the approval box would otherwise overwrite.
+        if (this.awaitingHuman) return;
 
-        // Promoting a SETTLED pane. Two things disqualify the burst: the user's
-        // keystrokes are still echoing, or a resize is still repainting. Either
-        // way the cycle is re-armed rather than consumed — a burst that proved
-        // nothing must not spend the one `onActive` this cycle gets, or a real
-        // autonomous turn arriving right behind it would stay silent for as
-        // long as it keeps the idle timer alive.
-        if (!this.inputIsQuiet() || Date.now() - this.lastResizeAtMs < RESIZE_REDRAW_GUARD_MS) {
+        // Promoting a SETTLED pane. Three things disqualify the burst: the
+        // turn that just ended is still painting its tail, the user's
+        // keystrokes are still echoing, or a resize is still repainting.
+        //
+        // Every rejection re-arms the cycle rather than consuming it. A burst
+        // that proved nothing must not spend the one `onActive` a cycle gets,
+        // or the real autonomous turn arriving right behind it would stay
+        // silent for as long as it kept the idle timer alive — which, for a
+        // TUI painting a live counter, is the whole turn. That applies to the
+        // cool-down too: the tail of the finishing turn is exactly the burst
+        // most likely to arrive just before a genuine one.
+        const now = Date.now();
+        if (
+          now - this.settledAtMs < DaemonPTYBridge.SETTLE_COOLDOWN_MS
+          || !this.inputIsQuiet()
+          || now - this.lastResizeAtMs < RESIZE_REDRAW_GUARD_MS
+        ) {
           activityMonitor.endTurn(ptyId);
           return;
         }
@@ -524,6 +586,13 @@ export class DaemonPTYBridge extends EventEmitter {
    * the caller before forwarding starts) is preserved.
    */
   setMuted(muted: boolean): void {
+    // Unmuting a recovered pane releases a full repaint at the new geometry,
+    // and `noteResize` only stamps when the dimensions actually CHANGED — a
+    // pane recovered at the size it was saved at gets the storm with no guard
+    // behind it. Stamp the same guard here so that repaint cannot be read as
+    // the agent starting a turn. Muted panes feed nothing, so the window is
+    // empty and the storm would otherwise clear the threshold on its own.
+    if (this.muted && !muted) this.lastResizeAtMs = Date.now();
     this.muted = muted;
   }
 
@@ -578,6 +647,8 @@ export class DaemonPTYBridge extends EventEmitter {
     this.inputInBracketedPaste = false;
     this.lastInputAt = 0;
     this.settledStatus = null;
+    this.settledAtMs = 0;
+    this.awaitingHuman = false;
     this.oscParser = null;
     this.modeTracker = null;
     this.agentDetector = null;

--- a/src/daemon/DaemonPTYBridge.ts
+++ b/src/daemon/DaemonPTYBridge.ts
@@ -89,6 +89,29 @@ export class DaemonPTYBridge extends EventEmitter {
   private explicitTerminalStatus = false;
   private submittedTurnPending = false;
 
+  /**
+   * Which terminal status settled the pane, while one has. Read only to keep
+   * `awaiting_input` out of the byte-promotion path below: that status means a
+   * HUMAN has to act, and only a human acting — `noteInput`, including the
+   * forceSubmitted approval controls — should retire it. Every other terminal
+   * status is a statement about the agent, which a turn the agent starts by
+   * itself can legitimately contradict.
+   */
+  private settledStatus: AgentEventStatus | null = null;
+
+  /**
+   * Last write to this PTY's stdin, from any client. Only the settled branch
+   * reads it: while a terminal status owns the pane, a burst that starts this
+   * soon after a keystroke is the TUI echoing the user's own typing, and
+   * letting it promote the pane to `running` would paint every draft message
+   * as work. Measured on Claude Code (2026-08-21, 140x41): typing peaks at
+   * ~1.5 KB per 3 s window against a 2 KB threshold, so the threshold alone
+   * already separates echo from work on that TUI — this guard is what keeps
+   * the separation from depending on one agent's repaint economy.
+   */
+  private lastInputAt = 0;
+  private static readonly INPUT_ECHO_QUIET_MS = 1500;
+
   /** Track bracketed-paste input so newlines inside a pasted draft are not
    * mistaken for Enter. The closing marker and the later CR are separate writes
    * in the normal renderer path; only that CR starts a turn. */
@@ -123,10 +146,17 @@ export class DaemonPTYBridge extends EventEmitter {
    * not include Enter but still resume the blocked turn.
    */
   noteInput(data: string, forceSubmitted = false): void {
+    // Stamped for EVERY write, including the ordinary keystrokes that fall out
+    // below. Output that arrives while the user is still typing is the TUI
+    // echoing them, and echo must never be mistaken for the agent working —
+    // see the settled branch in setupDataForwarding's data handler.
+    if (data.length > 0) this.lastInputAt = Date.now();
+
     const hasSubmitBoundary = this.scanSubmittedInput(data);
     if (!forceSubmitted && !hasSubmitBoundary) return;
 
     this.explicitTerminalStatus = false;
+    this.settledStatus = null;
     this.submittedTurnPending = true;
     if (this.resizeGuardTimer) {
       clearTimeout(this.resizeGuardTimer);
@@ -146,14 +176,31 @@ export class DaemonPTYBridge extends EventEmitter {
   noteAgentStatus(status: AgentEventStatus): void {
     if (status === 'running') {
       this.explicitTerminalStatus = false;
+      this.settledStatus = null;
       return;
     }
     this.explicitTerminalStatus = true;
+    this.settledStatus = status;
     this.submittedTurnPending = false;
     if (this.resizeGuardTimer) {
       clearTimeout(this.resizeGuardTimer);
       this.resizeGuardTimer = null;
     }
+    // Re-arm the activity cycle on the turn end so the NEXT burst has to earn
+    // `running` from scratch. Without this the cycle re-arms only after five
+    // seconds of byte silence, which a TUI painting a live counter never gives.
+    if (this.activityMonitor && this.sessionId) {
+      this.activityMonitor.endTurn(this.sessionId);
+    }
+  }
+
+  /**
+   * True when nothing has been written to this PTY's stdin recently enough for
+   * the current output to be an echo of it. `lastInputAt` starts at 0, so a
+   * pane nobody has typed into is quiet from the moment it spawns.
+   */
+  private inputIsQuiet(): boolean {
+    return Date.now() - this.lastInputAt >= DaemonPTYBridge.INPUT_ECHO_QUIET_MS;
   }
 
   private scanSubmittedInput(data: string): boolean {
@@ -224,6 +271,8 @@ export class DaemonPTYBridge extends EventEmitter {
     this.explicitTerminalStatus = false;
     this.submittedTurnPending = false;
     this.inputInBracketedPaste = false;
+    this.lastInputAt = 0;
+    this.settledStatus = null;
 
     const activityMonitor = new ActivityMonitor();
     this.activityMonitor = activityMonitor;
@@ -236,31 +285,59 @@ export class DaemonPTYBridge extends EventEmitter {
       if (this.explicitTerminalStatus) return;
       this.emit('idle', { sessionId: ptyId });
     });
-    // Activity → active notification. Passive bursts are accepted only while
-    // no explicit terminal state owns the pane. A submitted turn is re-armed by
-    // beginTurn(), so its very first output emits running even for a short reply.
+    // Activity → active notification. A submitted turn is re-armed by
+    // beginTurn(), so its very first output emits running even for a short
+    // reply. A settled pane can be promoted too, but only by a burst that
+    // cleared the threshold from a cycle the turn end re-armed, with the user's
+    // keystrokes quiet and outside the resize-redraw window — the three things
+    // that separate an autonomous turn from echo and repaints.
     this.activeUnsubscribe = activityMonitor.onActive((ptyId) => {
-      if (this.explicitTerminalStatus) return;
-
-      const inputStartedTurn = this.submittedTurnPending;
-      this.submittedTurnPending = false;
-
-      // Real submitted input already reset detector dedup in noteInput(). For a
-      // passive startup/autonomous burst, retain the resize-redraw guard: a TUI
-      // repaint is not a new turn and must not make an unchanged footer emit
-      // another waiting notification.
       let likelyRepaint = false;
-      if (!inputStartedTurn) {
-        const elapsed = Date.now() - this.lastResizeAtMs;
-        likelyRepaint = elapsed < RESIZE_REDRAW_GUARD_MS;
-        if (likelyRepaint) {
-          if (this.resizeGuardTimer) clearTimeout(this.resizeGuardTimer);
-          this.resizeGuardTimer = setTimeout(() => {
-            this.resizeGuardTimer = null;
+
+      if (this.explicitTerminalStatus) {
+        // `awaiting_input` is the one settle bytes may never retire — a pane
+        // holding a question stays in the "needs you" count until a human
+        // answers it, however much a subagent paints behind the prompt.
+        if (this.settledStatus === 'awaiting_input') return;
+
+        // Promoting a SETTLED pane. Two things disqualify the burst: the user's
+        // keystrokes are still echoing, or a resize is still repainting. Either
+        // way the cycle is re-armed rather than consumed — a burst that proved
+        // nothing must not spend the one `onActive` this cycle gets, or a real
+        // autonomous turn arriving right behind it would stay silent for as
+        // long as it keeps the idle timer alive.
+        if (!this.inputIsQuiet() || Date.now() - this.lastResizeAtMs < RESIZE_REDRAW_GUARD_MS) {
+          activityMonitor.endTurn(ptyId);
+          return;
+        }
+        this.explicitTerminalStatus = false;
+        this.settledStatus = null;
+        this.submittedTurnPending = false;
+        // Deliberately NOT resetEmissionState(). The unsettled path below
+        // clears the detector's dedup so a new turn's footer can speak again;
+        // doing it here would let the idle chrome that is still on screen
+        // answer the `complete` this pane just recorded with a stale
+        // `waiting` — trading a silent wrong status for a loud one.
+      } else {
+        const inputStartedTurn = this.submittedTurnPending;
+        this.submittedTurnPending = false;
+
+        // Real submitted input already reset detector dedup in noteInput(). For
+        // a passive startup/autonomous burst, retain the resize-redraw guard: a
+        // TUI repaint is not a new turn and must not make an unchanged footer
+        // emit another waiting notification.
+        if (!inputStartedTurn) {
+          const elapsed = Date.now() - this.lastResizeAtMs;
+          likelyRepaint = elapsed < RESIZE_REDRAW_GUARD_MS;
+          if (likelyRepaint) {
+            if (this.resizeGuardTimer) clearTimeout(this.resizeGuardTimer);
+            this.resizeGuardTimer = setTimeout(() => {
+              this.resizeGuardTimer = null;
+              this.agentDetector?.resetEmissionState();
+            }, RESIZE_REDRAW_GUARD_MS - elapsed);
+          } else {
             this.agentDetector?.resetEmissionState();
-          }, RESIZE_REDRAW_GUARD_MS - elapsed);
-        } else {
-          this.agentDetector?.resetEmissionState();
+          }
         }
       }
 
@@ -352,11 +429,18 @@ export class DaemonPTYBridge extends EventEmitter {
       const buf = Buffer.from(data);
 
       // Byte activity is weaker than a detector/hook terminal edge. Process it
-      // FIRST only while the pane is unsettled, so a waiting/complete pattern
-      // found in this same chunk is forwarded last and remains authoritative.
-      // While settled, ignore idle TUI repaints entirely until noteInput() sees
-      // a submitted turn (or an explicit running hook reopens the gate).
-      if (!this.muted && !this.explicitTerminalStatus) {
+      // FIRST, so a waiting/complete pattern found in this same chunk is
+      // forwarded last and remains authoritative.
+      //
+      // While the pane is settled the bytes still count, but only once the
+      // user's own keystrokes have gone quiet (#935). A turn the agent starts
+      // by ITSELF — a background task finishing and the agent picking up —
+      // submits no input and, on a hook install without PostToolUse, produces
+      // no explicit running edge either, so those two openers left the pane
+      // wearing the previous turn's `complete` for the whole autonomous turn.
+      // Echo is what the settled branch has to exclude, and the input stamp
+      // names it directly instead of blocking every byte to be safe.
+      if (!this.muted && (!this.explicitTerminalStatus || this.inputIsQuiet())) {
         try {
           activityMonitor.feed(sessionId, buf.length);
         } catch {
@@ -492,6 +576,8 @@ export class DaemonPTYBridge extends EventEmitter {
     this.explicitTerminalStatus = false;
     this.submittedTurnPending = false;
     this.inputInBracketedPaste = false;
+    this.lastInputAt = 0;
+    this.settledStatus = null;
     this.oscParser = null;
     this.modeTracker = null;
     this.agentDetector = null;

--- a/src/daemon/__tests__/DaemonPTYBridge.turnPriority.test.ts
+++ b/src/daemon/__tests__/DaemonPTYBridge.turnPriority.test.ts
@@ -28,6 +28,8 @@ import { DaemonPTYBridge } from '../DaemonPTYBridge';
 import { RingBuffer } from '../RingBuffer';
 
 const BIG = 'x'.repeat(3000); // > ActivityMonitor's 2 KB active threshold
+// Past the settle cool-down (6 s) and the typing-echo quiet window (3 s).
+const PAST_GUARDS_MS = 6100;
 const PASTE_START = '\x1b[200~';
 const PASTE_END = '\x1b[201~';
 
@@ -88,6 +90,7 @@ describe('DaemonPTYBridge turn priority', () => {
     it('ignores a repaint a resize explains', () => {
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       bridge.noteResize();
       feed(BIG);
       feed(BIG);
@@ -101,6 +104,7 @@ describe('DaemonPTYBridge turn priority', () => {
       (status) => {
         bridge.noteAgentStatus(status);
         active.length = 0;
+        vi.advanceTimersByTime(PAST_GUARDS_MS);
         feed('.');           // dribble stays under the threshold
         expect(active).toEqual([]);
         feed(BIG);           // a real burst is the agent working again
@@ -108,11 +112,47 @@ describe('DaemonPTYBridge turn priority', () => {
       },
     );
 
+    it('stays settled for the whole cool-down, however much it repaints', () => {
+      // The cool-down is not just about the tail. The status a promotion writes
+      // is cleared by the byte-silence idle 5 s later, and main drops that idle
+      // within 10 s of the pane's last lifecycle event — so a promotion earlier
+      // than 6 s can leave the pane stuck reporting `running` after it
+      // finished. Re-arming (not consuming) the cycle is what lets the burst
+      // after the cool-down still be heard.
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      for (let t = 0; t < 5500; t += 500) {
+        feed(BIG);
+        vi.advanceTimersByTime(500);
+      }
+      expect(active).toEqual([]);
+
+      vi.advanceTimersByTime(1000);
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('holds the tail of the turn that just ended below the cool-down', () => {
+      // A turn keeps painting after its Stop hook — the summary line, the
+      // footer, the cursor restore. Promoting on that would report a finished
+      // pane as running AND rebut the completion alarm's open window.
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      feed(BIG);
+      feed(BIG);
+      expect(active).toEqual([]);
+
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+
     it('never lets bytes retire awaiting_input — only a human does', () => {
       // A pane holding a question stays in the "needs you" count however much
       // a subagent paints behind the prompt. Answering it is what ends it.
       bridge.noteAgentStatus('awaiting_input');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       feed(BIG);
       feed(BIG);
       vi.advanceTimersByTime(10_000);
@@ -146,8 +186,44 @@ describe('DaemonPTYBridge turn priority', () => {
     it('reports running when the resumed turn produces real output', () => {
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       feed(BIG);
       expect(active).toEqual(['sess-1']);
+    });
+
+    it('keeps the exemption across a running edge nobody human produced', () => {
+      // HookIngest projects `agent.subagent_stop` and every metadata kind as
+      // `running`, so those edges arrive with the question still unanswered.
+      // Such an edge opens the gate (its own status broadcast has already
+      // moved the pane, which this change does not alter), but it must not
+      // ERASE the fact that a human is owed an answer: once the pane settles
+      // again, bytes still may not retire it.
+      bridge.noteAgentStatus('awaiting_input');
+      bridge.noteAgentStatus('running');       // e.g. a subagent finished
+      bridge.noteAgentStatus('complete');      // and the pane settles again
+      active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
+      feed(BIG);
+      feed(BIG);
+      expect(active).toEqual([]);
+
+      bridge.noteInput('2', true);             // the human finally answers
+      feed('.');
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('keeps the exemption when the footer under an approval box says waiting', () => {
+      // The Claude idle-prompt patterns still match while a question is on
+      // screen, so `settledStatus` alone would be downgraded to `waiting` and
+      // the pane would become promotable — silently dropping a real approval
+      // out of the "needs you" count.
+      bridge.noteAgentStatus('awaiting_input');
+      bridge.noteAgentStatus('waiting');
+      active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
+      feed(BIG);
+      feed(BIG);
+      expect(active).toEqual([]);
     });
 
     it('needs a NEW burst, not the one still in flight at the turn end', () => {
@@ -156,6 +232,7 @@ describe('DaemonPTYBridge turn priority', () => {
       feed('y'.repeat(1900));           // just under the threshold
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       feed('y'.repeat(200));            // would have crossed 2 KB cumulatively
       expect(active).toEqual([]);
       feed(BIG);
@@ -172,6 +249,7 @@ describe('DaemonPTYBridge turn priority', () => {
       statuses.length = 0;
 
       bridge.noteAgentStatus('complete');
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       feed(BIG);
       feed('  shift+tab to cycle modes\n');
       expect(statuses).toEqual([]);
@@ -182,6 +260,7 @@ describe('DaemonPTYBridge turn priority', () => {
     it('suppresses a burst that arrives while the user is still typing', () => {
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       bridge.noteInput('draft message');   // no CR — still composing
       feed(BIG);
       expect(active).toEqual([]);
@@ -190,11 +269,12 @@ describe('DaemonPTYBridge turn priority', () => {
     it('accepts the same burst once the keystrokes have gone quiet', () => {
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       bridge.noteInput('draft message');
       feed(BIG);
       expect(active).toEqual([]);
 
-      vi.advanceTimersByTime(1600);        // past INPUT_ECHO_QUIET_MS
+      vi.advanceTimersByTime(PAST_GUARDS_MS);   // past INPUT_ECHO_QUIET_MS
       feed(BIG);
       expect(active).toEqual(['sess-1']);
     });
@@ -205,11 +285,12 @@ describe('DaemonPTYBridge turn priority', () => {
       // consumed cycle would keep the pane silent for the whole next turn.
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       bridge.noteInput('x');
       feed(BIG);                            // rejected: echo
       expect(active).toEqual([]);
 
-      vi.advanceTimersByTime(1600);
+      vi.advanceTimersByTime(PAST_GUARDS_MS);
       feed(BIG);                            // same cycle would be spent already
       expect(active).toEqual(['sess-1']);
     });

--- a/src/daemon/__tests__/DaemonPTYBridge.turnPriority.test.ts
+++ b/src/daemon/__tests__/DaemonPTYBridge.turnPriority.test.ts
@@ -5,15 +5,22 @@
 // hook lifecycle edge (waiting / complete / awaiting input) is authoritative.
 // Before this, an idle Claude repaint five seconds after a Stop hook resurrected
 // stale `running` metadata, so a pane that was actually blocked on a question
-// reported itself as busy.
+// reported itself as busy. The settle that fixed it was absolute, which bought
+// the opposite error (#935): a turn the agent started by itself wore the
+// previous turn's `complete` for its whole length.
 //
 // The rule these lock:
-//   1. An explicit terminal status SETTLES the turn. While settled, passive
-//      bytes are ignored entirely.
-//   2. Only a real submitted-input boundary (CR/LF outside bracketed paste, or
-//      an explicit forceSubmitted control) re-opens the gate.
-//   3. An explicit `running` edge also re-opens it (autonomous work).
-//   4. Within one chunk, activity is processed FIRST so a terminal pattern found
+//   1. An explicit terminal status SETTLES the turn.
+//   2. A real submitted-input boundary (CR/LF outside bracketed paste, or an
+//      explicit forceSubmitted control) re-opens the gate.
+//   3. An explicit `running` edge also re-opens it.
+//   4. A burst of passive bytes re-opens it too (#935) — but only one that
+//      cleared the threshold from a cycle the turn end re-armed, with the
+//      user's keystrokes quiet and outside the resize-redraw window. Those
+//      three conditions are what separate a turn the agent started BY ITSELF
+//      from the pane echoing a draft message and from a repaint.
+//   5. `awaiting_input` is exempt from 4: only a human retires a question.
+//   6. Within one chunk, activity is processed FIRST so a terminal pattern found
 //      in that same chunk is forwarded LAST and wins.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { IPty } from 'node-pty';
@@ -78,9 +85,10 @@ describe('DaemonPTYBridge turn priority', () => {
       expect(idle).toEqual([]);
     });
 
-    it('ignores a later full-screen repaint entirely', () => {
+    it('ignores a repaint a resize explains', () => {
       bridge.noteAgentStatus('complete');
       active.length = 0;
+      bridge.noteResize();
       feed(BIG);
       feed(BIG);
       vi.advanceTimersByTime(10_000);
@@ -88,23 +96,121 @@ describe('DaemonPTYBridge turn priority', () => {
       expect(idle).toEqual([]);
     });
 
-    it.each(['waiting', 'complete', 'awaiting_input', 'error'] as const)(
-      'treats %s as terminal',
+    it.each(['waiting', 'complete', 'error'] as const)(
+      'treats %s as terminal until a burst contradicts it',
       (status) => {
         bridge.noteAgentStatus(status);
         active.length = 0;
-        feed(BIG);
+        feed('.');           // dribble stays under the threshold
         expect(active).toEqual([]);
+        feed(BIG);           // a real burst is the agent working again
+        expect(active).toEqual(['sess-1']);
       },
     );
 
-    it('an explicit running edge re-opens the gate for autonomous work', () => {
-      bridge.noteAgentStatus('complete');
+    it('never lets bytes retire awaiting_input — only a human does', () => {
+      // A pane holding a question stays in the "needs you" count however much
+      // a subagent paints behind the prompt. Answering it is what ends it.
+      bridge.noteAgentStatus('awaiting_input');
+      active.length = 0;
       feed(BIG);
+      feed(BIG);
+      vi.advanceTimersByTime(10_000);
+      expect(active).toEqual([]);
+
+      bridge.noteInput('2', true);
+      feed('.');
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('an explicit running edge re-opens the gate for autonomous work', () => {
+      // The point here is the hook edge, so keep the bytes below the threshold
+      // that would open the gate on its own (see the #935 block for that path).
+      bridge.noteAgentStatus('complete');
+      feed('.');
       expect(active).toEqual([]);
 
       bridge.noteAgentStatus('running');
+      feed('.');
+      expect(active).toEqual([]);   // still under the threshold, but ungated
       feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+  });
+
+  describe('a turn the agent starts by itself (#935)', () => {
+    // The shape from the report: the agent launches a background task, ends its
+    // turn, and the task's completion resumes it. There is no submitted input,
+    // and on a hook install without PostToolUse there is no running edge
+    // either — so before this the pane wore `complete` for the whole turn.
+    it('reports running when the resumed turn produces real output', () => {
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('needs a NEW burst, not the one still in flight at the turn end', () => {
+      // endTurn() zeroes the window at the boundary, so bytes that were already
+      // counted toward the finishing turn cannot be spent again on the next one.
+      feed('y'.repeat(1900));           // just under the threshold
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      feed('y'.repeat(200));            // would have crossed 2 KB cumulatively
+      expect(active).toEqual([]);
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('does not reset the detector dedup, so idle chrome cannot answer back', () => {
+      // A full resetEmissionState() here would let the footer still on screen
+      // re-emit `waiting` right after the pane recorded `complete` — trading a
+      // silently wrong status for a loudly wrong one.
+      const statuses: string[] = [];
+      bridge.on('agent', (e: { event: { status: string } }) => statuses.push(e.event.status));
+      feed('Claude Code v2.1.172\n  shift+tab to cycle modes\n');
+      statuses.length = 0;
+
+      bridge.noteAgentStatus('complete');
+      feed(BIG);
+      feed('  shift+tab to cycle modes\n');
+      expect(statuses).toEqual([]);
+    });
+  });
+
+  describe('typing echo never counts as work', () => {
+    it('suppresses a burst that arrives while the user is still typing', () => {
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      bridge.noteInput('draft message');   // no CR — still composing
+      feed(BIG);
+      expect(active).toEqual([]);
+    });
+
+    it('accepts the same burst once the keystrokes have gone quiet', () => {
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      bridge.noteInput('draft message');
+      feed(BIG);
+      expect(active).toEqual([]);
+
+      vi.advanceTimersByTime(1600);        // past INPUT_ECHO_QUIET_MS
+      feed(BIG);
+      expect(active).toEqual(['sess-1']);
+    });
+
+    it('hands the cycle back so the real turn behind the echo still reports', () => {
+      // A rejected burst must not spend the one onActive a cycle gets. Output
+      // here never goes quiet for the five seconds the idle timer needs, so a
+      // consumed cycle would keep the pane silent for the whole next turn.
+      bridge.noteAgentStatus('complete');
+      active.length = 0;
+      bridge.noteInput('x');
+      feed(BIG);                            // rejected: echo
+      expect(active).toEqual([]);
+
+      vi.advanceTimersByTime(1600);
+      feed(BIG);                            // same cycle would be spent already
       expect(active).toEqual(['sess-1']);
     });
   });

--- a/src/main/pty/ActivityMonitor.ts
+++ b/src/main/pty/ActivityMonitor.ts
@@ -99,6 +99,39 @@ export class ActivityMonitor {
     s.lastReschedule = 0;
   }
 
+  /**
+   * Re-arm a cycle from an authoritative TURN END, so the pane's next turn can
+   * report `running` again.
+   *
+   * `onActive` fires once per cycle and the cycle is otherwise re-armed only
+   * inside the idle timer, which needs IDLE_DELAY_MS of complete byte silence.
+   * A TUI painting a live elapsed counter keeps rescheduling that timer, so the
+   * cycle never re-arms and the `complete` written by the Stop hook survives
+   * the whole next turn.
+   *
+   * Deliberately NOT `beginTurn`: that one is proof a turn is STARTING (the
+   * user pressed Enter), so it lets the very first byte count. A turn end is
+   * proof of the opposite and the pane may keep emitting idle chrome, so this
+   * re-arms the THRESHOLD path instead — the next genuine burst proves the new
+   * turn, a stray repaint does not. No callback fires here.
+   */
+  endTurn(ptyId: string): void {
+    const s = this.states.get(ptyId);
+    if (!s) return;
+    if (s.idleTimer) clearTimeout(s.idleTimer);
+    s.bytes = 0;
+    s.windowStart = Date.now();
+    s.active = false;
+    // `notified` false so feed()'s first gate (`!active && !notified`) is open
+    // again. Leaving it true would route the next burst through the re-arm
+    // branch, which is equivalent here but claims something this edge does not
+    // mean: that an idle callback had already been delivered.
+    s.notified = false;
+    s.activeFired = false;
+    s.idleTimer = null;
+    s.lastReschedule = 0;
+  }
+
   feed(ptyId: string, byteCount: number): void {
     const s = this.states.get(ptyId);
     if (!s) return;
@@ -136,9 +169,15 @@ export class ActivityMonitor {
         this.activeCallbacks.forEach((cb) => cb(ptyId));
       }
 
+      // `s.active` is re-read because a listener may have called endTurn() to
+      // hand the cycle back (a burst it judged to be echo or a repaint). The
+      // outer check ran before the callbacks; scheduling an idle timer for a
+      // cycle that no longer exists would leave a dangling timer behind every
+      // such rejection.
       if (
-        !s.idleTimer ||
-        now - s.lastReschedule >= ActivityMonitor.RESCHEDULE_THROTTLE_MS
+        s.active &&
+        (!s.idleTimer ||
+          now - s.lastReschedule >= ActivityMonitor.RESCHEDULE_THROTTLE_MS)
       ) {
         if (s.idleTimer) clearTimeout(s.idleTimer);
         s.lastReschedule = now;

--- a/src/main/pty/__tests__/ActivityMonitor.test.ts
+++ b/src/main/pty/__tests__/ActivityMonitor.test.ts
@@ -265,4 +265,72 @@ describe('ActivityMonitor', () => {
       expect(fired).toEqual([]);
     });
   });
+  describe('endTurn — re-arming from an authoritative turn end', () => {
+    let activeFired: string[];
+
+    beforeEach(() => {
+      activeFired = [];
+      monitor.onActive((id) => activeFired.push(id));
+    });
+
+    it('lets a NEW burst report running without waiting out byte silence', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 5000);
+      expect(activeFired).toEqual(['p1']);
+
+      // The turn ends while the TUI is still painting, so the idle timer that
+      // normally re-arms the cycle keeps being rescheduled and never fires.
+      monitor.endTurn('p1');
+      activeFired.length = 0;
+      monitor.feed('p1', 5000);
+      expect(activeFired).toEqual(['p1']);
+    });
+
+    it('re-arms the THRESHOLD, not the first byte', () => {
+      // Unlike beginTurn, a turn END is not proof that a turn is starting, so
+      // idle chrome must not be enough to report running.
+      monitor.start('p1');
+      monitor.endTurn('p1');
+      monitor.feed('p1', 10);
+      expect(activeFired).toEqual([]);
+      monitor.feed('p1', 5000);
+      expect(activeFired).toEqual(['p1']);
+    });
+
+    it('drops bytes already counted toward the finishing turn', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 1900);
+      monitor.endTurn('p1');
+      monitor.feed('p1', 200);   // 2100 cumulative, but the window was zeroed
+      expect(activeFired).toEqual([]);
+    });
+
+    it('fires no callback of its own', () => {
+      monitor.start('p1');
+      monitor.feed('p1', 5000);
+      activeFired.length = 0;
+      monitor.endTurn('p1');
+      vi.advanceTimersByTime(10_000);
+      expect(activeFired).toEqual([]);
+      expect(fired).toEqual([]);
+    });
+
+    it('leaves no dangling idle timer when a listener re-arms mid-callback', () => {
+      // The bridge calls endTurn() from inside onActive to hand back a cycle it
+      // judged to be echo. feed() re-reads `active` after the callbacks so it
+      // does not schedule an idle timer for a cycle that no longer exists.
+      const monitor2 = new ActivityMonitor();
+      const seen: string[] = [];
+      monitor2.onActive((id) => { seen.push(id); monitor2.endTurn(id); });
+      monitor2.onActiveToIdle((id) => seen.push(`idle:${id}`));
+      monitor2.start('p1');
+      monitor2.feed('p1', 5000);
+      vi.advanceTimersByTime(10_000);
+      expect(seen).toEqual(['p1']);
+    });
+
+    it('is a no-op for an unknown pty', () => {
+      expect(() => monitor.endTurn('does-not-exist')).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
Closes part of #935 — the direction #939 left open.

## The bug

A pane's `agentStatus` is a level, but every writer of it is edge-triggered. Inside the daemon a detector or hook terminal edge settles the pane, and from then on byte throughput was ignored entirely, so exactly two things could start the next turn: a submitted-input boundary, or an explicit `running` edge.

A turn the agent starts **by itself** produces neither. A background task finishes, the agent picks up and works, and nothing submitted any input; the only sources of a `running` edge are hook kinds a plugin-less install does not wire (`PostToolUse`, the permission-gate `PreToolUse`) and `AgentDetector`'s one-shot "agent started" at gate time. So the `complete` written when the previous turn ended stayed on the pane for the whole autonomous turn.

Reproduced live on the unfixed build — the pane held `complete` across 49 seconds of visible work, then recorded a second `complete` ending a turn it never reported starting:

```
24.5s  activity.active            <- the submitted turn
29.4s  agent.event complete       hook/agent.stop
       ... 49s of visible work, no status event at all ...
79.1s  agent.event complete       hook/agent.stop
```

## The fix

Bytes now count while a pane is settled, and a burst clearing the threshold promotes it. Three guards keep that from being the loose heuristic the settle was introduced to stop:

- **A six-second cool-down after the turn end.** A turn keeps painting after its Stop hook, and that tail is not a new turn. The length is set by the tighter of two constraints: the status a promotion writes is cleared by the byte-silence idle 5 s later, and main drops any idle landing within `AGENT_EVENT_SUPPRESSION_MS` (10 s) of the last lifecycle event — so a promotion earlier than six seconds could strand a pane reporting `running` after it finished.
- **The user's keystrokes must have gone quiet.** A pane echoing a draft message is not a pane doing work. The window covers a full activity window, so bytes banked before a keystroke cannot combine with the echo that followed it.
- **The resize-redraw window still disqualifies a repaint**, now including the repaint storm an unmute releases.

A burst failing a guard hands the cycle back instead of consuming it — otherwise a real turn arriving behind a rejected one would stay silent for as long as it kept the idle timer alive, which for a TUI painting a live counter is the whole turn.

`awaiting_input` is exempt: it means a human has to act, and only a human acting retires it. The flag survives both a later detector `waiting` off the footer under the approval box and the `running` that HookIngest projects for `agent.subagent_stop`.

The promotion deliberately does not reset the detector's emission dedup. The unsettled path clears it so a new turn's footer can speak again; doing it here would let idle chrome still on screen answer a fresh `complete` with a stale `waiting`, trading a silent wrong status for a loud one.

## Why bytes, and not a text pattern

The obvious alternative — teach `AgentDetector` a `running` pattern — was tried in #943 and is being closed in favour of this. Its anchor was `esc to interrupt`, and current Claude Code does not paint that string: **zero occurrences across 41 MB / 448k lines of live pane output on this machine**. A version-specific chrome string is also agent-specific, where the byte path covers every agent at once.

The byte path is viable because the numbers separate. Measured against a real Claude Code pane at 140x41, peak bytes per 3 s window against the 2 KB threshold:

| phase | peak 3 s | over threshold |
|---|---|---|
| idle, 20 s | 528 B | no |
| typing, 5 chars/s | 1493 B | no |
| typing, 20 chars/s | 1523 B | no |
| 600-char paste | 1374 B | no |
| **working** | **2757 B** | **yes** |
| after the turn, 12 s | 0 B | no |

That TUI repaints differentially, which is why typing is cheap — about 13 bytes per keystroke, not a frame. The keystroke guard is what keeps the separation from depending on one agent's repaint economy.

## Verification

`scripts/autonomous-turn-status-dogfood.mjs` drives the whole scenario against a private daemon instance and a real agent: it launches a background task, ends the turn, and watches what the pane reports while the completion resumes it. It also types a 60-character draft into a settled pane and asserts nothing reports running. It fails on the unfixed build and passes on this one:

```
29.4s  agent.event complete       hook/agent.stop
75.1s  activity.active            <- the autonomous turn, now reported
78.2s  agent.event complete       hook/agent.stop
```

Full suite green (11,770 passing). The regression tests that encoded the old absolute rule were rewritten rather than deleted, so what replaced it is pinned in the same place.

## Known limits, not fixed here

- **Local (non-daemon) mode is unchanged.** The gate lives in `DaemonPTYBridge`; `PTYBridge` has no equivalent, so the two modes can disagree on this case. Daemon mode is the packaged path.
- **A `running` edge still clears the pane's question state.** `HookIngest` projects `agent.subagent_stop` and the metadata kinds as `running`, and that broadcast moves the pane out of the "needs you" count on its own. That predates this change and is untouched by it; the exemption added here only stops *bytes* from doing the same.
- **An autonomous turn whose output lands entirely inside the user's typing window is delayed, not reported.** The promotion waits for the keystrokes to stop. Bounded, and strictly better than never promoting.
- **The clearing idle can still be swallowed** if a lifecycle event lands between the promotion and the idle, restarting main's 10 s suppression. The cool-down removes the case this change creates; the general one belongs in the router.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pane activity reporting so autonomous agent work is shown as **running** after a turn completes.
  - Prevented typing echoes, terminal repainting, and minor output bursts from falsely marking settled panes as active.
  - Preserved **awaiting input** status while approval prompts remain unanswered.
  - Activity now resumes only after genuine agent output, appropriate cooldowns, and quiet input periods.

- **Tests**
  - Expanded coverage for turn transitions, autonomous activity, input handling, repainting, and status accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->