### PR TITLE
Contain a pane's z-indexes inside the pane

### DIFF
--- a/changelog.d/967.md
+++ b/changelog.d/967.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **A pane's own overlays can no longer paint over app chrome.** The pane box
+  did not contain its layering, so anything inside one — a decoration badge, a
+  terminal find bar — could land on top of a dialog or an overlay elsewhere in
+  the app. Panes now stack independently, and the terminal's right-click menu
+  opens above everything instead of being clipped or misplaced by the pane
+  around it.

--- a/scripts/pane-stacking-dogfood.mjs
+++ b/scripts/pane-stacking-dogfood.mjs
@@ -1,0 +1,287 @@
+// Live check for #957 — does the pane actually contain its layering, and does
+// the terminal context menu actually open outside the pane?
+//
+// jsdom cannot answer either question: it has no layout, no stacking, and no
+// hit testing, so the unit tests can only pin the class name and the parent
+// node. This drives the packaged app over CDP and reads the computed style and
+// the real hit test.
+//
+// No OS-level clicking. Every interaction is an event dispatched inside the
+// page, so it cannot land in the wrong window.
+//
+// Usage: node scripts/pane-stacking-dogfood.mjs <cdp-port>
+const PORT = process.argv[2];
+if (!PORT) {
+  console.error('usage: node scripts/pane-stacking-dogfood.mjs <cdp-port>');
+  process.exit(2);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function rendererTarget() {
+  const res = await fetch(`http://127.0.0.1:${PORT}/json`);
+  const targets = await res.json();
+  // The app window, not a devtools page or the daemon's web view.
+  return targets.find((t) => t.type === 'page' && !t.url.startsWith('devtools://'));
+}
+
+let nextId = 1;
+function connect(wsUrl) {
+  const ws = new WebSocket(wsUrl);
+  const pending = new Map();
+  ws.addEventListener('message', (ev) => {
+    const msg = JSON.parse(ev.data);
+    const p = pending.get(msg.id);
+    if (!p) return;
+    pending.delete(msg.id);
+    if (msg.error) p.reject(new Error(JSON.stringify(msg.error)));
+    else p.resolve(msg.result);
+  });
+  const ready = new Promise((res, rej) => {
+    ws.addEventListener('open', () => res());
+    ws.addEventListener('error', (e) => rej(new Error(`ws error: ${e?.message ?? 'unknown'}`)));
+  });
+  const send = (method, params = {}) => new Promise((resolve, reject) => {
+    const id = nextId++;
+    pending.set(id, { resolve, reject });
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+  return { ws, ready, send };
+}
+
+/** Evaluate in the page and return the parsed value, surfacing page throws. */
+async function evalJson(send, expression) {
+  const r = await send('Runtime.evaluate', {
+    expression: `JSON.stringify((() => { ${expression} })())`,
+    returnByValue: true,
+    awaitPromise: true,
+  });
+  if (r.exceptionDetails) {
+    throw new Error(`page threw: ${r.exceptionDetails.exception?.description ?? r.exceptionDetails.text}`);
+  }
+  return JSON.parse(r.result.value);
+}
+
+const results = [];
+const record = (name, pass, evidence) => {
+  results.push({ name, pass, evidence });
+  console.log(`[${pass ? 'PASS' : 'FAIL'}] ${name}`);
+  console.log(`        ${evidence}`);
+};
+
+(async () => {
+  const target = await rendererTarget();
+  if (!target) throw new Error('no renderer page target on that port');
+  console.log(`[setup] attached to ${target.url}`);
+  const { send, ready } = connect(target.webSocketDebuggerUrl);
+  await ready;
+  await send('Runtime.enable');
+  await send('Page.enable');
+
+  // Wait for a pane to exist — a fresh instance boots into one.
+  let panes = 0;
+  for (let i = 0; i < 40; i++) {
+    panes = await evalJson(send, `return document.querySelectorAll('[data-wmux-pane-root]').length;`);
+    if (panes > 0) break;
+    await sleep(500);
+  }
+  if (!panes) throw new Error('no pane rendered after 20s');
+  console.log(`[setup] ${panes} pane(s) on screen`);
+
+  // A first-run instance opens the onboarding modal over the pane. It is app
+  // chrome doing exactly what it should, but it owns the hit test, so dismiss
+  // it before asking who is on top. Dispatched in-page by text, never by
+  // screen coordinates.
+  // A first run stacks SEVERAL of these (onboarding, then the auto-update
+  // prompt), so dismiss until none is left rather than once.
+  for (let i = 0; i < 6; i++) {
+    const step = await evalJson(send, `
+      const modal = document.querySelector('div.fixed.inset-0');
+      if (!modal) return { modal: false };
+      const btn = [...modal.querySelectorAll('button')]
+        .find((b) => /skip|later|no thanks|not now|dismiss|close/i.test(b.textContent || ''))
+        ?? [...modal.querySelectorAll('button')].pop();
+      if (!btn) return { modal: true, clicked: false, text: (modal.textContent || '').trim().slice(0, 60) };
+      btn.click();
+      return { modal: true, clicked: true, label: (btn.textContent || '').trim().slice(0, 40) };
+    `);
+    if (!step.modal) break;
+    if (!step.clicked) { console.log(`[setup] a modal has no dismiss button: ${step.text}`); break; }
+    console.log(`[setup] dismissed a first-run modal via "${step.label}"`);
+    await sleep(600);
+  }
+
+  // ── 1. The pane root actually creates a stacking context ────────────────
+  const iso = await evalJson(send, `
+    const el = document.querySelector('[data-wmux-pane-root]');
+    const cs = getComputedStyle(el);
+    return { isolation: cs.isolation, position: cs.position, zIndex: cs.zIndex };
+  `);
+  record(
+    'pane root creates its own stacking context',
+    iso.isolation === 'isolate',
+    `computed isolation=${iso.isolation} position=${iso.position} zIndex=${iso.zIndex}`,
+  );
+
+  // ── 2. A pane-internal z-index no longer outranks app chrome ────────────
+  // Probe rather than assert on a specific component: plant an element inside
+  // the pane at the old offending z, and a chrome-level element at the overlay
+  // baseline, then ask the browser which one is actually on top. Before the
+  // isolation this returned the pane's element.
+  const stack = await evalJson(send, `
+    const pane = document.querySelector('[data-wmux-pane-root]');
+    const r = pane.getBoundingClientRect();
+    const x = Math.round(r.left + r.width / 2);
+    const y = Math.round(r.top + r.height / 2);
+
+    const inside = document.createElement('div');
+    inside.id = 'wmux-probe-inside';
+    Object.assign(inside.style, {
+      position: 'fixed', left: x - 40 + 'px', top: y - 20 + 'px',
+      width: '80px', height: '40px', zIndex: '9999', background: 'red',
+    });
+    pane.appendChild(inside);
+
+    const chrome = document.createElement('div');
+    chrome.id = 'wmux-probe-chrome';
+    Object.assign(chrome.style, {
+      position: 'fixed', left: x - 40 + 'px', top: y - 20 + 'px',
+      width: '80px', height: '40px',
+      zIndex: getComputedStyle(document.documentElement).getPropertyValue('--z-overlay').trim() || '50',
+      background: 'lime',
+    });
+    document.body.appendChild(chrome);
+
+    // Order the two probes against EACH OTHER. Asking who is topmost overall
+    // answers a different question — any app chrome above both (a first-run
+    // modal at --z-modal) would win and tell us nothing.
+    const order = document.elementsFromPoint(x, y)
+      .map((e) => e.id)
+      .filter((id) => id === 'wmux-probe-inside' || id === 'wmux-probe-chrome');
+    inside.remove();
+    chrome.remove();
+    return { winner: order[0] ?? null, order, x, y };
+  `);
+  record(
+    'a pane-internal z-index cannot outrank app chrome',
+    stack.winner === 'wmux-probe-chrome',
+    `of the two probes the front one is #${stack.winner} (chrome first = contained); order=${JSON.stringify(stack.order)}`,
+  );
+
+  // ── 3. Why the context menu had to leave the pane ───────────────────────
+  // The menu itself cannot be opened from here: its ONLY trigger is a
+  // right-click that hits `a[href]` (useTerminal.ts), and this build renders
+  // the terminal on WebGL, where links are painted on `.xterm-link-layer` and
+  // no DOM anchor exists — measured on this instance, 0 anchors in the pane.
+  // So verify the property the portal exists for instead: an element at
+  // `--z-popover-top`, which is what the menu carries, is TRAPPED while it is
+  // a pane descendant and free once it is a child of body.
+  const portal = await evalJson(send, `
+    const pane = document.querySelector('[data-wmux-pane-root]');
+    const r = pane.getBoundingClientRect();
+    const x = Math.round(r.left + r.width / 2);
+    const y = Math.round(r.top + r.height / 2);
+    const css = getComputedStyle(document.documentElement);
+    const popoverZ = css.getPropertyValue('--z-popover-top').trim() || '9999';
+    const overlayZ = css.getPropertyValue('--z-overlay').trim() || '50';
+
+    const box = (z, bg) => {
+      const d = document.createElement('div');
+      Object.assign(d.style, {
+        position: 'fixed', left: x - 40 + 'px', top: y - 20 + 'px',
+        width: '80px', height: '40px', zIndex: z, background: bg,
+      });
+      return d;
+    };
+
+    // Chrome-level element, always on body, always at the overlay baseline.
+    const chrome = box(overlayZ, 'lime');
+    chrome.id = 'probe-chrome';
+    document.body.appendChild(chrome);
+
+    // The menu's z, mounted the OLD way: inside the pane.
+    const inPane = box(popoverZ, 'red');
+    inPane.id = 'probe-in-pane';
+    pane.appendChild(inPane);
+    const trappedWinner = document.elementsFromPoint(x, y)
+      .map((e) => e.id).filter((id) => id === 'probe-chrome' || id === 'probe-in-pane')[0] ?? null;
+    inPane.remove();
+
+    // The menu's z, mounted the NEW way: on body.
+    const onBody = box(popoverZ, 'red');
+    onBody.id = 'probe-on-body';
+    document.body.appendChild(onBody);
+    const portalWinner = document.elementsFromPoint(x, y)
+      .map((e) => e.id).filter((id) => id === 'probe-chrome' || id === 'probe-on-body')[0] ?? null;
+    onBody.remove();
+    chrome.remove();
+
+    return { trappedWinner, portalWinner, popoverZ, overlayZ };
+  `);
+  record(
+    'the menu\'s z-index is TRAPPED while it lives inside the pane',
+    portal.trappedWinner === 'probe-chrome',
+    `z:${portal.popoverZ} inside the pane loses to chrome z:${portal.overlayZ} — winner #${portal.trappedWinner}`,
+  );
+  record(
+    'the same element on document.body is on top, as the portal makes it',
+    portal.portalWinner === 'probe-on-body',
+    `winner #${portal.portalWinner}`,
+  );
+
+  // ── 4. The same probe, with the isolation switched off ──────────────────
+  // A containment test that passes on the broken build proves nothing. Drop
+  // `isolation` from the pane root in place, re-run the ordering, and put it
+  // back: the pane-internal element must win there, which is the bug.
+  const baseline = await evalJson(send, `
+    const pane = document.querySelector('[data-wmux-pane-root]');
+    const before = pane.style.isolation;
+    pane.style.isolation = 'auto';                 // beats the class
+    const r = pane.getBoundingClientRect();
+    const x = Math.round(r.left + r.width / 2);
+    const y = Math.round(r.top + r.height / 2);
+    const css = getComputedStyle(document.documentElement);
+
+    const box = (z, id) => {
+      const d = document.createElement('div');
+      d.id = id;
+      Object.assign(d.style, {
+        position: 'fixed', left: x - 40 + 'px', top: y - 20 + 'px',
+        width: '80px', height: '40px', zIndex: z, background: 'red',
+      });
+      return d;
+    };
+    const chrome = box(css.getPropertyValue('--z-overlay').trim() || '50', 'probe-chrome');
+    document.body.appendChild(chrome);
+    const inPane = box(css.getPropertyValue('--z-popover-top').trim() || '9999', 'probe-in-pane');
+    pane.appendChild(inPane);
+
+    const winner = document.elementsFromPoint(x, y)
+      .map((e) => e.id).filter((id) => id === 'probe-chrome' || id === 'probe-in-pane')[0] ?? null;
+
+    inPane.remove();
+    chrome.remove();
+    pane.style.isolation = before;                 // restore
+    const restored = getComputedStyle(pane).isolation;
+    return { winner, restored };
+  `);
+  record(
+    'without the isolation the pane-internal element wins (the bug reproduces)',
+    baseline.winner === 'probe-in-pane' && baseline.restored === 'isolate',
+    `winner #${baseline.winner}; isolation restored to ${baseline.restored}`,
+  );
+
+  // A picture, so a human can check what the assertions cannot describe.
+  const shot = await send('Page.captureScreenshot', { format: 'png' });
+  const out = `${process.env.TMPDIR || '/tmp'}/wmux-957-contextmenu.png`;
+  const { writeFileSync } = await import('node:fs');
+  writeFileSync(out, Buffer.from(shot.data, 'base64'));
+  console.log(`\n[screenshot] ${out}`);
+
+  const failed = results.filter((r) => !r.pass);
+  console.log(`\n=== ${results.length - failed.length}/${results.length} passed ===`);
+  process.exit(failed.length ? 1 : 0);
+})().catch((err) => {
+  console.error('[error]', err?.message ?? err);
+  process.exit(1);
+});

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -61,7 +61,19 @@ export function composePaneClassName(opts: {
   completeBlink?: boolean;
 }): string {
   const { hasUnread, ringState, paneRingEnabled, flashing, completeBlink } = opts;
-  const classes = ['flex', 'flex-col', 'h-full', 'w-full', 'relative', 'box-border'];
+  // `isolate` gives the pane root its own stacking context (#957). Without it
+  // a pane is `relative` with no z-index, so every z value inside one competes
+  // document-wide: the pane decorations painting over modals (#946) was that
+  // leak surfacing, and lowering them below `--z-overlay` closed the case
+  // rather than the hole. Contained, the scale inside a pane is purely local
+  // and no future pane-internal element can express the collision at all.
+  //
+  // Safe only because nothing inside a pane needs to escape it any more. The
+  // agent toolbar's popovers used to and were the stated blocker, but the bar
+  // moved out to the workspace column on 2026-08-18 (DESIGN.md) and now sits
+  // in ToolbarHost's own `absolute z-20` context; the terminal context menu
+  // was the last one, and it portals to document.body as of this change.
+  const classes = ['flex', 'flex-col', 'h-full', 'w-full', 'relative', 'isolate', 'box-border'];
   if (hasUnread) classes.push('notification-ring');
   if (completeBlink) {
     classes.push('pane-complete-blink');

--- a/src/renderer/components/Pane/__tests__/Pane.notificationRing.test.tsx
+++ b/src/renderer/components/Pane/__tests__/Pane.notificationRing.test.tsx
@@ -44,6 +44,26 @@ describe('composePaneClassName — base classes', () => {
     expect(cls).toContain('box-border');
   });
 
+  it('isolates the pane so its z-indexes cannot reach app chrome (#957)', () => {
+    // `relative` alone creates no stacking context, so every z value inside a
+    // pane used to compete document-wide — that leak is what let the pane
+    // decorations paint over modals (#946). This class is what makes the
+    // collision inexpressible rather than merely absent, so it is pinned on
+    // every ring state: dropping it from any branch reopens the hole.
+    for (const ringState of [null, 'flash', 'glow'] as const) {
+      for (const completeBlink of [false, true]) {
+        const cls = composePaneClassName({
+          hasUnread: true,
+          ringState,
+          paneRingEnabled: true,
+          flashing: true,
+          completeBlink,
+        });
+        expect(cls).toContain('isolate');
+      }
+    }
+  });
+
   it('emits no ring classes when nothing is active', () => {
     const cls = composePaneClassName({
       hasUnread: false,

--- a/src/renderer/components/Terminal/ContextMenu.tsx
+++ b/src/renderer/components/Terminal/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useT } from '../../hooks/useT';
 
 interface ContextMenuProps {
@@ -58,7 +59,15 @@ export default function ContextMenu({ x, y, hasSelection, selectedText, linkUrl,
     onClose();
   }, [onClose]);
 
-  return (
+  // Portalled to document.body (#957). The menu is viewport-positioned, so it
+  // never needed to be a descendant of the pane — and being one was the last
+  // thing inside a pane that had to out-z its siblings to be seen, which is
+  // what kept the pane root from owning a stacking context. Two things it
+  // fixes on its own: a `position: fixed` element resolves against a
+  // transformed ancestor rather than the viewport, and panes carry animated
+  // rings; and a menu clipped by an `overflow` ancestor is a bug waiting for
+  // whoever adds one to a pane.
+  return createPortal((
     <div
       ref={menuRef}
       className="fixed z-[var(--z-popover-top)] min-w-[168px] p-[5px]"
@@ -139,7 +148,7 @@ export default function ContextMenu({ x, y, hasSelection, selectedText, linkUrl,
         </>
       )}
     </div>
-  );
+  ), document.body);
 }
 
 function MenuItem({ label, shortcut, onClick }: { label: string; shortcut?: string; onClick: () => void }) {

--- a/src/renderer/components/Terminal/__tests__/ContextMenu.portal.test.tsx
+++ b/src/renderer/components/Terminal/__tests__/ContextMenu.portal.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+//
+// Issue #957 — the terminal context menu renders through a portal.
+//
+// This is the load-bearing half of containing the pane's stacking context. The
+// menu is the only thing left inside a pane that has to out-z its siblings to
+// be seen, so as long as it is a DESCENDANT of the pane, giving the pane root
+// `isolation: isolate` would trap it under any later-DOM sibling pane. Pinning
+// the portal here means a refactor that quietly puts it back inside the tree
+// fails in this file rather than in a screenshot months later.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+vi.mock('../../../hooks/useT', () => ({ useT: () => (k: string) => k }));
+
+import ContextMenu from '../ContextMenu';
+
+const noop = vi.fn();
+
+function baseProps() {
+  return {
+    x: 40,
+    y: 60,
+    hasSelection: true,
+    selectedText: 'hello',
+    linkUrl: null,
+    onCopy: noop,
+    onPaste: noop,
+    onOpenLink: noop,
+    onCopyLink: noop,
+    onClose: noop,
+  };
+}
+
+describe('ContextMenu portal (#957)', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    // Stand in for the pane root: the menu is rendered from inside it, and the
+    // point of the portal is that the DOM node does not land here.
+    host.setAttribute('data-wmux-pane-root', 'pane-1');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  function menuEl(): HTMLElement | null {
+    return document.querySelector('.fixed.min-w-\\[168px\\]');
+  }
+
+  it('mounts on document.body, not inside the pane that rendered it', () => {
+    act(() => { root.render(<ContextMenu {...baseProps()} />); });
+
+    const el = menuEl();
+    expect(el).not.toBeNull();
+    // The pane subtree must not contain it...
+    expect(host.contains(el)).toBe(false);
+    // ...and body must be its parent, so no pane ancestor can clip it, apply a
+    // transform that would re-base its `position: fixed`, or out-stack it.
+    expect(el?.parentElement).toBe(document.body);
+  });
+
+  it('keeps the viewport coordinates it was given', () => {
+    act(() => { root.render(<ContextMenu {...baseProps()} />); });
+
+    const el = menuEl() as HTMLElement;
+    // Portalling must be behaviour-neutral for placement: the menu was already
+    // `position: fixed` against the viewport, so the same x/y has to land in
+    // the same place. jsdom reports 0-size rects, so the clamp is inert here
+    // and these are the raw props.
+    expect(el.style.left).toBe('40px');
+    expect(el.style.top).toBe('60px');
+  });
+
+  it('unmounts cleanly from body', () => {
+    act(() => { root.render(<ContextMenu {...baseProps()} />); });
+    expect(menuEl()).not.toBeNull();
+
+    act(() => { root.render(<></>); });
+    expect(menuEl()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #957.

## What was open

The pane root is `relative` with no `z-index`, so it creates no stacking context and every `z-index` inside a pane competes document-wide. #946 fixed the reported class — decoration rings painting over overlays and modals — by moving the decorations below the `--z-overlay` baseline. That closed the case, not the hole: anything pane-internal at 50 or above can express the same collision again.

`isolation: isolate` on the pane root ends it. The scale inside a pane becomes purely local, and the collision stops being *expressible* rather than merely absent.

One latent case goes with it. The terminal search bar sits at `z-50` — exactly `--z-overlay` — and until now that tie reached the whole document.

## The blocker, and a correction to the issue

Step 2 was gated on nothing inside a pane needing to escape it. The issue names the agent toolbar's popovers as that dependency, and it is **no longer true**: the bar moved out to the workspace column on 2026-08-18 (DESIGN.md, and #916 landed after), and now renders inside `ToolbarHost`'s own `absolute inset-0 z-20` — a positioned element with a z-index, so already its own stacking context. Its popovers are not pane descendants and never cross a pane boundary.

What actually remained was the **terminal context menu**: `className="fixed z-[var(--z-popover-top)]"` with no portal, rendered from inside the pane. That one is fixed here.

Portalling it to `document.body` is worth doing on its own terms, independent of the isolation. The menu is viewport-positioned, so being a pane descendant bought it nothing and cost it two hazards:

- `position: fixed` resolves against a **transformed ancestor** rather than the viewport, and panes carry animated rings;
- an `overflow` ancestor added to a pane later would clip it.

## Every z value in the pane subtree, enumerated before isolating

| element | z | after isolation |
|---|---|---|
| Terminal overlays | 9–10 | local, correct |
| ScrollToBottomButton, BookmarkIndicator, ViCopyMode, PaneDecorations | 20 | local, correct |
| SearchBar | 50 | local — was tying with `--z-overlay` document-wide |
| ContextMenu | `--z-popover-top` | portalled to body |

`FloatingPane`'s `z-index: 200` is unaffected — it renders at the AppLayout level, not inside a pane.

## Tests

- `ContextMenu.portal.test.tsx` (new) pins that the menu mounts on `document.body` and not in the pane subtree that rendered it, that portalling is placement-neutral, and that it unmounts cleanly. A refactor that quietly puts it back inside the tree fails here rather than in a screenshot months later.
- `composePaneClassName` now asserts `isolate` on every ring branch, so dropping it from any one of them reopens the hole.

Full suite green (11,758 passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pane layering so application controls remain visible above pane content.
  - Improved terminal context menus to appear above surrounding content without clipping or shifting.
  - Preserved menu positioning and ensured menus close cleanly.

- **Tests**
  - Added regression coverage for pane layering and context-menu behavior.
  - Added live validation for stacking and menu placement scenarios.

- **Documentation**
  - Documented pane stacking and terminal context-menu improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->