### PR TITLE
test(mcp): drop the weaker duplicate externalWire source-invariant scan

### DIFF
--- a/src/main/mcp/__tests__/rpcProvenance.test.ts
+++ b/src/main/mcp/__tests__/rpcProvenance.test.ts
@@ -1,7 +1,15 @@
-// The source-level invariant — which production files may write the
-// externalWire marker at all — is pinned by
-// src/main/pipe/__tests__/RpcDispatchProvenance.sourceInvariant.test.ts. This
-// file stays a unit test of the predicate itself (#958).
+// Two other tests hold the externalWire boundary, and they hold different
+// halves of it (#958):
+//   • WHICH production files may write the marker at all —
+//     src/main/pipe/__tests__/RpcDispatchProvenance.sourceInvariant.test.ts,
+//     which pins the file set (PipeServer + RpcRouter) over every property
+//     assignment and shorthand, whatever the initializer.
+//   • THAT RpcRouter's write stays conditional — RpcRouter.dispatchProvenance
+//     .test.ts ('does not inherit external-wire provenance into an unmarked
+//     nested dispatch'), which is the test that fails if that ternary is ever
+//     widened to a bare `true`. The source invariant would not: the file set
+//     is unchanged by that edit.
+// This file stays a unit test of the predicate itself.
 
 import { describe, expect, it } from 'vitest';
 import { isLocalExternalWireContext } from '../rpcProvenance';

--- a/src/main/mcp/__tests__/rpcProvenance.test.ts
+++ b/src/main/mcp/__tests__/rpcProvenance.test.ts
@@ -1,48 +1,10 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as ts from 'typescript';
+// The source-level invariant — which production files may write the
+// externalWire marker at all — is pinned by
+// src/main/pipe/__tests__/RpcDispatchProvenance.sourceInvariant.test.ts. This
+// file stays a unit test of the predicate itself (#958).
+
 import { describe, expect, it } from 'vitest';
 import { isLocalExternalWireContext } from '../rpcProvenance';
-
-const MAIN_DIR = path.resolve(__dirname, '..', '..');
-
-function collectProductionTsFiles(dir: string): string[] {
-  const out: string[] = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name === '__tests__') continue;
-      out.push(...collectProductionTsFiles(full));
-    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
-      out.push(full);
-    }
-  }
-  return out;
-}
-
-function writesExternalWireTrue(file: string): boolean {
-  const source = ts.createSourceFile(
-    file,
-    fs.readFileSync(file, 'utf8'),
-    ts.ScriptTarget.Latest,
-    true,
-  );
-  let found = false;
-  const visit = (node: ts.Node): void => {
-    if (
-      ts.isPropertyAssignment(node) &&
-      (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)) &&
-      node.name.text === 'externalWire' &&
-      node.initializer.kind === ts.SyntaxKind.TrueKeyword
-    ) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(source);
-  return found;
-}
 
 describe('local external-wire provenance', () => {
   it('requires the positive PipeServer marker and excludes other sources', () => {
@@ -67,14 +29,5 @@ describe('local external-wire provenance', () => {
         operator: true,
       }),
     ).toBe(false);
-  });
-
-  it('keeps PipeServer as the only production writer of externalWire authority', () => {
-    const writers = collectProductionTsFiles(MAIN_DIR)
-      .filter(writesExternalWireTrue)
-      .map((file) => path.relative(MAIN_DIR, file).replaceAll('\\', '/'))
-      .sort();
-
-    expect(writers).toEqual(['pipe/PipeServer.ts']);
   });
 });


### PR DESCRIPTION
Closes #958. Follow-up to #950, which deduplicated the predicate but left a second, weaker duplicate in the AST invariant.

Two tests pinned "who may write `externalWire`", with different expected sets:

- `src/main/mcp/__tests__/rpcProvenance.test.ts` asserted `['pipe/PipeServer.ts']`, but its matcher only accepted a `TrueKeyword` initializer — so `RpcRouter.ts:292`'s `externalWire: externalWire ? true : undefined` was invisible to it. It passed while meaning "PipeServer is the only file writing a bare `true` literal", not what its name claimed.
- `src/main/pipe/__tests__/RpcDispatchProvenance.sourceInvariant.test.ts` matches every property assignment plus shorthand regardless of initializer, correctly lists both writers, and is the one that would catch a transport widening the boundary with a ternary, `as const`, or a computed boolean.

This deletes the weaker scan and its helper, leaving `rpcProvenance.test.ts` as a focused unit test of `isLocalExternalWireContext` with a pointer to where the source invariant lives. The strong invariant is untouched, so the boundary stays covered — no production code changes.

Verified: both suites pass (`vitest run src/main/mcp/__tests__/rpcProvenance.test.ts src/main/pipe/__tests__/RpcDispatchProvenance.sourceInvariant.test.ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined coverage for detecting local external wire contexts.
  * Moved enforcement of external wire-writing rules to a separate test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->