### PR TITLE
feat(hooks): let setup-hooks install the lifecycle signals without the permission gate (#970)

### DIFF
--- a/changelog.d/970.md
+++ b/changelog.d/970.md
@@ -1,0 +1,24 @@
+### Added
+
+- **`wmux setup-hooks --signals-only` installs the lifecycle signals without
+  the per-tool-call permission gate.** The remote-approval gate is a wide
+  `PreToolUse` hook, so Claude Code spawns the bridge on every single tool call
+  — ~120 ms on Windows 11, of which ~85 ms is bare `node` startup. That cost
+  cannot be optimised away once the hook is registered, and `gatedTools: []`
+  does not help: a policy of "gate nothing" still spawns the process that asks.
+  It buys nothing for a terminal-only operator either, because both things the
+  wide hook does need a web surface — approvals arm only under
+  `wmux web --allow-input`, and the tool-name liveness it feeds is fanned out
+  only to web clients. `--signals-only` installs the turn-boundary signals and
+  the approval-card pair and stops there; `--with-gate` puts the gate back. The
+  profile is derived from `settings.json` rather than stored beside it, so a
+  bare `wmux setup-hooks` — the app-update refresh and the in-app install
+  button included — keeps whatever is already installed instead of quietly
+  re-adding the gate.
+
+- **`wmux web --allow-input` now says when the permission-gate hook is
+  missing.** Enabling input is what arms the gate, so it is the only place that
+  can catch a signals-only install: without the hook no tool call ever raises
+  an approval, and nothing else reports it — the phone simply never rings.
+  `wmux setup-hooks --status` also stops calling an absent gate a defect when
+  the signals-only profile is the reason it is absent.

--- a/integrations/claude/README.md
+++ b/integrations/claude/README.md
@@ -48,9 +48,11 @@ install the same 4 hooks directly into your Claude Code user settings
 (`~/.claude/settings.json`):
 
 ```
-wmux setup-hooks            # install
-wmux setup-hooks --status   # show install + bridge freshness
-wmux setup-hooks --remove   # uninstall (leaves your other hooks intact)
+wmux setup-hooks                 # install (keeps the profile already on disk)
+wmux setup-hooks --signals-only  # install WITHOUT the per-tool-call gate hook
+wmux setup-hooks --with-gate     # put the gate back
+wmux setup-hooks --status        # show profile, install + bridge freshness
+wmux setup-hooks --remove        # uninstall (leaves your other hooks intact)
 ```
 
 This copies the bridge to a stable path (`~/.wmux/hooks/wmux-bridge.mjs`)
@@ -61,6 +63,40 @@ and references it from settings.json, so it survives app updates. Re-run
 plugin (Option A/B) and the `setup-hooks` settings entries, each turn
 fires the hook twice. wmux dedups hook-vs-detector, but not
 hook-vs-hook, so you'd get double signals. Pick one path.
+
+### Hook profiles — `--signals-only` (#970)
+
+The permission gate is a **wide `PreToolUse` hook**: Claude Code spawns the
+bridge on every single tool call. That costs ~120 ms per call on Windows 11, of
+which ~85 ms is bare `node` startup — so once the hook is registered the cost
+cannot be optimised away, only not paid. `gatedTools: []` does not help; a
+policy of "gate nothing" still spawns the process that asks.
+
+Both things the wide hook does need a web surface to be worth anything:
+
+- it resolves remote permission gates, which arm only under
+  `wmux web --allow-input`, and
+- it feeds `agent.tool_started` liveness, which is fanned out to web clients
+  and is a no-op with no server running.
+
+So a terminal-only operator pays the spawn for neither. `--signals-only`
+installs the turn-boundary signals (`Stop` / `SubagentStop` / `SessionStart`)
+and the `AskUserQuestion` approval pair, and nothing else — no wmux hook then
+runs per tool call. Remote approvals stop working until `--with-gate` puts the
+gate back, and `wmux web --allow-input` says so on startup rather than leaving
+your phone waiting on approvals that will never be raised.
+
+The profile is derived from `settings.json` itself, not stored beside it, so a
+bare `wmux setup-hooks` — including the app-update refresh and the in-app
+"install hooks" button — keeps whatever profile is already installed.
+
+**This is a `setup-hooks` feature only.** A Claude Code plugin ships one
+`hooks/hooks.json`, and this plugin's includes the gate; there is no per-install
+profile switch in the plugin format, and a gate that disabled itself at runtime
+would still pay the spawn that is the actual cost. Running
+`wmux setup-hooks --signals-only` with the plugin active therefore reports that
+it had no effect instead of pretending. To get the signals-only profile,
+uninstall or disable the plugin and use Option C.
 
 ### After either path
 

--- a/src/cli/__tests__/web.gateWarning.test.ts
+++ b/src/cli/__tests__/web.gateWarning.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { sendDaemonStringRequestMock, isPermissionGateInstalledMock } = vi.hoisted(() => ({
+  sendDaemonStringRequestMock: vi.fn(),
+  isPermissionGateInstalledMock: vi.fn(),
+}));
+
+vi.mock('../client', () => ({
+  sendDaemonStringRequest: sendDaemonStringRequestMock,
+}));
+
+vi.mock('../commands/setupHooks', () => ({
+  isPermissionGateInstalled: isPermissionGateInstalledMock,
+}));
+
+import { handleWeb } from '../commands/web';
+
+let lines: string[];
+
+beforeEach(() => {
+  lines = [];
+  sendDaemonStringRequestMock.mockReset();
+  isPermissionGateInstalledMock.mockReset();
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function statusResponse(allowInput: boolean) {
+  return {
+    id: 'web-status',
+    ok: true as const,
+    result: {
+      running: true,
+      port: 7681,
+      host: '127.0.0.1',
+      allowInput,
+      allowUpload: false,
+      tls: false,
+      urls: [],
+    },
+  };
+}
+
+/**
+ * #970 — `--allow-input` is the only thing that ARMS the permission gate, so it
+ * is the only place that can notice the gate HOOK is missing. On the
+ * signals-only profile no tool call ever raises an approval and nothing else
+ * reports it: the phone just never rings. That silence is the failure mode this
+ * warning exists to break.
+ */
+describe('wmux web --allow-input permission-gate warning (#970)', () => {
+  it('warns when input is enabled but the gate hook is not installed', async () => {
+    sendDaemonStringRequestMock.mockResolvedValue(statusResponse(true));
+    isPermissionGateInstalledMock.mockReturnValue(false);
+
+    await handleWeb(['--status'], false);
+
+    const output = lines.join('\n');
+    expect(output).toContain('Input is ENABLED');
+    expect(output).toContain('permission gate hook is NOT installed');
+    expect(output).toContain('wmux setup-hooks --with-gate');
+  });
+
+  it('stays quiet when the gate hook is installed', async () => {
+    sendDaemonStringRequestMock.mockResolvedValue(statusResponse(true));
+    isPermissionGateInstalledMock.mockReturnValue(true);
+
+    await handleWeb(['--status'], false);
+
+    const output = lines.join('\n');
+    expect(output).toContain('Input is ENABLED');
+    expect(output).not.toContain('permission gate hook is NOT installed');
+  });
+
+  it('does not check, or warn, on a read-only server', async () => {
+    sendDaemonStringRequestMock.mockResolvedValue(statusResponse(false));
+    isPermissionGateInstalledMock.mockReturnValue(false);
+
+    await handleWeb(['--status'], false);
+
+    const output = lines.join('\n');
+    expect(output).toContain('Read-only');
+    expect(output).not.toContain('permission gate hook is NOT installed');
+    // Read-only can never arm the gate, so the check is pure cost there.
+    expect(isPermissionGateInstalledMock).not.toHaveBeenCalled();
+  });
+
+  it('says nothing in --json mode, which is a machine contract', async () => {
+    sendDaemonStringRequestMock.mockResolvedValue(statusResponse(true));
+    isPermissionGateInstalledMock.mockReturnValue(false);
+
+    await handleWeb(['--status'], true);
+
+    expect(lines.join('\n')).not.toContain('permission gate hook is NOT installed');
+  });
+});

--- a/src/cli/commands/__tests__/setupHooks.test.ts
+++ b/src/cli/commands/__tests__/setupHooks.test.ts
@@ -8,6 +8,8 @@ import {
   refreshHookBridge,
   statusHooks,
   findBridgeSourceFrom,
+  detectProfile,
+  isPermissionGateInstalled,
   type SetupHooksPaths,
 } from '../setupHooks';
 
@@ -701,5 +703,167 @@ describe('findBridgeSourceFrom', () => {
     const deep = path.join(tmpDir, 'a', 'b', 'c');
     fs.mkdirSync(deep, { recursive: true });
     expect(findBridgeSourceFrom(deep)).toBeNull();
+  });
+});
+
+/**
+ * #970 — the hook profile. The wide PreToolUse gate costs a node spawn on every
+ * tool call (~85 ms of it before the bridge reads a byte), and both things it
+ * does — resolving permission gates and feeding agent.tool_started liveness —
+ * are useless without a web surface. `--signals-only` lets a terminal-only
+ * operator not pay for it; the profile is DERIVED from settings.json so it
+ * cannot drift, and an absent gate then reads as a configuration, not a defect.
+ */
+describe('hook profile (#970)', () => {
+  const GATE = '--permission-gate';
+
+  it('--signals-only installs no per-tool-call hook', () => {
+    const outcome = installHooks(paths(), 'signals-only');
+    expect(outcome.ok).toBe(true);
+    expect(outcome.profile).toBe('signals-only');
+    expect(allHookCommands().some((c) => c.includes(GATE))).toBe(false);
+  });
+
+  it('keeps the approval card and every turn-boundary signal under --signals-only', () => {
+    installHooks(paths(), 'signals-only');
+    const s = statusHooks(paths());
+    expect(s.features.approvalCard.state).toBe('ok');
+    expect(s.features.turnEnd.state).toBe('ok');
+    expect(s.features.conversationRead.state).toBe('ok');
+    const pre = allHookCommands().filter((c) => c.includes('PreToolUse'));
+    expect(pre).toHaveLength(1);
+    expect(pre[0]).not.toContain(GATE);
+  });
+
+  it('defaults a fresh install to the full profile, gate included', () => {
+    const outcome = installHooks(paths());
+    expect(outcome.profile).toBe('full');
+    expect(allHookCommands().some((c) => c.includes(GATE))).toBe(true);
+  });
+
+  it('★ a bare re-run KEEPS signals-only — a refresh must not re-add the gate', () => {
+    installHooks(paths(), 'signals-only');
+    const again = installHooks(paths());
+    expect(again.profile).toBe('signals-only');
+    expect(allHookCommands().some((c) => c.includes(GATE))).toBe(false);
+  });
+
+  it('--with-gate is the way back from signals-only', () => {
+    installHooks(paths(), 'signals-only');
+    const outcome = installHooks(paths(), 'full');
+    expect(outcome.profile).toBe('full');
+    expect(allHookCommands().filter((c) => c.includes(GATE))).toHaveLength(1);
+  });
+
+  it('--signals-only strips a gate that is already installed', () => {
+    installHooks(paths());
+    expect(allHookCommands().some((c) => c.includes(GATE))).toBe(true);
+    installHooks(paths(), 'signals-only');
+    expect(allHookCommands().some((c) => c.includes(GATE))).toBe(false);
+  });
+
+  it('treats a PARTIAL install as broken-full and repairs it, gate included', () => {
+    installHooks(paths(), 'signals-only');
+    const settings = readSettings();
+    delete (settings.hooks as Record<string, unknown>)['SubagentStop'];
+    fs.writeFileSync(settingsPath, JSON.stringify(settings), 'utf8');
+    expect(detectProfile(readSettings())).toBe('full');
+    installHooks(paths());
+    expect(allHookCommands().some((c) => c.includes(GATE))).toBe(true);
+  });
+
+  it('reads a settings.json with no wmux hooks as the full default', () => {
+    expect(detectProfile({})).toBe('full');
+    const foreign = { hooks: { Stop: [{ hooks: [{ type: 'command', command: 'other.mjs' }] }] } };
+    expect(detectProfile(foreign)).toBe('full');
+  });
+
+  it('reports signals-only as a configuration, not a missing hook', () => {
+    installHooks(paths(), 'signals-only');
+    const s = statusHooks(paths());
+    expect(s.profile).toBe('signals-only');
+    expect(s.features.permissionGate.state).toBe('off');
+    expect(s.features.permissionGate.detail).toContain('signals-only');
+    expect(s.features.permissionGate.detail).toContain('--with-gate');
+    expect(s.features.permissionGate.detail).not.toContain('missing');
+  });
+
+  it('still reports a genuinely missing gate as something to fix', () => {
+    const s = statusHooks(paths());
+    expect(s.profile).toBe('full');
+    expect(s.features.permissionGate.state).toBe('off');
+    expect(s.features.permissionGate.detail).toContain('missing');
+  });
+
+  it('reports the full profile with the gate healthy after a default install', () => {
+    installHooks(paths());
+    const s = statusHooks(paths());
+    expect(s.profile).toBe('full');
+    expect(s.features.permissionGate.state).toBe('ok');
+  });
+
+  it('reports the full default for a corrupted settings.json', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, '{ not json', 'utf8');
+    const s = statusHooks(paths());
+    expect(s.settingsCorrupted).toBe(true);
+    expect(s.profile).toBe('full');
+  });
+
+  it('refuses --signals-only when the plugin owns the hooks, instead of faking it', () => {
+    writePluginManifest(JSON.stringify({ plugins: ['wmux-claude-integration@wmux'] }));
+    const outcome = installHooks(paths(), 'signals-only');
+    expect(outcome.ok).toBe(true);
+    expect(outcome.pluginDetected).toBe(true);
+    expect(outcome.profile).toBe('full');
+    expect(outcome.warning).toContain('--signals-only had no effect');
+  });
+});
+
+/**
+ * #970 — the guard on the silent half. `wmux web --allow-input` is the only
+ * thing that arms the gate, so it is the only place that can notice the hook is
+ * not installed; without this check the phone simply never rings and nothing
+ * anywhere reports it.
+ */
+describe('isPermissionGateInstalled (#970)', () => {
+  it('is false on the signals-only profile', () => {
+    installHooks(paths(), 'signals-only');
+    expect(isPermissionGateInstalled(settingsPath)).toBe(false);
+  });
+
+  it('is true on the full profile', () => {
+    installHooks(paths());
+    expect(isPermissionGateInstalled(settingsPath)).toBe(true);
+  });
+
+  it('is false before anything is installed', () => {
+    expect(isPermissionGateInstalled(settingsPath)).toBe(false);
+  });
+
+  it('is true when an active marketplace plugin supplies the gate', () => {
+    writePluginManifest(JSON.stringify({ plugins: ['wmux-claude-integration@wmux'] }));
+    expect(isPermissionGateInstalled(settingsPath)).toBe(true);
+  });
+
+  it('is false when the plugin is installed but explicitly disabled', () => {
+    writePluginManifest(JSON.stringify({ plugins: ['wmux-claude-integration@wmux'] }));
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    const disabled = { enabledPlugins: { 'wmux-claude-integration@wmux': false } };
+    fs.writeFileSync(settingsPath, JSON.stringify(disabled), 'utf8');
+    expect(isPermissionGateInstalled(settingsPath)).toBe(false);
+  });
+
+  it('fails CLOSED on a corrupted settings.json rather than claiming armed', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, '{ not json', 'utf8');
+    expect(isPermissionGateInstalled(settingsPath)).toBe(false);
+  });
+
+  it('does not count the AskUserQuestion PreToolUse as the gate', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    const only = { hooks: { PreToolUse: [wmuxHookGroup('PreToolUse', 'AskUserQuestion')] } };
+    fs.writeFileSync(settingsPath, JSON.stringify(only), 'utf8');
+    expect(isPermissionGateInstalled(settingsPath)).toBe(false);
   });
 });

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -27,15 +27,25 @@ const HELP_TEXT = `
 wmux setup-hooks — install official CLI lifecycle integrations
 
 USAGE
-  wmux setup-hooks [--remove | --status] [--json]
+  wmux setup-hooks [--remove | --status] [--signals-only | --with-gate] [--json]
 
 ACTIONS (mutually exclusive; default = install)
   (default)    Install or refresh Claude Code hooks, the Codex notify bridge,
                and the OpenCode lifecycle plugin. Existing foreign hooks,
                notify commands, and plugin files are never overwritten.
+               Re-running KEEPS the hook profile already on disk.
   --remove     Remove only wmux-owned Claude hook entries (legacy behavior;
                Codex/OpenCode files and foreign configuration are untouched).
   --status     Report Claude, Codex, and OpenCode lifecycle integration status.
+
+HOOK PROFILE (install only; mutually exclusive)
+  --signals-only  Install the lifecycle signals and the approval card WITHOUT
+                  the wide PreToolUse permission gate. Nothing wmux owns then
+                  runs per tool call, so the agent pays no hook cost between
+                  turns — at the price of remote approvals, which stop working
+                  until the gate is added back.
+  --with-gate     Install the full profile, gate included (the default for a
+                  fresh install). Use this to undo --signals-only.
 
 GLOBAL FLAGS
   --json       Output raw JSON (useful for scripting).
@@ -83,13 +93,61 @@ const PERMISSION_GATE_SPEC = {
   extraArgs: '--permission-gate',
 };
 
-/** Every wmux-owned hook in settings.json as (event, matcher) specs — the
- *  single source `installHooks` writes and `statusHooks` checks against. */
-const HOOK_SPECS: readonly { event: HookEvent; matcher: string; extraArgs?: string }[] = [
+/** One wmux-owned hook entry in settings.json. */
+interface HookSpec {
+  event: HookEvent;
+  matcher: string;
+  extraArgs?: string;
+}
+
+/**
+ * The turn-boundary signals plus the AskUserQuestion approval pair — every
+ * wmux hook that does NOT fire per tool call. Stop/SubagentStop/SessionStart
+ * are turn boundaries by definition, and the approval pair is scoped to a
+ * single tool name.
+ */
+const SIGNAL_SPECS: readonly HookSpec[] = [
   ...HOOK_EVENTS.map((event) => ({ event, matcher: '' })),
   ...ASK_QUESTION_HOOKS,
-  PERMISSION_GATE_SPEC,
 ];
+
+/**
+ * #970 — which hooks an install writes.
+ *
+ *   'full'         signals + the wide PreToolUse permission gate (default)
+ *   'signals-only' signals alone; nothing wmux owns runs per tool call
+ *
+ * The gate hook is spawned on EVERY PreToolUse, and a node process spawn is
+ * ~85 ms of the ~120 ms that costs before the bridge has read a byte of stdin
+ * — so once the hook exists the cost cannot be optimised away, only not paid.
+ * That matters because both things the wide hook does are useless without a
+ * web surface: it resolves permission gates (armed only under
+ * `wmux web --allow-input`, see WebTerminalServer.canResolveGates) and it
+ * feeds `agent.tool_started` liveness (fanned out by emitAgentLiveness, a
+ * no-op with no web server). A terminal-only operator pays the spawn for
+ * neither. #435 already made this trade once, removing a wide PostToolUse for
+ * the same per-tool-call reason; `gatedTools: []` cannot make it, because a
+ * policy of "gate nothing" still spawns the process that asks.
+ *
+ * This is deliberately NOT a persisted setting: settings.json IS the state, so
+ * the two can never drift. See `detectProfile`.
+ */
+export type HookProfile = 'full' | 'signals-only';
+
+/** Every wmux-owned hook in settings.json as (event, matcher) specs — the
+ *  single source `installHooks` writes and `statusHooks` checks against. */
+const HOOK_SPECS: readonly HookSpec[] = [...SIGNAL_SPECS, PERMISSION_GATE_SPEC];
+
+/** The specs a given profile installs. */
+function specsFor(profile: HookProfile): readonly HookSpec[] {
+  return profile === 'signals-only' ? SIGNAL_SPECS : HOOK_SPECS;
+}
+
+/** Stable identity of a spec — event plus argv tail, since the approval pair
+ *  and the gate share the PreToolUse event and only the tail tells them apart. */
+function specKey(spec: { event: HookEvent; extraArgs?: string }): string {
+  return `${spec.event}${spec.extraArgs ? ` ${spec.extraArgs}` : ''}`;
+}
 
 /** Substring that identifies a wmux-owned hook command in settings.json. */
 const WMUX_BRIDGE_MARKER = 'wmux-bridge.mjs';
@@ -112,10 +170,15 @@ export interface SetupHooksPaths {
   bridgeSource: string | null;
 }
 
+/** `~/.claude/settings.json` — the only path a gate-presence check needs. */
+function defaultSettingsPath(): string {
+  return path.join(os.homedir(), '.claude', 'settings.json');
+}
+
 export function defaultPaths(): SetupHooksPaths {
   const home = os.homedir();
   return {
-    settingsPath: path.join(home, '.claude', 'settings.json'),
+    settingsPath: defaultSettingsPath(),
     bridgeDest: path.join(home, '.wmux', 'hooks', 'wmux-bridge.mjs'),
     bridgeSource: findBridgeSource(),
   };
@@ -257,6 +320,44 @@ function hasArgvTail(
     if (typeof command !== 'string' || !command.includes(WMUX_BRIDGE_MARKER)) return false;
     return command.trim().endsWith(tail);
   });
+}
+
+/**
+ * The wmux specs currently registered in a settings object, keyed by specKey.
+ * Shared by `installHooks` (to keep an existing profile) and `statusHooks`
+ * (to report one), so the two can never disagree about what is installed.
+ */
+function installedSpecsIn(settings: Record<string, unknown>): Set<string> {
+  const found = new Set<string>();
+  const hooks = settings.hooks;
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) return found;
+  const hooksMap = hooks as Record<string, unknown>;
+  for (const spec of HOOK_SPECS) {
+    const groups = hooksMap[spec.event];
+    if (Array.isArray(groups) && groups.some((g) => isEffectiveWmuxGroupForSpec(g, spec))) {
+      found.add(specKey(spec));
+    }
+  }
+  return found;
+}
+
+/**
+ * #970 — the profile a settings.json is already on. DERIVED, never stored: the
+ * installed hooks ARE the profile, so no marker file can go stale against them,
+ * and a bare re-run can never resurrect a gate hook the operator removed by
+ * hand — which is the whole point for anyone who wants "wmux cannot participate
+ * in permission decisions" to hold by construction.
+ *
+ * 'signals-only' requires EVERY signal spec present AND the gate absent. A
+ * partial install (some signals missing) is a broken 'full' install to repair,
+ * not a profile to preserve, so it reads as 'full' and a bare `wmux setup-hooks`
+ * heals it. No wmux hooks at all also reads as 'full' — the fresh-install default.
+ */
+export function detectProfile(settings: Record<string, unknown>): HookProfile {
+  const installed = installedSpecsIn(settings);
+  const allSignals = SIGNAL_SPECS.every((spec) => installed.has(specKey(spec)));
+  const gate = installed.has(specKey(PERMISSION_GATE_SPEC));
+  return allSignals && !gate ? 'signals-only' : 'full';
 }
 
 // ----- Settings load (corruption-aware) -----------------------------------
@@ -428,6 +529,12 @@ export interface InstallOutcome {
   bridgeSource: string | null;
   /** Events written into settings.json. */
   events: HookEvent[];
+  /**
+   * #970 — the hook profile this run installed. Absent an explicit
+   * `--signals-only`/`--with-gate`, it is whatever settings.json was already
+   * on, so a refresh never silently changes it.
+   */
+  profile: HookProfile;
   bridgeCopied: boolean;
   /**
    * True when the wmux-claude-integration marketplace plugin was detected. In
@@ -443,13 +550,24 @@ export interface InstallOutcome {
   error: string | null;
 }
 
-export function installHooks(paths: SetupHooksPaths): InstallOutcome {
+/**
+ * @param requestedProfile explicit `--signals-only` / `--with-gate`. Omitted
+ *   (a bare `wmux setup-hooks`) means KEEP whatever profile settings.json is
+ *   already on — a refresh that quietly re-added the gate would undo the
+ *   operator's choice on the next app update, which is exactly the stale-script
+ *   failure `refreshHookBridge` exists to avoid.
+ */
+export function installHooks(
+  paths: SetupHooksPaths,
+  requestedProfile?: HookProfile,
+): InstallOutcome {
   const base: InstallOutcome = {
     ok: false,
     settingsPath: paths.settingsPath,
     bridgeDest: paths.bridgeDest,
     bridgeSource: paths.bridgeSource,
     events: [],
+    profile: requestedProfile ?? 'full',
     bridgeCopied: false,
     pluginDetected: false,
     removedForPlugin: 0,
@@ -471,6 +589,10 @@ export function installHooks(paths: SetupHooksPaths): InstallOutcome {
   }
 
   const settings = load.settings;
+  // Resolved BEFORE any mutation — `stripWmuxHooks` below erases the very
+  // entries the derivation reads.
+  const profile: HookProfile = requestedProfile ?? detectProfile(settings);
+  const specs = specsFor(profile);
 
   // 2. Plugin-aware short-circuit: when the wmux-claude-integration marketplace
   //    plugin is installed AND enabled it already registers these hooks.
@@ -485,7 +607,24 @@ export function installHooks(paths: SetupHooksPaths): InstallOutcome {
     if (removedForPlugin > 0) {
       writeJsonAtomic(paths.settingsPath, settings);
     }
-    return { ...base, ok: true, pluginDetected: true, removedForPlugin };
+    return {
+      ...base,
+      ok: true,
+      pluginDetected: true,
+      removedForPlugin,
+      // The plugin's hooks.json is a fixed profile that includes the gate, and
+      // settings.json entries would only double the signals. Say so instead of
+      // reporting a signals-only install that did not happen (#970).
+      profile: 'full',
+      ...(requestedProfile === 'signals-only'
+        ? {
+            warning:
+              '--signals-only had no effect: the wmux-claude-integration plugin owns these ' +
+              'hooks and its profile includes the permission gate. Disable or uninstall the ' +
+              'plugin and re-run to install the signals-only profile from settings.json.',
+          }
+        : {}),
+    };
   }
 
   // 3. Locate + copy the bridge; without it the hooks would be inert.
@@ -503,7 +642,7 @@ export function installHooks(paths: SetupHooksPaths): InstallOutcome {
       ? (settings.hooks as Record<string, unknown>)
       : {};
 
-  for (const spec of HOOK_SPECS) {
+  for (const spec of specs) {
     const group: HookGroup = {
       matcher: spec.matcher,
       hooks: [{ type: 'command', command: bridgeCommand(paths.bridgeDest, spec.event, spec.extraArgs) }],
@@ -520,7 +659,8 @@ export function installHooks(paths: SetupHooksPaths): InstallOutcome {
     ...base,
     ok: true,
     bridgeCopied: true,
-    events: HOOK_SPECS.map((s) => s.event),
+    profile,
+    events: specs.map((s) => s.event),
   };
 }
 
@@ -651,6 +791,13 @@ export interface StatusOutcome {
   settingsCorrupted: boolean;
   /** wmux hook events currently present in settings.json. */
   installedEvents: HookEvent[];
+  /**
+   * #970 — the hook profile settings.json is on, derived from the installed
+   * specs. 'signals-only' means the wide PreToolUse gate was deliberately not
+   * installed, so `features.permissionGate` being 'off' is a configuration and
+   * not a defect.
+   */
+  profile: HookProfile;
   bridgeDest: string;
   bridgeExists: boolean;
   bridgeSource: string | null;
@@ -719,31 +866,21 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     detectPluginViaManifest(paths.settingsPath) &&
     !isPluginExplicitlyDisabled(load.settings);
 
-  const installedEvents: HookEvent[] = [];
   // PreToolUse now carries TWO specs (the AskUserQuestion approval hook and the
   // wide permission gate), so `installedEvents` — an event list — can no longer
   // tell the features apart: the gate hook alone would report the approval card
   // as healthy. Features read this spec-level set instead.
-  const installedSpecs = new Set<string>();
-  const specKey = (spec: { event: HookEvent; extraArgs?: string }): string =>
-    `${spec.event}${spec.extraArgs ? ` ${spec.extraArgs}` : ''}`;
-  if (!load.corrupted) {
-    const hooks = load.settings.hooks;
-    if (hooks && typeof hooks === 'object' && !Array.isArray(hooks)) {
-      const hooksMap = hooks as Record<string, unknown>;
-      for (const spec of HOOK_SPECS) {
-        const groups = hooksMap[spec.event];
-        if (
-          Array.isArray(groups) &&
-          groups.some((group) => isEffectiveWmuxGroupForSpec(group, spec))
-        ) {
-          installedSpecs.add(specKey(spec));
-          // HOOK_SPECS carries each event once, but dedup defensively.
-          if (!installedEvents.includes(spec.event)) installedEvents.push(spec.event);
-        }
-      }
+  const installedSpecs = load.corrupted ? new Set<string>() : installedSpecsIn(load.settings);
+  const installedEvents: HookEvent[] = [];
+  for (const spec of HOOK_SPECS) {
+    // HOOK_SPECS carries PreToolUse twice (approval pair + gate), so dedup.
+    if (installedSpecs.has(specKey(spec)) && !installedEvents.includes(spec.event)) {
+      installedEvents.push(spec.event);
     }
   }
+  // #970 — a corrupt settings file has no derivable profile; report the default
+  // rather than inventing a 'signals-only' the operator never chose.
+  const profile: HookProfile = load.corrupted ? 'full' : detectProfile(load.settings);
 
   const bridgeExists = fs.existsSync(paths.bridgeDest);
   let bridgeStale = false;
@@ -815,11 +952,19 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     // real install state now, not a placeholder. It arms only while an
     // answering surface is up (`wmux web`); the detail says so, because a hook
     // that is installed and dormant would otherwise read as broken.
+    // #970 — and an ABSENT gate is now two states, not one. On the signals-only
+    // profile it is the operator's choice, so the detail names the profile and
+    // offers the way back rather than calling it missing. The old copy encoded
+    // "the gate is required" as a string — an answer to a design question that
+    // had not been asked yet.
     permissionGate: featureStatus(
       pluginActive,
       hasSpec('PreToolUse', PERMISSION_GATE_SPEC.extraArgs),
       'PreToolUse (all tools) → remote approval while `wmux web` is running',
-      `PreToolUse permission gate missing → run \`${FIX}\``,
+      profile === 'signals-only'
+        ? 'signals-only profile — no wmux hook runs per tool call; ' +
+          `\`${FIX} --with-gate\` to enable remote approvals`
+        : `PreToolUse permission gate missing → run \`${FIX}\``,
     ),
   };
 
@@ -828,6 +973,7 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     settingsExists: load.exists,
     settingsCorrupted: load.corrupted,
     installedEvents,
+    profile,
     bridgeDest: paths.bridgeDest,
     bridgeExists,
     bridgeSource: paths.bridgeSource,
@@ -835,6 +981,35 @@ export function statusHooks(paths: SetupHooksPaths): StatusOutcome {
     pluginAlsoInstalled: detectPluginInstalled(paths.settingsPath),
     features,
   };
+}
+
+/**
+ * #970 — is the wide PreToolUse permission gate hook actually installed?
+ *
+ * `wmux web --allow-input` is the only thing that ARMS the gate, which makes it
+ * the only place that can catch the signals-only mismatch. Without the hook no
+ * tool call ever reaches the broker, so the phone simply never rings: there is
+ * no error, no log line, and no timeout anywhere to notice — the failure is
+ * silent, which is strictly worse than a loud one.
+ *
+ * Deliberately cheaper than `statusHooks`: a settings read plus the plugin
+ * manifest, with no `plugins/` directory walk, no bridge byte-compare, and no
+ * `findBridgeSource` upward walk — it takes the settings path alone rather than
+ * a full `SetupHooksPaths`, because that is all it reads. This runs on a
+ * user-facing startup path.
+ *
+ * A corrupt settings.json returns FALSE. We cannot prove the gate is there, and
+ * a false "armed" reading is exactly the outcome this guard exists to prevent.
+ */
+export function isPermissionGateInstalled(settingsPath: string = defaultSettingsPath()): boolean {
+  const load = loadSettings(settingsPath);
+  if (load.corrupted) return false;
+  // An active marketplace plugin supplies the gate from its own hooks.json,
+  // where it is not optional — settings.json will be empty of wmux hooks then.
+  if (detectPluginViaManifest(settingsPath) && !isPluginExplicitlyDisabled(load.settings)) {
+    return true;
+  }
+  return installedSpecsIn(load.settings).has(specKey(PERMISSION_GATE_SPEC));
 }
 
 // ----- Printing -----------------------------------------------------------
@@ -851,6 +1026,7 @@ function printInstall(outcome: InstallOutcome, jsonMode: boolean): void {
   if (outcome.pluginDetected) {
     console.log('Detected the wmux-claude-integration plugin — it already registers these hooks.');
     console.log('Skipped writing settings.json hook entries to avoid double signals.');
+    if (outcome.warning) console.warn(outcome.warning);
     if (outcome.removedForPlugin > 0) {
       console.log(
         `Removed ${outcome.removedForPlugin} duplicate wmux hook entr${outcome.removedForPlugin === 1 ? 'y' : 'ies'} from ${outcome.settingsPath}.`,
@@ -864,6 +1040,13 @@ function printInstall(outcome: InstallOutcome, jsonMode: boolean): void {
   console.log(`Copied bridge → ${outcome.bridgeDest}`);
   console.log(`Updated settings → ${outcome.settingsPath}`);
   console.log(`Installed hooks for: ${outcome.events.join(', ')}`);
+  console.log(
+    outcome.profile === 'signals-only'
+      ? 'Profile: signals-only — no wmux hook runs per tool call. Remote approvals are OFF; '
+        + 'run `wmux setup-hooks --with-gate` to enable them.'
+      : 'Profile: full — the PreToolUse permission gate is installed; it arms under '
+        + '`wmux web --allow-input`.',
+  );
   if (outcome.warning) console.warn(outcome.warning);
   console.log('Restart your Claude Code session for the hooks to take effect.');
 }
@@ -913,7 +1096,10 @@ function printStatus(outcome: StatusOutcome, jsonMode: boolean): void {
   if (outcome.settingsCorrupted) {
     console.log(`settings: ${outcome.settingsPath} (UNPARSEABLE — fix before installing)`);
   } else if (outcome.installedEvents.length > 0) {
-    console.log(`settings: ${outcome.settingsPath} (hooks: ${outcome.installedEvents.join(', ')})`);
+    console.log(
+      `settings: ${outcome.settingsPath} (profile: ${outcome.profile}; ` +
+        `hooks: ${outcome.installedEvents.join(', ')})`,
+    );
   } else {
     console.log(`settings: ${outcome.settingsPath} (wmux hooks NOT installed)`);
   }
@@ -997,10 +1183,36 @@ export async function handleSetupHooks(args: string[], jsonMode: boolean): Promi
     return;
   }
 
+  // #970 — profile selection. Omitting both keeps whatever profile is already
+  // installed, so a refresh (or the in-app "install hooks" button) never
+  // silently re-adds a gate the operator removed.
+  const signalsOnly = args.includes('--signals-only');
+  const withGate = args.includes('--with-gate');
+  if (signalsOnly && withGate) {
+    console.error('--signals-only and --with-gate are mutually exclusive.');
+    process.exit(1);
+    return;
+  }
+  // Rejected rather than ignored: `--status --signals-only` reads as "report
+  // the signals-only profile", and silently reporting the installed one
+  // instead would answer a question the user did not ask.
+  if ((signalsOnly || withGate) && (remove || status)) {
+    console.error('--signals-only and --with-gate apply to install only; drop --remove/--status.');
+    process.exit(1);
+    return;
+  }
+  const requestedProfile: HookProfile | undefined = signalsOnly
+    ? 'signals-only'
+    : withGate
+      ? 'full'
+      : undefined;
+
   // Reject unknown arguments rather than silently falling through to a full
   // install — a typo like `--remov` must not WRITE hooks the user was trying
   // to delete.
-  const unknown = args.filter((a) => a !== '--remove' && a !== '--status');
+  const unknown = args.filter(
+    (a) => a !== '--remove' && a !== '--status' && a !== '--signals-only' && a !== '--with-gate',
+  );
   if (unknown.length > 0) {
     console.error(`Unknown argument(s): ${unknown.join(', ')}. Run 'wmux setup-hooks --help' for usage.`);
     process.exit(1);
@@ -1059,7 +1271,7 @@ export async function handleSetupHooks(args: string[], jsonMode: boolean): Promi
 
   // Run each integration independently so a corrupt Claude settings file does
   // not prevent safe Codex/OpenCode installation (and vice versa).
-  const claude = installHooks(paths);
+  const claude = installHooks(paths, requestedProfile);
   const integrations = lifecycle.installLifecycleIntegrations(lifecyclePaths);
   const outcome = {
     ...claude,

--- a/src/cli/commands/web.ts
+++ b/src/cli/commands/web.ts
@@ -9,6 +9,7 @@ import {
 } from '../tailscale';
 import type { RpcResponse } from '../../shared/rpc';
 import type { WebTlsConfig } from '../../shared/web';
+import { isPermissionGateInstalled } from './setupHooks';
 
 const DEFAULT_PORT = 7681;
 const LOOPBACK_HOST = '127.0.0.1';
@@ -448,6 +449,16 @@ function report(
     console.log('  Re-run with --allow-input to enable keyboard input.');
   } else {
     console.log('  Input is ENABLED: the browser can type into your panes.');
+    // #970 — --allow-input is what arms the permission gate, but the gate is a
+    // hook in Claude Code's settings, not something this server can switch on.
+    // On the signals-only hook profile no tool call ever raises an approval and
+    // nothing else reports it: the phone just never rings. Say it here, where
+    // the operator is already reading about what input enabled.
+    if (!isPermissionGateInstalled()) {
+      console.log('  ⚠ The PreToolUse permission gate hook is NOT installed (signals-only');
+      console.log('    hook profile), so no tool call will raise a remote approval. Run');
+      console.log('    `wmux setup-hooks --with-gate` and restart your Claude Code sessions.');
+    }
   }
   if (info.allowUpload) {
     console.log('  Photo upload is ENABLED: a paired phone can write JPEG/PNG files');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -137,7 +137,10 @@ MCP COMMANDS
   mcp unregister                    Remove wmux entries from ~/.claude.json
 
 CLAUDE CODE INTEGRATION
-  setup-hooks                       Install Claude Code hooks (no plugin needed)
+  setup-hooks [--signals-only]      Install Claude Code hooks (no plugin needed).
+                                    --signals-only omits the wide PreToolUse
+                                    permission gate, so no wmux hook runs per
+                                    tool call; --with-gate puts it back.
               [--remove]            Remove the wmux-owned hook entries
               [--status]            Report hook + bridge install state
   gate --list                       Show tools in the permission gate (#783)


### PR DESCRIPTION
Closes #970 — the design question, answered as **Supported**: `wmux setup-hooks --signals-only` installs the lifecycle signals and the approval card without the wide `PreToolUse` permission gate.

## Why this shape and not the other two

**The "make the dormant gate cheaper" shape is dead.** The reporter measured 113–161 ms per tool call and correctly called it a lower bound. Reproduced here, plus the piece that settles it:

| path | measured |
|---|---|
| `node -e ""` — bare spawn floor | 81–91 ms |
| `WMUX_GATE=0` fast exit | 121–166 ms |
| armed, outside a wmux pane | 121–168 ms |

~85 ms of the ~120 is **process spawn**, and `WMUX_GATE=0` already returns before reading stdin or touching a pipe. A persisted opt-in the gate reads before it round-trips would save ~20 ms of ~120. The cost is the hook existing, so the only way to not pay it is to not install it.

**The wide hook is not inert, and that argues for the split rather than against it.** `daemon/index.ts:3030-3032` does not return quietly on the dormant path — it emits `agent.tool_started`, which `agentLiveness.ts:121` projects into the phone header's "which tool is running". So the hook does two jobs. But `emitAgentLiveness` fans out to web clients only, and gate resolution arms only under `wmux web --allow-input` (`WebTerminalServer.canResolveGates`). **Both jobs need a web surface.** A terminal-only operator pays the spawn for neither.

**There is precedent.** `setupHooks.ts:52-58` records that #435 removed a wide `PostToolUse` for exactly this reason — "a ~110ms node bridge per tool call feeding the fleet running dot, which the daemon's byte-based ActivityMonitor now drives for free". #783 reintroduced the same per-tool-call cost for the gate. And `gatedTools: []` is not the same answer: a policy of "gate nothing" still spawns the process that asks.

## What changed

- **`--signals-only` / `--with-gate`** on `wmux setup-hooks`. Signals-only writes `Stop` / `SubagentStop` / `SessionStart` plus the `AskUserQuestion` approval pair, and nothing that fires per tool call.
- **The profile is derived from `settings.json`, not stored beside it.** A marker file could go stale against the hooks it describes. More importantly, a bare `wmux setup-hooks` — which is what the app-update refresh and the in-app "install hooks" button call — must never resurrect a gate the operator removed. It now keeps whatever profile is installed. A *partial* install (a signal missing) still reads as broken-full and gets repaired.
- **The silent half is guarded.** Signals-only + `wmux web --allow-input` leaves a phone waiting on approvals nothing will ever raise: no error, no log, no timeout. `--allow-input` now checks the hook and says so on startup.
- **`--status` copy.** An absent gate is now two states. On the signals-only profile it reads as a configuration with the way back, not as something to fix. The old string encoded "the gate is required" as copy — an answer to this issue's question, written before the decision was made.

## Scoped out, deliberately

Plugin users keep the full profile. A Claude Code plugin ships one `hooks/hooks.json` with no per-install switch, and the reporter's alternative — a self-disabling gate — would still pay the spawn that is the entire cost. So `--signals-only` with the plugin active **reports that it had no effect** instead of silently doing nothing, and `integrations/claude/README.md` documents the CLI path as the way to get it. A second marketplace plugin is a distribution decision, not a patch.

## Verification

- 20 new unit tests for the profile (`setupHooks.test.ts`) + 4 for the `--allow-input` warning (`web.gateWarning.test.ts`); 372 pass across `src/cli/`, `integrations/claude/`, and the in-app hooks bridge.
- End-to-end against a built CLI in an isolated HOME: signals-only install writes zero `--permission-gate` entries; a bare re-run keeps it at zero; `--with-gate` restores exactly one; a second bare re-run keeps it at one; all three flag-conflict paths error out.
- `tsc --noEmit` clean (6 pre-existing baseline errors, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hook setup profiles: full installation or signals-only mode.
  - Added `--signals-only` and `--with-gate` options for managing permission hooks.
  - Hook refreshes now preserve the selected profile.
  - Web input now warns when the permission gate is missing.

- **Documentation**
  - Expanded setup guidance for profiles, status checks, plugin behavior, and removal.

- **Bug Fixes**
  - Status reporting now correctly handles intentional signals-only installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->