### PR TITLE
Give the #596 restart suite a witness the re-harden cannot move

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,17 @@ jobs:
       - name: Type check push relay
         run: node_modules/.bin/tsc --noEmit -p relay/tsconfig.json
 
+      # `npm test` ends in `test:runtime`, and two of those suites drive the
+      # REAL bundled daemon (#546 boot marker, #596 web restore). Both skip
+      # when `dist/daemon-bundle/index.js` is absent — which it always was
+      # here, so neither has ever run in CI. A skip reads as green, so this
+      # step is what gives those suites any signal at all.
+      - name: Build daemon bundle (the runtime suites drive it)
+        run: npm run build:daemon
+
       - name: Test
         run: npm test
+        env:
+          # Tells those suites the bundle was promised, so removing the step
+          # above fails a test instead of silently retiring both files.
+          WMUX_REQUIRE_DAEMON_BUNDLE: '1'

--- a/src/daemon/__tests__/bootMarker.runtime.test.ts
+++ b/src/daemon/__tests__/bootMarker.runtime.test.ts
@@ -40,6 +40,18 @@ afterAll(() => {
 // fresh checkout without `npm run build:daemon` doesn't red the suite.
 const hasBundle = fs.existsSync(bundle);
 
+/** Set by the CI job that promises to build the bundle first (see
+ *  webRestart.runtime.test.ts). Outside the skipIf below on purpose: it has to
+ *  run precisely in the case where the suite itself cannot, so a workflow that
+ *  stops building the bundle goes red instead of quietly retiring this file. */
+const bundlePromised = process.env.WMUX_REQUIRE_DAEMON_BUNDLE === '1';
+
+describe.runIf(bundlePromised)('#546 boot marker suite prerequisites', () => {
+  it('has the daemon bundle the promising job was supposed to build', () => {
+    expect(hasBundle).toBe(true);
+  });
+});
+
 describe.skipIf(!hasBundle)('#546 boot marker lifecycle (real daemon)', () => {
   it('writes the marker during boot and clears it once ready', async () => {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/src/daemon/web/__tests__/webRestart.runtime.test.ts
+++ b/src/daemon/web/__tests__/webRestart.runtime.test.ts
@@ -41,6 +41,15 @@ if (CAN_RUN && !HAVE_OPENSSL) {
   console.warn('[#764 restart test] SKIPPED native TLS case — OpenSSL is unavailable');
 }
 
+/**
+ * Set by the one CI job that promises to build the bundle before running the
+ * suites. Without it a skip is indistinguishable from a pass: this file spent
+ * its whole life skipped in CI because no workflow ran `npm run build:daemon`,
+ * so it could not have caught a #596 regression at any point. The guard below
+ * turns a broken promise into a red test instead of silence.
+ */
+const BUNDLE_PROMISED = process.env.WMUX_REQUIRE_DAEMON_BUNDLE === '1';
+
 const SUFFIX = '-webrestart-test';
 const WMUX_DIR = path.join(os.homedir(), `.wmux${SUFFIX}`);
 const PIPE = `\\\\.\\pipe\\wmux-daemon${SUFFIX}-${os.userInfo().username || 'default'}`;
@@ -200,14 +209,30 @@ function freePort(): Promise<number> {
 
 const spawned: ChildProcess[] = [];
 
+/**
+ * Everything a spawned daemon printed. A boot's own log is the only witness
+ * that says WHICH code path ran — a filesystem side effect cannot, because
+ * more than one writer touches the same file (see awaitWebStateReHarden).
+ */
+const daemonOutput = new WeakMap<ChildProcess, string[]>();
+
+function outputOf(child: ChildProcess): string {
+  return (daemonOutput.get(child) ?? []).join('');
+}
+
 async function startDaemon(): Promise<ChildProcess> {
   const child = spawn(process.execPath, [BUNDLE], {
     env: { ...process.env, WMUX_DATA_SUFFIX: SUFFIX },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   spawned.push(child);
-  child.stdout?.resume();
-  child.stderr?.resume();
+  const chunks: string[] = [];
+  daemonOutput.set(child, chunks);
+  // Attaching a 'data' listener also resumes the stream, so this replaces the
+  // resume() that used to drop every line on the floor.
+  const capture = (chunk: Buffer): void => void chunks.push(chunk.toString());
+  child.stdout?.on('data', capture);
+  child.stderr?.on('data', capture);
   for (let i = 0; i < 60; i++) {
     await sleep(500);
     try {
@@ -218,6 +243,43 @@ async function startDaemon(): Promise<ChildProcess> {
     }
   }
   throw new Error('daemon never became ready');
+}
+
+/** What `secureWriteTokenFile` prints when it hardens a NEW record inline. */
+const SYNC_HARDEN = '[security] fresh token ACL harden';
+/** What the boot's deferred, off-event-loop re-harden of an EXISTING record prints. */
+const DEFERRED_HARDEN = '[security] deferred token ACL re-harden';
+
+/** Lines this daemon printed about hardening `web-state.json` specifically —
+ *  the same primitive also hardens the auth token and the device store. */
+function hardenLines(child: ChildProcess, marker: string): string[] {
+  return outputOf(child)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.includes(marker) && line.includes('(web-state.json)'));
+}
+
+/**
+ * Wait for the restore's deferred ACL re-harden of `web-state.json` to finish.
+ *
+ * This is why a filesystem check cannot be the evidence here. The re-harden
+ * rewrites the record through a FRESH INODE, so mtime and inode both move
+ * ~80 ms into every boot whether or not the restore wrote anything itself. An
+ * earlier revision asserted `mtimeMs` was unchanged and passed only by
+ * observing the file before that rewrite landed — inserting a 1.5 s sleep
+ * ahead of the same assertion failed it every time.
+ *
+ * Waiting for the completion line puts the observation AFTER both candidate
+ * writers, and doubles as proof the restore path ran at all.
+ */
+async function awaitWebStateReHarden(child: ChildProcess): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (hardenLines(child, DEFERRED_HARDEN).length > 0) return;
+    await sleep(100);
+  }
+  throw new Error(
+    `restored daemon never logged a deferred re-harden of web-state.json:\n${outputOf(child)}`,
+  );
 }
 
 /** SIGKILL — no graceful shutdown, which is what a crash or a reboot looks like. */
@@ -277,6 +339,15 @@ async function resetFixture(): Promise<void> {
 beforeEach(resetFixture);
 afterAll(resetFixture);
 
+// Deliberately OUTSIDE the skipIf above: it has to run precisely in the case
+// where the suite itself cannot. A green log that says nothing is how this file
+// went unrun for its whole life.
+describe.runIf(BUNDLE_PROMISED)('#596 restart suite prerequisites', () => {
+  it('has the daemon bundle the promising job was supposed to build', () => {
+    expect(HAVE_BUNDLE).toBe(true);
+  });
+});
+
 describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
   it(
     'restores the listener AND the token after the daemon is killed and replaced',
@@ -296,15 +367,13 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
       const token = started.token as string;
       expect(token).toBeTruthy();
       expect(await probe(port, '/api/config', token)).toEqual({ status: 200 });
-      const statePath = path.join(WMUX_DIR, 'web-state.json');
-      const persistedMtime = fs.statSync(statePath).mtimeMs;
 
       // ── crash / reboot / one-click update restart ──
       await killDaemon(d1);
       expect((await probe(port, '/api/config', token)).error).toBeTruthy();
 
       // ── a fresh daemon against the same data dir ──
-      await startDaemon();
+      const d2 = await startDaemon();
       const after = await rpc('daemon.web.status');
 
       // The listener is back...
@@ -319,8 +388,11 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
       expect(await probe(port, '/api/config', token)).toEqual({ status: 200 });
       // Restore must not rewrite an identical state record: on Windows that
       // no-op would synchronously shell out for ACL hardening and freeze the
-      // daemon event loop for seconds. Async ACL re-hardening leaves mtime put.
-      expect(fs.statSync(statePath).mtimeMs).toBe(persistedMtime);
+      // daemon event loop for seconds. The daemon's own log is the witness —
+      // that synchronous harden is exactly what a saveWebState would print,
+      // and the deferred re-harden a restore DOES perform is a different line.
+      await awaitWebStateReHarden(d2);
+      expect(hardenLines(d2, SYNC_HARDEN)).toEqual([]);
     },
     120_000,
   );
@@ -366,7 +438,6 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
           keyPath: fixture.keyPath,
         });
         expect(rawState).not.toContain(fs.readFileSync(fixture.keyPath, 'utf8').trim());
-        const persistedMtime = fs.statSync(statePath).mtimeMs;
 
         await killDaemon(d1);
         expect((await probe(port, '/api/config', token, true)).error).toBeTruthy();
@@ -379,7 +450,9 @@ describe.skipIf(!CAN_RUN)('#596 — wmux web survives a daemon restart', () => {
         expect(restored.token).toBe(token);
         expect(await probe(port, '/api/config', token, true)).toEqual({ status: 200 });
         expect((await probe(port, '/api/config', token)).error).toBeTruthy();
-        expect(fs.statSync(statePath).mtimeMs).toBe(persistedMtime);
+        // Same contract as the plaintext case, same witness — see above.
+        await awaitWebStateReHarden(d2);
+        expect(hardenLines(d2, SYNC_HARDEN)).toEqual([]);
 
         // Losing a persisted key must leave no listener at all after restart;
         // silently replaying the same port as HTTP would expose the bearer token.


### PR DESCRIPTION
## The bug in the test

`webRestart.runtime.test.ts` asserted that a restore left `web-state.json`
untouched by checking its mtime, on the premise its own comment stated —
*"Async ACL re-hardening leaves mtime put."*

It does not. `scheduleTokenFileReHarden` (`src/shared/security.ts`) hands the
file to `rewriteThroughFreshInodeAsync`, which stages a replacement and
`renameSync`s it into place. Measured directly on an already-hardened file:

```
mtimeMs before : 1787586542106.389  ino: 87257242780872620
t=+50ms          1787586542106.389  ino: 87257242780872620    SAME
[security] deferred token ACL re-harden took 80ms (web-state.json)
t=+150ms         1787586542188.7268 ino: 12666373952643324    *** MOVED ***
```

Both mtime and inode move ~80 ms into every boot, whether or not the restore
wrote anything. The assertion passed only by observing the file before that
rewrite landed — a `sleep(1500)` ahead of the same line failed it every time:

```
AssertionError: expected 1787586732240.7578 to be 1787586730197.0908
```

So the check was a coin flip on how long the rest of the test happened to
take, and the TLS case — which does more work before it looks — is the one
that came up red.

## The fix

Assert on the daemon's own log, which is the only witness that says *which
path ran*. A redundant `saveWebState` prints a **synchronous** harden line for
that file; the deferred re-harden a restore does perform prints a different
one. The suite now waits for the deferred line (which also proves the restore
path ran at all), then requires that no synchronous harden of `web-state.json`
happened.

Negative control — forcing the redundant rewrite in `restoreWebServer`:

```
× restores the listener AND the token after the daemon is killed and replaced
× restores native HTTPS without key material or plaintext downgrade
AssertionError: expected [ Array(1) ] to deeply equal []
```

Both cases now catch it. Under the mtime check, whether either one caught it
depended on timing.

## The reason nobody saw it

Neither this suite nor the #546 boot-marker suite has ever run in CI. Both
skip when `dist/daemon-bundle/index.js` is absent, and no workflow ever built
it — `validate` runs `build:mcp`, never `build:daemon`. A skip reads as green,
so both files have been decorative since the day they were written.

`validate` now builds the bundle, and declares `WMUX_REQUIRE_DAEMON_BUNDLE=1`.
Each suite carries a prerequisite test, deliberately outside its own skip
guard, that fails when the variable is set but the bundle is missing. Deleting
the build step turns both files red instead of quietly retiring them.

## Verification (Windows, real bundled daemon)

- `webRestart` + `bootMarker`, bundle present: **11 passed**
- Bundle hidden, `WMUX_REQUIRE_DAEMON_BUNDLE=1`: **2 failed, 9 skipped** — the
  guard fires, nothing pretends to pass
- Forced redundant persist: **2 failed** (both restore cases)
- `tsc --noEmit` clean; `eslint --max-warnings=0` clean on both files

No product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJtrPSP68cZPmp2mUyJqGX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon restart validation to confirm deferred security hardening completes successfully.
  * Added coverage for both plaintext and native HTTPS restart scenarios.

* **Testing**
  * Windows CI now builds the daemon bundle before testing.
  * CI fails when the required daemon bundle is unavailable instead of silently skipping runtime tests.
  * Enhanced diagnostics capture daemon output to make restart failures easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->