### PR TITLE
fix(shortcuts): distinguish "nothing to repair" from "the repair pass never ran"

### DIFF
--- a/changelog.d/1005.md
+++ b/changelog.d/1005.md
@@ -3,5 +3,7 @@
 - **A shortcut repair that could not run no longer reports success.** If
   Windows refused the COM object the icon-repair pass used, the pass quietly
   reported "nothing needed fixing" — so a taskbar icon that stayed blank after
-  an update left no trace of why. The pass now says it failed, retries once,
-  and logs what Windows returned.
+  an update left no trace of why. The pass now says it failed — whether COM
+  was refused outright or not one shortcut could be opened — retries a refused
+  COM object once inside the same time budget, and writes what Windows
+  returned to the install log.

--- a/changelog.d/1005.md
+++ b/changelog.d/1005.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A shortcut repair that could not run no longer reports success.** If
+  Windows refused the COM object the icon-repair pass used, the pass quietly
+  reported "nothing needed fixing" — so a taskbar icon that stayed blank after
+  an update left no trace of why. The pass now says it failed, retries once,
+  and logs what Windows returned.

--- a/src/main/__tests__/shortcutHygiene.runtime.test.ts
+++ b/src/main/__tests__/shortcutHygiene.runtime.test.ts
@@ -10,7 +10,12 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { repairInstalledShortcuts, stageRootIcon, type RepairLocations } from '../shortcutHygiene';
+import {
+  runShortcutRepairPass,
+  stageRootIcon,
+  type RepairLocations,
+  type ShortcutRepairAction,
+} from '../shortcutHygiene';
 
 const onWindows = process.platform === 'win32';
 
@@ -45,6 +50,11 @@ function makeLnk(lnkPath: string, target: string): void {
     `$l.TargetPath = ${q(target)}`,
     `$l.Save()`,
   ].join('\n'));
+  // Save() is synchronous, but this suite's whole job is to catch the cases
+  // where the shell layer disagrees with the filesystem. If the link is not
+  // there, say THAT rather than letting the pass report "nothing to repair"
+  // three lines later (#962).
+  if (!fs.existsSync(lnkPath)) throw new Error(`.lnk was not written: ${lnkPath}`);
 }
 
 function readLnk(lnkPath: string): { target: string; icon: string; workdir: string } {
@@ -94,6 +104,21 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     fs.rmSync(sandbox, { recursive: true, force: true });
   });
 
+  /**
+   * Run the pass and surface WHY it produced nothing.
+   *
+   * `repairInstalledShortcuts` returns `[]` both when nothing needed repair
+   * and when the pass could not run at all, and a CI flake landed on the
+   * second (#962): the failure read as `expected [] to deeply equal [...]`
+   * with nothing to go on. Every assertion below goes through here, so a
+   * refused COM object or a powershell that died says so instead.
+   */
+  const repair = (exec = execPath, at = loc): ShortcutRepairAction[] => {
+    const { actions, failure } = runShortcutRepairPass(exec, at);
+    if (failure) throw new Error(`shortcut repair pass did not run: ${failure}`);
+    return actions;
+  };
+
   it('retargets a dead versioned pin to the stub and pins its icon to app.ico', () => {
     const pin = path.join(pinDir, 'wmux-pin.lnk');
     makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe')); // dir never existed → dead
@@ -101,7 +126,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     expect(iconPath).toBe(path.join(root, 'app.ico'));
     expect(fs.existsSync(iconPath ?? '')).toBe(true);
 
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
 
     const after = readLnk(pin);
@@ -113,7 +138,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
   it('retargets a live-but-versioned pin (it would die on the next update)', () => {
     const pin = path.join(pinDir, 'wmux-pin.lnk');
     makeLnk(pin, execPath); // app-1.0.0 exists today
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
     expect(readLnk(pin).target.toLowerCase()).toBe(path.join(root, 'wmux.exe').toLowerCase());
   });
@@ -123,7 +148,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     makeLnk(legacy, path.join(root, 'app-0.5.0', 'wmux.exe'));
     makeLnk(path.join(programs, 'someauthor', 'wmux.lnk'), path.join(root, 'wmux.exe'));
 
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([{ path: legacy, action: 'removed' }]);
     expect(fs.existsSync(legacy)).toBe(false);
   });
@@ -132,7 +157,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     const legacy = loc.legacyLnks[0];
     makeLnk(legacy, path.join(root, 'app-0.5.0', 'wmux.exe'));
 
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([{ path: legacy, action: 'retargeted' }]);
     expect(fs.existsSync(legacy)).toBe(true);
     expect(readLnk(legacy).target.toLowerCase()).toBe(path.join(root, 'wmux.exe').toLowerCase());
@@ -147,7 +172,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     fs.writeFileSync(foreignTarget, 'x');
     makeLnk(foreign, foreignTarget);
 
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([]);
     expect(readLnk(foreign).target.toLowerCase()).toBe(foreignTarget.toLowerCase());
   });
@@ -160,7 +185,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe'));
     expect(fs.existsSync(path.join(root, 'app.ico'))).toBe(false); // not staged
 
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
 
     const after = readLnk(pin);
@@ -178,7 +203,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     fs.chmodSync(pin, 0o444);
     ps(`Set-ItemProperty -LiteralPath ${q(pin)} -Name IsReadOnly -Value $true`);
     try {
-      expect(repairInstalledShortcuts(execPath, loc)).toEqual([]);
+      expect(repair()).toEqual([]);
       expect(readLnk(pin).target.toLowerCase()).toBe(deadTarget.toLowerCase());
     } finally {
       ps(`Set-ItemProperty -LiteralPath ${q(pin)} -Name IsReadOnly -Value $false`);
@@ -213,7 +238,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
       makeLnk(pin, path.join(oddRoot, 'app-0.9.0', 'wmux.exe'));
       expect(stageRootIcon(oddExec)).toBe(path.join(oddRoot, 'app.ico'));
 
-      expect(repairInstalledShortcuts(oddExec, oddLoc)).toEqual([
+      expect(repair(oddExec, oddLoc)).toEqual([
         { path: pin, action: 'retargeted' },
       ]);
       const after = readLnk(pin);
@@ -228,7 +253,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
     fs.rmSync(path.join(root, 'wmux.exe'));
     const pin = path.join(pinDir, 'wmux-pin.lnk');
     makeLnk(pin, path.join(root, 'app-0.9.0', 'wmux.exe'));
-    expect(repairInstalledShortcuts(execPath, loc)).toEqual([]);
+    expect(repair()).toEqual([]);
     expect(readLnk(pin).target.toLowerCase()).toContain('app-0.9.0');
   });
 
@@ -270,7 +295,7 @@ describe.skipIf(!onWindows)('shortcutHygiene end-to-end (real .lnk, real PowerSh
       `[H.Api]::SetAumid(${q(pin)}, 'com.squirrel.wmux.wmux')`,
     ].join('\n'));
 
-    const actions = repairInstalledShortcuts(execPath, loc);
+    const actions = repair();
     expect(actions).toEqual([{ path: pin, action: 'retargeted' }]);
 
     const aumid = ps([

--- a/src/main/__tests__/shortcutHygiene.test.ts
+++ b/src/main/__tests__/shortcutHygiene.test.ts
@@ -123,12 +123,28 @@ describe('defaultRepairLocations', () => {
 // needed repair, and the pass never ran. A CI flake landed on the second and
 // left `expected [] to deeply equal [...]` as the entire evidence.
 describe('repair pass diagnostics', () => {
-  it('makes the script exit non-zero when the COM object is refused', () => {
+  it('makes the script exit non-zero, with a marker, when the COM object is refused', () => {
     const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC) ?? '';
     // Without this the SilentlyContinue preference turns every read through a
     // null $sh into a skipped candidate, and the script prints a clean `[]`.
     expect(s).toContain('if (-not $sh)');
     expect(s).toContain('exit 3');
+    // The marker, not the exit code, is what the retry is allowed to key on —
+    // a runtime abort also exits 3. It goes to stdout via Write-Output because
+    // ConstrainedLanguage (a likely reason COM was refused in the first place)
+    // blocks [Console]::Error.WriteLine.
+    expect(s).toContain("Write-Output 'WMUX_COM_UNAVAILABLE'");
+    expect(s).not.toContain('[Console]::Error');
+  });
+
+  it('fails the pass when candidate links existed and none could be opened', () => {
+    const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC) ?? '';
+    // The COM guard only covers CreateShortcut being unavailable at all. A
+    // per-link failure (locked/corrupt .lnk, WSH policy, a COM server that
+    // died mid-loop) leaves $l null, and skipping every candidate would emit
+    // the same misleading `[]`.
+    expect(s).toContain('if (-not $l) { $unopened++; continue }');
+    expect(s).toContain("if ($opened -eq 0 -and $unopened -gt 0) { Write-Output 'WMUX_NO_LINKS_READABLE'; exit 4 }");
   });
 
   it('reports no failure off win32 — there is nothing to repair, not a broken pass', () => {

--- a/src/main/__tests__/shortcutHygiene.test.ts
+++ b/src/main/__tests__/shortcutHygiene.test.ts
@@ -9,6 +9,7 @@ import {
   buildRepairScript,
   parseRepairOutput,
   defaultRepairLocations,
+  runShortcutRepairPass,
 } from '../shortcutHygiene';
 
 const LOC = {
@@ -115,5 +116,23 @@ describe('defaultRepairLocations', () => {
       path.join(pinned, 'StartMenu'),
     ]);
     expect(loc.publisherLnk).toBe(path.join(programs, '*', 'wmux.lnk'));
+  });
+});
+
+// #962 — an empty action list used to mean two different things: nothing
+// needed repair, and the pass never ran. A CI flake landed on the second and
+// left `expected [] to deeply equal [...]` as the entire evidence.
+describe('repair pass diagnostics', () => {
+  it('makes the script exit non-zero when the COM object is refused', () => {
+    const s = buildRepairScript('C:\\Users\\u\\AppData\\Local\\wmux', LOC) ?? '';
+    // Without this the SilentlyContinue preference turns every read through a
+    // null $sh into a skipped candidate, and the script prints a clean `[]`.
+    expect(s).toContain('if (-not $sh)');
+    expect(s).toContain('exit 3');
+  });
+
+  it('reports no failure off win32 — there is nothing to repair, not a broken pass', () => {
+    if (process.platform === 'win32') return;
+    expect(runShortcutRepairPass('/tmp/app-1.0.0/wmux')).toEqual({ actions: [], failure: null });
   });
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -188,6 +188,15 @@ if (process.platform === 'win32') {
     // mid-update on the version being superseded, where the NEWER version's
     // install/updated hook owns the takeover. Best-effort — a kill failure
     // must never block the install itself.
+    // The hook branches below are the ONLY production callers of the shortcut
+    // hygiene pass, and they run in a packaged Windows process with no parent
+    // console: without the sink, every console.warn they emit — including the
+    // one that now says WHY a repair pass could not run (#962) — goes nowhere
+    // at all. initLogSink is idempotent and resolves its path lazily, so
+    // calling it here just makes install-time output land in
+    // %APPDATA%\wmux\logs alongside everything else.
+    try { initLogSink(); } catch { /* best-effort — never block an install */ }
+
     if (squirrelCmd !== '--squirrel-obsolete') {
       try {
         const killed = terminateRunningAppInstances();

--- a/src/main/shortcutHygiene.ts
+++ b/src/main/shortcutHygiene.ts
@@ -68,6 +68,22 @@ export interface ShortcutRepairAction {
   action: 'retargeted' | 'removed';
 }
 
+/** Exit code the script uses for "the COM object could not be created" (#962). */
+const COM_UNAVAILABLE_EXIT = 3;
+
+/**
+ * Outcome of one repair pass.
+ *
+ * `failure` separates the two states an empty `actions` used to conflate:
+ * nothing needed repair (failure `null`) and the pass could not run at all.
+ * Callers still cannot be made to care — repairInstalledShortcuts drops it —
+ * but the log line and the runtime test can now say which one happened.
+ */
+export interface RepairPassResult {
+  actions: ShortcutRepairAction[];
+  failure: string | null;
+}
+
 /** Locations the repair pass reads. Overridable so tests use temp dirs. */
 export interface RepairLocations {
   /** Explicit .lnk paths to examine (the legacy top-level link). */
@@ -145,6 +161,12 @@ export function buildRepairScript(rootDir: string, loc: RepairLocations): string
     `foreach ($d in @(${pinArray})) { if (Test-Path $d) { $cands += @(Get-ChildItem -LiteralPath $d -Filter *.lnk | ForEach-Object { $_.FullName }) } }`,
     `$pubExists = @(Get-Item ${psQuote(loc.publisherLnk)}).Count -gt 0`,
     `$sh = New-Object -ComObject WScript.Shell`,
+    // A refused COM class factory (a loaded machine, an antivirus holding the
+    // registration) leaves $sh null, and with SilentlyContinue every read
+    // through it then fails quietly: the pass emits `[]` and reads exactly like
+    // "nothing needed repair". Fail loudly instead — a broken icon that never
+    // got fixed and a pass that never ran must not look the same (#962).
+    `if (-not $sh) { [Console]::Error.WriteLine('WScript.Shell COM object unavailable'); exit ${COM_UNAVAILABLE_EXIT} }`,
     `$out = @()`,
     `foreach ($p in $cands) {`,
     `  if (-not (Test-Path -LiteralPath $p)) { continue }`,
@@ -216,6 +238,69 @@ export function stageRootIcon(execPath: string): string | null {
   }
 }
 
+/** One powershell run: the script's stdout, or why it did not produce any. */
+function runRepairScript(script: string): { stdout: string } | { failure: string; comUnavailable: boolean } {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const powershell = path.join(
+    systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+  );
+  try {
+    const stdout = execFileSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', script], {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      windowsHide: true,
+    });
+    return { stdout };
+  } catch (err) {
+    const e = err as { status?: number; stderr?: string | Buffer; message?: string };
+    const stderr = e.stderr ? String(e.stderr).trim() : '';
+    const status = typeof e.status === 'number' ? e.status : null;
+    return {
+      failure: `powershell exited ${status ?? 'abnormally'}${stderr ? `: ${stderr}` : `: ${e.message ?? 'unknown error'}`}`,
+      comUnavailable: status === COM_UNAVAILABLE_EXIT,
+    };
+  }
+}
+
+/**
+ * Run the repair pass and report whether it actually ran. win32-only,
+ * best-effort, never throws — a hygiene failure must never block the install.
+ *
+ * Retries once when the COM object was refused: that failure is transient (a
+ * class-factory request lost to load or to an antivirus), and a second
+ * powershell start is its own backoff. Anything else is reported as-is; a
+ * retry would just double the cost of a real problem.
+ */
+export function runShortcutRepairPass(
+  execPath: string,
+  locations?: RepairLocations,
+): RepairPassResult {
+  if (process.platform !== 'win32') return { actions: [], failure: null };
+  try {
+    const appData = process.env.APPDATA;
+    const loc = locations ?? (appData ? defaultRepairLocations(appData) : null);
+    if (!loc) return { actions: [], failure: 'no repair locations (APPDATA unset)' };
+    const script = buildRepairScript(rootFromExecPath(execPath), loc);
+    if (!script) return { actions: [], failure: 'a path could not be embedded in the script safely' };
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const run = runRepairScript(script);
+      if ('stdout' in run) return { actions: parseRepairOutput(run.stdout), failure: null };
+      if (run.comUnavailable && attempt === 0) {
+        console.warn('[shortcutHygiene] COM refused the repair pass — retrying once');
+        continue;
+      }
+      console.warn(`[shortcutHygiene] shortcut repair pass did not run: ${run.failure}`);
+      return { actions: [], failure: run.failure };
+    }
+    return { actions: [], failure: 'the repair pass exhausted its retries' };
+  } catch (err) {
+    const failure = err instanceof Error ? err.message : String(err);
+    console.warn(`[shortcutHygiene] shortcut repair pass did not run: ${failure}`);
+    return { actions: [], failure };
+  }
+}
+
 /**
  * Run the repair pass. win32-only, best-effort, never throws — a hygiene
  * failure must never block the install itself.
@@ -224,24 +309,5 @@ export function repairInstalledShortcuts(
   execPath: string,
   locations?: RepairLocations,
 ): ShortcutRepairAction[] {
-  if (process.platform !== 'win32') return [];
-  try {
-    const appData = process.env.APPDATA;
-    const loc = locations ?? (appData ? defaultRepairLocations(appData) : null);
-    if (!loc) return [];
-    const script = buildRepairScript(rootFromExecPath(execPath), loc);
-    if (!script) return [];
-    const systemRoot = process.env.SystemRoot || 'C:\\Windows';
-    const powershell = path.join(
-      systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
-    );
-    const stdout = execFileSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', script], {
-      encoding: 'utf-8',
-      timeout: 15_000,
-      windowsHide: true,
-    });
-    return parseRepairOutput(stdout);
-  } catch {
-    return [];
-  }
+  return runShortcutRepairPass(execPath, locations).actions;
 }

--- a/src/main/shortcutHygiene.ts
+++ b/src/main/shortcutHygiene.ts
@@ -70,6 +70,26 @@ export interface ShortcutRepairAction {
 
 /** Exit code the script uses for "the COM object could not be created" (#962). */
 const COM_UNAVAILABLE_EXIT = 3;
+/** Exit code for "there were candidate links and not one could be opened". */
+const NO_LINKS_READABLE_EXIT = 4;
+/**
+ * Printed by the script before it exits with COM_UNAVAILABLE_EXIT.
+ *
+ * Exit 3 is not ours alone — a CRT abort ends with 3 too — and the retry below
+ * must not re-run the whole pass on one. The marker is what makes the code
+ * mean what it says. It goes to STDOUT on purpose: under WDAC/AppLocker
+ * ConstrainedLanguage, the environment most likely to refuse the COM object in
+ * the first place, `[Console]::Error.WriteLine` is itself a blocked method call.
+ */
+const COM_UNAVAILABLE_MARKER = 'WMUX_COM_UNAVAILABLE';
+/** Same idea for "candidates existed, none opened". */
+const NO_LINKS_READABLE_MARKER = 'WMUX_NO_LINKS_READABLE';
+/**
+ * Total wall-clock budget for the pass, retry included. This runs synchronously
+ * inside the Squirrel install hook, which Squirrel cancels at ~15 s — so the
+ * retry has to share the old single-attempt budget, not double it.
+ */
+const REPAIR_BUDGET_MS = 15_000;
 
 /**
  * Outcome of one repair pass.
@@ -166,11 +186,22 @@ export function buildRepairScript(rootDir: string, loc: RepairLocations): string
     // through it then fails quietly: the pass emits `[]` and reads exactly like
     // "nothing needed repair". Fail loudly instead — a broken icon that never
     // got fixed and a pass that never ran must not look the same (#962).
-    `if (-not $sh) { [Console]::Error.WriteLine('WScript.Shell COM object unavailable'); exit ${COM_UNAVAILABLE_EXIT} }`,
+    // Placed before ANY .lnk is touched, which is what makes the caller's retry
+    // safe: nothing has been written when this branch is taken.
+    `if (-not $sh) { Write-Output '${COM_UNAVAILABLE_MARKER}'; exit ${COM_UNAVAILABLE_EXIT} }`,
     `$out = @()`,
+    `$opened = 0`,
+    `$unopened = 0`,
     `foreach ($p in $cands) {`,
     `  if (-not (Test-Path -LiteralPath $p)) { continue }`,
     `  $l = $sh.CreateShortcut($p)`,
+    // CreateShortcut can fail per-link too (a locked or corrupt .lnk, WSH
+    // policy, a COM server that died mid-loop) and SilentlyContinue turns that
+    // into a skipped candidate — the same invisible `[]` one level down. Count
+    // them so "nothing needed repair" cannot be reported by a pass that could
+    // not read a single shortcut.
+    `  if (-not $l) { $unopened++; continue }`,
+    `  $opened++`,
     `  $t = $l.TargetPath`,
     `  if (-not $t) { continue }`,
     `  if (-not $t.StartsWith($root + '\\', [System.StringComparison]::OrdinalIgnoreCase)) { continue }`,
@@ -190,6 +221,7 @@ export function buildRepairScript(rootDir: string, loc: RepairLocations): string
     `  $out += @{ path = $p; action = 'retargeted' }`,
     `}`,
     `[System.Runtime.InteropServices.Marshal]::ReleaseComObject($sh) | Out-Null`,
+    `if ($opened -eq 0 -and $unopened -gt 0) { Write-Output '${NO_LINKS_READABLE_MARKER}'; exit ${NO_LINKS_READABLE_EXIT} }`,
     `ConvertTo-Json @($out) -Compress`,
   ].join('\n');
 }
@@ -239,7 +271,9 @@ export function stageRootIcon(execPath: string): string | null {
 }
 
 /** One powershell run: the script's stdout, or why it did not produce any. */
-function runRepairScript(script: string): { stdout: string } | { failure: string; comUnavailable: boolean } {
+type RunOutcome = { stdout: string } | { failure: string; retryable: boolean };
+
+function runRepairScript(script: string, timeoutMs: number): RunOutcome {
   const systemRoot = process.env.SystemRoot || 'C:\\Windows';
   const powershell = path.join(
     systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
@@ -247,19 +281,50 @@ function runRepairScript(script: string): { stdout: string } | { failure: string
   try {
     const stdout = execFileSync(powershell, ['-NoProfile', '-NonInteractive', '-Command', script], {
       encoding: 'utf-8',
-      timeout: 15_000,
+      timeout: timeoutMs,
       windowsHide: true,
     });
     return { stdout };
   } catch (err) {
-    const e = err as { status?: number; stderr?: string | Buffer; message?: string };
-    const stderr = e.stderr ? String(e.stderr).trim() : '';
+    const e = err as {
+      status?: number | null; signal?: string | null; code?: string;
+      stdout?: string | Buffer; stderr?: string | Buffer;
+    };
+    // Deliberately NOT e.message: execFileSync puts the whole command line in
+    // it, and that command line is kilobytes of PowerShell carrying the user's
+    // profile paths — which would then land in a log line and in a failing
+    // test's message. status/signal/code answer the question e.message was
+    // being used for, and they distinguish a timeout (signal) from a missing
+    // interpreter (code) instead of blurring both into "failed".
     const status = typeof e.status === 'number' ? e.status : null;
+    const out = `${e.stdout ? String(e.stdout) : ''}${e.stderr ? String(e.stderr) : ''}`.trim();
+    const comRefused = status === COM_UNAVAILABLE_EXIT && out.includes(COM_UNAVAILABLE_MARKER);
+    const where = comRefused
+      ? 'the WScript.Shell COM object was refused'
+      : status === NO_LINKS_READABLE_EXIT && out.includes(NO_LINKS_READABLE_MARKER)
+        ? 'no candidate shortcut could be opened'
+        : `powershell exited status=${status ?? 'none'} signal=${e.signal ?? 'none'} code=${e.code ?? 'none'}`;
     return {
-      failure: `powershell exited ${status ?? 'abnormally'}${stderr ? `: ${stderr}` : `: ${e.message ?? 'unknown error'}`}`,
-      comUnavailable: status === COM_UNAVAILABLE_EXIT,
+      failure: out ? `${where} [${out.slice(0, 200)}]` : where,
+      // Only a marked COM refusal is worth a second run. Exit 3 on its own is
+      // not ours — a runtime abort mid-loop ends with 3 too, and re-running
+      // the whole pass on one of those would repeat work already done.
+      retryable: comRefused,
     };
   }
+}
+
+/**
+ * The script's last statement is always `ConvertTo-Json`, so output that is not
+ * JSON means it died before reaching it — which is exactly the "reads like
+ * nothing needed repair" state this change exists to remove.
+ */
+function readActions(stdout: string): { actions: ShortcutRepairAction[] } | { failure: string } {
+  const trimmed = stdout.trim();
+  if (!trimmed.startsWith('[') && !trimmed.startsWith('{')) {
+    return { failure: `the script produced no JSON [${trimmed.slice(0, 120) || 'empty output'}]` };
+  }
+  return { actions: parseRepairOutput(trimmed) };
 }
 
 /**
@@ -276,28 +341,41 @@ export function runShortcutRepairPass(
   locations?: RepairLocations,
 ): RepairPassResult {
   if (process.platform !== 'win32') return { actions: [], failure: null };
+  // EVERY failure exit goes through here. Two of them used to return quietly,
+  // and since repairInstalledShortcuts drops the reason, those were still the
+  // silent empty list this change exists to remove.
+  const fail = (reason: string): RepairPassResult => {
+    console.warn(`[shortcutHygiene] shortcut repair pass did not run: ${reason}`);
+    return { actions: [], failure: reason };
+  };
   try {
     const appData = process.env.APPDATA;
     const loc = locations ?? (appData ? defaultRepairLocations(appData) : null);
-    if (!loc) return { actions: [], failure: 'no repair locations (APPDATA unset)' };
+    if (!loc) return fail('no repair locations (APPDATA unset)');
     const script = buildRepairScript(rootFromExecPath(execPath), loc);
-    if (!script) return { actions: [], failure: 'a path could not be embedded in the script safely' };
+    if (!script) return fail('a path could not be embedded in the script safely');
 
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const run = runRepairScript(script);
-      if ('stdout' in run) return { actions: parseRepairOutput(run.stdout), failure: null };
-      if (run.comUnavailable && attempt === 0) {
+    // One budget for the whole pass, retry included. This runs synchronously
+    // inside the Squirrel hook, which Squirrel cancels at ~15 s — so the retry
+    // has to share the old single-attempt budget rather than double it.
+    const deadline = Date.now() + REPAIR_BUDGET_MS;
+    let run = runRepairScript(script, REPAIR_BUDGET_MS);
+    if ('failure' in run && run.retryable) {
+      const left = deadline - Date.now();
+      if (left > 1_000) {
         console.warn('[shortcutHygiene] COM refused the repair pass — retrying once');
-        continue;
+        run = runRepairScript(script, left);
+      } else {
+        console.warn('[shortcutHygiene] COM refused the repair pass — no budget left to retry');
       }
-      console.warn(`[shortcutHygiene] shortcut repair pass did not run: ${run.failure}`);
-      return { actions: [], failure: run.failure };
     }
-    return { actions: [], failure: 'the repair pass exhausted its retries' };
+    if ('failure' in run) return fail(run.failure);
+
+    const read = readActions(run.stdout);
+    if ('failure' in read) return fail(read.failure);
+    return { actions: read.actions, failure: null };
   } catch (err) {
-    const failure = err instanceof Error ? err.message : String(err);
-    console.warn(`[shortcutHygiene] shortcut repair pass did not run: ${failure}`);
-    return { actions: [], failure };
+    return fail(err instanceof Error ? err.message : String(err));
   }
 }
 


### PR DESCRIPTION
Closes #962.

## What the flake was hiding

`shortcutHygiene.runtime.test.ts` failed once on CI with `expected [] to deeply equal [ { path: …wmux-pin.lnk, action: 'retargeted' } ]`, on a PR that touched only pipe handlers, and went green on re-run. The empty list was the whole evidence — and it could not be more, because `repairInstalledShortcuts` returns `[]` for two different outcomes:

- nothing needed repair, and
- the pass never ran.

The script sets `$ErrorActionPreference = 'SilentlyContinue'`, so a refused `New-Object -ComObject WScript.Shell` — a class-factory request lost to load or to antivirus, the usual suspect on a busy runner — leaves `$sh` null, every `$sh.CreateShortcut($p)` fails quietly, every candidate is skipped, and the script prints a clean `[]` with exit code 0.

That is worse in production than in CI: a real install where COM blinks keeps its blank taskbar icon (the whole #863 symptom) and logs nothing at all.

## Changes

- **The script fails loudly.** `if (-not $sh) { [Console]::Error.WriteLine(…); exit 3 }` — a pass that could not start no longer looks like a pass that found nothing.
- **`runShortcutRepairPass(execPath, locations)`** returns `{ actions, failure }` and `console.warn`s the failure (powershell's exit status and stderr). `repairInstalledShortcuts` is now a thin wrapper over it: same signature, same never-throws contract, same call sites in `index.ts` untouched.
- **One bounded retry on the COM failure specifically.** It is transient by nature, and a fresh powershell start is its own backoff. Every other failure is reported as-is — retrying a real problem just doubles its cost.
- **The runtime suite routes every call through a helper that throws the failure**, and `makeLnk` now asserts the `.lnk` actually landed. The next hit names the layer that gave out instead of showing an empty list.

## Tests

Two unit cases in `shortcutHygiene.test.ts`: the built script carries the COM guard and its exit code, and the pass reports no failure off win32 (nothing to repair is not a broken pass). The runtime suite is `describe.skipIf(!onWindows)`, so its side of this only runs on the Windows CI leg.

Verified locally (macOS): `tsc --noEmit`, `eslint` clean, `vitest run src/main/__tests__/shortcutHygiene*` — 18 passed, 11 skipped (the Windows-only runtime suite).