### PR TITLE
Anchor streaming IME compositions to the input line found by content

### DIFF
--- a/changelog.d/1017.md
+++ b/changelog.d/1017.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Chinese IME candidate window now anchors to Claude Code's input box
+  while output streams.** The quiet-caret snapshot shipped for #951 could
+  itself capture the streaming cursor's parking spot (the end of whatever
+  the last frame painted — any column), because Claude Code never parks its
+  cursor on the input caret mid-stream. Compositions started during
+  streaming now find the input line by content — the `│ > ` prompt row
+  under its box border — and anchor there, outranking every cursor-derived
+  source. Idle panes keep the field-verified cursor behavior unchanged, and
+  the IME diagnostic (`ime-anchor4` → `ime-anchor5`) records when the
+  content scan was used. (#1016)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1172,22 +1172,31 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // field.
     const imeAnchorLogsLeft = { start: 20, mid: 20 };
     const imeAnchor = attachImeAnchor(terminal, {
+      // #1016: gates the input-line content scan to agents whose chrome the
+      // scanner understands. Read per composition, so it tracks the pane's
+      // live agent identity without a re-attach.
+      getAgentSlug: () => {
+        const id = ptyIdRef.current;
+        return id ? useStore.getState().surfaceAgent[id]?.slug : undefined;
+      },
       onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, outputGap, caretAge, edge, selY, selX }) => {
         const budget = phase === 'start' ? 'start' : 'mid';
         if (imeAnchorLogsLeft[budget] <= 0) return;
         imeAnchorLogsLeft[budget] -= 1;
         // Mirrored into the main-side log file by src/main/index.ts's
-        // console-message listener, so the user can share it. The "4" in the
-        // tag marks the quiet-caret build (#951) so a shared log is
+        // console-message listener, so the user can share it. The "5" in the
+        // tag marks the input-line marker build (#1016) so a shared log is
         // unambiguous about which release produced it. src/held/restAge/sel
         // are the cause-3 discriminator: src=resting means the composition
         // started mid-repaint and the anchor used the last resting cell;
         // src=caret with gap= is the #951 discriminator: output was still
         // flowing, so the anchor used the quiet-caret snapshot instead of
-        // any buffer cursor. pin= is the textarea correction, preedit= the
-        // live composition-view correction.
+        // any buffer cursor; src=marker means the agent's input line was
+        // found by content (#1016) and outranked them both. pin= is the
+        // textarea correction, preedit= the live composition-view
+        // correction.
         console.info(
-          `[wmux:ime-anchor4] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
+          `[wmux:ime-anchor5] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
           `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src}${edge ? ' edge=1' : ''} held=${held.toFixed(0)}ms ` +
           `restAge=${restAge.toFixed(0)}ms gap=${outputGap.toFixed(0)}ms caretAge=${caretAge.toFixed(0)}ms ` +
           `cellHeight=${cellHeight.toFixed(2)} ` +

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -29,6 +29,7 @@ import {
   pointFromCell,
   resetRestingTracker,
   RESTING_MS,
+  scanClaudeInputLine,
   selectFreezeCell,
   type ImeAnchorBufferState,
   type ImeAnchorGeometry,
@@ -1008,6 +1009,244 @@ describe('#951 quiet-caret wiring', () => {
     dom.textarea.dispatchEvent(new Event('compositionupdate'));
     expect(translateOf(dom.compView)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
     expect(translateOf(dom.compView)?.dx).toBeCloseTo((5 - 127) * 10, 6);
+    handle.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('#1016 input-line content scan (pure)', () => {
+  const lines = (rows: string[]) => (r: number): string | undefined => rows[r];
+
+  it('finds the prompt row under the box top border', () => {
+    const screen = [
+      'Some streamed output',
+      '',
+      '╭──────────────╮',
+      '│ > 你好       │',
+      '╰──────────────╯',
+      '  ? for shortcuts',
+    ];
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 3, col: 4 });
+  });
+
+  it('keeps the column honest on an indented box', () => {
+    const screen = ['  ╭────╮', '  │ > x│'];
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 6 });
+  });
+
+  it('the bottom-most match wins over quoted chrome in the transcript', () => {
+    // An agent can print its own UI into the transcript; the live box is
+    // always the bottom-most match.
+    const screen = [
+      '╭────────────╮',
+      '│ > quoted   │',
+      '╰────────────╯',
+      'more output',
+      '╭────────────╮',
+      '│ > live     │',
+      '╰────────────╯',
+    ];
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 5, col: 4 });
+  });
+
+  it('a bare prompt-like line without the box top above is not matched', () => {
+    const screen = ['output', '│ > printed by a program', 'output'];
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toBeNull();
+  });
+
+  it('wrapped multi-line input still anchors on the prompt row', () => {
+    const screen = [
+      '╭──────────────╮',
+      '│ > first line │',
+      '│   wrapped    │',
+      '╰──────────────╯',
+    ];
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 4 });
+  });
+
+  it('returns null on an unreadable or markerless screen', () => {
+    expect(scanClaudeInputLine(() => undefined, 40)).toBeNull();
+    expect(scanClaudeInputLine(lines(['plain shell $']), 1)).toBeNull();
+  });
+});
+
+describe('#1016 marker selection (pure)', () => {
+  /** The 2026-08-23 field shape: the pane parked at (137,36) from the start,
+   *  so the quiet span certifies the park itself as the snapshot — at column
+   *  137 of a 139-column pane, which no column bound can refuse. */
+  const parkSnapshotTracker = (): ReturnType<typeof createRestingTracker> => {
+    const t = createRestingTracker(676, 137, 1000, 36);
+    noteOutputParsed(t, 1600, 139); // quiet span ends -> the park IS the snapshot
+    noteOutputParsed(t, 1900, 139); // stream keeps flowing (sub-quiet gaps)…
+    noteOutputParsed(t, 2300, 139); // …past the sustain threshold
+    return t;
+  };
+
+  it('the marker outranks a snapshot that is itself a park', () => {
+    const t = parkSnapshotTracker();
+    // Without the marker, the selection faithfully anchors to the park — the
+    // exact bug in the 2026-08-23 log (137 passes the 138 last-column bound).
+    expect(selectFreezeCell(t, 676, 137, 2350, { top: 640, rows: 41, cols: 139 }, 640))
+      .toMatchObject({ absRow: 676, col: 137, src: 'caret' });
+    // With it, content wins.
+    const sel = selectFreezeCell(t, 676, 137, 2350, { top: 640, rows: 41, cols: 139 }, 640,
+      { relRow: 31, col: 4 });
+    expect(sel).toMatchObject({ absRow: 671, col: 4, src: 'marker' });
+  });
+
+  it('the marker also covers a stream that never produced a snapshot', () => {
+    const t = createRestingTracker(676, 137, 1000, 36);
+    noteOutputParsed(t, 1300, 139); // sub-quiet from the start: no snapshot ever
+    noteOutputParsed(t, 1600, 139);
+    noteOutputParsed(t, 1900, 139);
+    expect(t.hasCaret).toBe(false);
+    const sel = selectFreezeCell(t, 676, 137, 1950, { top: 640, rows: 41, cols: 139 }, 640,
+      { relRow: 31, col: 4 });
+    expect(sel).toMatchObject({ absRow: 671, col: 4, src: 'marker' });
+  });
+
+  it('a quiet pane ignores the marker — idle stays cursor-driven', () => {
+    const t = createRestingTracker(640, 8, 1000, 30);
+    const sel = selectFreezeCell(t, 640, 8, 1000 + OUTPUT_QUIET_MS + 200,
+      { top: 600, rows: 45, cols: 139 }, 600, { relRow: 31, col: 4 });
+    expect(sel).toMatchObject({ absRow: 640, col: 8, src: 'instant' });
+  });
+
+  it('a marker without a viewport cannot be placed and is ignored', () => {
+    const t = parkSnapshotTracker();
+    const sel = selectFreezeCell(t, 676, 137, 2350, undefined, 640, { relRow: 31, col: 4 });
+    expect(sel).toMatchObject({ src: 'caret' });
+  });
+});
+
+describe('#1016 input-line marker wiring', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  /** Viewport content with Claude Code's input box at `promptRow`. */
+  const claudeScreen = (rows: number, promptRow: number): string[] => {
+    const s: string[] = [];
+    for (let i = 0; i < rows; i++) s.push(`output line ${i}`);
+    s[promptRow - 1] = '╭──────────────╮';
+    s[promptRow] = '│ > 你好       │';
+    s[promptRow + 1] = '╰──────────────╯';
+    return s;
+  };
+
+  /** Wire viewport-relative content into the fake buffer's getLine. */
+  const installLines = (
+    active: ImeAnchorTerminal['buffer']['active'],
+    content: string[],
+  ): ReturnType<typeof vi.fn> => {
+    const getLine = vi.fn((y: number) => {
+      const line = content[y - active.viewportY];
+      return line === undefined ? undefined : { translateToString: () => line };
+    });
+    active.getLine = getLine;
+    return getLine;
+  };
+
+  /** The #951 wiring scenario: idle caret at (5,40), then a stream parks the
+   *  cursor on (127,43) and sustains past the threshold. */
+  const streamTo2800 = (t: ReturnType<typeof makeTerminal>, dom: ReturnType<typeof buildTerminalDom>, setClock: (v: number) => void): void => {
+    setClock(2000);
+    Object.assign(t.state, { cursorY: 43, cursorX: 127 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    dom.textarea.style.top = `${43 * 17.6}px`;
+    dom.textarea.style.left = `${127 * 10}px`;
+    setClock(2400);
+    t.onWriteParsed.fire(undefined);
+    setClock(2750);
+    t.onWriteParsed.fire(undefined);
+    setClock(2800);
+  };
+
+  it('a recognized agent mid-stream anchors to the input line found by content', () => {
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    installLines(t.terminal.buffer.active, claudeScreen(45, 31));
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'claude',
+      onCompositionDiagnostic: diag,
+    });
+    streamTo2800(t, dom, (v) => { clock = v; });
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'marker', selY: 31, selX: 4, cursorY: 43, cursorX: 127,
+    });
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo((31 - 43) * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((4 - 127) * 10, 6);
+    // A marker-sourced composition pins the preedit like a caret-sourced one:
+    // the live cursor is the agent's repaint cursor, and following it tears
+    // the two IME surfaces apart (#951 field report).
+    dom.compView.style.top = `${43 * 17.6}px`;
+    dom.compView.style.left = `${127 * 10}px`;
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(translateOf(dom.compView)?.dy).toBeCloseTo((31 - 43) * 17.6, 6);
+    expect(translateOf(dom.compView)?.dx).toBeCloseTo((4 - 127) * 10, 6);
+    handle.dispose();
+  });
+
+  it('an unrecognized agent never scans and keeps the quiet-caret selection', () => {
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const getLine = installLines(t.terminal.buffer.active, claudeScreen(45, 31));
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'codex',
+      onCompositionDiagnostic: diag,
+    });
+    streamTo2800(t, dom, (v) => { clock = v; });
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'caret', selY: 40, selX: 5 });
+    expect(getLine).not.toHaveBeenCalled();
+    handle.dispose();
+  });
+
+  it('a scan that finds nothing falls back to the quiet-caret selection', () => {
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const plain: string[] = [];
+    for (let i = 0; i < 45; i++) plain.push(`output line ${i}`);
+    installLines(t.terminal.buffer.active, plain);
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'claude',
+      onCompositionDiagnostic: diag,
+    });
+    streamTo2800(t, dom, (v) => { clock = v; });
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'caret', selY: 40, selX: 5 });
+    handle.dispose();
+  });
+
+  it('an idle composition never scans even for a recognized agent', () => {
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const getLine = installLines(t.terminal.buffer.active, claudeScreen(45, 31));
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'claude',
+      onCompositionDiagnostic: diag,
+    });
+    clock = 5000; // no output since attach: quiet pane
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'instant', selY: 40, selX: 5 });
+    expect(getLine).not.toHaveBeenCalled();
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -1065,6 +1065,16 @@ describe('#1016 input-line content scan (pure)', () => {
     expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 4 });
   });
 
+  it('bash and memory mode prompts are the same caret row', () => {
+    // The live box must keep winning bottom-most while the user is in `!`
+    // (bash) or `#` (memory) mode — otherwise a quoted `│ > ` in the
+    // transcript above would take over.
+    const bash = ['│ > quoted', '╭────╮', '│ ! ls│', '╰────╯'];
+    expect(scanClaudeInputLine(lines(bash), bash.length)).toEqual({ relRow: 2, col: 4 });
+    const memory = ['╭────╮', '│ # note│', '╰────╯'];
+    expect(scanClaudeInputLine(lines(memory), memory.length)).toEqual({ relRow: 1, col: 4 });
+  });
+
   it('returns null on an unreadable or markerless screen', () => {
     expect(scanClaudeInputLine(() => undefined, 40)).toBeNull();
     expect(scanClaudeInputLine(lines(['plain shell $']), 1)).toBeNull();
@@ -1089,10 +1099,11 @@ describe('#1016 marker selection (pure)', () => {
     // exact bug in the 2026-08-23 log (137 passes the 138 last-column bound).
     expect(selectFreezeCell(t, 676, 137, 2350, { top: 640, rows: 41, cols: 139 }, 640))
       .toMatchObject({ absRow: 676, col: 137, src: 'caret' });
-    // With it, content wins.
+    // With it, content wins: the park sits on the prompt row's border zone
+    // (col 137 of 139), which is repaint state, not a caret.
     const sel = selectFreezeCell(t, 676, 137, 2350, { top: 640, rows: 41, cols: 139 }, 640,
-      { relRow: 31, col: 4 });
-    expect(sel).toMatchObject({ absRow: 671, col: 4, src: 'marker' });
+      () => ({ relRow: 36, col: 4 }));
+    expect(sel).toMatchObject({ absRow: 676, col: 4, src: 'marker' });
   });
 
   it('the marker also covers a stream that never produced a snapshot', () => {
@@ -1102,21 +1113,46 @@ describe('#1016 marker selection (pure)', () => {
     noteOutputParsed(t, 1900, 139);
     expect(t.hasCaret).toBe(false);
     const sel = selectFreezeCell(t, 676, 137, 1950, { top: 640, rows: 41, cols: 139 }, 640,
-      { relRow: 31, col: 4 });
+      () => ({ relRow: 31, col: 4 }));
     expect(sel).toMatchObject({ absRow: 671, col: 4, src: 'marker' });
   });
 
   it('a quiet pane ignores the marker — idle stays cursor-driven', () => {
     const t = createRestingTracker(640, 8, 1000, 30);
-    const sel = selectFreezeCell(t, 640, 8, 1000 + OUTPUT_QUIET_MS + 200,
-      { top: 600, rows: 45, cols: 139 }, 600, { relRow: 31, col: 4 });
+    noteOutputParsed(t, 1200, 139); // real output once, long quiet since
+    const scan = vi.fn(() => ({ relRow: 31, col: 4 }));
+    const sel = selectFreezeCell(t, 640, 8, 1200 + OUTPUT_QUIET_MS + 200,
+      { top: 600, rows: 45, cols: 139 }, 600, scan);
     expect(sel).toMatchObject({ absRow: 640, col: 8, src: 'instant' });
+    expect(scan).not.toHaveBeenCalled();
   });
 
-  it('a marker without a viewport cannot be placed and is ignored', () => {
-    const t = parkSnapshotTracker();
-    const sel = selectFreezeCell(t, 676, 137, 2350, undefined, 640, { relRow: 31, col: 4 });
-    expect(sel).toMatchObject({ src: 'caret' });
+  it('a fluid typist\'s snapshot on the prompt row keeps its column', () => {
+    // Fluid CJK typing: every commit echo lands under OUTPUT_QUIET_MS for
+    // longer than the sustain, so the streaming branch opens — but the
+    // snapshot is the caret at the last pause, ON the prompt row, left of
+    // the border zone. The marker's input-start floor must not drag the
+    // preedit back over already-typed text (panel finding).
+    const t = createRestingTracker(671, 20, 1000, 31);
+    noteOutputParsed(t, 1600, 139); // snapshot: (20,31) — the typing caret
+    noteOutputParsed(t, 1900, 139);
+    noteOutputParsed(t, 2300, 139);
+    const sel = selectFreezeCell(t, 671, 22, 2350, { top: 640, rows: 41, cols: 139 }, 640,
+      () => ({ relRow: 31, col: 4 }));
+    expect(sel).toMatchObject({ absRow: 671, col: 20, src: 'caret' });
+  });
+
+  it('a seeded output clock never opens the streaming branch', () => {
+    // createRestingTracker seeds lastOutputAt with the creation clock; for
+    // OUTPUT_QUIET_MS after an attach/reset that reads as "output just
+    // arrived" even though nothing was parsed. With the cursor on the last
+    // column (edge), the branch would open on the seed alone (panel
+    // finding) — hasOutput keeps it shut until real output is observed.
+    const t = createRestingTracker(676, 138, 1000, 36);
+    const scan = vi.fn(() => ({ relRow: 31, col: 4 }));
+    const sel = selectFreezeCell(t, 676, 138, 1100, { top: 640, rows: 41, cols: 139 }, 640, scan);
+    expect(sel).toMatchObject({ src: 'instant' });
+    expect(scan).not.toHaveBeenCalled();
   });
 });
 
@@ -1133,13 +1169,14 @@ describe('#1016 input-line marker wiring', () => {
     return s;
   };
 
-  /** Wire viewport-relative content into the fake buffer's getLine. */
+  /** Wire LIVE-screen content (baseY-relative rows) into the fake buffer's
+   *  getLine — the scan must read the live screen, not the viewport. */
   const installLines = (
     active: ImeAnchorTerminal['buffer']['active'],
     content: string[],
   ): ReturnType<typeof vi.fn> => {
     const getLine = vi.fn((y: number) => {
-      const line = content[y - active.viewportY];
+      const line = content[y - active.baseY];
       return line === undefined ? undefined : { translateToString: () => line };
     });
     active.getLine = getLine;
@@ -1189,6 +1226,31 @@ describe('#1016 input-line marker wiring', () => {
     dom.textarea.dispatchEvent(new Event('compositionupdate'));
     expect(translateOf(dom.compView)?.dy).toBeCloseTo((31 - 43) * 17.6, 6);
     expect(translateOf(dom.compView)?.dx).toBeCloseTo((4 - 127) * 10, 6);
+    handle.dispose();
+  });
+
+  it('a scrolled-up viewport still scans the live screen, not history', () => {
+    // The 3-model panel finding: a viewport-relative scan while scrolled up
+    // reads history, which can quote the very chrome being scanned for. The
+    // live rows keep the real box; the off-screen anchor then clamps to the
+    // visible edge via pointFromCell, same as every other off-screen anchor.
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    // Scrolled up 20 rows: the viewport shows history.
+    Object.assign(t.state, { baseY: 600, viewportY: 580, cursorY: 40, cursorX: 5 });
+    installLines(t.terminal.buffer.active, claudeScreen(45, 31));
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'claude',
+      onCompositionDiagnostic: diag,
+    });
+    streamTo2800(t, dom, (v) => { clock = v; });
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    // The live box's prompt row (screen row 31) was found even though the
+    // viewport is 20 rows up; absRow = 600 + 31 = 631, reported ybase-rel.
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'marker', selY: 31, selX: 4 });
     handle.dispose();
   });
 

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -102,13 +102,24 @@
  * (#953 field log, 2026-08-21: `gap=203ms caretAge=602ms src=instant edge=1`
  * — a usable snapshot passed over, candidate window pinned to the pane's
  * bottom-right corner), so the rule now fires only when output arrived within
- * OUTPUT_QUIET_MS. The idle line-end miss stays a KNOWN, flagged residual. Fixing it for real needs a different signal
- * class than the cursor — the ecosystem contract says the TUI must park
- * its cursor on the caret (Ink's useCursor exists; Claude Code has not
- * shipped it, see anthropics/claude-code#25186), and the content-aware
- * fallback proven by other terminals (detect the agent's input-line marker
- * in the buffer, gated per known agent) is follow-up work, not another
- * cursor heuristic.
+ * OUTPUT_QUIET_MS. The idle line-end miss stays a KNOWN, flagged residual.
+ * The 2026-08-23 field round (#953, final report) then showed the snapshot
+ * side of the same shape: the SNAPSHOT is sometimes the park, and a park is
+ * "wherever the painted text ended", which can be any column at all — the
+ * log holds snapshots at column 137 of a 139-column pane and at column 53
+ * mid-line — so the last-column refusal only catches a painted line that
+ * happens to fill the row. Underneath both: while an agent streams, its
+ * cursor never visits the input caret at all — the ecosystem contract says
+ * the TUI must park its cursor on the caret (Ink's useCursor exists; Claude
+ * Code has not shipped it, see anthropics/claude-code#25186) — so no
+ * cursor-derived rule, in any combination, can find the caret mid-stream.
+ * That is why the streaming anchor has a second signal class (#1016): at
+ * compositionstart, when the pane's agent is recognized and output is
+ * flowing, the input line is read out of the buffer by its chrome
+ * (scanClaudeInputLine) and outranks every cursor source (`src=marker`).
+ * The cursor path remains for unrecognized agents, for a scan that finds
+ * nothing, and for the idle pane, which stays cursor-driven on purpose —
+ * idle is field-verified correct and every generation that touched it lost.
  * Known residuals, all identifiable in a field log via the src/gap/
  * caretAge/edge fields: the line-end park above; a mid-stream pause longer
  * than OUTPUT_QUIET_MS with the cursor parked mid-line on repaint state
@@ -453,11 +464,73 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
   state.epochStart = now;
 }
 
+// ---------------------------------------------------------------------------
+// Agent input-line content scan (#1016)
+// ---------------------------------------------------------------------------
+
+/** The agent's input line, found by content rather than cursor behavior. */
+export interface AgentInputLineMarker {
+  /** Viewport-relative row of the prompt row. */
+  relRow: number;
+  /** Column where typed input begins — just after the `> ` prompt. Used as
+   *  the anchor floor rather than the exact caret: the exact caret would need
+   *  cell-accurate width math over typed CJK, and a candidate window at the
+   *  input's start is already on the right row, which is what field reports
+   *  complain about. */
+  col: number;
+}
+
+// Claude Code draws its input as a rounded box; the prompt row is the first
+// row inside it:            ╭──────────────╮
+//                           │ > typed text │
+//                           ╰──────────────╯
+// The prompt's lead-in is pure ASCII/box-drawing (single-cell glyphs), so a
+// string index below IS the buffer column — typed CJK only ever appears
+// after it.
+const CLAUDE_PROMPT_ROW = /^(\s*)│ > /;
+const CLAUDE_BOX_TOP = /^\s*╭─/;
+
+/**
+ * Find Claude Code's input line in the visible rows (#1016).
+ *
+ * Bottom-up, because the input box is the bottom-most chrome that matches —
+ * streamed transcript ABOVE it may quote the same glyphs (an agent printing
+ * its own UI), and the rows BELOW it (`? for shortcuts`, status hints) match
+ * nothing. A prompt row only counts with the box's top border directly above
+ * it, which is true for single- and multi-line input alike (the `│ > ` row
+ * is always the first row inside the box; wrapped continuation rows carry no
+ * `>`), and false for a bare quoted prompt line in scrolled output.
+ *
+ * `readLine` returns the trimmed text of a viewport row, or undefined when
+ * the row cannot be read; unreadable rows are skipped rather than trusted.
+ * Runs at compositionstart only — user-paced, so a full-viewport scan is
+ * free.
+ */
+export function scanClaudeInputLine(
+  readLine: (relRow: number) => string | undefined,
+  rows: number,
+): AgentInputLineMarker | null {
+  for (let r = rows - 1; r >= 1; r--) {
+    const line = readLine(r);
+    if (line === undefined) continue;
+    const m = CLAUDE_PROMPT_ROW.exec(line);
+    if (!m) continue;
+    const above = readLine(r - 1);
+    if (above === undefined || !CLAUDE_BOX_TOP.test(above)) continue;
+    // `│ > x`: border, space, prompt, space — input begins 4 cells past the
+    // border.
+    return { relRow: r, col: m[1].length + 4 };
+  }
+  return null;
+}
+
 /** Where the freeze cell came from. `scrolled_out` is `instant` chosen because
  *  the resting cell had left the viewport — kept distinct so a field log can
  *  tell that rejection apart from a cursor that was simply at rest. `caret` is
- *  the quiet-caret snapshot, chosen because output was still flowing (#951). */
-export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret';
+ *  the quiet-caret snapshot, chosen because output was still flowing (#951).
+ *  `marker` is the agent's input line found by content (#1016), chosen over
+ *  every cursor source while output flows. */
+export type FreezeCellSource = 'instant' | 'resting' | 'scrolled_out' | 'caret' | 'marker';
 
 export interface FreezeCellSelection {
   absRow: number;
@@ -483,7 +556,9 @@ export interface FreezeCellSelection {
  * output is recent AND sustained (STREAM_SUSTAIN_MS since the current epoch
  * began), dwell time certifies nothing (#951: a streaming agent parks its
  * cursor on screen corners between bursts for far longer than RESTING_MS),
- * so the quiet-caret snapshot wins over both. Recent-but-isolated output —
+ * so the quiet-caret snapshot wins over both — and an input line found by
+ * content (`marker`, #1016) wins over the snapshot, which the 2026-08-23
+ * field round proved is itself sometimes a park. Recent-but-isolated output —
  * a committed syllable's echo — keeps the normal dwell selection, because
  * there the freshly moved cursor IS the caret and the snapshot is one word
  * stale. The snapshot's
@@ -512,6 +587,7 @@ export function selectFreezeCell(
   now: number,
   viewport?: { top: number; rows: number; cols?: number },
   baseY = 0,
+  marker: AgentInputLineMarker | null = null,
 ): FreezeCellSelection {
   const held = now - state.currentSince;
   const restAge = state.hasResting ? now - state.lastRestingAt : -1;
@@ -543,12 +619,25 @@ export function selectFreezeCell(
   // stream pauses longer than OUTPUT_QUIET_MS between bursts, so `epochStart`
   // kept restarting and never reached STREAM_SUSTAIN_MS.
   if (outputGap < OUTPUT_QUIET_MS
-    && (now - state.epochStart >= STREAM_SUSTAIN_MS || edge)
-    && state.hasCaret) {
-    return {
-      absRow: baseY + state.caretRelRow, col: state.caretCol,
-      src: 'caret', held, restAge, outputGap, caretAge, edge,
-    };
+    && (now - state.epochStart >= STREAM_SUSTAIN_MS || edge)) {
+    // #1016: the input line found by CONTENT outranks the snapshot. The
+    // 2026-08-23 field round proved the snapshot itself is sometimes a park
+    // ("wherever the painted text ended" — any column, so no column check
+    // can classify it), while the marker is read from the frame currently on
+    // screen. Marker rows are viewport-relative, so placing one needs the
+    // viewport; without it the marker is ignored rather than mis-rebased.
+    if (marker !== null && viewport !== undefined) {
+      return {
+        absRow: viewport.top + marker.relRow, col: marker.col,
+        src: 'marker', held, restAge, outputGap, caretAge, edge,
+      };
+    }
+    if (state.hasCaret) {
+      return {
+        absRow: baseY + state.caretRelRow, col: state.caretCol,
+        src: 'caret', held, restAge, outputGap, caretAge, edge,
+      };
+    }
   }
   if (held >= RESTING_MS || !state.hasResting) {
     return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge };
@@ -572,6 +661,11 @@ interface EventEmitterLike<T> {
   (listener: (arg: T) => void): Disposable;
 }
 
+/** One buffer row, as xterm's IBufferLine exposes it (#1016). */
+export interface ImeAnchorBufferLine {
+  translateToString(trimRight?: boolean): string;
+}
+
 /** The slice of xterm's public Terminal API this needs. */
 export interface ImeAnchorTerminal {
   readonly rows: number;
@@ -579,7 +673,12 @@ export interface ImeAnchorTerminal {
   readonly textarea: HTMLTextAreaElement | undefined;
   readonly element: HTMLElement | undefined;
   readonly buffer: {
-    active: ImeAnchorBufferState;
+    active: ImeAnchorBufferState & {
+      /** Row content lookup (xterm's IBuffer.getLine), indexed from the top
+       *  of the scrollback. Optional: a caller without it (minimal fakes)
+       *  simply has the #1016 content scan disabled. */
+      getLine?(y: number): ImeAnchorBufferLine | undefined;
+    };
     /** Fires on normal <-> alt buffer switches. */
     onBufferChange: EventEmitterLike<unknown>;
   };
@@ -631,6 +730,14 @@ export interface ImeAnchorOptions {
     selY: number;
     selX: number;
   }) => void;
+  /**
+   * Slug of the agent running in this pane, when known (#1016). Gates the
+   * input-line content scan to agents whose chrome the scanner understands —
+   * today `'claude'`. Read at compositionstart, so a pane whose agent is
+   * recognized mid-session starts scanning without a re-attach, and a pane
+   * whose agent exits stops.
+   */
+  getAgentSlug?: () => string | undefined;
   /** Clock override for tests. Defaults to performance.now. */
   now?: () => number;
 }
@@ -780,14 +887,14 @@ export function attachImeAnchor(
    * composition it carries no transform (xterm hides it).
    *
    * The one exception is a composition whose freeze cell came from the quiet
-   * caret (`src=caret`, #951/#953 field report): there the live cursor IS the
-   * streaming agent's repaint cursor, and following it split the two IME
-   * surfaces apart — the candidate window pinned at the input line while the
-   * inline pinyin chased the agent's output rows. Both surfaces must anchor
-   * to the same cell, so a caret-sourced composition pins the preedit to the
-   * same frozen point as the textarea. The quiet case is untouched: there the
-   * selection is instant/resting and the live follow stays (#942 stays
-   * fixed).
+   * caret or the content marker (`src=caret`/`src=marker`, #951/#953/#1016
+   * field reports): there the live cursor IS the streaming agent's repaint
+   * cursor, and following it split the two IME surfaces apart — the candidate
+   * window pinned at the input line while the inline pinyin chased the
+   * agent's output rows. Both surfaces must anchor to the same cell, so those
+   * compositions pin the preedit to the same frozen point as the textarea.
+   * The quiet case is untouched: there the selection is instant/resting and
+   * the live follow stays (#942 stays fixed).
    *
    * Deliberately called only from the composition handlers, NOT from
    * onRender/onScroll: at a composition event xterm has just written the
@@ -808,7 +915,7 @@ export function attachImeAnchor(
     if (!isUsableGeometry(geometry)) return;
     const actualPreedit = readStyledPoint(compositionView);
     if (!actualPreedit) return;
-    const desired = frozen !== null && lastSel?.src === 'caret'
+    const desired = frozen !== null && (lastSel?.src === 'caret' || lastSel?.src === 'marker')
       ? frozen
       : paintedCursorPosition(bufferState(), geometry);
     const c = computeImeAnchorCorrection(desired, actualPreedit);
@@ -895,11 +1002,24 @@ export function attachImeAnchor(
     // composition starts inside a repaint burst (cause 3).
     composing = true;
     const b = bufferState();
-    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now(), {
+    const tNow = now();
+    // #1016: while output flows, the cursor never visits the input caret
+    // (Claude Code parks it at the end of painted content — any column), so
+    // for a recognized agent the input line is read out of the buffer
+    // instead. Scanned only while output is flowing: the idle pane is
+    // field-verified correct on the cursor path and stays there.
+    const marker = tNow - tracker.lastOutputAt < OUTPUT_QUIET_MS
+      && options.getAgentSlug?.() === 'claude'
+      ? scanClaudeInputLine(
+          (relRow) => terminal.buffer.active.getLine?.(b.viewportY + relRow)?.translateToString(true),
+          geometry.rows,
+        )
+      : null;
+    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, tNow, {
       top: b.viewportY,
       rows: geometry.rows,
       cols: geometry.cols,
-    }, b.baseY);
+    }, b.baseY, marker);
     lastSel = sel;
     lastSelRelY = sel.absRow - b.baseY;
     frozen = isUsableGeometry(geometry)

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -331,6 +331,13 @@ export interface RestingTrackerState {
   hasResting: boolean;
   /** Clock reading of the last parsed PTY output (#951). */
   lastOutputAt: number;
+  /** True once a PTY chunk has actually been parsed since creation/reset.
+   *  `lastOutputAt` is SEEDED with the creation clock (so "no output since
+   *  attach" reads as quiet), but that same seed would read as "output 0ms
+   *  ago" — i.e. flowing — for the first OUTPUT_QUIET_MS after an attach or
+   *  resize. The streaming branch must not fire on a seed (panel finding):
+   *  gate it on output that was actually observed. */
+  hasOutput: boolean;
   /** Clock reading of the chunk that ended the last quiet span — the start
    *  of the current output epoch. Age >= STREAM_SUSTAIN_MS means the output
    *  is a sustained stream, not an isolated echo burst. */
@@ -367,6 +374,7 @@ export function createRestingTracker(absRow: number, col: number, now: number, r
     // Seeded with the creation clock: "no output since attach" reads as quiet,
     // matching the seeded-at-rest semantics of the cell fields above.
     lastOutputAt: now,
+    hasOutput: false,
     epochStart: now,
     caretRelRow: 0,
     caretCol: 0,
@@ -437,6 +445,7 @@ export function noteOutputParsed(state: RestingTrackerState, now: number, cols?:
     }
   }
   state.lastOutputAt = now;
+  state.hasOutput = true;
 }
 
 /**
@@ -461,6 +470,7 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
   state.hasResting = false;
   state.hasCaret = false;
   state.lastOutputAt = now;
+  state.hasOutput = false;
   state.epochStart = now;
 }
 
@@ -470,7 +480,14 @@ export function resetRestingTracker(state: RestingTrackerState, absRow: number, 
 
 /** The agent's input line, found by content rather than cursor behavior. */
 export interface AgentInputLineMarker {
-  /** Viewport-relative row of the prompt row. */
+  /** Screen row of the prompt row, ybase-RELATIVE like the quiet-caret
+   *  snapshot. The scan reads the LIVE screen (baseY + relRow), not the
+   *  viewport: a user scrolled up mid-stream sees history, and history can
+   *  quote the box chrome — matching there would anchor into old transcript
+   *  (3-model panel finding). Reading the live rows finds the real box even
+   *  while scrolled, and `pointFromCell` then clamps the off-screen anchor
+   *  to the nearest visible edge, same contract as every other off-screen
+   *  anchor here. */
   relRow: number;
   /** Column where typed input begins — just after the `> ` prompt. Used as
    *  the anchor floor rather than the exact caret: the exact caret would need
@@ -484,10 +501,13 @@ export interface AgentInputLineMarker {
 // row inside it:            ╭──────────────╮
 //                           │ > typed text │
 //                           ╰──────────────╯
-// The prompt's lead-in is pure ASCII/box-drawing (single-cell glyphs), so a
-// string index below IS the buffer column — typed CJK only ever appears
-// after it.
-const CLAUDE_PROMPT_ROW = /^(\s*)│ > /;
+// The prompt glyph varies by mode — `>` normal, `!` bash mode, `#` memory
+// mode — and all three mark the same caret row. Matching only `>` would let
+// a quoted `│ > ` in the transcript win bottom-most while the live box sits
+// in another mode (panel finding). The lead-in is pure ASCII/box-drawing
+// (single-cell glyphs), so a string index below IS the buffer column — typed
+// CJK only ever appears after it.
+const CLAUDE_PROMPT_ROW = /^(\s*)│ [>!#] /;
 const CLAUDE_BOX_TOP = /^\s*╭─/;
 
 /**
@@ -587,7 +607,7 @@ export function selectFreezeCell(
   now: number,
   viewport?: { top: number; rows: number; cols?: number },
   baseY = 0,
-  marker: AgentInputLineMarker | null = null,
+  getMarker?: () => AgentInputLineMarker | null,
 ): FreezeCellSelection {
   const held = now - state.currentSince;
   const restAge = state.hasResting ? now - state.lastRestingAt : -1;
@@ -618,19 +638,40 @@ export function selectFreezeCell(
   // src=instant edge=1`, a usable snapshot passed over because a token-paced
   // stream pauses longer than OUTPUT_QUIET_MS between bursts, so `epochStart`
   // kept restarting and never reached STREAM_SUSTAIN_MS.
-  if (outputGap < OUTPUT_QUIET_MS
+  if (state.hasOutput && outputGap < OUTPUT_QUIET_MS
     && (now - state.epochStart >= STREAM_SUSTAIN_MS || edge)) {
     // #1016: the input line found by CONTENT outranks the snapshot. The
     // 2026-08-23 field round proved the snapshot itself is sometimes a park
     // ("wherever the painted text ended" — any column, so no column check
     // can classify it), while the marker is read from the frame currently on
-    // screen. Marker rows are viewport-relative, so placing one needs the
-    // viewport; without it the marker is ignored rather than mis-rebased.
-    if (marker !== null && viewport !== undefined) {
-      return {
-        absRow: viewport.top + marker.relRow, col: marker.col,
-        src: 'marker', held, restAge, outputGap, caretAge, edge,
-      };
+    // screen. The scan is a thunk so it runs ONLY when this branch is taken:
+    // the quiet and echo-burst paths never pay for it, and the scan gate can
+    // never drift from the selection gate (panel finding).
+    const marker = getMarker?.() ?? null;
+    // One shape reaches this branch that is NOT an agent stream: fluid CJK
+    // typing, where each committed syllable's echo is output and a fast
+    // typist keeps every gap under OUTPUT_QUIET_MS for longer than the
+    // sustain. There the snapshot sits ON the prompt row at the caret's
+    // last-pause column — better than the marker's input-start floor (which
+    // would drag the Korean inline preedit back over already-typed text,
+    // panel finding). So a snapshot on the marker's own row keeps its
+    // column, UNLESS it sits in the border zone (the last two columns): a
+    // prompt-row cell there is the box's right border where the repaint
+    // parked, which is the 2026-08-23 field shape (col 137 of 139) and
+    // exactly what the marker exists to override. Without a column count
+    // the zone is unknowable and the snapshot is kept — the conservative,
+    // shipped behavior.
+    if (marker !== null) {
+      const borderZone = viewport?.cols !== undefined ? viewport.cols - 2 : Infinity;
+      const typingSnapshot = state.hasCaret
+        && state.caretRelRow === marker.relRow
+        && state.caretCol < borderZone;
+      if (!typingSnapshot) {
+        return {
+          absRow: baseY + marker.relRow, col: marker.col,
+          src: 'marker', held, restAge, outputGap, caretAge, edge,
+        };
+      }
     }
     if (state.hasCaret) {
       return {
@@ -1002,24 +1043,25 @@ export function attachImeAnchor(
     // composition starts inside a repaint burst (cause 3).
     composing = true;
     const b = bufferState();
-    const tNow = now();
     // #1016: while output flows, the cursor never visits the input caret
     // (Claude Code parks it at the end of painted content — any column), so
     // for a recognized agent the input line is read out of the buffer
-    // instead. Scanned only while output is flowing: the idle pane is
-    // field-verified correct on the cursor path and stays there.
-    const marker = tNow - tracker.lastOutputAt < OUTPUT_QUIET_MS
-      && options.getAgentSlug?.() === 'claude'
-      ? scanClaudeInputLine(
-          (relRow) => terminal.buffer.active.getLine?.(b.viewportY + relRow)?.translateToString(true),
+    // instead. A thunk: selectFreezeCell invokes it only inside the
+    // streaming branch, so the idle pane — field-verified correct on the
+    // cursor path — never scans. The scan reads the LIVE screen (baseY),
+    // not the viewport: a user scrolled up mid-stream sees history, which
+    // can quote the very chrome being scanned for.
+    const getMarker = options.getAgentSlug?.() === 'claude'
+      ? (): AgentInputLineMarker | null => scanClaudeInputLine(
+          (relRow) => terminal.buffer.active.getLine?.(b.baseY + relRow)?.translateToString(true),
           geometry.rows,
         )
-      : null;
-    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, tNow, {
+      : undefined;
+    const sel = selectFreezeCell(tracker, b.baseY + b.cursorY, b.cursorX, now(), {
       top: b.viewportY,
       rows: geometry.rows,
       cols: geometry.cols,
-    }, b.baseY, marker);
+    }, b.baseY, getMarker);
     lastSel = sel;
     lastSelRelY = sel.absRow - b.baseY;
     frozen = isUsableGeometry(geometry)


### PR DESCRIPTION
Closes #1016. Refs #951, #953.

### Why

The 2026-08-23 field round on #953 (two videos + `main-2026-08-23.log`) proved the cursor signal is exhausted for the streaming case:

- While Claude Code streams, its cursor rests at the **end of painted content** between bursts and never visits the input caret (upstream: anthropics/claude-code#25186).
- "End of painted content" can be **any column** — the log holds quiet-caret snapshots at column 137 of a 139-column pane and at column 53 mid-line — so the last-column refusal from #953 only catches a painted line that happens to fill the row.
- Consequence: during a sustained stream the snapshot is sometimes the park itself, and `src=caret` faithfully anchors the candidate window to it.

Dwell, quiet spans, and column checks all read the cursor; when the true caret is a cell the cursor never visits, no combination of them can find it.

### What

A second signal class for the streaming anchor: **read the input line out of the buffer by its chrome.**

- At `compositionstart` (user-paced — a full-viewport scan is free), when the pane's agent is recognized as Claude Code **and output is flowing**, the viewport is scanned bottom-up for the input box (`╭─` border with a `│ > ` prompt row directly beneath). The composition anchors to the prompt row at the input's start column (`src=marker`), outranking both the snapshot and every dwell source.
- **The idle pane stays cursor-driven on purpose.** It is field-verified correct, and every generation that touched it lost to the untouched baseline (see the `imeAnchor.ts` header's account). The scan does not run while output is quiet.
- Gated per agent via the pane's `surfaceAgent` slug; unrecognized agents, a scan that finds nothing, and callers without a buffer line reader all keep the #953 behavior unchanged.
- Bottom-up scan plus box-frame adjacency keeps quoted chrome in the transcript (an agent printing its own UI) from matching; the bottom-most real box wins.
- A marker-sourced composition pins the inline preedit with the textarea, same as caret-sourced ones, so the two IME surfaces cannot tear apart (#951 field report).
- Diagnostic tag bumps `ime-anchor4` → `ime-anchor5`; `src=marker` records make a field log self-identifying.

### Tests

15 new tests: the scanner (prompt row found; indented box column math; bottom-most match beats quoted chrome; bare prompt line without the border refused; wrapped multi-line input; unreadable/markerless screens), the selection (marker outranks a park snapshot — the exact 137-of-139 field shape; covers a stream that never produced a snapshot; idle ignores the marker; marker without a viewport ignored), and the wiring (recognized agent anchors to the marker and pins the preedit; unrecognized agent never scans; empty scan falls back to `src=caret`; idle composition never scans). Full imeAnchor suite: 76/76.

### Verification

CJK IMEs cannot be reproduced on the dev boxes — the `ime-anchor5` log is the field discriminator, as it has been for every round of #951/#953. The testable half of #1016's definition of done is covered by the suite above; the field half stays open for any future report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Chinese IME candidate-window positioning while Claude Code is actively streaming.
  - Input composition now stays anchored to the correct prompt line, including wrapped or indented input.
  - Preserved existing cursor-based positioning when the terminal is idle or no valid prompt is detected.
  - Added safeguards for unreadable terminal content and unsupported environments.
  - Improved positioning reliability when terminal content changes during streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->