### PR TITLE
Adopt the live terminal across a pane split instead of replaying it

### DIFF
--- a/changelog.d/1010.md
+++ b/changelog.d/1010.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Splitting a pane no longer replays the conversation you were reading.** The
+  split rebuilt the surviving pane's terminal from scratch, so the daemon's
+  scrollback arrived in chunks and you watched the whole session scroll past
+  from the top before settling at the bottom. Nothing had restarted — only the
+  view was thrown away — so the terminal is now handed to the new layout intact,
+  buffer and scroll position included. Dragging a pane and closing a pane that
+  collapses a split reached the same flash, and are fixed with it. (#1010)

--- a/src/renderer/components/Pane/__tests__/PaneContainer.terminalAdoption.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneContainer.terminalAdoption.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+//
+// Dynamic verification for issue #1002 — the surviving pane adopts its terminal
+// across a split instead of rebuilding it.
+//
+// The fix rests on one claim about React that is easy to state and easy to get
+// wrong: a restructure unmounts and remounts the surviving leaf inside ONE
+// commit, and React flushes that commit's passive UNMOUNT effects before its
+// passive MOUNT effects. If that order were reversed — or if the two landed in
+// different commits — the mount would find nothing parked, adoption would never
+// fire, and the whole change would degrade to "dispose the terminal 250 ms
+// later" while the user still watched the conversation replay.
+//
+// So this mounts the REAL PaneContainer against the REAL store and splits with
+// the REAL splitPane, with the leaf Pane mocked down to the one thing that
+// matters: a mount that adopts and a teardown that parks, driving the REAL
+// terminalPark module. What it asserts is the ordering, not xterm.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Terminal } from '@xterm/xterm';
+
+import {
+  parkTerminal,
+  adoptTerminal,
+  PARK_TTL_MS,
+  __resetTerminalPark,
+} from '../../../terminal/terminalPark';
+
+/** Every park/adopt/dispose this render produced, in order, as `event:paneId`. */
+const events: string[] = [];
+
+// The leaf stands in for Pane → Terminal → useTerminal. Its ptyId is stable
+// across a restructure exactly as the real one is (the surviving LEAF keeps its
+// id; only the new branch above it gets a fresh one), so pane.id is the right
+// stand-in for the park key.
+vi.mock('../Pane', () => ({
+  default: ({ pane }: { pane: { id: string } }) => {
+    React.useEffect(() => {
+      const adopted = adoptTerminal(pane.id);
+      events.push(`${adopted ? 'adopt' : 'create'}:${pane.id}`);
+      return () => {
+        events.push(`park:${pane.id}`);
+        parkTerminal(
+          pane.id,
+          {} as unknown as Terminal,
+          document.createElement('div'),
+          () => events.push(`dispose:${pane.id}`),
+        );
+      };
+    }, [pane.id]);
+    return React.createElement('div', { 'data-testid': `leaf-${pane.id}` });
+  },
+}));
+
+import PaneContainer from '../PaneContainer';
+import { useStore } from '../../../stores';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// react-resizable-panels observes group elements; jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe(): void { /* layout reflow is irrelevant under jsdom */ }
+  unobserve(): void { /* no-op */ }
+  disconnect(): void { /* no-op */ }
+}
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver ??= ResizeObserverStub;
+
+let host: HTMLDivElement;
+let root: Root;
+
+const activeWorkspace = () =>
+  useStore.getState().workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+
+function render(): void {
+  const ws = activeWorkspace();
+  act(() => {
+    root.render(
+      React.createElement(PaneContainer, {
+        pane: ws.rootPane,
+        workspace: ws,
+        isWorkspaceVisible: true,
+      }),
+    );
+  });
+}
+
+const only = (prefix: string) => events.filter((e) => e.startsWith(`${prefix}:`));
+
+beforeEach(() => {
+  const state = useStore.getState();
+  for (const w of [...state.workspaces]) state.removeWorkspace(w.id);
+  state.addWorkspace();
+  useStore.setState({ zoomedPaneId: null });
+
+  events.length = 0;
+  host = document.createElement('div');
+  document.body.appendChild(host);
+  root = createRoot(host);
+  render();
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  host.remove();
+  __resetTerminalPark();
+  vi.useRealTimers();
+});
+
+describe('#1002 — terminal adoption across a pane-tree restructure', () => {
+  it('parks the surviving leaf before the remount asks to adopt it', () => {
+    const rootId = activeWorkspace().rootPane.id;
+    expect(events).toEqual([`create:${rootId}`]);
+
+    act(() => { useStore.getState().splitPane(rootId, 'horizontal'); });
+    render();
+
+    // The load-bearing order. React flushes passive unmount effects for the
+    // whole commit before passive mount effects, so the park is already in
+    // place when the remount looks for it.
+    const survivor = events.filter((e) => e.endsWith(`:${rootId}`));
+    expect(survivor).toEqual([`create:${rootId}`, `park:${rootId}`, `adopt:${rootId}`]);
+  });
+
+  it('never disposes the surviving leaf\'s terminal', () => {
+    vi.useFakeTimers();
+    const rootId = activeWorkspace().rootPane.id;
+
+    act(() => { useStore.getState().splitPane(rootId, 'horizontal'); });
+    render();
+    act(() => { vi.advanceTimersByTime(PARK_TTL_MS * 4); });
+
+    // Adoption cancelled the pending dispose. Without that, the adopting mount's
+    // terminal would die a quarter-second into its life.
+    expect(only('dispose')).toEqual([]);
+    expect(only('adopt')).toEqual([`adopt:${rootId}`]);
+  });
+
+  it('builds the NEW pane from scratch — only the survivor is adopted', () => {
+    const rootId = activeWorkspace().rootPane.id;
+
+    act(() => { useStore.getState().splitPane(rootId, 'horizontal'); });
+    render();
+
+    const newPaneId = useStore.getState().workspaces
+      .find((w) => w.id === useStore.getState().activeWorkspaceId)!.activePaneId;
+    expect(newPaneId).not.toBe(rootId);
+    expect(events).toContain(`create:${newPaneId}`);
+    expect(events).not.toContain(`adopt:${newPaneId}`);
+  });
+
+  it('adopts across a sibling close that collapses the branch', () => {
+    // Third path to the same restructure: closing one of two leaves collapses
+    // the branch back into a leaf, moving the survivor's depth again.
+    const rootId = activeWorkspace().rootPane.id;
+    act(() => { useStore.getState().splitPane(rootId, 'horizontal'); });
+    render();
+    const newPaneId = activeWorkspace().activePaneId;
+
+    events.length = 0;
+    act(() => { useStore.getState().closePane(newPaneId); });
+    render();
+
+    expect(events).toContain(`park:${rootId}`);
+    expect(events).toContain(`adopt:${rootId}`);
+    expect(events.indexOf(`park:${rootId}`)).toBeLessThan(events.indexOf(`adopt:${rootId}`));
+  });
+
+  it('still disposes when the pane really goes away', () => {
+    vi.useFakeTimers();
+    const rootId = activeWorkspace().rootPane.id;
+
+    act(() => { root.unmount(); });
+    expect(only('dispose')).toEqual([]);
+    act(() => { vi.advanceTimersByTime(PARK_TTL_MS); });
+
+    // A closed pane never comes back for its terminal — the park window just
+    // moves the dispose 250 ms later, it does not cancel it.
+    expect(only('dispose')).toEqual([`dispose:${rootId}`]);
+  });
+});

--- a/src/renderer/components/Pane/__tests__/PaneContainer.terminalAdoption.test.tsx
+++ b/src/renderer/components/Pane/__tests__/PaneContainer.terminalAdoption.test.tsx
@@ -8,7 +8,7 @@
 // commit, and React flushes that commit's passive UNMOUNT effects before its
 // passive MOUNT effects. If that order were reversed — or if the two landed in
 // different commits — the mount would find nothing parked, adoption would never
-// fire, and the whole change would degrade to "dispose the terminal 250 ms
+// fire, and the whole change would degrade to "dispose the terminal one task
 // later" while the user still watched the conversation replay.
 //
 // So this mounts the REAL PaneContainer against the REAL store and splits with
@@ -131,7 +131,7 @@ describe('#1002 — terminal adoption across a pane-tree restructure', () => {
     act(() => { vi.advanceTimersByTime(PARK_TTL_MS * 4); });
 
     // Adoption cancelled the pending dispose. Without that, the adopting mount's
-    // terminal would die a quarter-second into its life.
+    // terminal would die the moment the task that handed it over ended.
     expect(only('dispose')).toEqual([]);
     expect(only('adopt')).toEqual([`adopt:${rootId}`]);
   });
@@ -175,7 +175,7 @@ describe('#1002 — terminal adoption across a pane-tree restructure', () => {
     act(() => { vi.advanceTimersByTime(PARK_TTL_MS); });
 
     // A closed pane never comes back for its terminal — the park window just
-    // moves the dispose 250 ms later, it does not cancel it.
+    // moves the dispose to the end of the task, it does not cancel it.
     expect(only('dispose')).toEqual([`dispose:${rootId}`]);
   });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.daemonReattach.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.daemonReattach.test.ts
@@ -65,7 +65,10 @@ describe('Fix D — daemon session reattach (source-level)', () => {
 
   it('gates only the at-mount reattach on isDaemonModeActive(), never the event path (Codex P2)', () => {
     // active-at-mount has no event to ride, so it reads the module flag once.
-    expect(afterMainEffect).toMatch(/if\s*\(\s*isDaemonModeActive\(\)\s*\)\s*reattach\(/);
+    // The condition may carry additional terms (#1002 adds an adopted-mount
+    // suppression); what matters is that this call, and only this call, is
+    // behind the module flag.
+    expect(afterMainEffect).toMatch(/if\s*\([^;\n]*isDaemonModeActive\(\)[^;\n]*\)\s*reattach\('active-at-mount'\)/);
     // The reattach helper itself must NOT re-check the flag — a daemon:connected
     // that races AppLayout's flag flip would otherwise be dropped.
     const reIdx = afterMainEffect.indexOf('const reattach =');

--- a/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// #1002 — terminal adoption across a pane-tree restructure, locked at the
+// source level.
+//
+// The bug: splitting a pane replaced the target leaf with a new branch node, so
+// React unmounted and remounted the surviving leaf. The unmount disposed its
+// xterm; the remount built a fresh one and refilled it from the daemon ring
+// buffer, and the user watched the conversation get written from the top down.
+//
+// The fix parks the live terminal on teardown and adopts it on the next mount
+// for the same ptyId. Four things have to stay true or the replay comes back
+// silently, and none of them are reachable from a unit test of this hook —
+// useTerminal is a 2600-line xterm-bound effect. Matching the daemon-reattach
+// and A6 race-cancel tests, the invariants are asserted against the source.
+describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = fs.readFileSync(hookPath, 'utf-8');
+
+  // Main terminal-creation effect: from its unique `if (!container || !ptyId)
+  // return;` guard to the next `}, [ptyId, containerRef]);`.
+  const mainStart = src.indexOf('if (!container || !ptyId) return;');
+  const mainEffectEnd = src.indexOf('}, [ptyId, containerRef]);', mainStart);
+  const mainEffect = src.slice(mainStart, mainEffectEnd);
+  const afterMainEffect = src.slice(mainEffectEnd);
+
+  it('locates the main effect boundary', () => {
+    expect(mainStart).toBeGreaterThan(0);
+    expect(mainEffectEnd).toBeGreaterThan(mainStart);
+  });
+
+  it('asks for a parked terminal before it constructs one', () => {
+    const adoptAt = mainEffect.indexOf('adoptTerminal(ptyId)');
+    const constructAt = mainEffect.indexOf('new Terminal({');
+    expect(adoptAt).toBeGreaterThan(-1);
+    expect(constructAt).toBeGreaterThan(-1);
+    // A construct-then-discard order would create a second xterm per split —
+    // the cost the adoption is meant to remove.
+    expect(adoptAt).toBeLessThan(constructAt);
+    expect(mainEffect).toMatch(/const terminal = adopted \? adopted\.terminal : new Terminal\(\{/);
+  });
+
+  it('adopts by moving the element, never by re-opening the terminal', () => {
+    // terminal.open() rebuilds the screen — precisely what adoption preserves.
+    expect(mainEffect).toMatch(/if \(adopted\) \{[\s\S]*container\.appendChild\(adopted\.element\);[\s\S]*\} else \{[\s\S]*terminal\.open\(container\);/);
+    // And exactly one open() call site, still on the fresh-terminal side.
+    expect(mainEffect.match(/terminal\.open\(/g)).toHaveLength(1);
+  });
+
+  it('skips the scrollback restore for an adopted terminal', () => {
+    // The adopted instance already holds the scrollback; running the `.txt`
+    // restore would write a second copy over the screen it reproduces.
+    expect(mainEffect).toMatch(/if \(scrollbackFile && !adopted\) \{/);
+  });
+
+  it('clears the restore overlay on the adopting mount', () => {
+    // Terminal.tsx raises `restoring` for any scrollbackFile pane and drops it
+    // on first data. An adopted pane has no replay coming, so without this the
+    // split trades the scroll-from-the-top flash for a 3 s curtain.
+    expect(mainEffect).toMatch(/if \(adopted\) fireFirstData\(\);/);
+  });
+
+  it('suppresses only the active-at-mount daemon reattach after an adoption', () => {
+    // pty.reconnect is what makes the daemon replay its ring buffer. An
+    // adopting mount is still attached, so asking for one buys nothing but the
+    // replay.
+    expect(afterMainEffect).toMatch(/if \(isDaemonModeActive\(\) && !adoptedAtMountRef\.current\) reattach\('active-at-mount'\);/);
+    // A later connect/respawn is a real new daemon generation and MUST still
+    // reattach — gating that would strand the pane on a dead session.
+    expect(afterMainEffect).toMatch(/daemon\.onConnected\(\(\) => reattach\('daemon:connected'\)\)/);
+    expect(afterMainEffect).not.toMatch(/adoptedAtMountRef[\s\S]{0,80}daemon:connected/);
+  });
+
+  it('parks on teardown only when the buffer is a faithful copy of the session', () => {
+    // A dirty pane, or one mid-resync, is exactly the case that needs the
+    // replay: adopting it would leave a stale screen with nothing to repair it.
+    expect(mainEffect).toMatch(/const canPark = parkElement !== null\s*\n\s*&& !resyncRef\.current\.pending\s*\n\s*&& !isTerminalDirty\(terminal\);/);
+    expect(mainEffect).toMatch(/parkTerminal\(ptyId, terminal, parkElement, disposeTerminal\)/);
+  });
+
+  it('reads the resync flag before teardown clears it', () => {
+    // cancelResync() wipes `pending`, so a canPark computed after it would read
+    // false-clean on every pane that was mid-resync — the one case that must
+    // not be adopted.
+    const canParkAt = mainEffect.indexOf('const canPark =');
+    const cancelResyncAt = mainEffect.indexOf('cancelResync(ptyId);');
+    expect(canParkAt).toBeGreaterThan(-1);
+    expect(cancelResyncAt).toBeGreaterThan(canParkAt);
+  });
+
+  it('keeps a parked terminal\'s queued output and discards it if the park expires', () => {
+    // The scheduler queue belongs to the instance. Discarding it on the way out
+    // would drop bytes the adopting mount is the only reader of, and (unlike
+    // the dispose path) no resync follows to replace them.
+    expect(mainEffect).toMatch(/if \(!canPark\) discardTerminalOutput\(terminal\);/);
+    expect(mainEffect).toMatch(/const disposeTerminal = \(\) => \{\s*\n\s*discardTerminalOutput\(terminal\);\s*\n\s*disposeWhenDragEnds\(\(\) => terminal\.dispose\(\)\);/);
+  });
+
+  it('releases the addons it loaded before parking', () => {
+    // terminal.dispose() is what normally disposes them, and a parked terminal
+    // never reaches it — the adopting mount loads its own set, so without this
+    // the instance accumulates one per restructure.
+    expect(mainEffect).toMatch(/if \(canPark\) \{[\s\S]*fitAddon\.dispose\(\);[\s\S]*searchAddon\.dispose\(\);[\s\S]*webLinksAddon\.dispose\(\);[\s\S]*parkTerminal\(/);
+  });
+
+  it('still disposes directly when the terminal cannot be parked', () => {
+    expect(mainEffect).toMatch(/\} else \{\s*\n\s*disposeWhenDragEnds\(\(\) => terminal\.dispose\(\)\);\s*\n\s*\}/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
@@ -78,21 +78,33 @@ describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
   // is coming to repair. Each is pinned separately: a single regex over the
   // whole condition breaks on formatting and says nothing about WHICH guard
   // went missing.
-  const canParkBlock = mainEffect.slice(
+  const refusalLadder = mainEffect.slice(
+    mainEffect.indexOf('const parkRefusal ='),
     mainEffect.indexOf('const canPark ='),
-    mainEffect.indexOf(';', mainEffect.indexOf('const canPark =')),
   );
 
   it.each([
-    ['the element still exists', /parkElement !== null/],
-    ['no resync is in flight', /&& !resyncRef\.current\.pending/],
-    ['the buffer is not dirty', /&& !isTerminalDirty\(terminal\)/],
-    ['the scrollback restore settled', /&& restoreSettled/],
-    ['no .txt cache awaits the daemon verdict', /&& !didRestoreTxt/],
-    ['no daemon reconnect is retrying', /&& !reconnectInFlightRef\.current/],
-    ['this instance still owns the ptyId', /&& terminalRegistry\.get\(ptyId\) === terminal/],
-  ])('parks only when %s', (_label, pattern) => {
-    expect(canParkBlock).toMatch(pattern as RegExp);
+    ['no-element', /parkElement === null \? 'no-element'/],
+    ['resync-pending', /resyncRef\.current\.pending \? 'resync-pending'/],
+    ['dirty', /isTerminalDirty\(terminal\) \? 'dirty'/],
+    ['restore-unsettled', /!restoreSettled \? 'restore-unsettled'/],
+    ['txt-awaiting-verdict', /didRestoreTxt \? 'txt-awaiting-verdict'/],
+    ['reconnect-in-flight', /reconnectInFlightRef\.current \? 'reconnect-in-flight'/],
+    ['not-registry-owner', /terminalRegistry\.get\(ptyId\) !== terminal \? 'not-registry-owner'/],
+  ])('refuses to park with reason %s', (_reason, pattern) => {
+    expect(refusalLadder).toMatch(pattern as RegExp);
+  });
+
+  it('parks exactly when the ladder found no reason not to', () => {
+    expect(mainEffect).toMatch(/const canPark = parkRefusal === null;/);
+  });
+
+  it('logs the mount and teardown decision where another machine can read it', () => {
+    // Adoption can only be validated where the bug reproduces. Without the
+    // reason on the teardown line, "the split still replays" over there is
+    // indistinguishable from "one of seven guards refused".
+    expect(mainEffect).toMatch(/\[wmux:pane-adopt\] ptyId=\$\{ptyId\} mount=\$\{adopted \? 'adopted' : 'fresh'\}/);
+    expect(mainEffect).toMatch(/teardown=\$\{canPark \? 'parked' : `disposed reason=\$\{parkRefusal\}`\}/);
   });
 
   it('defers the viewport restore when the adopting container has no size yet', () => {
@@ -155,7 +167,7 @@ describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
     // terminal.dispose() is what normally disposes them, and a parked terminal
     // never reaches it — the adopting mount loads its own set, so without this
     // the instance accumulates one per restructure.
-    expect(mainEffect).toMatch(/if \(canPark\) \{[\s\S]*fitAddon\.dispose\(\);[\s\S]*searchAddon\.dispose\(\);[\s\S]*webLinksAddon\.dispose\(\);[\s\S]*parkTerminal\(/);
+    expect(mainEffect).toMatch(/if \(canPark && parkElement\) \{[\s\S]*fitAddon\.dispose\(\);[\s\S]*searchAddon\.dispose\(\);[\s\S]*webLinksAddon\.dispose\(\);[\s\S]*parkTerminal\(/);
   });
 
   it('still disposes directly when the terminal cannot be parked', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
@@ -73,11 +73,55 @@ describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
     expect(afterMainEffect).not.toMatch(/adoptedAtMountRef[\s\S]{0,80}daemon:connected/);
   });
 
-  it('parks on teardown only when the buffer is a faithful copy of the session', () => {
-    // A dirty pane, or one mid-resync, is exactly the case that needs the
-    // replay: adopting it would leave a stale screen with nothing to repair it.
-    expect(mainEffect).toMatch(/const canPark = parkElement !== null\s*\n\s*&& !resyncRef\.current\.pending\s*\n\s*&& !isTerminalDirty\(terminal\);/);
+  // Every clause of canPark is a state in which the adopting mount — which
+  // skips both the restore and the reconnect — would inherit a screen nothing
+  // is coming to repair. Each is pinned separately: a single regex over the
+  // whole condition breaks on formatting and says nothing about WHICH guard
+  // went missing.
+  const canParkBlock = mainEffect.slice(
+    mainEffect.indexOf('const canPark ='),
+    mainEffect.indexOf(';', mainEffect.indexOf('const canPark =')),
+  );
+
+  it.each([
+    ['the element still exists', /parkElement !== null/],
+    ['no resync is in flight', /&& !resyncRef\.current\.pending/],
+    ['the buffer is not dirty', /&& !isTerminalDirty\(terminal\)/],
+    ['the scrollback restore settled', /&& restoreSettled/],
+    ['no .txt cache awaits the daemon verdict', /&& !didRestoreTxt/],
+    ['no daemon reconnect is retrying', /&& !reconnectInFlightRef\.current/],
+    ['this instance still owns the ptyId', /&& terminalRegistry\.get\(ptyId\) === terminal/],
+  ])('parks only when %s', (_label, pattern) => {
+    expect(canParkBlock).toMatch(pattern as RegExp);
+  });
+
+  it('hands the park the element it captured, not a fresh lookup', () => {
     expect(mainEffect).toMatch(/parkTerminal\(ptyId, terminal, parkElement, disposeTerminal\)/);
+  });
+
+  it('settles the restore flag on BOTH the success and the failure path', () => {
+    // A rejected scrollback.load that left restoreSettled false would refuse
+    // every later park on that pane — the fix would silently stop applying.
+    expect(mainEffect.match(/restoreSettled = true;/g)).toHaveLength(2);
+    expect(mainEffect).toMatch(/let restoreSettled = !\(scrollbackFile && !adopted\);/);
+  });
+
+  it('removes the contextmenu listener that outlives a park', () => {
+    // It lives on terminal.element, which a park keeps alive. An anonymous
+    // handler was safe only because terminal.dispose() took the element with
+    // it: without this removal each restructure stacks another handler and one
+    // right-click pastes the clipboard into the shell once per split.
+    expect(mainEffect).toMatch(/const onTerminalContextMenu = \(e: MouseEvent\) =>/);
+    expect(mainEffect).toMatch(/addEventListener\('contextmenu', onTerminalContextMenu\)/);
+    expect(mainEffect).toMatch(/removeEventListener\('contextmenu', onTerminalContextMenu\)/);
+  });
+
+  it('tracks the in-flight reconnect where the park decision can read it', () => {
+    expect(afterMainEffect).toMatch(/reconnectInFlightRef\.current = true;/);
+    expect(afterMainEffect).toMatch(/inFlight = false; reconnectInFlightRef\.current = false;/);
+    // Reset per effect run, mirroring the local guard — a ref left true from a
+    // previous ptyId would disable parking for the rest of the session.
+    expect(afterMainEffect).toMatch(/let inFlight = false;\s*\n\s*reconnectInFlightRef\.current = false;/);
   });
 
   it('reads the resync flag before teardown clears it', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
@@ -95,6 +95,15 @@ describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
     expect(canParkBlock).toMatch(pattern as RegExp);
   });
 
+  it('defers the viewport restore when the adopting container has no size yet', () => {
+    // A restructure on a hidden workspace (an agent splitting a background
+    // pane) adopts into a zero-size container, where there is no valid fit to
+    // restore against. Dropping the parked reading there would leave the pane
+    // wherever the reveal fit happened to land it.
+    expect(mainEffect).toMatch(/\} else if \(adopted\) \{\s*\n\s*pendingAdoptViewport = adopted;/);
+    expect(mainEffect).toMatch(/if \(pendingAdoptViewport\) \{\s*\n\s*restoreParkedViewport\(pendingAdoptViewport\);\s*\n\s*pendingAdoptViewport = null;/);
+  });
+
   it('hands the park the element it captured, not a fresh lookup', () => {
     expect(mainEffect).toMatch(/parkTerminal\(ptyId, terminal, parkElement, disposeTerminal\)/);
   });

--- a/src/renderer/hooks/__tests__/useTerminal.rightClickPasteMouseMode.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.rightClickPasteMouseMode.test.ts
@@ -25,9 +25,11 @@ const SRC = readFileSync(
   'utf8',
 );
 
-// Slice just the contextmenu handler: from its registration to the catch that
-// logs '[wmux:clipboard] right-click error:'.
-const handlerStart = SRC.indexOf("addEventListener('contextmenu'");
+// Slice just the contextmenu handler: from its declaration to the catch that
+// logs '[wmux:clipboard] right-click error:'. Anchored on the declaration, not
+// the addEventListener call — #1002 named the handler so teardown can remove
+// it, which moved the registration below the body.
+const handlerStart = SRC.indexOf('const onTerminalContextMenu =');
 const handlerEnd = SRC.indexOf('right-click error:', handlerStart);
 const HANDLER = SRC.slice(handlerStart, handlerEnd);
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -955,6 +955,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // come with it, so there is no ring-buffer replay for the user to watch.
     const adopted = adoptTerminal(ptyId);
     adoptedAtMountRef.current = adopted !== null;
+    console.log(`[wmux:pane-adopt] ptyId=${ptyId} mount=${adopted ? 'adopted' : 'fresh'}`);
 
     const terminal = adopted ? adopted.terminal : new Terminal({
       cursorBlink: true,
@@ -2393,33 +2394,45 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
       // #1002: can this terminal be handed to the next mount instead of being
       // disposed? Only when every source of truth for this pane has settled on
-      // it. Each clause below is a state where the adopting mount — which skips
+      // it. Each rung below is a state where the adopting mount — which skips
       // the restore AND the reconnect — would inherit a screen that nothing is
       // coming to repair, which is strictly worse than the replay this fix
       // removes. Refusing just falls back to the old behaviour.
+      //
+      // A ladder rather than one `&&` chain because the REASON is the useful
+      // part: adoption can only be validated on the platform that reproduces
+      // the bug, and "the split still replays" is indistinguishable from "a
+      // guard refused" without knowing which one fired.
       const parkElement = terminal.element ?? null;
-      const canPark = parkElement !== null
+      const parkRefusal =
+        parkElement === null ? 'no-element'
         // Mid-resync or dirty: exactly the pane that NEEDS the replay.
-        && !resyncRef.current.pending
-        && !isTerminalDirty(terminal)
+        : resyncRef.current.pending ? 'resync-pending'
+        : isTerminalDirty(terminal) ? 'dirty'
         // Restore still in flight: its callbacks bail on the null terminalRef
         // we are about to write, dropping the .txt content and the pendingData
         // behind it, and the adopting mount would not redo either.
-        && restoreSettled
+        : !restoreSettled ? 'restore-unsettled'
         // A .txt cache is on screen awaiting the daemon's verdict. The
         // late-connect listener that clears it before the ring replay lands
         // dies with this mount, so an adopted pane would compose the replay on
         // top of the cache — the corruption A6 exists to prevent.
-        && !didRestoreTxt
+        : didRestoreTxt ? 'txt-awaiting-verdict'
         // A reconnect is still retrying. It aborts the moment terminalRef goes
         // null (reconnectPtyWithRetry's isCurrent guard), and the adopting
         // mount skips its own active-at-mount attempt, so the pane would end up
         // with no session pipe at all.
-        && !reconnectInFlightRef.current
+        : reconnectInFlightRef.current ? 'reconnect-in-flight'
         // Two live instances on one ptyId (the fast unmount→remount ordering
         // the WebGL pool note describes): if the registry no longer points at
         // us, a later mount already owns this pane and ours is the stale copy.
-        && terminalRegistry.get(ptyId) === terminal;
+        : terminalRegistry.get(ptyId) !== terminal ? 'not-registry-owner'
+        : null;
+      const canPark = parkRefusal === null;
+      // Mirrored into the main log by the webContents console-message relay,
+      // so a dogfood pass on another machine can read the decision instead of
+      // inferring it from what the screen did.
+      console.log(`[wmux:pane-adopt] ptyId=${ptyId} teardown=${canPark ? 'parked' : `disposed reason=${parkRefusal}`}`);
 
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (pendingFitRaf !== null) cancelAnimationFrame(pendingFitRaf);
@@ -2502,7 +2515,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         discardTerminalOutput(terminal);
         disposeWhenDragEnds(() => terminal.dispose());
       };
-      if (canPark) {
+      // The `parkElement` re-test is for the type checker: the ladder above
+      // already refuses with 'no-element' when it is null.
+      if (canPark && parkElement) {
         // The addons above outlive terminal.dispose() only because it disposes
         // them; a parked terminal never reaches that call, and the adopting
         // mount loads its own fit/search/links addons. Release ours here or the

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -52,7 +52,7 @@ import {
   promoteTerminalToPriorityDrain,
 } from '../terminal/terminalOutputScheduler';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
-import { adoptTerminal, parkTerminal, restoreParkedViewport } from '../terminal/terminalPark';
+import { adoptTerminal, parkTerminal, restoreParkedViewport, type ParkedTerminal } from '../terminal/terminalPark';
 
 // Module-level terminal registry for scrollback persistence
 const terminalRegistry = new Map<string, Terminal>();
@@ -1388,6 +1388,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // If the workspace starts hidden (display:none), skip the initial fit so we
     // don't corrupt the terminal with 0 cols/rows. The visibility-watcher effect
     // below will trigger a proper fit when the workspace is shown.
+    // #1002: an adoption whose container has no size yet (a restructure on a
+    // hidden workspace — an agent splitting a background pane, say) has no
+    // valid fit to restore against. Hold the parked viewport until one runs.
+    let pendingAdoptViewport: ParkedTerminal | null = null;
     if (container.offsetWidth > 0 && container.offsetHeight > 0) {
       fitAddon.fit();
       // #1002: the fit runs AFTER the adopted element is back in the DOM and
@@ -1397,6 +1401,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // the bottom, not scrolled up by the height difference between the
       // pre-split and post-split panel.
       if (adopted) restoreParkedViewport(adopted);
+    } else if (adopted) {
+      pendingAdoptViewport = adopted;
     }
 
     // Wait for fonts to fully load, then rebuild the WebGL glyph atlas.
@@ -1485,6 +1491,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           const newYBase = term.buffer.active.baseY;
           const targetYDisp = Math.max(0, newYBase - distFromBottom);
           term.scrollToLine(targetYDisp);
+        }
+
+        // #1002: first real fit after adopting into a hidden container. The
+        // park's own reading wins over the one taken above, which was measured
+        // against a viewport that had no size to be scrolled in.
+        if (pendingAdoptViewport) {
+          restoreParkedViewport(pendingAdoptViewport);
+          pendingAdoptViewport = null;
         }
 
         const { cols, rows } = term;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -52,6 +52,7 @@ import {
   promoteTerminalToPriorityDrain,
 } from '../terminal/terminalOutputScheduler';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
+import { adoptTerminal, parkTerminal, restoreParkedViewport } from '../terminal/terminalPark';
 
 // Module-level terminal registry for scrollback persistence
 const terminalRegistry = new Map<string, Terminal>();
@@ -642,6 +643,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // reattach path, which is keyed on ptyId alone and would otherwise capture a
   // stale value. Seeded to the same optimistic default the daemon holds.
   const viewerVisibleRef = useRef(true);
+  // #1002 — set by the main effect when this mount adopted a parked terminal.
+  // Read by the daemon reattach effect (which runs later in the same commit)
+  // to skip its active-at-mount reconnect: the session pipe never detached, so
+  // asking for one only buys the ring-buffer replay adoption exists to avoid.
+  const adoptedAtMountRef = useRef(false);
   const onFirstDataRef = useRef(onFirstData);
   onFirstDataRef.current = onFirstData;
   const onContextMenuRef = useRef(onContextMenu);
@@ -935,7 +941,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // pays the addEventListener cost.
     _ensureDragListeners();
 
-    const terminal = new Terminal({
+    // #1002: a pane-tree restructure (split, drag-move, sibling collapse)
+    // unmounts and remounts this leaf inside ONE React commit. If the previous
+    // mount parked its terminal on the way out, take it back instead of
+    // building a fresh one — the buffer, the screen and the scroll position
+    // come with it, so there is no ring-buffer replay for the user to watch.
+    const adopted = adoptTerminal(ptyId);
+    adoptedAtMountRef.current = adopted !== null;
+
+    const terminal = adopted ? adopted.terminal : new Terminal({
       cursorBlink: true,
       cursorStyle: terminalCursorStyle,
       fontSize: terminalFontSize,
@@ -1051,15 +1065,22 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         });
       },
     }));
-    // Activate Unicode 11 width tables — required for correct CJK / emoji
-    // width. Without this, xterm defaults to v6 and TUI apps that use cursor
-    // positioning (Claude Code, vim, etc.) collide frames over Korean text.
-    // Shared with the daemon's snapshot terminals through this helper; if the
-    // two sides ever measure differently, a restored snapshot paints
-    // cell-shifted against the live screen.
-    applyUnicodeWidthModel(terminal);
-    terminal.open(container);
-
+    if (adopted) {
+      // Adoption is a DOM move, not an open(): xterm keeps its element, and
+      // re-opening would rebuild the screen we are trying to preserve. The
+      // element is detached at this point (React removed the old container
+      // before flushing passive effects), so appending is all that is left.
+      container.appendChild(adopted.element);
+    } else {
+      // Activate Unicode 11 width tables — required for correct CJK / emoji
+      // width. Without this, xterm defaults to v6 and TUI apps that use cursor
+      // positioning (Claude Code, vim, etc.) collide frames over Korean text.
+      // Shared with the daemon's snapshot terminals through this helper; if the
+      // two sides ever measure differently, a restored snapshot paints
+      // cell-shifted against the live screen.
+      applyUnicodeWidthModel(terminal);
+      terminal.open(container);
+    }
     // Grok lives on the alt screen, where xterm has no scrollback and turns the
     // wheel into Up/Down — which Grok's prompt-focused view reads as history,
     // not conversation scroll. PageUp/PageDown is what Grok documents instead.
@@ -1362,6 +1383,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // below will trigger a proper fit when the workspace is shown.
     if (container.offsetWidth > 0 && container.offsetHeight > 0) {
       fitAddon.fit();
+      // #1002: the fit runs AFTER the adopted element is back in the DOM and
+      // can change how many rows the viewport holds, which moves what "the
+      // bottom" means — so put the user's scroll position back on this side of
+      // it. A pane parked at the bottom (the case the issue is about) lands at
+      // the bottom, not scrolled up by the height difference between the
+      // pre-split and post-split panel.
+      if (adopted) restoreParkedViewport(adopted);
     }
 
     // Wait for fonts to fully load, then rebuild the WebGL glyph atlas.
@@ -2063,7 +2091,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       });
     };
 
-    if (scrollbackFile) {
+    // #1002: an adopted terminal carries its own buffer across the restructure,
+    // so the `.txt` restore below would write a second copy of the scrollback
+    // over the screen it is meant to reproduce. It takes the fresh-terminal
+    // branch instead: listeners and registry, no replay.
+    if (scrollbackFile && !adopted) {
       // Register PTY listeners immediately to avoid data loss during scrollback load.
       // scrollback.load() is async (IPC round-trip). If PTY sends data before it
       // resolves, connectPty() would not yet be called and data would be lost.
@@ -2229,8 +2261,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       });
     } else {
       connectPty();
-      // No scrollback to restore — register immediately for fresh terminals.
+      // Nothing to restore (fresh terminal, or one adopted with its buffer
+      // intact) — register immediately.
       registerTerminal(ptyId, terminal);
+      // #1002: an adopted terminal is already showing the session, so the
+      // restore overlay Terminal.tsx raises for a scrollbackFile pane has
+      // nothing to wait for. Clearing it here instead of leaving it to the 3 s
+      // fallback keeps a split from drawing a "restoring" curtain over a screen
+      // that never went away — the exact flash this fix exists to remove.
+      if (adopted) fireFirstData();
       // Fix D — daemon (re)attach is owned by the daemon-mode effect below
       // (fires at mount if active, or on a later daemon:connected). connectPty
       // above has already registered pty.onData/onExit, so replay lands safely.
@@ -2262,7 +2301,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     // Terminal registry registration is now per-branch above:
     //   - scrollback branch: after restore completes (Race B guard)
-    //   - fresh branch: immediately after connectPty()
+    //   - fresh/adopted branch: immediately after connectPty()
 
     terminalRef.current = terminal;
     fitAddonRef.current = fitAddon;
@@ -2315,6 +2354,16 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // so release the replay mute here rather than leaving the next terminal
       // that reuses this hook unable to accept a clipboard write.
       resetReplayMute(replayMuteRef.current);
+
+      // #1002: can this terminal be handed to the next mount instead of being
+      // disposed? Only when its buffer is a faithful copy of the session — a
+      // dirty pane or one mid-resync is exactly the case that NEEDS the replay,
+      // and adopting it would leave a stale screen with nothing to repair it.
+      const parkElement = terminal.element ?? null;
+      const canPark = parkElement !== null
+        && !resyncRef.current.pending
+        && !isTerminalDirty(terminal);
+
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (pendingFitRaf !== null) cancelAnimationFrame(pendingFitRaf);
       if (isMac) { container.removeEventListener('paste', blockNativePaste, true); }
@@ -2379,8 +2428,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
       // Drop any output still queued in the shared scheduler — the terminal
       // is being disposed, parsing the backlog would be wasted work and a
-      // post-dispose drain write would throw.
-      discardTerminalOutput(terminal);
+      // post-dispose drain write would throw. A PARKED terminal keeps its
+      // queue: it is the same instance the next mount will drain, and there is
+      // no resync behind it to replace what we would discard here (#1002).
+      if (!canPark) discardTerminalOutput(terminal);
       // #582: defer terminal.dispose() if a mouse drag is active on any
       // terminal. xterm nullifies _renderService before removing its
       // document-level mouseup/mousemove listeners — a mouseup landing on the
@@ -2389,7 +2440,26 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // (including onData, so no stray input flows during the wait), so
       // deferring only the internal dispose is safe. See disposeWhenDragEnds
       // for the wait/force policy.
-      disposeWhenDragEnds(() => terminal.dispose());
+      const disposeTerminal = () => {
+        discardTerminalOutput(terminal);
+        disposeWhenDragEnds(() => terminal.dispose());
+      };
+      if (canPark) {
+        // The addons above outlive terminal.dispose() only because it disposes
+        // them; a parked terminal never reaches that call, and the adopting
+        // mount loads its own fit/search/links addons. Release ours here or the
+        // instance accumulates one set per restructure.
+        fitAddon.dispose();
+        searchAddon.dispose();
+        webLinksAddon.dispose();
+        // parkTerminal owns the dispose from here: it runs it if no mount
+        // claims the terminal inside the park window, which is every case
+        // except a tree restructure — a closed pane still disposes, just 250 ms
+        // later than it used to.
+        parkTerminal(ptyId, terminal, parkElement, disposeTerminal);
+      } else {
+        disposeWhenDragEnds(() => terminal.dispose());
+      }
       terminalRef.current = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;
@@ -2445,7 +2515,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Daemon already connected when we mounted: its daemon:connected fired before
     // the renderer could listen, so we reattach now off the module flag (set by
     // AppLayout's serialized startup before the pane gate opens).
-    if (isDaemonModeActive()) reattach('active-at-mount');
+    // #1002: an adopting mount is still attached — its predecessor unmounted
+    // microseconds ago and nothing detached the session. Only the fresh-mount
+    // case needs the reconnect. Later connect/respawn events below are NOT
+    // gated: those are real daemon generations that must reattach.
+    if (isDaemonModeActive() && !adoptedAtMountRef.current) reattach('active-at-mount');
     // Every LATER connect/respawn reattaches to the new daemon generation.
     // Codex P2: do NOT gate this on isDaemonModeActive() and do NOT latch it —
     // (a) our listener can run before AppLayout's flips the module flag true, so

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -643,6 +643,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // reattach path, which is keyed on ptyId alone and would otherwise capture a
   // stale value. Seeded to the same optimistic default the daemon holds.
   const viewerVisibleRef = useRef(true);
+  // #1002 — true while this pane's daemon reattach is still retrying. The park
+  // decision reads it: reconnectPtyWithRetry bails the moment terminalRef goes
+  // null, so a restructure mid-reconnect kills the attempt, and an adopting
+  // mount that also skips its own active-at-mount reconnect would leave the
+  // pane with no session pipe at all. Reset per effect run, like the local
+  // in-flight guard it mirrors.
+  const reconnectInFlightRef = useRef(false);
   // #1002 — set by the main effect when this mount adopted a parked terminal.
   // Read by the daemon reattach effect (which runs later in the same commit)
   // to skip its active-at-mount reconnect: the session pipe never detached, so
@@ -1763,7 +1770,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // so the paste branch can suppress a paste that lands within
     // RIGHT_CLICK_PASTE_SUPPRESS_MS — the fix for the copy↔paste collision.
     let lastRightClickCopyAt = 0;
-    terminal.element?.addEventListener('contextmenu', (e) => {
+    // Named, and removed on teardown (#1002): this listener lives on
+    // terminal.element, which survives a park. terminal.dispose() used to take
+    // the element with it, so an anonymous handler was safe; with adoption it
+    // is not — each restructure would stack another handler, and one
+    // right-click would paste the clipboard into the shell once per split.
+    const onTerminalContextMenu = (e: MouseEvent) => {
       e.preventDefault();
 
       // Detect if right-click target is a link element
@@ -1860,7 +1872,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           }
         }
       })().catch((err) => console.error('[wmux:clipboard] right-click error:', err));
-    });
+    };
+    terminal.element?.addEventListener('contextmenu', onTerminalContextMenu);
 
     // Drag-and-drop is handled globally in preload via webUtils.getPathForFile()
 
@@ -1934,6 +1947,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // for `daemon:connected` — when it fires, clear + reset the terminal
     // before SessionPipe replay arrives, so the daemon flush lands on a
     // fresh xterm with no stale prefix.
+    // #1002 — has the scrollback restore finished with this terminal? The park
+    // decision reads it: the restore's own callbacks bail on
+    // `terminalRef.current !== terminal`, so parking mid-restore drops both the
+    // `.txt` content and the pendingData buffered behind it, and the adopting
+    // mount skips the restore entirely — a pane with no history that the
+    // autosave then writes back over the file it lost.
+    let restoreSettled = !(scrollbackFile && !adopted);
     let didRestoreTxt = false;
     let removeDaemonConnectedForRestore: (() => void) | null = null;
     // Flush-marker reset gating (see docs/internal/scrollback-restore-design.md).
@@ -2220,6 +2240,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           });
         }
         scrollbackLoaded = true;
+        restoreSettled = true;
         // P0-1 (app-weight review, Codex Eng #1): route the buffered boot
         // bytes through routePtyData — NOT terminal.write — so a hidden
         // boot-restored pane obeys retention (queue, don't parse) and a
@@ -2251,6 +2272,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         console.error(`[useTerminal] scrollback.load FAILED surfaceFile=${scrollbackFile} ptyId=${ptyId} err=${msg}`);
         if (terminalRef.current !== terminal) return;
         scrollbackLoaded = true;
+        restoreSettled = true;
         // Same retention-aware routing as the success path above (P0-1).
         for (const data of pendingData) {
           routePtyData(data);
@@ -2356,13 +2378,34 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       resetReplayMute(replayMuteRef.current);
 
       // #1002: can this terminal be handed to the next mount instead of being
-      // disposed? Only when its buffer is a faithful copy of the session — a
-      // dirty pane or one mid-resync is exactly the case that NEEDS the replay,
-      // and adopting it would leave a stale screen with nothing to repair it.
+      // disposed? Only when every source of truth for this pane has settled on
+      // it. Each clause below is a state where the adopting mount — which skips
+      // the restore AND the reconnect — would inherit a screen that nothing is
+      // coming to repair, which is strictly worse than the replay this fix
+      // removes. Refusing just falls back to the old behaviour.
       const parkElement = terminal.element ?? null;
       const canPark = parkElement !== null
+        // Mid-resync or dirty: exactly the pane that NEEDS the replay.
         && !resyncRef.current.pending
-        && !isTerminalDirty(terminal);
+        && !isTerminalDirty(terminal)
+        // Restore still in flight: its callbacks bail on the null terminalRef
+        // we are about to write, dropping the .txt content and the pendingData
+        // behind it, and the adopting mount would not redo either.
+        && restoreSettled
+        // A .txt cache is on screen awaiting the daemon's verdict. The
+        // late-connect listener that clears it before the ring replay lands
+        // dies with this mount, so an adopted pane would compose the replay on
+        // top of the cache — the corruption A6 exists to prevent.
+        && !didRestoreTxt
+        // A reconnect is still retrying. It aborts the moment terminalRef goes
+        // null (reconnectPtyWithRetry's isCurrent guard), and the adopting
+        // mount skips its own active-at-mount attempt, so the pane would end up
+        // with no session pipe at all.
+        && !reconnectInFlightRef.current
+        // Two live instances on one ptyId (the fast unmount→remount ordering
+        // the WebGL pool note describes): if the registry no longer points at
+        // us, a later mount already owns this pane and ours is the stale copy.
+        && terminalRegistry.get(ptyId) === terminal;
 
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (pendingFitRaf !== null) cancelAnimationFrame(pendingFitRaf);
@@ -2370,6 +2413,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       detachAltScreenWheel();
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
       terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
+      terminal.element?.removeEventListener('contextmenu', onTerminalContextMenu);
       glyphRepaint.dispose();
       glyphRepaintRef.current = null;
       unregisterAtlasGuard();
@@ -2453,9 +2497,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         searchAddon.dispose();
         webLinksAddon.dispose();
         // parkTerminal owns the dispose from here: it runs it if no mount
-        // claims the terminal inside the park window, which is every case
-        // except a tree restructure — a closed pane still disposes, just 250 ms
-        // later than it used to.
+        // claims the terminal before this task ends, which is every case except
+        // a tree restructure — a closed pane still disposes, one task later
+        // than it used to.
         parkTerminal(ptyId, terminal, parkElement, disposeTerminal);
       } else {
         disposeWhenDragEnds(() => terminal.dispose());
@@ -2490,9 +2534,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // permanent latch — once an attempt settles, a later connect/respawn
     // reattaches again. Lives in the effect-run closure so it resets per ptyId.
     let inFlight = false;
+    reconnectInFlightRef.current = false;
     const reattach = (reason: string) => {
       if (inFlight) return;
       inFlight = true;
+      reconnectInFlightRef.current = true;
       // #998: the RingBuffer replay this triggers arrives as ordinary
       // pty:data, so there is no write of ours to hang the mute on — open a
       // window here and let the data flow close it.
@@ -2510,7 +2556,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           if (ptyIdRef.current !== id) return;
           reportViewerVisibility(id, viewerVisibleRef.current);
         })
-        .finally(() => { inFlight = false; });
+        .finally(() => { inFlight = false; reconnectInFlightRef.current = false; });
     };
     // Daemon already connected when we mounted: its daemon:connected fired before
     // the renderer could listen, so we reattach now off the module flag (set by

--- a/src/renderer/terminal/__tests__/terminalPark.test.ts
+++ b/src/renderer/terminal/__tests__/terminalPark.test.ts
@@ -47,7 +47,7 @@ describe('terminalPark', () => {
     expect(adopted?.terminal).toBe(asTerminal(term));
     expect(dispose).not.toHaveBeenCalled();
     // Claiming transfers ownership: the pending dispose must be cancelled, or
-    // the adopting mount's terminal dies 250 ms into its life.
+    // the adopting mount's terminal dies the moment the task ends.
     vi.advanceTimersByTime(PARK_TTL_MS * 4);
     expect(dispose).not.toHaveBeenCalled();
     expect(__isParked('pty-1')).toBe(false);
@@ -137,6 +137,34 @@ describe('terminalPark', () => {
 
       expect(term.scrollToLine).toHaveBeenCalledWith(120);
       expect(term.scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    it('measures against the CURRENT bottom, so a reflow does not misplace the reader', () => {
+      // The split changes the pane's width, and on a reflow-capable buffer that
+      // rewraps every line — the absolute row the user was reading is not the
+      // same row afterwards. Restoring by distance-from-bottom lands them near
+      // what they were reading instead of somewhere else entirely.
+      const term = fakeTerminal(400, 500); // 100 rows up from the bottom
+      parkTerminal('pty-1', asTerminal(term), fakeElement(), vi.fn());
+      const adopted = adoptTerminal('pty-1');
+
+      term.buffer.active.baseY = 620; // the fit rewrapped: 120 more rows exist
+
+      restoreParkedViewport(adopted!);
+
+      expect(term.scrollToLine).toHaveBeenCalledWith(520);
+    });
+
+    it('never scrolls above the top of the buffer', () => {
+      const term = fakeTerminal(10, 500);
+      parkTerminal('pty-1', asTerminal(term), fakeElement(), vi.fn());
+      const adopted = adoptTerminal('pty-1');
+
+      term.buffer.active.baseY = 30; // rewrapped far shorter than the offset
+
+      restoreParkedViewport(adopted!);
+
+      expect(term.scrollToLine).toHaveBeenCalledWith(0);
     });
 
     it('does not take the adopting mount down when scrolling throws', () => {

--- a/src/renderer/terminal/__tests__/terminalPark.test.ts
+++ b/src/renderer/terminal/__tests__/terminalPark.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+import {
+  parkTerminal,
+  adoptTerminal,
+  restoreParkedViewport,
+  PARK_TTL_MS,
+  __resetTerminalPark,
+  __isParked,
+} from '../terminalPark';
+
+// #1002. The park window exists so a pane-tree restructure — split, drag-move,
+// sibling collapse — can hand its xterm to the mount that replaces it instead
+// of disposing it and watching the daemon replay the whole conversation back.
+// Everything here is about the two halves of that contract: an adopter inside
+// the window gets the SAME instance, and no adopter means the terminal is
+// disposed exactly as it was before this module existed.
+
+interface FakeTerminal {
+  buffer: { active: { viewportY: number; baseY: number } };
+  scrollToBottom: ReturnType<typeof vi.fn>;
+  scrollToLine: ReturnType<typeof vi.fn>;
+}
+
+function fakeTerminal(viewportY = 100, baseY = 100): FakeTerminal {
+  return {
+    buffer: { active: { viewportY, baseY } },
+    scrollToBottom: vi.fn(),
+    scrollToLine: vi.fn(),
+  };
+}
+
+const asTerminal = (t: FakeTerminal): Terminal => t as unknown as Terminal;
+const fakeElement = (): HTMLElement => ({ tagName: 'DIV' } as unknown as HTMLElement);
+
+describe('terminalPark', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { __resetTerminalPark(); vi.useRealTimers(); });
+
+  it('hands the same terminal back to a mount that adopts inside the window', () => {
+    const term = fakeTerminal();
+    const dispose = vi.fn();
+    parkTerminal('pty-1', asTerminal(term), fakeElement(), dispose);
+
+    const adopted = adoptTerminal('pty-1');
+
+    expect(adopted?.terminal).toBe(asTerminal(term));
+    expect(dispose).not.toHaveBeenCalled();
+    // Claiming transfers ownership: the pending dispose must be cancelled, or
+    // the adopting mount's terminal dies 250 ms into its life.
+    vi.advanceTimersByTime(PARK_TTL_MS * 4);
+    expect(dispose).not.toHaveBeenCalled();
+    expect(__isParked('pty-1')).toBe(false);
+  });
+
+  it('disposes on the caller\'s behalf when nobody adopts — a closed pane', () => {
+    const dispose = vi.fn();
+    parkTerminal('pty-1', asTerminal(fakeTerminal()), fakeElement(), dispose);
+
+    expect(dispose).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(PARK_TTL_MS);
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(adoptTerminal('pty-1')).toBeNull();
+  });
+
+  it('disposes only once, even if the ttl fires after an eviction attempt', () => {
+    const dispose = vi.fn();
+    parkTerminal('pty-1', asTerminal(fakeTerminal()), fakeElement(), dispose);
+    vi.advanceTimersByTime(PARK_TTL_MS);
+    vi.advanceTimersByTime(PARK_TTL_MS * 10);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys parks by ptyId, so one pane never adopts another pane\'s terminal', () => {
+    const one = fakeTerminal();
+    const two = fakeTerminal();
+    parkTerminal('pty-1', asTerminal(one), fakeElement(), vi.fn());
+    parkTerminal('pty-2', asTerminal(two), fakeElement(), vi.fn());
+
+    expect(adoptTerminal('pty-2')?.terminal).toBe(asTerminal(two));
+    expect(adoptTerminal('pty-1')?.terminal).toBe(asTerminal(one));
+    expect(adoptTerminal('pty-3')).toBeNull();
+  });
+
+  it('disposes immediately rather than parking an empty ptyId', () => {
+    const dispose = vi.fn();
+    parkTerminal('', asTerminal(fakeTerminal()), fakeElement(), dispose);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(adoptTerminal('')).toBeNull();
+  });
+
+  it('releases the older instance when a second park lands on one ptyId', () => {
+    // Two live terminals on one ptyId is the unmount/remount race the WebGL
+    // pool comment already warns about. The first is unreachable once the
+    // second parks, so it must be disposed rather than leaked.
+    const firstDispose = vi.fn();
+    const second = fakeTerminal();
+    parkTerminal('pty-1', asTerminal(fakeTerminal()), fakeElement(), firstDispose);
+    parkTerminal('pty-1', asTerminal(second), fakeElement(), vi.fn());
+
+    expect(firstDispose).toHaveBeenCalledTimes(1);
+    expect(adoptTerminal('pty-1')?.terminal).toBe(asTerminal(second));
+  });
+
+  it('parks a terminal whose buffer cannot be read', () => {
+    const hostile = {
+      get buffer(): never { throw new Error('disposed'); },
+      scrollToBottom: vi.fn(),
+      scrollToLine: vi.fn(),
+    } as unknown as Terminal;
+    const dispose = vi.fn();
+
+    expect(() => parkTerminal('pty-1', hostile, fakeElement(), dispose)).not.toThrow();
+    expect(adoptTerminal('pty-1')?.atBottom).toBe(true);
+  });
+
+  describe('viewport restoration', () => {
+    it('puts a pane that was pinned to the bottom back at the bottom', () => {
+      // The #1002 case: the pane is at the latest output when the user splits.
+      const term = fakeTerminal(500, 500);
+      parkTerminal('pty-1', asTerminal(term), fakeElement(), vi.fn());
+      const adopted = adoptTerminal('pty-1');
+
+      restoreParkedViewport(adopted!);
+
+      expect(term.scrollToBottom).toHaveBeenCalledTimes(1);
+      expect(term.scrollToLine).not.toHaveBeenCalled();
+    });
+
+    it('puts a pane scrolled back into history back where it was', () => {
+      const term = fakeTerminal(120, 500);
+      parkTerminal('pty-1', asTerminal(term), fakeElement(), vi.fn());
+      const adopted = adoptTerminal('pty-1');
+
+      restoreParkedViewport(adopted!);
+
+      expect(term.scrollToLine).toHaveBeenCalledWith(120);
+      expect(term.scrollToBottom).not.toHaveBeenCalled();
+    });
+
+    it('does not take the adopting mount down when scrolling throws', () => {
+      const term = fakeTerminal(500, 500);
+      term.scrollToBottom.mockImplementation(() => { throw new Error('disposed'); });
+      parkTerminal('pty-1', asTerminal(term), fakeElement(), vi.fn());
+      const adopted = adoptTerminal('pty-1');
+
+      expect(() => restoreParkedViewport(adopted!)).not.toThrow();
+    });
+  });
+});

--- a/src/renderer/terminal/terminalPark.ts
+++ b/src/renderer/terminal/terminalPark.ts
@@ -19,19 +19,29 @@ import type { Terminal } from '@xterm/xterm';
 // adopts it — moving its DOM element into the new container, buffer, scroll
 // position and all — so there is nothing to replay.
 //
-// The window is deliberately tiny. React flushes a commit's passive UNMOUNT
-// effects before its passive MOUNT effects, so a restructure parks and adopts
-// inside one synchronous flush; no timer can fire in between. The TTL is slack
-// for a commit that gets split, not a cache: a pane the user actually closed
-// never comes back for its terminal, and 250 ms later it is disposed exactly as
-// before.
+// The window is exactly one task, and that is a safety property rather than a
+// tuning choice. React flushes a commit's passive UNMOUNT effects before its
+// passive MOUNT effects, so a restructure parks and adopts inside one
+// synchronous flush — a `setTimeout(…, 0)` armed during the park cannot run
+// until after the adopting mount has had its turn.
+//
+// Holding the park open any longer would be the dangerous direction. Between
+// park and adopt this pane has no PTY data listener, and the adopting mount
+// skips the reconnect that would replay what it missed; bytes arriving in a gap
+// would be lost with nothing coming to repair the screen. Confining adoption to
+// the same task means a restructure that somehow spanned two of them simply
+// fails to adopt and disposes as it always did — no improvement, but never a
+// silently wrong screen.
 
 export interface ParkedTerminal {
   terminal: Terminal;
   /** xterm's root element, detached with the old container but still intact. */
   element: HTMLElement;
-  /** Viewport row at park time, restored after the adopting mount fits. */
-  viewportY: number;
+  /** Rows between the viewport and the bottom at park time. Absolute buffer
+   *  indices do not survive the reflow a width change causes, and a split
+   *  always changes width — the offset does, well enough to land the reader
+   *  near what they were reading. */
+  fromBottom: number;
   /** Whether the pane was pinned to the bottom (the common case). */
   atBottom: boolean;
 }
@@ -41,8 +51,8 @@ interface ParkEntry extends ParkedTerminal {
   dispose: () => void;
 }
 
-/** Slack for a split commit, not a cache lifetime. See the note above. */
-export const PARK_TTL_MS = 250;
+/** One task. Not a cache lifetime — see the note above before raising it. */
+export const PARK_TTL_MS = 0;
 
 const parked = new Map<string, ParkEntry>();
 
@@ -71,12 +81,12 @@ export function parkTerminal(
   // older one is unreachable, so let it go rather than leaking it.
   evict(ptyId);
 
-  let viewportY = 0;
+  let fromBottom = 0;
   let atBottom = true;
   try {
     const buffer = terminal.buffer.active;
-    viewportY = buffer.viewportY;
-    atBottom = buffer.viewportY >= buffer.baseY;
+    fromBottom = Math.max(0, buffer.baseY - buffer.viewportY);
+    atBottom = fromBottom === 0;
   } catch {
     // A terminal too far into teardown to read still parks — the adopting
     // mount just falls back to scrolling to the bottom.
@@ -87,7 +97,7 @@ export function parkTerminal(
     dispose();
   }, ttlMs);
 
-  parked.set(ptyId, { terminal, element, viewportY, atBottom, timer, dispose });
+  parked.set(ptyId, { terminal, element, fromBottom, atBottom, timer, dispose });
 }
 
 /**
@@ -100,8 +110,8 @@ export function adoptTerminal(ptyId: string): ParkedTerminal | null {
   if (!entry) return null;
   parked.delete(ptyId);
   clearTimeout(entry.timer);
-  const { terminal, element, viewportY, atBottom } = entry;
-  return { terminal, element, viewportY, atBottom };
+  const { terminal, element, fromBottom, atBottom } = entry;
+  return { terminal, element, fromBottom, atBottom };
 }
 
 /**
@@ -111,8 +121,11 @@ export function adoptTerminal(ptyId: string): ParkedTerminal | null {
  */
 export function restoreParkedViewport(entry: ParkedTerminal): void {
   try {
-    if (entry.atBottom) entry.terminal.scrollToBottom();
-    else entry.terminal.scrollToLine(entry.viewportY);
+    if (entry.atBottom) { entry.terminal.scrollToBottom(); return; }
+    // Measured against the CURRENT bottom: the fit that just ran can have
+    // rewrapped the buffer, moving every absolute row number.
+    const baseY = entry.terminal.buffer.active.baseY;
+    entry.terminal.scrollToLine(Math.max(0, baseY - entry.fromBottom));
   } catch {
     // Scroll restoration is cosmetic; a disposed or unsized terminal must not
     // take the mount down with it.

--- a/src/renderer/terminal/terminalPark.ts
+++ b/src/renderer/terminal/terminalPark.ts
@@ -1,0 +1,131 @@
+import type { Terminal } from '@xterm/xterm';
+
+// #1002 — terminal adoption across a pane-tree restructure.
+//
+// Splitting a pane replaces the target leaf with a NEW branch node that holds
+// the old leaf as a child (paneSlice.splitPane). React resolves that as an
+// unmount + mount of the surviving leaf: either the component type changes
+// (`<Pane>` → `<Group>` at the workspace root) or the parent Fragment's key
+// changes from the leaf id to the new branch id. Dragging a pane and closing a
+// sibling that collapses a branch restructure the tree the same way.
+//
+// The unmount tore down the xterm instance, so the remount built a fresh one
+// and refilled it from the daemon ring buffer — the user watched the whole
+// conversation get written from the top and land at the bottom. Nothing had
+// restarted; only the view was destroyed and replayed.
+//
+// This module is the other half of that: on teardown the hook hands the live
+// Terminal here instead of disposing it, and the next mount on the same ptyId
+// adopts it — moving its DOM element into the new container, buffer, scroll
+// position and all — so there is nothing to replay.
+//
+// The window is deliberately tiny. React flushes a commit's passive UNMOUNT
+// effects before its passive MOUNT effects, so a restructure parks and adopts
+// inside one synchronous flush; no timer can fire in between. The TTL is slack
+// for a commit that gets split, not a cache: a pane the user actually closed
+// never comes back for its terminal, and 250 ms later it is disposed exactly as
+// before.
+
+export interface ParkedTerminal {
+  terminal: Terminal;
+  /** xterm's root element, detached with the old container but still intact. */
+  element: HTMLElement;
+  /** Viewport row at park time, restored after the adopting mount fits. */
+  viewportY: number;
+  /** Whether the pane was pinned to the bottom (the common case). */
+  atBottom: boolean;
+}
+
+interface ParkEntry extends ParkedTerminal {
+  timer: ReturnType<typeof setTimeout>;
+  dispose: () => void;
+}
+
+/** Slack for a split commit, not a cache lifetime. See the note above. */
+export const PARK_TTL_MS = 250;
+
+const parked = new Map<string, ParkEntry>();
+
+function evict(ptyId: string): void {
+  const entry = parked.get(ptyId);
+  if (!entry) return;
+  parked.delete(ptyId);
+  clearTimeout(entry.timer);
+  entry.dispose();
+}
+
+/**
+ * Hand a live terminal over instead of disposing it. `dispose` is the caller's
+ * own teardown — it runs if nobody adopts within the TTL, so the no-adopter
+ * path stays byte-identical to the pre-#1002 behaviour.
+ */
+export function parkTerminal(
+  ptyId: string,
+  terminal: Terminal,
+  element: HTMLElement,
+  dispose: () => void,
+  ttlMs: number = PARK_TTL_MS,
+): void {
+  if (!ptyId) { dispose(); return; }
+  // A second park on one ptyId means two live instances existed for it; the
+  // older one is unreachable, so let it go rather than leaking it.
+  evict(ptyId);
+
+  let viewportY = 0;
+  let atBottom = true;
+  try {
+    const buffer = terminal.buffer.active;
+    viewportY = buffer.viewportY;
+    atBottom = buffer.viewportY >= buffer.baseY;
+  } catch {
+    // A terminal too far into teardown to read still parks — the adopting
+    // mount just falls back to scrolling to the bottom.
+  }
+
+  const timer = setTimeout(() => {
+    parked.delete(ptyId);
+    dispose();
+  }, ttlMs);
+
+  parked.set(ptyId, { terminal, element, viewportY, atBottom, timer, dispose });
+}
+
+/**
+ * Claim the terminal parked for this ptyId, if any. Claiming cancels the
+ * pending dispose — from here on the adopting mount owns the instance.
+ */
+export function adoptTerminal(ptyId: string): ParkedTerminal | null {
+  if (!ptyId) return null;
+  const entry = parked.get(ptyId);
+  if (!entry) return null;
+  parked.delete(ptyId);
+  clearTimeout(entry.timer);
+  const { terminal, element, viewportY, atBottom } = entry;
+  return { terminal, element, viewportY, atBottom };
+}
+
+/**
+ * Put the adopted viewport back where the user left it. Call this AFTER the
+ * adopting mount has fitted, since a fit can change how many rows the viewport
+ * holds and therefore what "the bottom" means.
+ */
+export function restoreParkedViewport(entry: ParkedTerminal): void {
+  try {
+    if (entry.atBottom) entry.terminal.scrollToBottom();
+    else entry.terminal.scrollToLine(entry.viewportY);
+  } catch {
+    // Scroll restoration is cosmetic; a disposed or unsized terminal must not
+    // take the mount down with it.
+  }
+}
+
+/** Test seam: drop every park without running its dispose. */
+export function __resetTerminalPark(): void {
+  for (const entry of parked.values()) clearTimeout(entry.timer);
+  parked.clear();
+}
+
+/** Test seam: is a terminal currently parked for this ptyId? */
+export function __isParked(ptyId: string): boolean {
+  return parked.has(ptyId);
+}


### PR DESCRIPTION
Fixes #1002.

## Problem

Splitting a pane makes the pane you were reading scroll its whole conversation
from the top and land at the bottom. The pane never restarted — the shell and
the agent are untouched — but the view was destroyed and re-filled.

`splitPane` (`src/renderer/stores/slices/paneSlice.ts:502`) replaces the target
leaf with a **new** branch node carrying a fresh id, holding the old leaf as a
child. React resolves that by unmounting:

- leaf was the workspace root → `PaneContainer` switches from `<Pane>` to
  `<Group>` at the same position (different component type);
- leaf had a parent → the parent's `<Fragment key={child.id}>` key changes from
  the leaf id to the new branch id.

The unmount tears down the xterm instance, the remount builds a fresh one and
refills it from the daemon ring buffer, and that replay arrives in chunks.
Dragging a pane and closing a sibling that collapses a branch restructure the
tree the same way, so the same flash is reachable without a split at all.

## Fix

Teardown parks the live terminal by ptyId instead of disposing it
(`src/renderer/terminal/terminalPark.ts`), and the next mount on that ptyId
adopts it — the element moves into the new container with its buffer, screen
and scroll position intact, so there is nothing to replay.

React flushes a commit's passive **unmount** effects before its passive
**mount** effects, so a restructure parks and adopts inside one synchronous
flush; no timer fires and no PTY byte arrives in between. The 250 ms TTL is
slack for a split commit, not a cache — a pane the user actually closed never
comes back for its terminal and disposes exactly as before, just later.

Three things the adopting mount must skip, because each one *is* the replay:

| step | why it is skipped |
|---|---|
| `terminal.open(container)` | rebuilds the screen adoption preserves; adoption is a DOM move |
| the `.txt` scrollback restore | the adopted buffer already holds it — restoring writes a second copy |
| `active-at-mount` daemon reconnect | the session pipe never detached, so the reconnect buys only the ring-buffer flush |

Later `daemon:connected` and `pty:restarted` reattaches are **not** gated —
those are real new daemon generations that must reattach.

Parking is refused when the buffer is not a faithful copy of the session
(`isTerminalDirty`, or a resync in flight): that is exactly the case that needs
the replay, and adopting it would leave a stale screen with nothing to repair
it. Those dispose on the old path.

Two smaller consequences handled here:

- **The queued output survives with the instance.** `discardTerminalOutput` is
  skipped on the park path — the queue belongs to the terminal the next mount
  will drain, and unlike the dispose path no resync follows to replace what we
  would drop.
- **No "restoring" curtain.** `Terminal.tsx` raises the restore overlay for any
  `scrollbackFile` pane and drops it on first data. An adopted pane has no
  replay coming, so the mount clears it directly instead of leaving it to the
  3 s fallback — otherwise the fix would trade a scroll-from-the-top flash for
  a blank one.

## Verification

- `src/renderer/terminal/__tests__/terminalPark.test.ts` — 10 tests over the
  park contract: adoption inside the window returns the same instance and
  cancels the pending dispose; no adopter disposes exactly once; parks are keyed
  by ptyId; a second park on one ptyId releases the older instance rather than
  leaking it; viewport restoration for a bottom-pinned pane and for one scrolled
  back into history.
- `src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts` — 11
  source-level locks, matching the existing daemon-reattach and A6 race-cancel
  tests (`useTerminal` is a 2600-line xterm-bound effect that is not reachable
  from a unit test). They pin the ordering that makes the fix work: adopt before
  construct, exactly one `terminal.open` and only on the fresh side, the restore
  gated on `!adopted`, the reattach suppression narrowed to `active-at-mount`,
  and `canPark` computed **before** `cancelResync` clears the flag it reads.
- `useTerminal.daemonReattach.test.ts` — one assertion widened. It pinned the
  at-mount reattach as `if (isDaemonModeActive()) reattach(`, which now carries
  a second term. The invariant it locks (this call, and only this call, sits
  behind the module flag; `reattach` itself never re-checks it) is unchanged.
- Full suite: 11,916 passing. `tsc --noEmit` clean. No new lint findings.

## What still needs a human

The repro is Windows 10 and I could only exercise this on macOS, so the DOM move
itself — xterm keeping its renderer across a reparent, and the WebGL addon
re-loading onto the adopted instance — has not been watched on the reporter's
platform. This wants a dogfood pass on the three restructure paths (split,
drag-move, sibling collapse) before it lands, not a green test suite.

## Review pass

Three independent reviewers went over the first two commits. Twelve findings,
ten of them acted on; the two declined are recorded below rather than dropped.

The one real leak was the `contextmenu` listener at `useTerminal.ts:1712`: an
anonymous handler on `terminal.element`, removed only by `terminal.dispose()`
taking the element with it. A parked element outlives that, so every restructure
would have stacked another handler — each with its own suppression-window
closure, so they could not even suppress one another — and a single right-click
would have pasted the clipboard into the shell once per split. It is now named
and removed on teardown.

The rest narrowed when a terminal may be parked at all. A refusal costs only the
improvement — it falls back to the dispose-and-replay this PR set out to remove
— so every state where the adopting mount would inherit a screen with no repair
path behind it now refuses:

- the scrollback restore has not settled (its callbacks bail on the null
  `terminalRef` teardown is about to write, losing the `.txt` content and the
  `pendingData` behind it, which the autosave then writes back over the file);
- a `.txt` cache is on screen awaiting the daemon's verdict (the late-connect
  listener that clears it before the ring replay dies with the mount);
- a daemon reconnect is still retrying (`reconnectPtyWithRetry` bails when
  `terminalRef` goes null, and the adopting mount skips its own attempt — the
  pane would end up with no session pipe at all);
- the registry no longer points at this instance (under the fast
  unmount-after-remount ordering, ours is the stale copy).

The park window went from 250 ms to a single task. That is a safety property
rather than a tuning choice: between park and adopt there is no PTY data
listener and no reconnect behind it, so bytes arriving in a longer gap would be
lost with nothing to repair the screen — and a `daemon:connected` landing in
that gap would leave the pane unattached to the new generation. Confining
adoption to one synchronous passive-effect flush makes both unreachable, and
anything that somehow spanned two tasks now disposes exactly as it always did.

Viewport restoration keeps the distance from the bottom rather than an absolute
row (a split always changes width, and a reflowed buffer renumbers every row),
and an adoption into a zero-size container — a restructure on a hidden
workspace — holds that reading until a fit actually runs.

**Declined, with reasons:**

- *WebGL is handed over torn down.* The park path still releases the pool slot
  and disposes the addon, so the adopted terminal arrives on the DOM renderer
  and repaints once before re-acquiring a context. Transferring pool ownership
  across mounts is a real amount of machinery for a repaint of content that is
  already correct, and it is worth measuring on Windows first — the split
  already repaints. Noted as follow-up, not fixed here.
- *A throwing mount effect orphans the adopted terminal.* True, but equally true
  of the freshly constructed one today: React registers no destroy function for
  a setup that threw. Wrapping the effect to cover it would swallow real errors,
  which is a worse trade than the leak.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pane splitting, dragging, and collapsing now preserve terminal buffers, scroll positions, and conversation output.
  * Terminal sessions are reused during pane changes instead of being unnecessarily recreated.
  * Improved terminal cleanup and viewport restoration during pane restructuring.
  * Preserved right-click paste behavior, including Shift-click overrides.

* **Tests**
  * Added comprehensive coverage for terminal preservation, adoption, disposal, viewport restoration, and pane restructuring scenarios.

* **Documentation**
  * Added a changelog entry describing terminal state preservation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->