### PR TITLE
fix(updater): stop the install handoff from killing the renderer it is about to wait on (#980)

### DIFF
--- a/changelog.d/980.md
+++ b/changelog.d/980.md
@@ -28,7 +28,9 @@
   well after it asked to quit for an install, it now reports what happened —
   including the waiter's own reason when it left one — and clears the
   in-progress latch, so the next attempt is not answered with "an update install
-  is already in progress" forever.
+  is already in progress" forever. And a retry cannot race the first attempt's
+  waiter into launching the installer twice: only one waiter per install root
+  ever runs — a newcomer finds a live incumbent and yields to it.
 
 - **The install waiter no longer goes blind after 24 days of uptime.** Its
   budget was measured with a 32-bit millisecond counter that wraps and turns

--- a/changelog.d/980.md
+++ b/changelog.d/980.md
@@ -1,0 +1,37 @@
+### Fixed
+
+- **The in-app update installs again.** Clicking "Install now" downloaded and
+  verified the release, restarted wmux, and came back on the old version — with
+  Settings still offering an install that then did nothing at all until the app
+  was restarted by hand. The installer is launched by a detached waiter that
+  refuses to run until every process under the install root is gone, and wmux
+  was holding that root open itself: the handoff force-killed every `wmux.exe`
+  under the root except the daemon, and on Windows our own renderer, GPU and
+  utility processes are that same `wmux.exe`. The very next step quits, and the
+  quit handler waits for a session save in the renderer that was just killed, so
+  the quit never finished. The main process stayed alive for a full day across
+  two attempts, holding the tree the waiter was waiting to see released.
+  The force-kill now takes only what nothing else ends — the MCP servers, which
+  run out of the install root but belong to agent hosts. Our own processes exit
+  with the app, and the waiter still waits for all of them, so the installer
+  still cannot start against a live tree.
+
+- **A quit can no longer wedge the app.** The teardown's force-exit fallback was
+  armed only after every teardown step had finished, so a step that never
+  settled left a process that had cancelled its own quit, latched the quit flag,
+  and armed no timer — alive, window-less, and ignoring taskbar clicks and
+  relaunches, recoverable only by killing it. The deadline is now armed before
+  anything can hang, and the renderer's session save is bounded rather than
+  waited on indefinitely.
+
+- **A refused install says so instead of going quiet.** If wmux is still running
+  well after it asked to quit for an install, it now reports what happened —
+  including the waiter's own reason when it left one — and clears the
+  in-progress latch, so the next attempt is not answered with "an update install
+  is already in progress" forever.
+
+- **The install waiter no longer goes blind after 24 days of uptime.** Its
+  budget was measured with a 32-bit millisecond counter that wraps and turns
+  negative, at which point the remaining time overflowed, the wait threw, the
+  error was swallowed, and the whole guard silently became a no-op. It is
+  measured with a monotonic clock now.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1910,10 +1910,50 @@ async function abortInstallQuit(): Promise<void> {
   });
 }
 
+/**
+ * #980 — outer bound on the whole before-quit teardown.
+ *
+ * Generous on purpose: daemon.shutdown alone is budgeted 8 s and the renderer
+ * save adds ~0.5 s, so a healthy quit never comes close. This is not a
+ * performance knob — it is the guarantee that a quit ALWAYS ends in an exit.
+ */
+const QUIT_HARD_DEADLINE_MS = 20_000;
+
+/**
+ * #980 — how long the renderer gets to run its beforeunload save. Short: the
+ * save is a synchronous dispatch, so anything past this is a renderer that is
+ * not going to answer at all.
+ */
+const RENDERER_SAVE_TIMEOUT_MS = 3_000;
+
 app.on('before-quit', async (e) => {
   if (isQuitting) return; // second pass — let quit proceed
   e.preventDefault();
   isQuitting = true;
+
+  // #980 — everything below is a sequence of awaits, and the force-exit
+  // fallback at the BOTTOM is only armed once they have all resolved. Anything
+  // that never settles therefore leaves a process that has preventDefault'ed
+  // its own quit, latched `isQuitting`, and armed no timer: alive indefinitely,
+  // with 'second-instance' and 'activate' both early-returning on that latch.
+  //
+  // Not hypothetical. On the install path the updater force-killed our own
+  // renderer and then quit, so the session-save await below was addressing a
+  // process that no longer existed — and the main process stayed up for a day
+  // holding the install root the installer was waiting to see released. The
+  // renderer kill is fixed at its source (AutoUpdater), but a quit that can
+  // wedge AT ALL is the more expensive defect: it strands the user with a live
+  // process no click can reach, and on the update path it silently blocks every
+  // future release. So the deadline is armed FIRST, before anything can hang.
+  //
+  // Deliberately never cleared: a normal quit exits long before it fires, and
+  // clearing it anywhere would reintroduce a window in which nothing is armed.
+  const quitDeadline = setTimeout(() => {
+    console.error(`[Main] before-quit did not finish within ${QUIT_HARD_DEADLINE_MS}ms — forcing app.exit(0)`);
+    logLine('error', 'main', `before-quit hard deadline (${QUIT_HARD_DEADLINE_MS}ms) fired — forcing exit`);
+    app.exit(0);
+  }, QUIT_HARD_DEADLINE_MS);
+  quitDeadline.unref();
 
   // Broker dies with the app: shims exit and hosts mark the server down,
   // same visible behavior as the old per-agent child dying with wmux.
@@ -1933,15 +1973,26 @@ app.on('before-quit', async (e) => {
     }
   }
 
-  // Attempt session save from renderer
+  // Attempt session save from renderer.
+  //
+  // #980 — bounded. `isCrashed()` only reports a renderer Electron has already
+  // noticed is gone; between an external kill and that notification the guard
+  // passes and this call goes to a process that will never answer. The periodic
+  // save is the fallback the catch below already relies on, so waiting longer
+  // than the save itself needs buys nothing and risks everything.
   if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.webContents.isCrashed()) {
     try {
-      await mainWindow.webContents.executeJavaScript(
-        `try { window.dispatchEvent(new Event('beforeunload')); } catch(e) {}`
-      );
+      await Promise.race([
+        mainWindow.webContents.executeJavaScript(
+          `try { window.dispatchEvent(new Event('beforeunload')); } catch(e) {}`
+        ),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('renderer session-save timed out')), RENDERER_SAVE_TIMEOUT_MS),
+        ),
+      ]);
       await new Promise(resolve => setTimeout(resolve, 500));
     } catch {
-      // Renderer unavailable — rely on last periodic save
+      // Renderer unavailable, or too slow to answer — rely on last periodic save
     }
   }
 

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -20,7 +20,7 @@ import { IPC } from '../../shared/constants';
 import { isAllowedDownloadUrl, digestsEqual, validateManifest, type UpdateManifest } from './verifyUpdate';
 import { LocalUpdateFeed } from './LocalUpdateFeed';
 import {
-  collectInstallRootPids,
+  collectInstallRootProcesses,
   clearAbortMarker,
   freeSpaceShortfall,
   INSTALL_ABORT_MARKER,
@@ -65,6 +65,12 @@ const INSTALL_STAGING_HEADROOM_BYTES = 200 * 1024 * 1024;
 // can hold files for a while, and waiting is free while refusing costs the user
 // their update.
 const INSTALL_LOCK_BUDGET_MS = 60_000;
+// #980 — how long we give our own quit before concluding it did not happen.
+// Longer than main's before-quit hard deadline (20 s), so on any path where
+// that deadline is armed the process is already gone and this never fires. It
+// exists for the paths where it is NOT armed — a quit that never reaches a
+// before-quit handler at all leaves nothing else to notice.
+const INSTALL_QUIT_WATCHDOG_MS = 30_000;
 // Squirrel downloading and unpacking a ~120 MB bundle before it reports
 // 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
 // makes this minutes, and aborting a healthy update is worse than waiting.
@@ -719,13 +725,30 @@ export class AutoUpdater {
       return;
     }
 
-    // Everything running out of the install root, minus ourselves. The daemon
-    // is in here too: it is handed to the waiter so the installer waits for its
-    // graceful shutdown to finish, but it is NOT force-killed below — the full
-    // shutdown branch flushes its scrollback first.
-    const pids = collectInstallRootPids(installRoot);
+    // #980 — the WAIT list and the KILL list are different sets on purpose, and
+    // conflating them is what broke this path:
+    //
+    //   wait : everything under the root. Nothing may hold the tree open when
+    //          Setup.exe starts, regardless of who is responsible for ending it.
+    //   kill : only what nothing else ends — the MCP servers, which run out of
+    //          the install root but are owned by agent hosts rather than by us.
+    //
+    // Our own Electron helpers (renderer, GPU, utility) are the same wmux.exe
+    // under the same root, so the old "everything except the daemon" filter
+    // force-killed them too — and the very next thing this function does is
+    // quit, into a before-quit handler that awaits a session save IN THE
+    // RENDERER it had just killed. They exit with `app.quit()`; they stay on the
+    // wait list, so sparing them cannot let the installer start early.
+    //
+    // The daemon is spared for its own, older reason: the full-shutdown branch
+    // flushes its scrollback first. A null daemon pid still fails safe — it is
+    // force-killed like anything else foreign, costing a flush but not the
+    // install — unless it is one of our descendants, in which case app.quit()
+    // is already taking it down.
+    const survey = collectInstallRootProcesses(installRoot);
+    const pids = survey.pids;
     const daemonPid = this.hooks.getDaemonPid();
-    const forceKillPids = pids.filter((p) => p !== daemonPid);
+    const forceKillPids = pids.filter((p) => p !== daemonPid && !survey.ownTree.has(p));
 
     // ORDER MATTERS, and it is the reverse of the obvious one.
     //
@@ -768,7 +791,9 @@ export class AutoUpdater {
     // update goes wrong, and the log is the only place to answer it from.
     console.log(
       `[AutoUpdater] install handoff: waiter=${waiterPath} watching ${pids.length} process(es) under ${installRoot}; ` +
-      `force-killed ${killed.length}/${forceKillPids.length}, daemon pid ${daemonPid ?? 'unknown'} left to the graceful shutdown`,
+      `force-killed ${killed.length}/${forceKillPids.length} foreign, ` +
+      `${survey.ownTree.size} of our own left to app.quit(), ` +
+      `daemon pid ${daemonPid ?? 'unknown'} left to the graceful shutdown`,
     );
 
     // Sessions do NOT survive this install. The daemon holds the install root
@@ -777,6 +802,50 @@ export class AutoUpdater {
     // reason the failure looked so surprising.
     console.log('[AutoUpdater] quitting for install — the daemon goes down with us so the installer runs against a dead tree');
     app.quit();
+    this.armInstallQuitWatchdog(abortMarkerPath);
+  }
+
+  /**
+   * #980 — `app.quit()` is a request, and on this path nothing else notices when
+   * it is refused.
+   *
+   * Everything downstream assumes we die: the waiter is blocked on our own
+   * process handles, so a surviving wmux holds the install root open until the
+   * lock budget expires and the installer is refused. Meanwhile `isInstalling`
+   * stays latched — it is deliberately never cleared on the success path,
+   * because on the success path there is no process left to clear it in — so
+   * every retry answers "an update install is already in progress" and the UI
+   * keeps offering an "Install now" that can no longer do anything. That
+   * combination is what turned one failed install into a permanently stuck
+   * updater in the field, recoverable only by restarting the app by hand.
+   *
+   * Still being here at the deadline IS the failure signal. Report it, and
+   * unlatch so the next attempt is at least possible. No attempt is made to
+   * put the app back together: unlike the macOS path, by this point
+   * `before-quit` has already stopped the pipe server, destroyed the tray and
+   * disposed the IPC handlers, so "recovery" would hand the user a hollow
+   * window. Say what happened and name the restart instead of pretending.
+   */
+  private armInstallQuitWatchdog(abortMarkerPath: string): void {
+    const timer = setTimeout(() => {
+      // The waiter may already have refused and left a reason; prefer it over
+      // our own guess, since it knows WHICH process would not let go.
+      const reason = readAbortMarker(abortMarkerPath);
+      this.isInstalling = false;
+      console.error(
+        `[AutoUpdater] still running ${INSTALL_QUIT_WATCHDOG_MS}ms after quitting for install — ` +
+        `the installer never started${reason ? ` (${reason})` : ''}`,
+      );
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: reason
+          ? `The update did not install (${reason}). Your current version is unchanged — restart wmux and try again.`
+          : 'The update did not install: wmux could not shut down to let the installer run. Your current version is unchanged — restart wmux and try again.',
+      });
+    }, INSTALL_QUIT_WATCHDOG_MS);
+    // A healthy quit is long gone before this fires, and an unref'd timer must
+    // never be the reason the process stays up.
+    timer.unref();
   }
 
   /**

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -123,7 +123,12 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
   // Stubbed here so the ORDER and the refusal branches stay observable; the
   // real thing is exercised against a sandbox in installTeardown.runtime.test.
   const teardown = {
-    collectInstallRootPids: vi.fn((_root: string): number[] => [4242, 4243]),
+    // #980 — 4242 is a stranger's MCP server, 4243 is the daemon, 4244 is one
+    // of our own Electron helpers. Only the first may be force-killed.
+    collectInstallRootProcesses: vi.fn((_root: string) => ({
+      pids: [4242, 4243, 4244],
+      ownTree: new Set([4244]),
+    })),
     terminatePids: vi.fn((pids: readonly number[]): number[] => [...pids]),
     spawnInstallWaiter: vi.fn((_plan: { setupExePath: string }): string | null =>
       'C:\\Temp\\waiter\\wait-and-install.ps1'),

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -464,6 +464,17 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
       // And the latch is clear, so the next press is not answered with
       // "an update install is already in progress" forever.
       expect((updater as unknown as { isInstalling: boolean }).isInstalling).toBe(false);
+
+      // The retry is ALLOWED to spawn a second waiter — the first one may
+      // still be inside its budget, and the collision between the two is
+      // resolved by the waiter's own single-instance mutex (a live incumbent
+      // wins, the newcomer exits 5), not by refusing the retry here. Refusing
+      // would trade a solved race for an unretryable updater, which is the
+      // state this watchdog exists to end.
+      const retry = installHandler();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await retry;
+      expect(loaded.teardown.spawnInstallWaiter).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -37,7 +37,7 @@ function quitHooks() {
     onBeforeInstallQuit: vi.fn(),
     onInstallQuitAborted: vi.fn(),
     onInstallRequiresFullShutdown: vi.fn(),
-    getDaemonPid: vi.fn(() => null),
+    getDaemonPid: vi.fn((): number | null => null),
   };
 }
 
@@ -150,9 +150,12 @@ async function loadForPlatform(
   // node processes. Stubbed so the handoff stays observable; the real thing is
   // exercised against a sandbox in installTeardown.runtime.test.
   const teardown = {
-    collectInstallRootPids: vi.fn((_root: string): number[] => [4242]),
+    collectInstallRootProcesses: vi.fn((_root: string) => ({
+      pids: [4242],
+      ownTree: new Set<number>(),
+    })),
     terminatePids: vi.fn((pids: readonly number[]): number[] => [...pids]),
-    spawnInstallWaiter: vi.fn((_plan: { setupExePath: string }): string | null =>
+    spawnInstallWaiter: vi.fn((_plan: { setupExePath: string; pids: number[] }): string | null =>
       'C:\\Temp\\waiter\\wait-and-install.ps1'),
     freeSpaceShortfall: vi.fn(() => null),
     probeVolume: vi.fn(() => ({ volume: 'C:\\', freeBytes: 9e12 })),
@@ -355,10 +358,16 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
    * registered directly (not via start()) so no stray 15s background-check
    * timer outlives the test.
    */
-  async function downloadUpdateFor(loaded: Awaited<ReturnType<typeof loadForPlatform>>) {
+  async function downloadUpdateFor(
+    loaded: Awaited<ReturnType<typeof loadForPlatform>>,
+    // #980 — the daemon pid reaches the updater through the HOOKS, not through
+    // the teardown module, so a test about which pids get force-killed has to
+    // be able to say what it is.
+    hooks: ReturnType<typeof quitHooks> = quitHooks(),
+  ) {
     const { AutoUpdater, ipcHandlers } = loaded;
     const { win, sent } = makeWin();
-    const updater = new AutoUpdater(() => win as never, quitHooks());
+    const updater = new AutoUpdater(() => win as never, hooks);
     (updater as unknown as { registerIpcHandlers: () => void }).registerIpcHandlers();
 
     const installHandler = ipcHandlers.get(IPC.UPDATE_INSTALL);
@@ -389,6 +398,96 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
     expect(loaded.appQuit).toHaveBeenCalledTimes(1);
   });
 
+  it('win32: the kill list is what nothing else ends — not our helpers, not the daemon (#980)', async () => {
+    const loaded = await loadForPlatform('win32', downloadRoutes);
+    // 4242 is a stranger's MCP server; 4243 is the daemon; 4244/4245 are our
+    // own renderer and GPU process, which are the same wmux.exe under the same
+    // root and so are indistinguishable by path alone.
+    loaded.teardown.collectInstallRootProcesses.mockReturnValue({
+      pids: [4242, 4243, 4244, 4245],
+      ownTree: new Set([4244, 4245]),
+    });
+    const hooks = { ...quitHooks(), getDaemonPid: vi.fn(() => 4243 as number | null) };
+    const { installHandler } = await downloadUpdateFor(loaded, hooks);
+
+    await installHandler();
+
+    // Only the foreign process is killed. Killing our own renderer is what
+    // broke this path: the very next step is a quit whose before-quit handler
+    // awaits a session save in that renderer, and the quit then never
+    // completed — leaving the main process holding the install root open.
+    expect(loaded.teardown.terminatePids).toHaveBeenCalledWith([4242]);
+
+    // The WAIT list stays broader than the kill list on purpose: our helpers
+    // and the daemon still have to be gone before Setup.exe may run, they just
+    // get there by app.quit() and by the graceful shutdown instead.
+    const plan = loaded.teardown.spawnInstallWaiter.mock.calls[0]![0] as { pids: number[] };
+    expect(plan.pids).toEqual([4242, 4243, 4244, 4245]);
+  });
+
+  it('win32: an unknown daemon pid still fails safe when the daemon is not ours (#980)', async () => {
+    const loaded = await loadForPlatform('win32', downloadRoutes);
+    loaded.teardown.collectInstallRootProcesses.mockReturnValue({
+      pids: [4242, 4243],
+      ownTree: new Set<number>(),
+    });
+    // The pid file was unreadable (quitHooks' getDaemonPid returns null).
+    // Sparing a daemon we cannot identify would leave the root locked;
+    // force-killing it costs a scrollback flush, which is the cheaper failure.
+    const { installHandler } = await downloadUpdateFor(loaded);
+
+    await installHandler();
+
+    expect(loaded.teardown.terminatePids).toHaveBeenCalledWith([4242, 4243]);
+  });
+
+  it('win32: a quit that never happens is reported and unlatched, not silent (#980)', async () => {
+    const loaded = await loadForPlatform('win32', downloadRoutes);
+    const { updater, installHandler, sent } = await downloadUpdateFor(loaded);
+    vi.useFakeTimers();
+    try {
+      const install = installHandler();
+      await vi.advanceTimersByTimeAsync(1_000); // performInstall's session-save wait
+      await install;
+      expect(loaded.appQuit).toHaveBeenCalledTimes(1);
+      // Nothing is claimed while the quit could still be in flight.
+      expect(sent.filter((m) => m.channel === IPC.UPDATE_ERROR)).toHaveLength(0);
+
+      // Still alive well past the deadline: the quit was refused. Nothing else
+      // can notice — the waiter is blocked on OUR process handle, and the UI is
+      // still showing "Install now".
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
+      expect(err).toBeDefined();
+      expect(String(err!.data.message)).toContain('restart wmux');
+      // And the latch is clear, so the next press is not answered with
+      // "an update install is already in progress" forever.
+      expect((updater as unknown as { isInstalling: boolean }).isInstalling).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('win32: the waiter reason wins over our guess when it left one (#980)', async () => {
+    const loaded = await loadForPlatform('win32', downloadRoutes);
+    const { installHandler, sent } = await downloadUpdateFor(loaded);
+    // The waiter already refused and said which way. It knows what we do not.
+    loaded.teardown.readAbortMarker.mockReturnValue('install-aborted: install root still locked');
+    vi.useFakeTimers();
+    try {
+      const install = installHandler();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await install;
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
+      expect(String(err?.data.message)).toContain('install root still locked');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('win32: a handoff that cannot be prepared reports UPDATE_ERROR and does NOT quit', async () => {
     const loaded = await loadForPlatform('win32', downloadRoutes);
     const { installHandler, sent } = await downloadUpdateFor(loaded);
@@ -415,7 +514,7 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
 
     await installHandler();
 
-    expect(loaded.teardown.collectInstallRootPids).not.toHaveBeenCalled();
+    expect(loaded.teardown.collectInstallRootProcesses).not.toHaveBeenCalled();
     expect(loaded.teardown.terminatePids).not.toHaveBeenCalled();
     expect(loaded.teardown.spawnInstallWaiter).not.toHaveBeenCalled();
     expect(loaded.appQuit).not.toHaveBeenCalled();

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -10,7 +10,8 @@
 // script, but the test observes an exit code instead of racing a background
 // process against afterEach teardown — an earlier detached version of this file
 // produced inverted, timing-dependent results that said nothing about the code.
-// Exit codes are the contract: 0 = installer launched, 2 = refused.
+// Exit codes are the contract: 0 = installer launched, 2 = refused,
+// 5 = another waiter already owns this install root (#980).
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -234,4 +235,92 @@ describe.skipIf(!onWindows)('probeVolume', () => {
     expect(ratio).toBeGreaterThan(0.9);
     expect(ratio).toBeLessThan(1.1);
   }, 30_000);
+});
+
+describe.skipIf(!onWindows)('concurrent waiters (#980)', () => {
+  let sandbox: string;
+  let root: string;
+  let heldExe: string;
+  let setupStamp: string;
+  let fakeSetup: string;
+  const children: ChildProcess[] = [];
+
+  beforeEach(() => {
+    sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-waiter2-')));
+    root = path.join(sandbox, 'wmux');
+    fs.mkdirSync(path.join(root, 'app-1.0.0'), { recursive: true });
+    heldExe = path.join(root, 'app-1.0.0', 'held.exe');
+    fs.writeFileSync(heldExe, 'x');
+    setupStamp = path.join(sandbox, 'setup-ran.txt');
+    fakeSetup = path.join(sandbox, 'fake-setup.cmd');
+    fs.writeFileSync(fakeSetup, `@echo off\r\necho ran > "${setupStamp}"\r\n`);
+  });
+
+  afterEach(() => {
+    for (const c of children.splice(0)) { try { c.kill(); } catch { /* already gone */ } }
+    try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch { /* lock lingers */ }
+  });
+
+  it('a second waiter for the same root yields to the incumbent instead of racing it', () => {
+    // The quit watchdog unlatches isInstalling after 30s so a refused quit
+    // stays retryable — but the first waiter can still be inside its own
+    // budget. Without the mutex both reach Start-Process on the same
+    // Setup.exe: two concurrent Squirrel installs against one root, which is
+    // the exact corruption #866 exists to prevent.
+    const holderA = spawn(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-Command',
+        `$s=[System.IO.File]::Open(${q(heldExe)},'Open','Read','None'); Start-Sleep -Seconds 120; $s.Close()`],
+      { windowsHide: true, stdio: 'ignore' },
+    );
+    children.push(holderA);
+
+    const planFor = (marker: string): WaiterPlan => ({
+      pids: [holderA.pid as number],
+      setupExePath: fakeSetup,
+      installRoot: root,
+      abortMarkerPath: marker,
+      lockBudgetMs: 90_000,
+    });
+
+    // Waiter A: async, long budget — parked in WaitForExit holding the mutex.
+    const scriptA = path.join(sandbox, 'waiter-a.ps1');
+    fs.writeFileSync(scriptA, buildWaiterScript(planFor(path.join(sandbox, 'abort-a.txt'))) as string, 'utf-8');
+    const waiterA = spawn(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptA],
+      { windowsHide: true, stdio: 'ignore' },
+    );
+    children.push(waiterA);
+
+    // Deterministic gate, not a sleep: proceed only once A actually HOLDS the
+    // mutex — otherwise B could win the race and this test would invert.
+    const mtxName = 'wmux-install-waiter-' + root.replace(/[^A-Za-z0-9]/g, '_');
+    const deadline = Date.now() + 15_000;
+    let held = false;
+    while (Date.now() < deadline) {
+      const probe = spawnSync(
+        PS,
+        ['-NoProfile', '-NonInteractive', '-Command',
+          `try { $m=[System.Threading.Mutex]::OpenExisting('${mtxName}'); exit 0 } catch { exit 1 }`],
+        { windowsHide: true, timeout: 10_000 },
+      );
+      if (probe.status === 0) { held = true; break; }
+    }
+    expect(held).toBe(true);
+
+    // Waiter B, same root: must yield IMMEDIATELY (exit 5), touch neither the
+    // installer nor its own marker, and leave reporting to the incumbent.
+    const markerB = path.join(sandbox, 'abort-b.txt');
+    const scriptB = path.join(sandbox, 'waiter-b.ps1');
+    fs.writeFileSync(scriptB, buildWaiterScript(planFor(markerB)) as string, 'utf-8');
+    const resB = spawnSync(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptB],
+      { encoding: 'utf-8', timeout: 20_000, windowsHide: true },
+    );
+    expect(resB.status).toBe(5);
+    expect(fs.existsSync(markerB)).toBe(false);
+    expect(fs.existsSync(setupStamp)).toBe(false);
+  }, 120_000);
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -406,3 +406,40 @@ describe('buildWaiterScript — the clock has to survive a long uptime (#980)', 
     expect(buildWaiterScript(plan)!).toContain('$h.WaitForExit([int]$left)');
   });
 });
+
+describe('buildWaiterScript — one waiter per install root (#980, coderabbit)', () => {
+  const plan = {
+    pids: [11],
+    setupExePath: 'C:/Temp/Setup.exe',
+    installRoot: 'C:/Root',
+    abortMarkerPath: 'C:/Data/aborted.txt',
+    lockBudgetMs: 60_000,
+  };
+  const script = () => buildWaiterScript(plan)!;
+
+  it('takes a named mutex before doing anything else', () => {
+    // The quit watchdog unlatches after 30s while a spawned waiter can still be
+    // inside its budget, so a retry spawns a second waiter for the same root.
+    // The collision is resolved HERE, not by timing arithmetic between the
+    // watchdog and the budgets: the mutex exists only while some process holds
+    // it, so a live incumbent blocks the newcomer and a dead one blocks nobody.
+    const s = script();
+    const mutexAt = s.indexOf('System.Threading.Mutex');
+    expect(mutexAt).toBeGreaterThan(-1);
+    expect(mutexAt).toBeLessThan(s.indexOf('$handles = @()'));
+    expect(mutexAt).toBeLessThan(s.indexOf('Start-Process'));
+  });
+
+  it('yields silently (exit 5) — the incumbent owns the install AND the marker', () => {
+    const s = script();
+    const yieldAt = s.indexOf('exit 5');
+    expect(yieldAt).toBeGreaterThan(-1);
+    // No marker write on this path: a "refused" marker from the loser would
+    // overwrite or pre-empt whatever the incumbent has to report.
+    expect(s.slice(0, yieldAt)).not.toContain('Set-Content');
+  });
+
+  it('scopes the mutex to the install root, so two installations never collide', () => {
+    expect(script()).toContain(`'wmux-install-waiter-' + ($root -replace '[^A-Za-z0-9]', '_')`);
+  });
+});

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -13,6 +13,7 @@ import {
   isSafePsPathLiteral,
   freeSpaceShortfall,
   selectInstallRootPids,
+  selectOwnTreePids,
   parseProcessRows,
   buildWaiterScript,
   readDaemonPid,
@@ -134,12 +135,22 @@ describe('selectInstallRootPids', () => {
 });
 
 describe('parseProcessRows', () => {
-  it('parses the array form and the single-object form', () => {
-    expect(parseProcessRows('[{"ProcessId":1,"ExecutablePath":"C:\\\\a.exe"}]')).toEqual([
-      { pid: 1, executablePath: 'C:\\a.exe' },
+  it('parses the array form and the single-object form, carrying parentage', () => {
+    expect(parseProcessRows('[{"ProcessId":1,"ParentProcessId":7,"ExecutablePath":"C:\\\\a.exe"}]')).toEqual([
+      { pid: 1, parentPid: 7, executablePath: 'C:\\a.exe' },
     ]);
-    expect(parseProcessRows('{"ProcessId":2,"ExecutablePath":"C:\\\\b.exe"}')).toEqual([
-      { pid: 2, executablePath: 'C:\\b.exe' },
+    expect(parseProcessRows('{"ProcessId":2,"ParentProcessId":7,"ExecutablePath":"C:\\\\b.exe"}')).toEqual([
+      { pid: 2, parentPid: 7, executablePath: 'C:\\b.exe' },
+    ]);
+    // #980 — an absent or malformed parent reads as 0, which belongs to no
+    // tree. Unreadable parentage can only make a process look FOREIGN, and a
+    // foreign process is the one case it is safe to be wrong about: it gets
+    // force-killed, which is what the old code did to everything anyway.
+    expect(parseProcessRows('[{"ProcessId":3,"ExecutablePath":"C:\\\\c.exe"}]')).toEqual([
+      { pid: 3, parentPid: 0, executablePath: 'C:\\c.exe' },
+    ]);
+    expect(parseProcessRows('[{"ProcessId":4,"ParentProcessId":-1,"ExecutablePath":""}]')).toEqual([
+      { pid: 4, parentPid: 0, executablePath: '' },
     ]);
   });
 
@@ -149,8 +160,8 @@ describe('parseProcessRows', () => {
     expect(parseProcessRows('[{"ProcessId":0},{"ExecutablePath":"x"}]')).toEqual([]);
     // A null ExecutablePath (access denied) still yields a row, with '' — which
     // selectInstallRootPids then filters out rather than treating as a match.
-    expect(parseProcessRows('[{"ProcessId":9,"ExecutablePath":null}]')).toEqual([
-      { pid: 9, executablePath: '' },
+    expect(parseProcessRows('[{"ProcessId":9,"ParentProcessId":1,"ExecutablePath":null}]')).toEqual([
+      { pid: 9, parentPid: 1, executablePath: '' },
     ]);
   });
 });
@@ -309,5 +320,89 @@ describe('buildWaiterScript — the lock probe covers loadable images, not just 
     expect(s).toContain(".node");
     expect(s).toContain(".asar");
     expect(s).not.toContain('-Filter *.exe');
+  });
+});
+
+/**
+ * #980 — who may be force-killed on the install path.
+ *
+ * Every Electron helper is the same wmux.exe under the same install root as the
+ * process running the update, so an executable-path match cannot tell our own
+ * renderer from a stranger's MCP server. Parentage can, and the distinction is
+ * load-bearing: the install path force-killed our own renderer and then quit
+ * into a before-quit handler that awaits a session save in it. The quit never
+ * completed, and the main process held the install root open for a day.
+ */
+describe('selectOwnTreePids (#980)', () => {
+  // 100 = us. 101/102 are our helpers, 103 is a helper's own child, 200 is a
+  // stranger's MCP server that merely runs out of the same directory.
+  const rows = [
+    { pid: 101, parentPid: 100 },
+    { pid: 102, parentPid: 100 },
+    { pid: 103, parentPid: 101 },
+    { pid: 200, parentPid: 999 },
+  ];
+
+  it('claims our children and their children, and nothing else', () => {
+    expect(selectOwnTreePids(rows, 100)).toEqual(new Set([101, 102, 103]));
+  });
+
+  it('never claims ourselves — the caller already excludes us from the wait list', () => {
+    expect(selectOwnTreePids(rows, 100).has(100)).toBe(false);
+  });
+
+  it('leaves a foreign process foreign, which is the one the kill list is FOR', () => {
+    expect(selectOwnTreePids(rows, 100).has(200)).toBe(false);
+  });
+
+  it('treats an unreadable parent (0) as foreign rather than adopting it', () => {
+    // Fails in the safe direction: an unclassifiable process gets force-killed,
+    // which is exactly what the old code did to everything.
+    expect(selectOwnTreePids([{ pid: 5, parentPid: 0 }], 100)).toEqual(new Set());
+    expect(selectOwnTreePids([{ pid: 5, parentPid: 0 }], 0)).toEqual(new Set());
+  });
+
+  it('terminates on a pid-recycle cycle instead of walking forever', () => {
+    // Windows recycles pids, so a stale parent reference can close a loop.
+    const cyclic = [
+      { pid: 101, parentPid: 100 },
+      { pid: 100, parentPid: 101 },
+    ];
+    expect(selectOwnTreePids(cyclic, 100)).toEqual(new Set([101]));
+  });
+
+  it('is empty when nothing descends from us', () => {
+    expect(selectOwnTreePids(rows, 555)).toEqual(new Set());
+  });
+});
+
+describe('buildWaiterScript — the clock has to survive a long uptime (#980)', () => {
+  const plan = {
+    pids: [11, 12],
+    setupExePath: 'C:/Temp/Setup.exe',
+    installRoot: 'C:/Root',
+    abortMarkerPath: 'C:/Data/aborted.txt',
+    lockBudgetMs: 60_000,
+  };
+
+  it('uses a monotonic Stopwatch, never [Environment]::TickCount', () => {
+    const script = buildWaiterScript(plan)!;
+    // TickCount is a signed 32-bit ms counter: it wraps every ~24.9 days and
+    // then runs negative, at which point `TickCount + budget` widens past
+    // Int32.MaxValue, WaitForExit throws on the timeout argument, the catch
+    // swallows it, and the wait silently becomes a no-op — on exactly the
+    // long-uptime machines that most need it.
+    expect(script).not.toContain('TickCount');
+    expect(script).toContain('[System.Diagnostics.Stopwatch]::StartNew()');
+  });
+
+  it('measures both the handle wait and the lock loop against that clock', () => {
+    const script = buildWaiterScript(plan)!;
+    expect(script).toContain('$left = $budget - $clock.ElapsedMilliseconds');
+    expect(script).toContain('$lockClock.ElapsedMilliseconds -lt $budget');
+  });
+
+  it('hands WaitForExit an int, so a widened remainder cannot throw the wait away', () => {
+    expect(buildWaiterScript(plan)!).toContain('$h.WaitForExit([int]$left)');
   });
 });

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -153,6 +153,10 @@ export function selectInstallRootPids(
   installRoot: string,
   ownPid: number,
 ): number[] {
+  // NOTE (#980): this stays the WAIT list and deliberately keeps our own
+  // helpers and the daemon in it. Everything here has to be gone before
+  // Setup.exe may run; which of them we kill ourselves is a separate question,
+  // answered by `selectOwnTreePids`.
   // Backslash explicitly, not `path.sep`. Every input here is a Windows path
   // read out of Win32_Process, and this only ever runs on win32 — but the
   // function is pure, so it is unit-tested on the Linux and macOS CI legs too,
@@ -166,8 +170,23 @@ export function selectInstallRootPids(
     .map((r) => r.pid);
 }
 
+/**
+ * One row of the install-root process enumeration.
+ *
+ * `parentPid` is carried because #980 turned on a distinction the original
+ * query could not make: every Electron helper is the SAME `wmux.exe` under the
+ * SAME root as the process doing the update, so an executable-path match cannot
+ * tell our own renderer from a stranger's MCP server. Parentage can.
+ */
+export interface InstallRootProcess {
+  pid: number;
+  /** 0 when the enumeration did not report one — treated as "not ours". */
+  parentPid: number;
+  executablePath: string;
+}
+
 /** Parse `Get-CimInstance ... | ConvertTo-Json` rows. Tolerates the single-object form. */
-export function parseProcessRows(stdout: string): Array<{ pid: number; executablePath: string }> {
+export function parseProcessRows(stdout: string): InstallRootProcess[] {
   const trimmed = stdout.trim();
   if (!trimmed) return [];
   let parsed: unknown;
@@ -177,18 +196,77 @@ export function parseProcessRows(stdout: string): Array<{ pid: number; executabl
     return [];
   }
   const items = Array.isArray(parsed) ? parsed : [parsed];
-  const out: Array<{ pid: number; executablePath: string }> = [];
+  const out: InstallRootProcess[] = [];
   for (const item of items) {
     if (!item || typeof item !== 'object') continue;
     const o = item as Record<string, unknown>;
     const pid = typeof o.ProcessId === 'number' ? o.ProcessId : NaN;
     if (!Number.isInteger(pid) || pid <= 0) continue;
+    // A missing or malformed parent reads as 0, which belongs to no tree — so
+    // an unreadable parentage can only ever make a process look FOREIGN, never
+    // make a stranger's process look like one of ours.
+    const rawParent = o.ParentProcessId;
+    const parentPid =
+      typeof rawParent === 'number' && Number.isInteger(rawParent) && rawParent > 0
+        ? rawParent
+        : 0;
     out.push({
       pid,
+      parentPid,
       executablePath: typeof o.ExecutablePath === 'string' ? o.ExecutablePath : '',
     });
   }
   return out;
+}
+
+/**
+ * #980 — the pids that belong to OUR OWN process tree, transitively.
+ *
+ * The force-kill on the install path was documented as "the processes nothing
+ * else takes down" — the MCP servers, which run out of the install root but are
+ * owned by agent hosts rather than by us. It was IMPLEMENTED as "every process
+ * under the root except the daemon", and on Windows every Electron helper is
+ * the same `wmux.exe` under the same root, so it swept up our own renderer, GPU
+ * and utility children as well.
+ *
+ * That is not a cosmetic over-reach. The next thing the install path does is
+ * `app.quit()`, whose `before-quit` handler awaits a session save IN THE
+ * RENDERER — the renderer that was just force-killed. The await never settles,
+ * the quit never completes, and the main process stays alive holding the very
+ * install root the waiter is waiting to see released. Measured on the reporter's
+ * machine: the main process survived a full day across two install attempts.
+ *
+ * Our own children need no killing. `app.quit()` takes them down, and they stay
+ * in the waiter's WAIT list either way — so the installer still cannot start
+ * before they are gone. Sparing them costs nothing and buys back the quit.
+ */
+export function selectOwnTreePids(
+  rows: ReadonlyArray<{ pid: number; parentPid: number }>,
+  ownPid: number,
+): Set<number> {
+  const childrenOf = new Map<number, number[]>();
+  for (const r of rows) {
+    if (r.parentPid <= 0) continue;
+    const siblings = childrenOf.get(r.parentPid);
+    if (siblings) siblings.push(r.pid);
+    else childrenOf.set(r.parentPid, [r.pid]);
+  }
+  // Breadth-first from ourselves. `seen` doubles as the cycle guard: Windows
+  // recycles pids, so a stale parent reference can close a loop and an
+  // unguarded walk would never terminate.
+  const own = new Set<number>();
+  const queue = [ownPid];
+  const seen = new Set<number>([ownPid]);
+  while (queue.length > 0) {
+    const pid = queue.shift() as number;
+    for (const child of childrenOf.get(pid) ?? []) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      own.add(child);
+      queue.push(child);
+    }
+  }
+  return own;
 }
 
 /**
@@ -222,12 +300,20 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // and by then wmux has already quit — so the update would silently stall
     // with no marker and nothing to tell the user on the next boot. The whole
     // wait shares one deadline rather than giving each handle a fresh budget.
-    `$waitDeadline = [Environment]::TickCount + $budget`,
+    // A Stopwatch, not [Environment]::TickCount. TickCount is a signed 32-bit
+    // millisecond counter that WRAPS every ~24.9 days of uptime and then runs
+    // negative: past the wrap, `TickCount + $budget` widens to Int64 while
+    // TickCount itself is still negative, so `$left` comes out larger than
+    // Int32.MaxValue, WaitForExit throws ArgumentOutOfRange, the `catch {}`
+    // below swallows it, and every handle is skipped without ever setting
+    // $stuck. The wait silently becomes a no-op on exactly the long-uptime
+    // machines that most need it. A Stopwatch is monotonic and 64-bit (#980).
+    `$clock = [System.Diagnostics.Stopwatch]::StartNew()`,
     `$stuck = $false`,
     `foreach ($h in $handles) {`,
-    `  $left = $waitDeadline - [Environment]::TickCount`,
+    `  $left = $budget - $clock.ElapsedMilliseconds`,
     `  if ($left -le 0) { $stuck = $true; break }`,
-    `  try { if (-not $h.WaitForExit($left)) { $stuck = $true; break } } catch { }`,
+    `  try { if (-not $h.WaitForExit([int]$left)) { $stuck = $true; break } } catch { }`,
     `}`,
     `if ($stuck) {`,
     `  Set-Content -LiteralPath $marker -Value 'install-aborted: a process under the install root would not exit' -Encoding utf8`,
@@ -251,8 +337,11 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `  }`,
     `  return $false`,
     `}`,
-    `$deadline = [Environment]::TickCount + $budget`,
-    `while ((Test-RootLocked) -and ([Environment]::TickCount -lt $deadline)) { Start-Sleep -Milliseconds 500 }`,
+    // Same clock, same reason. This loop is the gate that decides whether the
+    // installer runs at all, so a wrapped counter here does not merely mistime
+    // it — it collapses the whole budget into a single pass.
+    `$lockClock = [System.Diagnostics.Stopwatch]::StartNew()`,
+    `while ((Test-RootLocked) -and ($lockClock.ElapsedMilliseconds -lt $budget)) { Start-Sleep -Milliseconds 500 }`,
     `if (Test-RootLocked) {`,
     // Refusing leaves a working old version. Launching anyway is precisely the
     // failure this module exists to prevent, so there is no "best effort" here.
@@ -273,28 +362,60 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
   ].join('\n');
 }
 
+/**
+ * What the install path needs to know about the tree it is about to take down.
+ *
+ * `pids` is the WAIT list — everything under the install root except ourselves.
+ * `ownTree` is the subset of those that are our own descendants, which the
+ * caller must NOT force-kill (see `selectOwnTreePids`). Both come from ONE
+ * enumeration on purpose: two queries would be two different moments, and a
+ * process that appeared between them would land in the kill list without ever
+ * having been classified.
+ */
+export interface InstallRootSurvey {
+  /** Everything under the root except us — what the waiter waits for. */
+  pids: number[];
+  /** Of those, our own descendants. They exit with `app.quit()`. */
+  ownTree: Set<number>;
+}
+
 /** Enumerate, best-effort. win32-only; never throws into the update path. */
-export function collectInstallRootPids(installRoot: string): number[] {
-  if (process.platform !== 'win32') return [];
+export function collectInstallRootProcesses(installRoot: string): InstallRootSurvey {
+  const empty: InstallRootSurvey = { pids: [], ownTree: new Set() };
+  if (process.platform !== 'win32') return empty;
   try {
     const systemRoot = process.env.SystemRoot || 'C:\\Windows';
     const powershell = path.join(
       systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
     );
     const exeName = path.basename(process.execPath);
-    if (!/^[\w][\w .-]*\.exe$/i.test(exeName)) return [];
+    if (!/^[\w][\w .-]*\.exe$/i.test(exeName)) return empty;
     const stdout = execFileSync(
       powershell,
       [
         '-NoProfile', '-NonInteractive', '-Command',
-        `Get-CimInstance Win32_Process -Filter "Name='${exeName}'" -ErrorAction SilentlyContinue | Select-Object ProcessId,ExecutablePath | ConvertTo-Json -Compress`,
+        `Get-CimInstance Win32_Process -Filter "Name='${exeName}'" -ErrorAction SilentlyContinue | Select-Object ProcessId,ParentProcessId,ExecutablePath | ConvertTo-Json -Compress`,
       ],
       { encoding: 'utf-8', timeout: 10_000, windowsHide: true },
     );
-    return selectInstallRootPids(parseProcessRows(stdout), installRoot, process.pid);
+    const rows = parseProcessRows(stdout);
+    const pids = selectInstallRootPids(rows, installRoot, process.pid);
+    // Intersect: a descendant of ours that does NOT run out of the install root
+    // is not on the wait list either, so it has no business in this survey.
+    const under = new Set(pids);
+    const ownTree = new Set(
+      [...selectOwnTreePids(rows, process.pid)].filter((p) => under.has(p)),
+    );
+    return { pids, ownTree };
   } catch {
-    return [];
+    return empty;
   }
+}
+
+/** Wait-list only. Kept for callers (and the runtime suite) that never needed
+ *  the ownership split. */
+export function collectInstallRootPids(installRoot: string): number[] {
+  return collectInstallRootProcesses(installRoot).pids;
 }
 
 /**

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -290,6 +290,27 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `$setup = ${psQuote(plan.setupExePath)}`,
     `$marker = ${psQuote(plan.abortMarkerPath)}`,
     `$budget = ${plan.lockBudgetMs}`,
+    // Single-instance gate, FIRST — before a handle is captured or anything
+    // else happens. The quit watchdog unlatches `isInstalling` after 30 s so a
+    // refused quit stays retryable, but the waiter it spawned can still be
+    // inside its own budget (up to two lock windows) — so a retry would spawn
+    // a SECOND waiter watching the same root, and two of them can reach
+    // Start-Process on the same Setup.exe. Two concurrent Squirrel installs
+    // against one root is precisely the corruption #866 exists to prevent, so
+    // the guard lives HERE, where the collision happens, not in timing
+    // arithmetic between the watchdog and the budgets (coderabbit, #980).
+    //
+    // A named mutex gives exactly the wanted semantics for free: it exists
+    // only while some process holds a handle to it, so a LIVE earlier waiter
+    // blocks the newcomer (exit 5, silently — the incumbent owns the install
+    // and the marker), while a dead or finished one leaves nothing behind and
+    // the newcomer proceeds. No state file to go stale, nothing to clean up.
+    // The name embeds the install root so two different installations (per
+    // user, portable copies) can never block each other.
+    `$mtxName = 'wmux-install-waiter-' + ($root -replace '[^A-Za-z0-9]', '_')`,
+    `$mtxCreated = $false`,
+    `$mtx = New-Object System.Threading.Mutex -ArgumentList $true, $mtxName, ([ref]$mtxCreated)`,
+    `if (-not $mtxCreated) { exit 5 }`,
     // Capture HANDLES first. GetProcessById opens a handle now, so a later pid
     // recycle cannot make an exited process look alive (or a stranger's
     // process look like ours).


### PR DESCRIPTION
Closes #980.

## Root cause

`Setup.exe` deletes the install root as its first action, so #866 made a detached waiter launch it only once every process under that root is gone. **wmux was holding the root open itself.**

`collectInstallRootPids` matches every `wmux.exe` under the root minus our own pid, and the handoff force-killed all of it except the daemon. On Windows the renderer, GPU and utility processes **are** that same `wmux.exe` under that same root. The next statement is `app.quit()` — whose `before-quit` handler awaits a session save *in the renderer that was just killed*.

Measured against a live wmux (`selectInstallRootPids` + `selectOwnTreePids` over the real `Win32_Process` rows):

```
install root : C:\Users\...\AppData\Local\wmux
main (self)  : 22764        daemon.pid : 7420

WAIT list (unchanged): 20624, 22248, 7420, 13684, 2936, 2584

OLD force-kill (5): 20624, 22248, 13684, 2936, 2584
NEW force-kill (1): 2936

   20624  parent=22764  gpu-process    OURS    → app.quit()
   22248  parent=22764  utility        OURS    → app.quit()
    7420  parent=22764  daemon         daemon(graceful)
   13684  parent=22764  renderer       OURS    → app.quit()
    2936  parent=14712  <mcp server>   FOREIGN → kill
    2584  parent=22764  utility        OURS    → app.quit()
```

One of those five is a stranger's process. That matches the reporter's field log exactly ("force-killed 4/4, daemon pid 26304 left to the graceful shutdown", then a main process alive a day later with the daemon never asked to shut down — the handler never reached that branch).

The comment on `terminatePids` already described the intended set: *"the processes nothing else takes down on the install path: the MCP servers run out of the install root but are owned by agent hosts, not by us."* The implementation was `everything except the daemon`. This makes them agree.

## On the reporter's question 1

> Should the gracefully-shutting-down daemon PID be in the waiter's wait list at all? The handoff log treats it as intentionally spared, while the waiter treats it as a blocker. One of the two has to give.

Neither, as it turns out — the two lists are answering different questions and the log line was what implied a contradiction:

- **wait**: everything under the root. Nothing may hold the tree open when `Setup.exe` starts, regardless of who is responsible for ending it.
- **kill**: only what nothing else ends.

Our helpers exit with `app.quit()`, the daemon via its graceful shutdown; both still have to be *waited* for. The handoff log now names the three groups instead of two.

## What else ships

Three things that turned one bad kill into a permanently stuck updater:

- **`before-quit` could wedge.** Its force-exit fallback was armed only *after* every teardown step resolved, so a step that never settled left a process that had `preventDefault()`ed its own quit, latched `isQuitting`, and armed no timer — and `second-instance` / `activate` both early-return on that latch. The deadline is armed first now, and the renderer session save is bounded (`isCrashed()` only reports a renderer Electron has already noticed is gone).
- **Nothing noticed a quit that did not happen.** `isInstalling` is deliberately never cleared on the success path — there is no process left to clear it in — so a failed quit left every retry answering "an update install is already in progress" while the UI kept offering *Install now*. A watchdog now reports it, preferring the waiter's own reason when it left one, and unlatches. No recovery is attempted: by then `before-quit` has stopped the pipe server and destroyed the tray, so "recovery" would hand back a hollow window. It names the restart instead.
- **The waiter went blind after ~24 days of uptime.** Its budget used `[Environment]::TickCount`, a signed 32-bit ms counter that wraps and runs negative; past the wrap the remaining time widens past `Int32.MaxValue`, `WaitForExit` throws on it, the `catch {}` swallows that, and the guard silently becomes a no-op — on exactly the long-uptime machines that most need it. Monotonic `Stopwatch` now. This is also a candidate for why `%APPDATA%\wmux\update-install-aborted.txt` was never written.

## Deliberately not in this PR

Ask 4 — reusing a verified artifact instead of re-downloading 150 MB. That cost is a *symptom* of the cycle failing; with the install completing there is no repeating cycle to pay it. The residual case (one wasted download after a genuine abort) needs a reuse path through the download-verify code, which does not belong in a PR about process teardown. Filing separately.

## Verification

- 13 new tests: `selectOwnTreePids` (subtree, grandchildren, foreign, unreadable parent, pid-recycle cycle), the waiter's clock, the win32 kill-list split, the unknown-daemon-pid fail-safe, and the quit watchdog (reported, unlatched, waiter reason preferred). 115 pass across `src/main/updater/`.
- `installTeardown.runtime.test.ts` — the waiter against **real processes and real file locks** — 8/8 with the new clock.
- The classification above run against this machine's live wmux process tree.
- `tsc --noEmit` clean (6 pre-existing baseline errors, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4Bt1acTZWk1gjxcLrVsA7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update installation reliability on Windows by preventing unintended process termination.
  * Added safeguards for stalled shutdowns, including bounded cleanup and clearer failure reporting.
  * Fixed stale installation state after refused or failed updates.
  * Improved session saving during application exit.
  * Corrected timing behavior for long-running applications and installation waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->