### PR TITLE
fix(hooks): remove wmux hook leaves, not the groups they share

### DIFF
--- a/changelog.d/1008.md
+++ b/changelog.d/1008.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`setup-hooks` no longer removes a hook of your own that shares a matcher
+  group with wmux's.** Claude Code allows several commands under one matcher.
+  If you had added yours next to wmux's, `wmux setup-hooks --remove` took yours
+  with it — and so did every reinstall, including the bridge refresh that runs
+  on app update. Removal now drops only the wmux command and leaves the group,
+  its matcher, and your commands in place. Hooks in groups of their own were
+  never affected. (#1008)

--- a/integrations/claude/README.md
+++ b/integrations/claude/README.md
@@ -59,6 +59,12 @@ This copies the bridge to a stable path (`~/.wmux/hooks/wmux-bridge.mjs`)
 and references it from settings.json, so it survives app updates. Re-run
 `wmux setup-hooks` after a wmux update to refresh the copied bridge.
 
+"Leaves your other hooks intact" is per **command**, not per matcher group.
+Claude Code allows several commands under one matcher, so if you have added one
+of your own beside wmux's, `--remove` — and every re-install, including the
+bridge refresh above — takes out only the wmux command and leaves your group,
+its matcher, and your commands exactly where they are (#1008).
+
 **Caveat — do not combine with the plugin.** If you install BOTH this
 plugin (Option A/B) and the `setup-hooks` settings entries, each turn
 fires the hook twice. wmux dedups hook-vs-detector, but not

--- a/src/cli/commands/__tests__/setupHooks.test.ts
+++ b/src/cli/commands/__tests__/setupHooks.test.ts
@@ -169,7 +169,8 @@ describe('installHooks', () => {
     // Claude Code's schema allows several command leaves under one matcher, so
     // the user hand-adds theirs to the group wmux wrote for Stop.
     const seeded = readSettings();
-    const stopGroups = (seeded.hooks as Record<string, { hooks: unknown[] }[]>).Stop;
+    const stopGroups = (seeded.hooks as Record<string, { matcher?: string; hooks: unknown[] }[]>).Stop;
+    const seededMatcher = stopGroups[0].matcher;
     stopGroups[0].hooks.push({ type: 'command', command: 'echo mine' });
     fs.writeFileSync(settingsPath, JSON.stringify(seeded), 'utf8');
 
@@ -182,7 +183,11 @@ describe('installHooks', () => {
     >).Stop;
     // The user's leaf keeps its group (and its matcher); wmux's own hook is
     // re-added beside it, exactly once, in a group of its own.
-    expect(stop.filter((g) => g.hooks.some((h) => h.command === 'echo mine'))).toHaveLength(1);
+    const mine = stop.filter((g) => g.hooks.some((h) => h.command === 'echo mine'));
+    expect(mine).toHaveLength(1);
+    // Asserted explicitly: the group is handed back whole, so a strip that
+    // rebuilt it and dropped the matcher would otherwise pass here.
+    expect(mine[0].matcher).toBe(seededMatcher);
     expect(
       stop.filter((g) => g.hooks.some((h) => h.command === `node "${bridgeDest}" Stop`)),
     ).toHaveLength(1);

--- a/src/cli/commands/__tests__/setupHooks.test.ts
+++ b/src/cli/commands/__tests__/setupHooks.test.ts
@@ -164,6 +164,31 @@ describe('installHooks', () => {
     }
   });
 
+  it('keeps a foreign leaf the user added inside a wmux group across a re-install', () => {
+    installHooks(paths());
+    // Claude Code's schema allows several command leaves under one matcher, so
+    // the user hand-adds theirs to the group wmux wrote for Stop.
+    const seeded = readSettings();
+    const stopGroups = (seeded.hooks as Record<string, { hooks: unknown[] }[]>).Stop;
+    stopGroups[0].hooks.push({ type: 'command', command: 'echo mine' });
+    fs.writeFileSync(settingsPath, JSON.stringify(seeded), 'utf8');
+
+    installHooks(paths()); // clear-then-add — the strip runs over that group
+
+    expect(allHookCommands()).toContain('echo mine');
+    const stop = (readSettings().hooks as Record<
+      string,
+      { matcher?: string; hooks: { command: string }[] }[]
+    >).Stop;
+    // The user's leaf keeps its group (and its matcher); wmux's own hook is
+    // re-added beside it, exactly once, in a group of its own.
+    expect(stop.filter((g) => g.hooks.some((h) => h.command === 'echo mine'))).toHaveLength(1);
+    expect(
+      stop.filter((g) => g.hooks.some((h) => h.command === `node "${bridgeDest}" Stop`)),
+    ).toHaveLength(1);
+    expect(stop.every((g) => g.hooks.length === 1)).toBe(true);
+  });
+
   it('aborts without writing when settings.json is corrupted', () => {
     fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
     const corrupt = '{ this is not json';
@@ -368,6 +393,62 @@ describe('removeHooks', () => {
     expect(outcome.ok).toBe(false);
     expect(outcome.error).toContain('not valid JSON');
     expect(fs.readFileSync(settingsPath, 'utf8')).toBe(corrupt);
+  });
+
+  it('removes only the wmux leaf from a group it shares with a foreign hook', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'AskUserQuestion',
+              hooks: [
+                { type: 'command', command: `node "${bridgeDest}" PreToolUse` },
+                { type: 'command', command: 'echo mine' },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    const outcome = removeHooks(paths());
+    expect(outcome.ok).toBe(true);
+    expect(outcome.removed).toBe(1);
+    // The group survives, carrying the user's leaf and its matcher unchanged.
+    expect((readSettings().hooks as Record<string, unknown[]>).PreToolUse).toEqual([
+      { matcher: 'AskUserQuestion', hooks: [{ type: 'command', command: 'echo mine' }] },
+    ]);
+  });
+
+  it('counts the wmux leaves it removes, not the groups they sat in', () => {
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          // Two wmux leaves in one group: the current install plus a stale copy
+          // from an older bridge path the user merged in by hand.
+          Stop: [
+            {
+              matcher: '',
+              hooks: [
+                { type: 'command', command: `node "${bridgeDest}" Stop` },
+                { type: 'command', command: 'node "/old/.wmux/hooks/wmux-bridge.mjs" Stop' },
+              ],
+            },
+          ],
+        },
+      }),
+      'utf8',
+    );
+
+    expect(removeHooks(paths()).removed).toBe(2);
+    // Nothing foreign was in that group, so it goes, and the empty map with it.
+    expect(readSettings().hooks).toBeUndefined();
   });
 });
 

--- a/src/cli/commands/setupHooks.ts
+++ b/src/cli/commands/setupHooks.ts
@@ -264,18 +264,29 @@ interface HookGroup {
   [k: string]: unknown;
 }
 
-/** True when a hook group contains a wmux-owned command leaf. */
+/** True when a single hook leaf is a wmux-owned command. */
+function isWmuxLeaf(leaf: unknown): boolean {
+  return (
+    !!leaf &&
+    typeof leaf === 'object' &&
+    typeof (leaf as HookLeaf).command === 'string' &&
+    (leaf as HookLeaf).command.includes(WMUX_BRIDGE_MARKER)
+  );
+}
+
+/**
+ * True when a hook group contains a wmux-owned command leaf.
+ *
+ * Ownership is per GROUP here because that is what DETECTION needs: a group
+ * carrying our leaf provides the spec no matter what else the user put beside
+ * it. REMOVAL asks a different question and answers it per leaf — see
+ * `stripWmuxHooks`.
+ */
 function isWmuxGroup(group: unknown): boolean {
   if (!group || typeof group !== 'object') return false;
   const hooks = (group as HookGroup).hooks;
   if (!Array.isArray(hooks)) return false;
-  return hooks.some(
-    (h) =>
-      h &&
-      typeof h === 'object' &&
-      typeof (h as HookLeaf).command === 'string' &&
-      (h as HookLeaf).command.includes(WMUX_BRIDGE_MARKER),
-  );
+  return hooks.some(isWmuxLeaf);
 }
 
 /**
@@ -404,17 +415,23 @@ function loadSettings(settingsPath: string): LoadResult {
 }
 
 /**
- * Strip all wmux-owned hook groups from a settings.hooks map, dropping any event
- * arrays (and the `hooks` key itself) left empty. Returns the count removed.
- * Mutates `settings` in place. Used by both install (clear-then-add) and remove.
+ * Strip every wmux-owned hook LEAF from a settings.hooks map, dropping any
+ * group, event array (and the `hooks` key itself) left empty. Returns the
+ * number of leaves removed. Mutates `settings` in place. Used by both install
+ * (clear-then-add) and remove.
  *
- * PRESERVES every foreign (non-wmux) hook group: a group is removed only when
- * `isWmuxGroup` confirms it carries a wmux-bridge.mjs command leaf. A user's
- * hand-registered foreign PreToolUse pointing at a DIFFERENT script is never
- * touched — `installHooks` then re-adds only wmux's own specs. (#781: the
- * report of "setup-hooks wiped my PreToolUse" was a group whose command
- * pointed at wmux-bridge.mjs itself, which is correctly wmux-owned and thus
- * refreshed, not a foreign hook destroyed.)
+ * PRESERVES every foreign (non-wmux) hook, including one the user put INSIDE a
+ * group of ours. Claude Code's schema lets a single matcher group hold several
+ * command leaves, so "is this group wmux's?" and "is this command wmux's?" are
+ * different questions: filtering whole groups answers the first and takes the
+ * user's own leaf as collateral — on `--remove`, and on every reinstall, since
+ * install is clear-then-add through this same function. Every group wmux
+ * writes holds exactly one leaf and nothing else, so for wmux's own output the
+ * two granularities are byte-identical; they diverge only in the hand-mixed
+ * case, which is the one worth getting right. (#781: the report of
+ * "setup-hooks wiped my PreToolUse" was a group whose command pointed at
+ * wmux-bridge.mjs itself, which is correctly wmux-owned and thus refreshed,
+ * not a foreign hook destroyed.)
  */
 function stripWmuxHooks(settings: Record<string, unknown>): number {
   const hooks = settings.hooks;
@@ -424,8 +441,21 @@ function stripWmuxHooks(settings: Record<string, unknown>): number {
   for (const event of Object.keys(hooksMap)) {
     const groups = hooksMap[event];
     if (!Array.isArray(groups)) continue;
-    const kept = groups.filter((g) => !isWmuxGroup(g));
-    removed += groups.length - kept.length;
+    const kept: unknown[] = [];
+    for (const group of groups) {
+      if (!isWmuxGroup(group)) {
+        kept.push(group);
+        continue;
+      }
+      const leaves = (group as HookGroup).hooks as unknown[];
+      const foreign = leaves.filter((leaf) => !isWmuxLeaf(leaf));
+      removed += leaves.length - foreign.length;
+      // Ours alone: the group goes with the leaf, exactly as before.
+      if (foreign.length === 0) continue;
+      // Hand-mixed: keep the group, the matcher, and the user's leaves.
+      (group as HookGroup).hooks = foreign as HookLeaf[];
+      kept.push(group);
+    }
     if (kept.length === 0) {
       delete hooksMap[event];
     } else {


### PR DESCRIPTION
## Summary

`setup-hooks` **owns** its hooks one command leaf at a time but **removes** them
a whole matcher group at a time. Claude Code's schema lets one matcher group
hold several command leaves, so a user who put their own command beside ours
inside one group loses it — on `wmux setup-hooks --remove`, and on every
reinstall, since install is clear-then-add through the same function. Removal is
now per leaf.

## Changes

- **`stripWmuxHooks` filters leaves, not groups.** Our leaves go; the group
  survives carrying the user's leaves and its `matcher` unchanged; a group left
  empty still disappears with its event array, and the `hooks` key with it when
  that was the last one.
- **`isWmuxLeaf` extracted**; `isWmuxGroup` is now `hooks.some(isWmuxLeaf)` and
  deliberately keeps its group-level meaning. Detection asks "does this group
  provide the spec?", which a mixed group still does, so `installedSpecsIn`,
  profile derivation (#970) and `--status` are untouched.
- **The removal count counts leaves.** Byte-identical for everything wmux
  writes — `installHooks` only ever emits single-leaf wmux-only groups — and
  different only where one group held more than one of ours.
- **The doc comment now describes the code.** It claimed to preserve "every
  foreign (non-wmux) hook group": true per group, false per leaf.
- **`integrations/claude/README.md`** says which granularity "leaves your other
  hooks intact" means, since the interesting case is exactly the one a reader
  cannot infer from the sentence.

## CHANGELOG entry

### Fixed

- **`setup-hooks` no longer removes a hook of your own that shares a matcher
  group with wmux's.** Claude Code allows several commands under one matcher. If
  you added yours next to wmux's, `wmux setup-hooks --remove` took yours with
  it — and so did every reinstall, including the bridge refresh that runs on
  app update. Removal now drops only the wmux command and leaves the group, its
  matcher, and your commands in place. Hooks in groups of their own were never
  affected. (#1008)

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

No RPC, event, or pipe surface changes. The observable change is confined to
which entries `setup-hooks` writes back to `~/.claude/settings.json`, in the
direction of touching less of the file than before.

## Substrate contract impact (Substrate 3.0)

n/a — settings.json hook registration only.

## Test plan

- **Unit** — `src/cli/commands/__tests__/setupHooks.test.ts`, 3 cases added
  (68 total, green):
  - `--remove` on a hand-mixed group keeps the foreign leaf **and** the group's
    matcher;
  - a reinstall keeps that leaf, and re-adds wmux's own hook exactly once, in a
    group of its own;
  - the count reports leaves rather than groups (two wmux leaves in one group,
    one stale path — `removed === 2`).

  The reinstall case also asserts the preserved group keeps its `matcher`
  (review): removal already pinned that with a whole-group `toEqual`, install
  did not, so a strip that rebuilt the group and dropped the matcher passed.
  Control for that one specifically: make `stripWmuxHooks` rebuild as
  `kept.push({ hooks: foreign })` and two tests go red where one did before.
- **Control run** — revert `setupHooks.ts` only, keep the tests: exactly those
  three go red and the other 65 stay green, so each new test pins behaviour that
  did not exist before.

  ```
  × keeps a foreign leaf the user added inside a wmux group across a re-install
  × removes only the wmux leaf from a group it shares with a foreign hook
  × counts the wmux leaves it removes, not the groups they sat in
  Tests  3 failed | 65 passed (68)
  ```

- **State table walked** for `stripWmuxHooks`, since the bug was one unenumerated
  case: group with no wmux leaf (untouched) / all leaves wmux (group goes, as
  before) / mixed (new behaviour) / `hooks` not an array or empty (untouched,
  as before) / non-object junk beside a wmux leaf (kept — anything we cannot
  prove is ours is the user's).
- `npx tsc --noEmit` clean; `eslint` clean on both touched files.
- Full suite: 11 889 passed. 14 failures in 7 files, none of which import `setupHooks` —
  `logSink` (Windows file-rotation/lock timing), `worktree.handler`,
  `mergeSession`, `atlasCoherence`, `brokerLifecycle.dynamic`, and the
  `THIRD_PARTY_NOTICES` drift guard, which is stale locally because my
  `node_modules` predates the dependency bumps in #988/#994/#1007. Two runs of
  the identical tree failed *different* sets (20 tests, then 14), so those are
  environment/timing, not the diff. CI is the arbiter.

## Related issues / PRs

Refines #781, which established that a group carrying our bridge command is
ours to refresh. That is still true — this narrows it from the group to the
command.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hook removal to delete only wmux-owned commands while preserving user-added commands and matchers.
  - Reinstallations and app updates now retain independently configured hook entries.
  - Empty hook groups and unused entries are still cleaned up automatically.

- **Documentation**
  - Clarified how hook removal, reinstallation, and bridge refresh operations preserve custom configuration.

- **Tests**
  - Added coverage for selective uninstall, reinstall preservation, and accurate removal counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->