### PR TITLE
fix(updater): reuse a verified installer already in temp instead of re-downloading it

### DIFF
--- a/changelog.d/1003.md
+++ b/changelog.d/1003.md
@@ -5,4 +5,11 @@
   that aborted — forgot about the ~150 MB Setup.exe sitting in temp, and the
   cleanup sweep deleted it a day later. wmux now recognizes an installer it
   already has, re-checks its SHA-256 against the current manifest before
-  trusting it, and keeps one for a version you have not installed yet.
+  trusting it, and keeps the installer for the version you have not taken yet.
+
+- **An installer is checked again in the moment it is run.** Verification used
+  to happen when an update was found, and the install could be days later —
+  long enough for the file in the shared temp directory to become a different
+  file. wmux now re-checks the bytes against the release digest immediately
+  before handing them to the installer, and refuses to run them if they do not
+  match.

--- a/changelog.d/1003.md
+++ b/changelog.d/1003.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **An update you already downloaded is no longer downloaded again.** The
+  verified installer's path lived only in memory, so a restart — or an install
+  that aborted — forgot about the ~150 MB Setup.exe sitting in temp, and the
+  cleanup sweep deleted it a day later. wmux now recognizes an installer it
+  already has, re-checks its SHA-256 against the current manifest before
+  trusting it, and keeps one for a version you have not installed yet.

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -13,7 +13,7 @@
 
 import { autoUpdater, app, type BrowserWindow, ipcMain, net, shell } from 'electron';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { readdir, stat, unlink } from 'node:fs/promises';
+import { lstat, readdir, stat, unlink } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { IPC } from '../../shared/constants';
@@ -93,10 +93,12 @@ const TEMP_ARTIFACT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 // It still expires, just far later: if auto-update is off the poll that would
 // consume it never runs, and nothing should sit in temp forever.
 const TEMP_ARTIFACT_PENDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
-// An artifact whose bytes fail the hash is either a corrupted leftover (delete)
-// or another instance's download in flight (leave alone). Recent writes mean
-// the second, so only a file that has been quiet this long is removed.
-const TEMP_ARTIFACT_QUIET_MS = 60 * 1000;
+// An artifact whose bytes fail the hash is either a corrupted leftover or
+// another instance's download in flight. Only age tells them apart, and the
+// age that means "nobody is writing this" is the sweep's own floor — a shorter
+// one would delete a slow download out from under the instance that owns it,
+// which on POSIX leaves that instance verifying a file whose path is gone.
+const TEMP_ARTIFACT_MISMATCH_DELETE_AFTER_MS = TEMP_ARTIFACT_MAX_AGE_MS;
 
 // In-app auto-update runs on Windows (Squirrel.Windows `.Setup.exe`) and on
 // Apple Silicon macOS (Squirrel.Mac, signed+notarized ZIP). Everything else —
@@ -179,6 +181,12 @@ export class AutoUpdater {
   private enabled = true;
   private pendingUpdate: UpdateInfo | null = null;
   private downloadedPath: string | null = null;
+  // The digest `downloadedPath` was accepted under. Kept so the bytes can be
+  // re-checked immediately before they are executed: verification happens when
+  // the update is found, the install happens when the user presses Restart —
+  // which can be days later, in a temp dir any process running as this user can
+  // write to. Verifying once and then trusting a path is not verifying.
+  private downloadedSha: string | null = null;
   private isDownloading = false;
   // When a user presses "check for updates" it reads as an "update now" intent:
   // once an update is detected + verified, install it (restart) automatically
@@ -310,10 +318,27 @@ export class AutoUpdater {
     }
     const now = Date.now();
     const current = app.getVersion();
+    // Only the single newest pending version is worth keeping. wmux ships every
+    // few days, so a user who postpones restarting collects one ~150 MB
+    // installer per release — and the older ones can never be installed anyway,
+    // because a check always offers the latest. Without this, replacing the
+    // 24 h floor with a 7-day one removes the only bound on that pile.
+    let newestPending: string | null = null;
     for (const name of names) {
       if (!name.startsWith(TEMP_ARTIFACT_PREFIX)) continue;
       const parsed = parseArtifactName(name);
-      const isPendingInstaller = parsed !== null && isVersionNewer(parsed.version, current);
+      if (!parsed || !isVersionNewer(parsed.version, current)) continue;
+      if (newestPending === null || isVersionNewer(parsed.version, newestPending)) {
+        newestPending = parsed.version;
+      }
+    }
+    for (const name of names) {
+      if (!name.startsWith(TEMP_ARTIFACT_PREFIX)) continue;
+      const parsed = parseArtifactName(name);
+      const isPendingInstaller =
+        parsed !== null &&
+        newestPending !== null &&
+        normalizeVersion(parsed.version) === normalizeVersion(newestPending);
       const maxAge = isPendingInstaller ? TEMP_ARTIFACT_PENDING_MAX_AGE_MS : TEMP_ARTIFACT_MAX_AGE_MS;
       const full = join(tempDir, name);
       try {
@@ -338,9 +363,13 @@ export class AutoUpdater {
    *
    * NEVER trusted on its name: the file sat in a world-writable temp dir across
    * a restart, so the SHA-256 is re-computed and compared to the manifest exactly
-   * as a fresh download's is. A mismatch is dropped (unless it is still being
-   * written — that is another instance's download, not our garbage) and the
-   * caller falls through to a normal download.
+   * as a fresh download's is — and again immediately before the install, because
+   * this check and that install are separated by however long the user takes to
+   * press Restart (see verifyArtifactStillMatches).
+   *
+   * A mismatch is only deleted once it is older than the sweep's own floor:
+   * anything newer may be an in-flight download owned by another instance, and
+   * unlinking that would leave its owner verifying a path that no longer exists.
    */
   private async adoptExistingArtifact(manifest: UpdateManifest): Promise<string | null> {
     const tempDir = app.getPath('temp');
@@ -359,21 +388,59 @@ export class AutoUpdater {
       if (parsed.fileName !== wantFile) continue;
       const full = join(tempDir, name);
       try {
+        // lstat, not stat: a symlink planted under one of these names would
+        // otherwise be hashed through and then handed to the installer as if
+        // it were the verified artifact — and a symlink can be re-pointed
+        // atomically afterwards, without rewriting 150 MB. Only a regular file
+        // is a candidate.
+        const info = await lstat(full);
+        if (!info.isFile()) {
+          console.warn(`[AutoUpdater] ignoring temp entry ${name}: not a regular file`);
+          continue;
+        }
         const actual = await this.hashFile(full);
         if (digestsEqual(actual, manifest.sha256)) {
           console.log(`[AutoUpdater] reusing verified installer already in temp (${name}) — skipping download`);
           return full;
         }
-        const info = await stat(full);
-        if (info.mtimeMs < Date.now() - TEMP_ARTIFACT_QUIET_MS) {
+        if (info.mtimeMs < Date.now() - TEMP_ARTIFACT_MISMATCH_DELETE_AFTER_MS) {
           await unlink(full);
           console.warn(`[AutoUpdater] discarded temp artifact ${name}: sha256 does not match the manifest`);
+        } else {
+          console.warn(`[AutoUpdater] ignoring temp artifact ${name}: sha256 does not match (too recent to delete — may be another instance's download)`);
         }
       } catch {
         /* unreadable or vanished mid-scan — fall through to a fresh download */
       }
     }
     return null;
+  }
+
+  /**
+   * Re-check an artifact against the digest it was accepted under, immediately
+   * before it is executed. Fail-closed in every direction: an unreadable file,
+   * a non-regular one, or a missing recorded digest all answer false.
+   */
+  private async verifyArtifactStillMatches(artifactPath: string): Promise<boolean> {
+    const expected = this.downloadedSha;
+    if (!expected) {
+      console.error('[AutoUpdater] refusing install: no recorded digest for the staged installer');
+      return false;
+    }
+    try {
+      const info = await lstat(artifactPath);
+      if (!info.isFile()) {
+        console.error('[AutoUpdater] refusing install: staged installer is not a regular file');
+        return false;
+      }
+      const actual = await this.hashFile(artifactPath);
+      if (digestsEqual(actual, expected)) return true;
+      console.error('[AutoUpdater] refusing install: staged installer no longer matches its verified digest');
+      return false;
+    } catch (err) {
+      console.error('[AutoUpdater] refusing install: staged installer could not be re-verified:', err);
+      return false;
+    }
   }
 
   /** Stream a file through SHA-256. Streamed, not read: these artifacts are ~150 MB. */
@@ -435,6 +502,7 @@ export class AutoUpdater {
           // artifact from disk too, or every release leaves one behind in temp.
           void unlink(this.downloadedPath).catch(() => { /* best-effort cleanup */ });
           this.downloadedPath = null;
+          this.downloadedSha = null;
         }
         this.sendToRenderer(IPC.UPDATE_AVAILABLE, {
           status: 'available',
@@ -512,6 +580,7 @@ export class AutoUpdater {
         return;
       }
       this.downloadedPath = tempPath;
+      this.downloadedSha = validated.manifest.sha256;
       console.log('[AutoUpdater] Update downloaded + verified (sha256 match) — ready to install');
       this.sendToRenderer(IPC.UPDATE_AVAILABLE, {
         status: 'downloaded',
@@ -533,6 +602,7 @@ export class AutoUpdater {
         await unlink(tempPath).catch(() => { /* best-effort cleanup */ });
       }
       this.downloadedPath = null;
+      this.downloadedSha = null;
       this.sendToRenderer(IPC.UPDATE_ERROR, {
         status: 'error',
         message: `Update could not be downloaded or verified: ${message}`,
@@ -751,6 +821,24 @@ export class AutoUpdater {
       } catch {
         console.warn('[AutoUpdater] Could not trigger session save before update');
       }
+    }
+
+    // Verify the bytes AGAIN, as late as possible, against the digest they were
+    // accepted under. Everything before this happened when the update was
+    // FOUND: minutes ago for a background download, potentially days for an
+    // adopted artifact — and all of it in a directory any process running as
+    // this user can write to. Hashing once and then launching a path is not a
+    // check, it is a window; this closes it for both paths at the cost of one
+    // read of an already-warm file.
+    if (!(await this.verifyArtifactStillMatches(tempPath))) {
+      this.isInstalling = false;
+      this.downloadedPath = null;
+      this.downloadedSha = null;
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: 'The staged installer no longer matches the release it was verified against, so it was not run. Check for updates again to fetch a fresh copy.',
+      });
+      return;
     }
 
     if (isDarwin) {

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -12,12 +12,23 @@
  */
 
 import { autoUpdater, app, type BrowserWindow, ipcMain, net, shell } from 'electron';
-import { createWriteStream } from 'node:fs';
+import { createReadStream, createWriteStream } from 'node:fs';
 import { readdir, stat, unlink } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
 import { createHash } from 'node:crypto';
 import { IPC } from '../../shared/constants';
-import { isAllowedDownloadUrl, digestsEqual, validateManifest, type UpdateManifest } from './verifyUpdate';
+import {
+  artifactTempName,
+  digestsEqual,
+  isAllowedDownloadUrl,
+  isVersionNewer,
+  normalizeVersion,
+  parseArtifactName,
+  sanitizeArtifactFileName,
+  TEMP_ARTIFACT_PREFIX,
+  validateManifest,
+  type UpdateManifest,
+} from './verifyUpdate';
 import { LocalUpdateFeed } from './LocalUpdateFeed';
 import {
   collectInstallRootPids,
@@ -70,12 +81,22 @@ const INSTALL_LOCK_BUDGET_MS = 60_000;
 // makes this minutes, and aborting a healthy update is worse than waiting.
 const INSTALL_STAGING_TIMEOUT_MS = 10 * 60 * 1000;
 
-// Verified installers are named `wmux-update-<version>-<pid>-<artifact>`. A
-// stage-then-stall leaves one behind (only the supersede and error paths
-// unlink), so they accumulate at ~120 MB each. Swept at startup; the age floor
-// keeps a concurrent instance's in-flight download safe.
-const TEMP_ARTIFACT_PREFIX = 'wmux-update-';
+// Verified installers are named `wmux-update-<version>-<pid>-<artifact>` (see
+// artifactTempName). A stage-then-stall leaves one behind (only the supersede
+// and error paths unlink), so they accumulate at ~120 MB each. Swept at
+// startup; the age floor keeps a concurrent instance's in-flight download safe.
 const TEMP_ARTIFACT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+// #995: an artifact for a version NEWER than the one running is not garbage —
+// it is the installer for an update we have not taken yet, and the next check
+// re-verifies and adopts it instead of pulling ~150 MB down again. Sweeping it
+// on the 24 h floor is what made every aborted install cost a fresh download.
+// It still expires, just far later: if auto-update is off the poll that would
+// consume it never runs, and nothing should sit in temp forever.
+const TEMP_ARTIFACT_PENDING_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+// An artifact whose bytes fail the hash is either a corrupted leftover (delete)
+// or another instance's download in flight (leave alone). Recent writes mean
+// the second, so only a file that has been quiet this long is removed.
+const TEMP_ARTIFACT_QUIET_MS = 60 * 1000;
 
 // In-app auto-update runs on Windows (Squirrel.Windows `.Setup.exe`) and on
 // Apple Silicon macOS (Squirrel.Mac, signed+notarized ZIP). Everything else —
@@ -273,6 +294,11 @@ export class AutoUpdater {
    * completed. Best-effort and never blocks startup: a failure here costs disk,
    * not correctness. Only files older than TEMP_ARTIFACT_MAX_AGE_MS are removed
    * so a second instance downloading right now keeps its artifact.
+   *
+   * #995: an artifact whose version is NEWER than the running app is held far
+   * longer, because it is the one thing adoptExistingArtifact can reuse. The
+   * old rule deleted it at 24 h and the next check paid for the same 150 MB
+   * again — on the #980 failure loop, three times over.
    */
   private async sweepStaleArtifacts(): Promise<void> {
     const tempDir = app.getPath('temp');
@@ -282,19 +308,83 @@ export class AutoUpdater {
     } catch {
       return;
     }
-    const cutoff = Date.now() - TEMP_ARTIFACT_MAX_AGE_MS;
+    const now = Date.now();
+    const current = app.getVersion();
     for (const name of names) {
       if (!name.startsWith(TEMP_ARTIFACT_PREFIX)) continue;
+      const parsed = parseArtifactName(name);
+      const isPendingInstaller = parsed !== null && isVersionNewer(parsed.version, current);
+      const maxAge = isPendingInstaller ? TEMP_ARTIFACT_PENDING_MAX_AGE_MS : TEMP_ARTIFACT_MAX_AGE_MS;
       const full = join(tempDir, name);
       try {
         const info = await stat(full);
-        if (info.mtimeMs >= cutoff) continue;
+        if (info.mtimeMs >= now - maxAge) continue;
         await unlink(full);
         console.log(`[AutoUpdater] swept stale update artifact ${name}`);
       } catch {
         /* best-effort — another instance may own it, or it vanished mid-sweep */
       }
     }
+  }
+
+  /**
+   * Reuse an installer this machine already downloaded and verified (#995).
+   *
+   * `downloadedPath` is in-memory only, so a quit-for-install that aborted (or
+   * simply a restart) leaves a perfectly good ~150 MB Setup.exe in temp with
+   * nothing pointing at it, and the next check downloads it all over again.
+   * The file name carries the version, so the artifact plus the freshly fetched
+   * manifest hash is all the record needed — no new state on disk.
+   *
+   * NEVER trusted on its name: the file sat in a world-writable temp dir across
+   * a restart, so the SHA-256 is re-computed and compared to the manifest exactly
+   * as a fresh download's is. A mismatch is dropped (unless it is still being
+   * written — that is another instance's download, not our garbage) and the
+   * caller falls through to a normal download.
+   */
+  private async adoptExistingArtifact(manifest: UpdateManifest): Promise<string | null> {
+    const tempDir = app.getPath('temp');
+    let names: string[];
+    try {
+      names = await readdir(tempDir);
+    } catch {
+      return null;
+    }
+    const wantVersion = normalizeVersion(manifest.version);
+    const wantFile = sanitizeArtifactFileName(manifest.fileName);
+    for (const name of names) {
+      const parsed = parseArtifactName(name);
+      if (!parsed) continue;
+      if (normalizeVersion(parsed.version) !== wantVersion) continue;
+      if (parsed.fileName !== wantFile) continue;
+      const full = join(tempDir, name);
+      try {
+        const actual = await this.hashFile(full);
+        if (digestsEqual(actual, manifest.sha256)) {
+          console.log(`[AutoUpdater] reusing verified installer already in temp (${name}) — skipping download`);
+          return full;
+        }
+        const info = await stat(full);
+        if (info.mtimeMs < Date.now() - TEMP_ARTIFACT_QUIET_MS) {
+          await unlink(full);
+          console.warn(`[AutoUpdater] discarded temp artifact ${name}: sha256 does not match the manifest`);
+        }
+      } catch {
+        /* unreadable or vanished mid-scan — fall through to a fresh download */
+      }
+    }
+    return null;
+  }
+
+  /** Stream a file through SHA-256. Streamed, not read: these artifacts are ~150 MB. */
+  private hashFile(path: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const hash = createHash('sha256');
+      const stream = createReadStream(path);
+      stream.on('data', (chunk: Buffer | string) => hash.update(chunk));
+      stream.on('error', (err: Error) => reject(err));
+      stream.on('end', () => resolve(hash.digest('hex')));
+    });
   }
 
   setEnabled(enabled: boolean): void {
@@ -399,9 +489,16 @@ export class AutoUpdater {
       if (!validated.ok) {
         throw new Error(`update manifest rejected: ${validated.reason}`);
       }
-      tempPath = await this.downloadAndVerify(validated.manifest, (percent) => {
-        this.sendToRenderer(IPC.UPDATE_DOWNLOAD, { status: 'downloading', percent });
-      });
+      // #995: this machine may already hold a verified installer for exactly
+      // this version (an aborted install, or a restart before the user pressed
+      // Restart). Re-verify it against the manifest we just fetched and reuse
+      // it rather than pulling the same ~150 MB down again.
+      tempPath = await this.adoptExistingArtifact(validated.manifest);
+      if (!tempPath) {
+        tempPath = await this.downloadAndVerify(validated.manifest, (percent) => {
+          this.sendToRenderer(IPC.UPDATE_DOWNLOAD, { status: 'downloading', percent });
+        });
+      }
       if (this.pendingUpdate?.name !== pending.name) {
         // A newer release superseded this download mid-flight (check() replaced
         // pendingUpdate). Committing it would let a one-shot install restart the
@@ -520,8 +617,7 @@ export class AutoUpdater {
       // Keep the manifest's artifact name (sanitized) so the temp file carries
       // the right extension on every platform (.Setup.exe on Windows, .zip on
       // macOS) instead of a hardcoded Windows one.
-      const safeName = manifest.fileName.replace(/[^A-Za-z0-9._-]/g, '_');
-      const dest = join(app.getPath('temp'), `wmux-update-${manifest.version}-${process.pid}-${safeName}`);
+      const dest = join(app.getPath('temp'), artifactTempName(manifest.version, process.pid, manifest.fileName));
       const hash = createHash('sha256');
       const out = createWriteStream(dest);
       let settled = false;

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -40,8 +40,13 @@ afterEach(() => {
 
 interface Sent { channel: string; data: Record<string, unknown>; }
 
+/** A file parked in the fake temp dir (#995 adoption paths). */
+interface TempFile { body: Buffer; mtimeMs?: number }
+
 /** Load AutoUpdater (win32) with a URL-routing net mock, fs mocked, window capture. */
-async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
+async function loadWin32(
+  { sha = GOOD_SHA, tempFiles = {} }: { sha?: string; tempFiles?: Record<string, TempFile> } = {},
+) {
   vi.resetModules();
   Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
@@ -101,6 +106,11 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
   // Mock fs so no real installer file is written; capture the streamed bytes.
   // `once('close')` fires synchronously on destroy so the fail-path cleanup
   // (unlink of a partial/mismatched download) runs inside the test.
+  //
+  // The read side backs the fake temp dir `tempFiles` describes: readdir/stat
+  // list it and createReadStream replays a parked artifact's bytes, which is
+  // what the adoption path (#995) hashes.
+  const baseName = (p: string) => String(p).split(/[\\/]/).pop() ?? '';
   vi.doMock('node:fs', () => ({
     createWriteStream: () => {
       const closeCbs: Array<() => void> = [];
@@ -112,9 +122,28 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
         once: (ev: string, cb: () => void) => { if (ev === 'close') closeCbs.push(cb); },
       };
     },
+    createReadStream: (p: string) => {
+      const entry = tempFiles[baseName(p)];
+      const cbs: Record<string, (a?: unknown) => void> = {};
+      const stream = { on(ev: string, cb: (a?: unknown) => void) { cbs[ev] = cb; return stream; } };
+      Promise.resolve().then(() => {
+        if (!entry) { cbs['error']?.(new Error(`ENOENT: ${p}`)); return; }
+        cbs['data']?.(entry.body);
+        cbs['end']?.();
+      });
+      return stream;
+    },
   }));
-  const unlinkMock = vi.fn(async (_path: string) => undefined);
-  vi.doMock('node:fs/promises', () => ({ unlink: unlinkMock }));
+  const unlinkMock = vi.fn(async (path: string) => { delete tempFiles[baseName(path)]; });
+  vi.doMock('node:fs/promises', () => ({
+    unlink: unlinkMock,
+    readdir: async (_dir: string) => Object.keys(tempFiles),
+    stat: async (p: string) => {
+      const entry = tempFiles[baseName(p)];
+      if (!entry) throw new Error(`ENOENT: ${p}`);
+      return { mtimeMs: entry.mtimeMs ?? Date.now() };
+    },
+  }));
 
   // #866: the install path enumerates and force-kills every process under the
   // install root, which is derived from process.execPath. Under test that is
@@ -155,7 +184,7 @@ async function loadWin32({ sha = GOOD_SHA }: { sha?: string } = {}) {
   }));
 
   const mod = await import('../AutoUpdater');
-  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, sent, openPath, quit, win, feed, unlinkMock, teardown };
+  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, sent, openPath, quit, win, feed, unlinkMock, teardown, tempFiles };
 }
 
 /** Flush queued microtasks so the chained net responses (feed→manifest→download) settle. */
@@ -373,5 +402,79 @@ describe('AutoUpdater two-step flow (win32)', () => {
     expect(unlinkMock.mock.calls.some((c) => String(c[0]).includes(`wmux-update-${NEW_VERSION}`))).toBe(true);
     const downloadsAfter = sent.filter((s) => s.channel === IPC.UPDATE_AVAILABLE && s.data.status === 'downloaded').length;
     expect(downloadsAfter).toBe(downloadsBefore + 1);
+  });
+});
+
+/**
+ * #995 — `downloadedPath` is in-memory, so a restart (or an aborted install)
+ * used to throw away a perfectly good ~150 MB installer and fetch it again.
+ * The artifact's name plus the manifest hash is the record that lets the next
+ * run pick it back up — and re-verification is what makes that safe.
+ */
+describe('AutoUpdater temp artifact reuse (win32)', () => {
+  const backgroundCheck = (updater: unknown) =>
+    (updater as { check: (oneShot?: boolean) => Promise<void> }).check();
+  const parkedName = `wmux-update-${NEW_VERSION}-4242-wmux-${NEW_VERSION}.Setup.exe`;
+
+  it('reuses a verified installer left in temp instead of downloading it again', async () => {
+    const { AutoUpdater, requestUrls, sent, win } = await loadWin32({
+      tempFiles: { [parkedName]: { body: INSTALLER_BODY } },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+
+    await backgroundCheck(updater);
+    await flush();
+
+    // The manifest is still fetched (that is where the hash to verify against
+    // comes from) — the 150 MB installer download is what must not happen.
+    expect(requestUrls.some((u) => u.includes('update-manifest.json'))).toBe(true);
+    expect(requestUrls).not.toContain(DL_URL);
+    expect(sent.map((s) => `${s.channel}:${s.data.status}`)).toContain(`${IPC.UPDATE_AVAILABLE}:downloaded`);
+  });
+
+  it('re-verifies before reusing: a tampered artifact is discarded and the installer downloaded', async () => {
+    const { AutoUpdater, requestUrls, sent, unlinkMock, win } = await loadWin32({
+      tempFiles: { [parkedName]: { body: Buffer.from('TAMPERED'), mtimeMs: Date.now() - 10 * 60_000 } },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+
+    await backgroundCheck(updater);
+    await flush();
+
+    expect(unlinkMock.mock.calls.some((c) => String(c[0]).includes(parkedName))).toBe(true);
+    expect(requestUrls).toContain(DL_URL);
+    expect(sent.map((s) => `${s.channel}:${s.data.status}`)).toContain(`${IPC.UPDATE_AVAILABLE}:downloaded`);
+  });
+
+  it('leaves a just-written mismatching artifact alone — that is another instance downloading', async () => {
+    const { AutoUpdater, unlinkMock, win } = await loadWin32({
+      tempFiles: { [parkedName]: { body: Buffer.from('PARTIAL'), mtimeMs: Date.now() } },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+
+    await backgroundCheck(updater);
+    await flush();
+
+    expect(unlinkMock.mock.calls.some((c) => String(c[0]).includes(parkedName))).toBe(false);
+  });
+
+  it('the startup sweep keeps an installer for a newer version and drops one for the running version', async () => {
+    const threeDaysAgo = Date.now() - 3 * 24 * 60 * 60 * 1000;
+    const pending = `wmux-update-${NEW_VERSION}-1-wmux-${NEW_VERSION}.Setup.exe`;
+    const alreadyInstalled = `wmux-update-${FAKE_VERSION}-1-wmux-${FAKE_VERSION}.Setup.exe`;
+    const { AutoUpdater, unlinkMock, win } = await loadWin32({
+      tempFiles: {
+        [pending]: { body: INSTALLER_BODY, mtimeMs: threeDaysAgo },
+        [alreadyInstalled]: { body: INSTALLER_BODY, mtimeMs: threeDaysAgo },
+      },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+
+    updater.start();
+    await flush();
+
+    const swept = unlinkMock.mock.calls.map((c) => String(c[0]));
+    expect(swept.some((p) => p.includes(alreadyInstalled))).toBe(true);
+    expect(swept.some((p) => p.includes(pending))).toBe(false);
   });
 });

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -41,7 +41,7 @@ afterEach(() => {
 interface Sent { channel: string; data: Record<string, unknown>; }
 
 /** A file parked in the fake temp dir (#995 adoption paths). */
-interface TempFile { body: Buffer; mtimeMs?: number }
+interface TempFile { body: Buffer; mtimeMs?: number; isFile?: boolean }
 
 /** Load AutoUpdater (win32) with a URL-routing net mock, fs mocked, window capture. */
 async function loadWin32(
@@ -112,11 +112,17 @@ async function loadWin32(
   // what the adoption path (#995) hashes.
   const baseName = (p: string) => String(p).split(/[\\/]/).pop() ?? '';
   vi.doMock('node:fs', () => ({
-    createWriteStream: () => {
+    createWriteStream: (p: string) => {
       const closeCbs: Array<() => void> = [];
+      const chunks: Buffer[] = [];
       return {
-        write: vi.fn(),
-        end: (cb?: () => void) => cb && cb(),
+        write: (chunk: Buffer) => { chunks.push(Buffer.from(chunk)); return true; },
+        // A completed write lands in the fake temp dir, so the pre-install
+        // re-verification can read back exactly what was downloaded.
+        end: (cb?: () => void) => {
+          tempFiles[baseName(p)] = { body: Buffer.concat(chunks) };
+          if (cb) cb();
+        },
         destroy: () => { for (const cb of closeCbs.splice(0)) cb(); },
         on: () => undefined,
         once: (ev: string, cb: () => void) => { if (ev === 'close') closeCbs.push(cb); },
@@ -135,14 +141,16 @@ async function loadWin32(
     },
   }));
   const unlinkMock = vi.fn(async (path: string) => { delete tempFiles[baseName(path)]; });
+  const statLike = async (p: string) => {
+    const entry = tempFiles[baseName(p)];
+    if (!entry) throw new Error(`ENOENT: ${p}`);
+    return { mtimeMs: entry.mtimeMs ?? Date.now(), isFile: () => entry.isFile !== false };
+  };
   vi.doMock('node:fs/promises', () => ({
     unlink: unlinkMock,
     readdir: async (_dir: string) => Object.keys(tempFiles),
-    stat: async (p: string) => {
-      const entry = tempFiles[baseName(p)];
-      if (!entry) throw new Error(`ENOENT: ${p}`);
-      return { mtimeMs: entry.mtimeMs ?? Date.now() };
-    },
+    stat: statLike,
+    lstat: statLike,
   }));
 
   // #866: the install path enumerates and force-kills every process under the
@@ -322,7 +330,12 @@ describe('AutoUpdater two-step flow (win32)', () => {
   });
 
   it('a failed one-shot fast-path install clears the intent (no unattended restart later)', async () => {
-    const { AutoUpdater, quit, win, teardown } = await loadWin32();
+    // The staged installer is injected below, so it has to exist in the fake
+    // temp dir with its digest — performInstall re-verifies before handing off.
+    const staged = `wmux-update-${NEW_VERSION}-1-wmux-${NEW_VERSION}.Setup.exe`;
+    const { AutoUpdater, quit, win, teardown } = await loadWin32({
+      tempFiles: { [staged]: { body: INSTALLER_BODY } },
+    });
     // #866: the failure mode is now "the waiter could not be prepared". When
     // that happens the install must be ABANDONED — falling back to launching
     // Setup.exe directly is the bug this change exists to remove.
@@ -333,11 +346,13 @@ describe('AutoUpdater two-step flow (win32)', () => {
     const internals = updater as unknown as {
       oneShotInstall: boolean;
       downloadedPath: string | null;
+      downloadedSha: string | null;
       pendingUpdate: { name: string; notes: string; url: string } | null;
       check: (oneShot?: boolean) => Promise<void>;
     };
     // Pretend a background poll already downloaded + verified this version.
-    internals.downloadedPath = 'C:/tmp/wmux-update-9.9.10.Setup.exe';
+    internals.downloadedPath = `/tmp/${staged}`;
+    internals.downloadedSha = GOOD_SHA;
     internals.pendingUpdate = { name: NEW_VERSION, notes: 'n', url: DL_URL };
 
     // Manual press → fast path → performInstall, whose handoff fails.
@@ -434,7 +449,9 @@ describe('AutoUpdater temp artifact reuse (win32)', () => {
 
   it('re-verifies before reusing: a tampered artifact is discarded and the installer downloaded', async () => {
     const { AutoUpdater, requestUrls, sent, unlinkMock, win } = await loadWin32({
-      tempFiles: { [parkedName]: { body: Buffer.from('TAMPERED'), mtimeMs: Date.now() - 10 * 60_000 } },
+      // Older than the sweep's floor: nothing can still be writing it, so it is
+      // ours to delete. A newer one is left alone (next test).
+      tempFiles: { [parkedName]: { body: Buffer.from('TAMPERED'), mtimeMs: Date.now() - 48 * 60 * 60_000 } },
     });
     const updater = new AutoUpdater(() => win as never, quitHooks());
 
@@ -446,7 +463,7 @@ describe('AutoUpdater temp artifact reuse (win32)', () => {
     expect(sent.map((s) => `${s.channel}:${s.data.status}`)).toContain(`${IPC.UPDATE_AVAILABLE}:downloaded`);
   });
 
-  it('leaves a just-written mismatching artifact alone — that is another instance downloading', async () => {
+  it('leaves a recent mismatching artifact alone — that is another instance downloading', async () => {
     const { AutoUpdater, unlinkMock, win } = await loadWin32({
       tempFiles: { [parkedName]: { body: Buffer.from('PARTIAL'), mtimeMs: Date.now() } },
     });
@@ -456,6 +473,68 @@ describe('AutoUpdater temp artifact reuse (win32)', () => {
     await flush();
 
     expect(unlinkMock.mock.calls.some((c) => String(c[0]).includes(parkedName))).toBe(false);
+  });
+
+  it('refuses to install an artifact whose bytes changed after it was verified', async () => {
+    // The panel's finding: verification happens when the update is FOUND, the
+    // install when the user presses Restart. Between the two, anything running
+    // as this user can rewrite the file in temp.
+    const { AutoUpdater, ipcHandlers, sent, teardown, tempFiles, win } = await loadWin32({
+      tempFiles: { [parkedName]: { body: INSTALLER_BODY } },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+    updater.start();
+
+    await backgroundCheck(updater);
+    await flush();
+    expect(sent.map((s) => `${s.channel}:${s.data.status}`)).toContain(`${IPC.UPDATE_AVAILABLE}:downloaded`);
+
+    // Swap the bytes under the verified path, then press "Restart to install".
+    tempFiles[parkedName] = { body: Buffer.from('SWAPPED-PAYLOAD') };
+    await ipcHandlers.get(IPC.UPDATE_INSTALL)!();
+    await flush();
+
+    expect(teardown.spawnInstallWaiter).not.toHaveBeenCalled();
+    const errors = sent.filter((s) => s.channel === IPC.UPDATE_ERROR);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(String(errors[errors.length - 1].data.message)).toContain('no longer matches');
+  });
+
+  it('never adopts a temp entry that is not a regular file', async () => {
+    // A symlink can be re-pointed atomically after the hash passes — hashing
+    // through one and then launching its path is the same window, reopened.
+    const { AutoUpdater, requestUrls, win } = await loadWin32({
+      tempFiles: { [parkedName]: { body: INSTALLER_BODY, isFile: false } },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+
+    await backgroundCheck(updater);
+    await flush();
+
+    expect(requestUrls).toContain(DL_URL); // downloaded instead of adopted
+  });
+
+  it('the sweep keeps only the newest pending installer, not one per release', async () => {
+    const old = Date.now() - 3 * 24 * 60 * 60 * 1000;
+    const superseded = `wmux-update-9.9.10-1-wmux-9.9.10.Setup.exe`;
+    const newest = `wmux-update-9.9.11-1-wmux-9.9.11.Setup.exe`;
+    const { AutoUpdater, unlinkMock, win } = await loadWin32({
+      tempFiles: {
+        [superseded]: { body: INSTALLER_BODY, mtimeMs: old },
+        [newest]: { body: INSTALLER_BODY, mtimeMs: old },
+      },
+    });
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+
+    updater.start();
+    await flush();
+
+    // Both are newer than the running 9.9.9, but only the newest can ever be
+    // installed — keeping every release's installer for a week is how a user
+    // who postpones restarting ends up with a gigabyte of them.
+    const swept = unlinkMock.mock.calls.map((c) => String(c[0]));
+    expect(swept.some((p) => p.includes(superseded))).toBe(true);
+    expect(swept.some((p) => p.includes(newest))).toBe(false);
   });
 
   it('the startup sweep keeps an installer for a newer version and drops one for the running version', async () => {

--- a/src/main/updater/__tests__/verifyUpdate.test.ts
+++ b/src/main/updater/__tests__/verifyUpdate.test.ts
@@ -5,6 +5,9 @@ import {
   digestsEqual,
   sha256Hex,
   validateManifest,
+  artifactTempName,
+  parseArtifactName,
+  isVersionNewer,
 } from '../verifyUpdate';
 
 // NN2-T4 — the fail-closed verification core. The pre-fix updater launched an
@@ -120,5 +123,58 @@ describe('validateManifest', () => {
     expect(validateManifest(darwin({ url: 'https://evil.com/x.zip' }), '2.14.1').ok).toBe(false);
     expect(validateManifest(darwin({ sha256: 'deadbeef' }), '2.14.1').ok).toBe(false);
     expect(validateManifest(darwin(), '2.99.0').ok).toBe(false);
+  });
+});
+
+// #995 — the temp artifact's NAME is the only record that a verified installer
+// already exists (the path is in-memory and a restart clears it), so format and
+// parse have to survive each other.
+describe('temp artifact naming', () => {
+  it('round-trips version, pid and file name', () => {
+    const name = artifactTempName('3.45.0', 25728, 'wmux-3.45.0.Setup.exe');
+    expect(name).toBe('wmux-update-3.45.0-25728-wmux-3.45.0.Setup.exe');
+    expect(parseArtifactName(name)).toEqual({
+      version: '3.45.0',
+      pid: 25728,
+      fileName: 'wmux-3.45.0.Setup.exe',
+    });
+  });
+
+  it('round-trips a prerelease version, whose own hyphens must not be read as the pid', () => {
+    const name = artifactTempName('3.45.0-rc.1', 42, 'wmux-3.45.0-rc.1.Setup.exe');
+    expect(parseArtifactName(name)).toEqual({
+      version: '3.45.0-rc.1',
+      pid: 42,
+      fileName: 'wmux-3.45.0-rc.1.Setup.exe',
+    });
+  });
+
+  it('sanitizes the manifest file name into the temp name', () => {
+    expect(artifactTempName('3.45.0', 7, 'wmux 3.45.0/../Setup.exe'))
+      .toBe('wmux-update-3.45.0-7-wmux_3.45.0_.._Setup.exe');
+  });
+
+  it('returns null for anything that is not one of our artifacts', () => {
+    expect(parseArtifactName('some-other-temp-file')).toBeNull();
+    expect(parseArtifactName('wmux-update-3.45.0.Setup.exe')).toBeNull();
+  });
+});
+
+describe('isVersionNewer', () => {
+  it('compares the numeric core', () => {
+    expect(isVersionNewer('3.45.0', '3.44.0')).toBe(true);
+    expect(isVersionNewer('3.44.1', '3.44.0')).toBe(true);
+    expect(isVersionNewer('4.0.0', '3.99.99')).toBe(true);
+    expect(isVersionNewer('3.44.0', '3.44.0')).toBe(false);
+    expect(isVersionNewer('3.43.0', '3.44.0')).toBe(false);
+    expect(isVersionNewer('v3.45.0', '3.44.0')).toBe(true);
+  });
+
+  it('answers false for anything it cannot read as three numbers', () => {
+    // Conservative on purpose: the caller keeps "newer" artifacts around for
+    // days, so an unreadable version must fall back to the ordinary sweep.
+    expect(isVersionNewer('3.45.0-rc.1', '3.44.0')).toBe(false);
+    expect(isVersionNewer('nightly', '3.44.0')).toBe(false);
+    expect(isVersionNewer('3.45', '3.44.0')).toBe(false);
   });
 });

--- a/src/main/updater/__tests__/verifyUpdate.test.ts
+++ b/src/main/updater/__tests__/verifyUpdate.test.ts
@@ -157,6 +157,24 @@ describe('temp artifact naming', () => {
   it('returns null for anything that is not one of our artifacts', () => {
     expect(parseArtifactName('some-other-temp-file')).toBeNull();
     expect(parseArtifactName('wmux-update-3.45.0.Setup.exe')).toBeNull();
+    // Not a semver core → not ours. Adoption then downloads instead, which is
+    // the safe direction.
+    expect(parseArtifactName('wmux-update-nightly-42-wmux.Setup.exe')).toBeNull();
+  });
+
+  it('keeps a numeric prerelease attached to the version instead of reading it as the pid', () => {
+    const name = artifactTempName('3.46.0-1', 12345, 'wmux-3.46.0-1.Setup.exe');
+    expect(parseArtifactName(name)).toEqual({
+      version: '3.46.0-1',
+      pid: 12345,
+      fileName: 'wmux-3.46.0-1.Setup.exe',
+    });
+  });
+
+  it('sanitizes the version too — it is fetched over the network and joined onto a path', () => {
+    const name = artifactTempName('3.45.0/../../etc', 7, 'wmux.Setup.exe');
+    expect(name).not.toContain('/');
+    expect(name).toBe('wmux-update-3.45.0_.._.._etc-7-wmux.Setup.exe');
   });
 });
 
@@ -170,11 +188,20 @@ describe('isVersionNewer', () => {
     expect(isVersionNewer('v3.45.0', '3.44.0')).toBe(true);
   });
 
+  it('reads past a prerelease or build suffix on either side', () => {
+    // Requiring a bare X.Y.Z on both sides switched the whole mechanism off on
+    // any build whose own version carries a suffix (a nightly, an rc).
+    expect(isVersionNewer('3.45.0-rc.1', '3.44.0')).toBe(true);
+    expect(isVersionNewer('3.45.0', '3.44.0-rc.1')).toBe(true);
+    expect(isVersionNewer('3.44.0-rc.1', '3.44.0')).toBe(false); // same core
+    expect(isVersionNewer('3.45.0+build.7', '3.44.0')).toBe(true);
+  });
+
   it('answers false for anything it cannot read as three numbers', () => {
     // Conservative on purpose: the caller keeps "newer" artifacts around for
     // days, so an unreadable version must fall back to the ordinary sweep.
-    expect(isVersionNewer('3.45.0-rc.1', '3.44.0')).toBe(false);
     expect(isVersionNewer('nightly', '3.44.0')).toBe(false);
     expect(isVersionNewer('3.45', '3.44.0')).toBe(false);
+    expect(isVersionNewer('3.45.0', 'unknown')).toBe(false);
   });
 });

--- a/src/main/updater/verifyUpdate.ts
+++ b/src/main/updater/verifyUpdate.ts
@@ -129,16 +129,29 @@ export function sanitizeArtifactFileName(fileName: string): string {
   return fileName.replace(/[^A-Za-z0-9._-]/g, '_');
 }
 
-/** Build the temp file name for a downloaded artifact (sanitizing the manifest's name). */
+/**
+ * Build the temp file name for a downloaded artifact.
+ *
+ * BOTH halves are sanitized. The manifest is fetched over the network, and this
+ * name is join()ed onto the temp dir — a `version` carrying a path separator
+ * would place the "temp file" wherever it liked. The version is attacker-
+ * controlled in exactly the scenario this module exists for.
+ */
 export function artifactTempName(version: string, pid: number, fileName: string): string {
-  return `${TEMP_ARTIFACT_PREFIX}${version}-${pid}-${sanitizeArtifactFileName(fileName)}`;
+  return `${TEMP_ARTIFACT_PREFIX}${sanitizeArtifactFileName(version)}-${pid}-${sanitizeArtifactFileName(fileName)}`;
 }
 
 /** Read `<version>`, `<pid>` and `<file>` back out of a temp artifact name. */
 export function parseArtifactName(name: string): ParsedArtifactName | null {
-  // Non-greedy version so a prerelease ("3.45.0-rc.1") backtracks correctly:
-  // the pid is the first all-digit segment that is followed by the file name.
-  const m = new RegExp(`^${TEMP_ARTIFACT_PREFIX}(.+?)-(\\d+)-(.+)$`).exec(name);
+  // The version is matched as semver, not as "anything", and its optional
+  // prerelease is greedy: `3.46.0-1-12345-wmux.Setup.exe` has to read as
+  // version 3.46.0-1 / pid 12345, not version 3.46.0 / pid 1 with the rest
+  // swallowed into the file name. A name this cannot parse is simply not one
+  // of ours — the caller then downloads instead of adopting, which is the safe
+  // direction.
+  const m = new RegExp(
+    `^${TEMP_ARTIFACT_PREFIX}(\\d+\\.\\d+\\.\\d+(?:[-+][0-9A-Za-z.-]*)?)-(\\d+)-(.+)$`,
+  ).exec(name);
   if (!m) return null;
   return { version: m[1], pid: Number(m[2]), fileName: m[3] };
 }
@@ -147,13 +160,18 @@ export function parseArtifactName(name: string): ParsedArtifactName | null {
  * True when `candidate` is a strictly newer release than `current`, comparing
  * the numeric MAJOR.MINOR.PATCH core only.
  *
- * Anything that does not read as three numbers answers FALSE, which is the
- * conservative side: the caller treats such an artifact as ordinary garbage on
- * the normal sweep schedule instead of keeping it around indefinitely.
+ * A prerelease or build suffix on either side is ignored, so 3.46.0-rc.1 and
+ * 3.46.0 compare equal. Anything that does not read as three numbers answers
+ * FALSE, which is the conservative side: the caller treats such an artifact as
+ * ordinary garbage on the normal sweep schedule instead of keeping it around.
  */
 export function isVersionNewer(candidate: string, current: string): boolean {
   const core = (v: string): number[] | null => {
-    const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(normalizeVersion(v));
+    // A prerelease/build suffix is read past, not rejected. Requiring a bare
+    // X.Y.Z on BOTH sides meant a nightly or rc build of wmux — where
+    // app.getVersion() carries a suffix — answered false for every artifact
+    // and silently switched this whole mechanism off.
+    const m = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(normalizeVersion(v));
     return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
   };
   const a = core(candidate);

--- a/src/main/updater/verifyUpdate.ts
+++ b/src/main/updater/verifyUpdate.ts
@@ -106,3 +106,61 @@ export function validateManifest(raw: unknown, offeredVersion: string): Manifest
     manifest: { version: o.version, fileName, sha256: o.sha256.trim(), url: o.url },
   };
 }
+
+/**
+ * A verified installer is parked in temp as `wmux-update-<version>-<pid>-<file>`.
+ * That name is the ONLY record of what the file is: the downloaded path lives in
+ * memory and a restart clears it, so a later run has to read the name back to
+ * recognize an installer it already has (#995). Format and parse therefore live
+ * together — they are one contract, and a drift between them silently turns
+ * every parked artifact into garbage.
+ */
+export const TEMP_ARTIFACT_PREFIX = 'wmux-update-';
+
+export interface ParsedArtifactName {
+  version: string;
+  pid: number;
+  /** Artifact name as sanitized when it was written, e.g. `wmux-3.45.0.Setup.exe`. */
+  fileName: string;
+}
+
+/** The manifest's artifact name, reduced to characters a temp file name may hold. */
+export function sanitizeArtifactFileName(fileName: string): string {
+  return fileName.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+/** Build the temp file name for a downloaded artifact (sanitizing the manifest's name). */
+export function artifactTempName(version: string, pid: number, fileName: string): string {
+  return `${TEMP_ARTIFACT_PREFIX}${version}-${pid}-${sanitizeArtifactFileName(fileName)}`;
+}
+
+/** Read `<version>`, `<pid>` and `<file>` back out of a temp artifact name. */
+export function parseArtifactName(name: string): ParsedArtifactName | null {
+  // Non-greedy version so a prerelease ("3.45.0-rc.1") backtracks correctly:
+  // the pid is the first all-digit segment that is followed by the file name.
+  const m = new RegExp(`^${TEMP_ARTIFACT_PREFIX}(.+?)-(\\d+)-(.+)$`).exec(name);
+  if (!m) return null;
+  return { version: m[1], pid: Number(m[2]), fileName: m[3] };
+}
+
+/**
+ * True when `candidate` is a strictly newer release than `current`, comparing
+ * the numeric MAJOR.MINOR.PATCH core only.
+ *
+ * Anything that does not read as three numbers answers FALSE, which is the
+ * conservative side: the caller treats such an artifact as ordinary garbage on
+ * the normal sweep schedule instead of keeping it around indefinitely.
+ */
+export function isVersionNewer(candidate: string, current: string): boolean {
+  const core = (v: string): number[] | null => {
+    const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(normalizeVersion(v));
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const a = core(candidate);
+  const b = core(current);
+  if (!a || !b) return false;
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] > b[i];
+  }
+  return false;
+}


### PR DESCRIPTION
Closes #995.

## The loop

`downloadedPath` is in-memory only. After a quit-for-install — successful or aborted — the next launch has no record that a verified installer already exists, so a ~150 MB Setup.exe gets fetched again even though the identical, already-verified bytes are sitting in temp. The startup sweep made it worse by deleting that artifact on the 24 h floor. #980's field data shows three such downloads across one failure loop.

## What changed

The artifact's file name already carries its version, so the file plus the freshly fetched manifest hash is the whole record — no new state file.

- **Adopt before downloading.** `downloadUpdate()` scans temp for an artifact whose version and file name match the pending manifest and re-hashes it. A SHA-256 match becomes `downloadedPath` and the download never runs; the manifest fetch still happens (that is where the hash comes from).
- **Re-verify, never trust the name.** The file sat in a world-writable temp dir across a restart, so it goes through the same digest gate a fresh download does. A mismatch is discarded and a normal download follows.
- **Do not delete another instance's download.** A mismatching artifact written in the last minute is left alone — that is an in-flight download, not garbage. Only a quiet one is unlinked.
- **The sweep stops eating the pending installer.** An artifact for a version *newer* than the running app — the only kind adoption can reuse — is kept for 7 days instead of 24 h. Everything else keeps the old floor, and the longer bound still expires (with auto-update off, the poll that would consume it never runs, and nothing should sit in temp forever).

Naming moved next to parsing in `verifyUpdate.ts` (`artifactTempName` / `parseArtifactName`, both pure and unit-tested), so the writer and the reader of that name cannot drift apart.

## Non-goals (per the issue)

Partial-download resume, and macOS — the ZIP is deleted on successful staging already and this failure loop was Windows-specific. The change is platform-neutral, though: adoption keys off the manifest's own file name.

## Tests

`src/main/updater/__tests__/AutoUpdater.download.test.ts` grows a fake temp dir (readdir/stat/createReadStream) and four cases: reuse without downloading, tampered artifact discarded then downloaded, just-written mismatch left alone, and the sweep keeping the newer-version artifact while dropping the running-version one. `verifyUpdate.test.ts` pins the name round-trip (including a prerelease version, whose hyphens must not be read as the pid) and `isVersionNewer`.

Verified: `tsc --noEmit`, `eslint src/main/updater` (no new warnings), `vitest run src/main/updater` — 104 passed. Removing the adoption call and the sweep exemption fails three of the four new tests, so they are real gates.