### PR TITLE
fix(usage): let the expired-token status clear itself after a re-login

### DIFF
--- a/changelog.d/1024.md
+++ b/changelog.d/1024.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **"Token expired" clears itself once you log back in.** The Anthropic usage
+  meter stopped polling the moment Anthropic refused its token, so the titlebar
+  kept reading `Token expired — log in to Claude Code again` after a successful
+  re-login — there was nothing left running to notice. It now keeps looking, and
+  the notice goes away on its own within a few minutes of Claude Code writing a
+  new token. It still will not sit there re-sending a credential it already
+  knows is bad: while the notice stands, a check that finds the same token on
+  disk stops before the request, and a genuine retry happens no more often than
+  the ordinary hourly check would have — so a refusal that was never about your
+  token clears itself too. The refresh button still forces a real attempt
+  whenever you want one. (#1024)

--- a/src/main/claude/UsagePoller.ts
+++ b/src/main/claude/UsagePoller.ts
@@ -13,8 +13,17 @@
 //     called or the credential file is observed to appear (future
 //     follow-up — for now manual refresh is the recovery).
 //   - 401/403 (token expired or revoked) → emit 'unauthorized' status
-//     and STOP the interval. User must re-login and toggle Settings
-//     off/on (or click manual refresh).
+//     and remember the token that was rejected. The interval KEEPS
+//     RUNNING, on a shorter cadence, but a tick that reads back that
+//     same rejected token returns before the network call — so we
+//     never re-send a credential we already know is bad, and the
+//     status clears by itself as soon as Claude Code writes a new one
+//     (a re-login, or its own token refresh). That skip also expires
+//     after `intervalMs`, so a 401 that was never about the token at
+//     all still gets one retry per poll period — the same traffic a
+//     healthy poller spends, and never more. Stopping the interval
+//     outright was the old behaviour, and it left the widget reading
+//     "Token expired" forever after a successful re-login (#1012).
 //   - Network / 5xx → emit 'network-error' / 'http-error' with the
 //     last error. The interval KEEPS RUNNING; next tick is the retry.
 //     Avoids the failure mode where a transient outage permanently
@@ -36,7 +45,9 @@ export type PollerStatus =
   | 'ok'
   /** Claude Code is not logged in / credential file missing. */
   | 'token-missing'
-  /** Anthropic returned 401/403. Poller paused. */
+  /** Anthropic returned 401/403. The poller keeps running, but it will
+   *  not re-send the token that was refused until the credential on
+   *  disk changes (or a whole poll interval has passed). */
   | 'unauthorized'
   /** Non-auth HTTP failure. Poller keeps running, retrying. */
   | 'http-error'
@@ -66,6 +77,20 @@ export interface PollerOptions {
   intervalMs?: number;
   /** Skip a tick if the window has been hidden longer than this. Default 30 min. */
   hiddenSkipThresholdMs?: number;
+  /** While a refusal is still fresh, re-read the credential this often
+   *  instead of waiting out `intervalMs`. A recheck costs one
+   *  credential read and sends nothing unless the token changed (or a
+   *  whole `intervalMs` has passed since the refusal), so it can be
+   *  far shorter than the poll interval. Clamped to `intervalMs`,
+   *  since a recheck slower than the poll it stands in for would only
+   *  lengthen the wrong-status window. Default 5 min.
+   *
+   *  "Fresh" is the pin's age, not anything about the displayed
+   *  status: a credential that reads as missing for one tick during a
+   *  re-login moves the status to 'token-missing' without giving up
+   *  either the fast cadence or the skip, because that tick is
+   *  precisely when recovery is landing. */
+  unauthorizedRecheckMs?: number;
   /** Injectable for tests. */
   now?: () => number;
   /** Injectable for tests. */
@@ -76,6 +101,7 @@ export interface PollerOptions {
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const THIRTY_MIN_MS = 30 * 60 * 1000;
+const FIVE_MIN_MS = 5 * 60 * 1000;
 
 /**
  * Owns a single in-process interval. The poller is created once and
@@ -86,6 +112,7 @@ const THIRTY_MIN_MS = 30 * 60 * 1000;
 export class UsagePoller {
   private readonly intervalMs: number;
   private readonly hiddenSkipThresholdMs: number;
+  private readonly unauthorizedRecheckMs: number;
   private readonly now: () => number;
   private readonly fetchImpl: typeof fetch;
   private readonly loadCredential: () => Promise<LoadResult>;
@@ -97,8 +124,36 @@ export class UsagePoller {
     subscriptionType: null,
   };
   private timer: ReturnType<typeof setInterval> | null = null;
+  /** Period the live interval was armed with, so `arm()` can tell a
+   *  cadence change from a no-op re-arm. Null exactly when `timer` is. */
+  private timerPeriodMs: number | null = null;
   private immediateTimer: ReturnType<typeof setTimeout> | null = null;
+  /** The access token Anthropic answered 401/403 for. A tick that reads
+   *  this same token back off disk returns without spending a request.
+   *  It deliberately outlives the 'unauthorized' chip: a credential read
+   *  that fails mid-relogin moves the status on without making the token
+   *  underneath any more sendable. Cleared by start(), by stop(), and by
+   *  any tick that gets past the skip — never by a status change. */
+  private rejectedAccessToken: string | null = null;
+  /** When that answer came back. The skip above expires after
+   *  `intervalMs`, so a 401 that was never about the token (an auth
+   *  outage, an org policy since reverted) still gets one retry per
+   *  normal poll period — never more traffic than a healthy poller. */
+  private rejectedAtMs = 0;
   private inflight = false;
+  /** The run currently in flight, so a tick that must not be dropped
+   *  can wait the slot out instead of returning. */
+  private inflightRun: Promise<void> | null = null;
+  /** The generation that run belongs to. A tick only stands down for a
+   *  pass from its own session; one left behind by a stopped session is
+   *  going to abandon its result anyway. */
+  private inflightGeneration = -1;
+  /** Bumped by every start(), stop() and dispose(). A tick captures it
+   *  on entry and abandons its result if the session it belonged to
+   *  ended while it was awaiting. Without it a fetch can outlive its
+   *  own poller: repainting a status the toggle already turned off, or
+   *  sending a credential the recheck deliberately withholds. */
+  private generation = 0;
   private windowVisible = true;
   private windowHiddenAtMs = 0;
   private disposed = false;
@@ -108,6 +163,14 @@ export class UsagePoller {
   constructor(opts: PollerOptions = {}) {
     this.intervalMs = opts.intervalMs ?? ONE_HOUR_MS;
     this.hiddenSkipThresholdMs = opts.hiddenSkipThresholdMs ?? THIRTY_MIN_MS;
+    // Never slower than the poll it replaces: the recheck exists to
+    // shorten the time a wrong "Token expired" stays on screen, and a
+    // caller with a sub-5-minute interval would otherwise have that
+    // window stretched by hitting an unauthorized state.
+    this.unauthorizedRecheckMs = Math.min(
+      this.intervalMs,
+      opts.unauthorizedRecheckMs ?? FIVE_MIN_MS,
+    );
     this.now = opts.now ?? (() => Date.now());
     this.fetchImpl = opts.fetchImpl ?? fetch;
     this.loadCredential = opts.loadCredential ?? loadClaudeCredential;
@@ -118,9 +181,13 @@ export class UsagePoller {
   start(): void {
     if (this.disposed) return;
     if (this.timer) return;
-    this.timer = setInterval(() => {
-      void this.tick();
-    }, this.intervalMs);
+    // A fresh session re-verifies from scratch. A refreshNow() taken
+    // while the toggle was off can leave a verdict behind that stop()
+    // never saw, and it must not silence the first tick of the next
+    // session.
+    this.generation += 1;
+    this.clearRejection();
+    this.arm(this.intervalMs);
     // Immediate first fetch (deliberate: don't make the user wait for
     // the interval). `setTimeout(fn, 0)` rather than queueMicrotask so
     // tests can drive it via `vi.advanceTimersByTimeAsync(0)`. The
@@ -140,14 +207,35 @@ export class UsagePoller {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+      this.timerPeriodMs = null;
     }
     if (this.immediateTimer) {
       clearTimeout(this.immediateTimer);
       this.immediateTimer = null;
     }
+    // The toggle went off, so nothing is left to withhold a token from.
+    // The bump makes that true even against a tick still awaiting: its
+    // result is abandoned rather than landing after this line, and a
+    // waiter queued on it stands down instead of taking the slot.
+    this.generation += 1;
+    this.clearRejection();
     if (this.state.status !== 'idle') {
       this.setState({ status: 'idle' });
     }
+  }
+
+  /** Single owner of the interval, so the cadence can change (normal
+   *  poll ↔ unauthorized recheck) without leaking a timer. Re-arming
+   *  at the period already running is a no-op, which keeps a tick from
+   *  pushing its own next tick further away on every pass. */
+  private arm(periodMs: number): void {
+    if (this.disposed) return;
+    if (this.timer && this.timerPeriodMs === periodMs) return;
+    if (this.timer) clearInterval(this.timer);
+    this.timerPeriodMs = periodMs;
+    this.timer = setInterval(() => {
+      void this.tick();
+    }, periodMs);
   }
 
   /** Manual refresh — the StatusBar widget's "refresh now" button. The
@@ -155,7 +243,12 @@ export class UsagePoller {
    *  Returns the snapshot for callers that want to await the result. */
   async refreshNow(): Promise<PollerState> {
     if (this.disposed) return this.state;
-    await this.tick();
+    // `force`: the user asked for this one by hand, so it outranks both
+    // the hidden-window skip and the "same token already 401'd" skip.
+    // Re-sending a known-bad token is wasteful on a timer and correct
+    // on a button — the user may have just fixed something we cannot
+    // see from the credential alone.
+    await this.tick({ force: true });
     return this.state;
   }
 
@@ -197,94 +290,247 @@ export class UsagePoller {
 
   /** Single poll iteration. Guarded against re-entry so a 1h interval
    *  tick can't overlap a slow in-flight fetch. */
-  private async tick(): Promise<void> {
+  private async tick(opts: { force?: boolean } = {}): Promise<void> {
     if (this.disposed) return;
-    if (this.inflight) return;
+    // Captured before the wait below, never after it. A tick belongs to
+    // the session that scheduled it; adopting whatever session happens
+    // to be current when a slot finally opens is how a tick queued
+    // before stop() ends up reading the credential and sending a
+    // request after the meter was switched off, and painting a status
+    // no live timer is left to correct.
+    const generation = this.generation;
+    if (this.inflight) {
+      // Yield to a peer, never to a corpse. An ordinary interval tick
+      // steps aside for a pass from its own session, because that pass
+      // is about to produce the same answer. It must NOT step aside for
+      // one left over from a session that has since been stopped: that
+      // pass will abandon its own result at the first `isStale` check,
+      // so yielding to it means a toggle off and back on during a slow
+      // read costs the new session its opening fetch, and the widget
+      // then waits out a whole poll interval with nothing in it.
+      //
+      // A forced tick never steps aside at all. The pass in flight may
+      // have taken the unauthorized skip below and sent nothing, and
+      // the button the user just pressed would then have done nothing.
+      const peerIsCurrent = this.inflightGeneration === generation;
+      if (!opts.force && peerIsCurrent) return;
+      // Loop rather than return: several waiters can be queued on the
+      // same run, and each forced one has to get its own pass instead
+      // of the first waiter's arrival becoming the reason to drop the
+      // rest.
+      while (this.inflight) {
+        const run = this.inflightRun;
+        if (!run) break;
+        try {
+          await run;
+        } catch {
+          // That pass's failure is its own; we only waited for the slot.
+        }
+        if (this.isStale(generation)) return;
+      }
+      if (this.isStale(generation)) return;
+      // Ordinary ticks coalesce. Only a stale peer sent one in here, and
+      // if the slot has since been used by a pass belonging to this
+      // session, that pass already produced the answer this tick was
+      // going to ask for — several interval firings queued behind one
+      // slow read must not turn into that many requests when it lands.
+      // A forced tick is exempt: each click is its own question.
+      if (!opts.force && this.inflightGeneration === generation) return;
+    }
     // Hidden-window skip — only applies to interval-driven ticks, NOT
     // explicit refreshNow() or window-show kicks. Caller-driven probes
     // are always honored.
-    if (!this.windowVisible && this.windowHiddenAtMs > 0) {
+    if (!opts.force && !this.windowVisible && this.windowHiddenAtMs > 0) {
       const hiddenForMs = this.now() - this.windowHiddenAtMs;
       if (hiddenForMs >= this.hiddenSkipThresholdMs) {
-        // Skip this tick; state unchanged.
+        // Skip this tick; state unchanged. The cadence still ages,
+        // though: without this the recheck period outlives the pin's
+        // freshness window for as long as the window stays hidden,
+        // because the finally below is the only other place that
+        // re-arms and this return never reaches it.
+        this.syncCadence(generation);
         return;
       }
     }
     this.inflight = true;
+    this.inflightGeneration = generation;
+    const run = this.runTick(opts, generation);
+    this.inflightRun = run;
     try {
-      const credResult = await this.loadCredential();
-      if (!credResult.ok) {
-        if (credResult.reason === 'not-found') {
-          this.setState({
-            status: 'token-missing',
-            lastError: null,
-            subscriptionType: null,
-          });
-          return;
-        }
+      await run;
+    } finally {
+      this.inflight = false;
+      this.inflightRun = null;
+      // One place decides the cadence, after the outcome is known and
+      // only for a session that is still the current one.
+      this.syncCadence(generation);
+    }
+  }
+
+  /** The work of one tick. Split from `tick()` so the re-entry guard,
+   *  the in-flight handle and the cadence update have a single owner. */
+  private async runTick(opts: { force?: boolean }, generation: number): Promise<void> {
+    const credResult = await this.loadCredential();
+    if (this.isStale(generation)) return;
+    if (!credResult.ok) {
+      // Deliberately keeps any rejected-token pin. A credential that
+      // reads as missing for one tick is exactly what a re-login looks
+      // like mid-write, and dropping the pin here would drop the fast
+      // recheck cadence with it — stranding the new token for a whole
+      // poll interval at the precise moment recovery was arriving. It
+      // would also release the skip below on the tick after that, since
+      // the credential coming back unchanged is not a reason to re-send
+      // it.
+      if (credResult.reason === 'not-found') {
         this.setState({
-          status: 'read-error',
-          lastError: credResult.detail ?? credResult.reason,
+          status: 'token-missing',
+          lastError: null,
+          subscriptionType: null,
         });
         return;
       }
-      const { credential } = credResult;
-      try {
-        const snapshot = await fetchUsage(credential.accessToken, this.fetchImpl);
-        this.setState({
-          status: 'ok',
-          snapshot,
-          lastError: null,
-          subscriptionType: credential.subscriptionType,
-        });
-      } catch (err) {
-        if (err instanceof UsageApiException) {
-          if (err.detail.kind === 'unauthorized') {
-            // STOP the interval — the credential is bad and pummeling
-            // Anthropic with 401s helps nobody. User must re-login then
-            // re-toggle.
-            this.stop();
-            this.setState({
-              status: 'unauthorized',
-              lastError: 'HTTP 401/403',
-              subscriptionType: credential.subscriptionType,
-            });
-            return;
-          }
-          if (err.detail.kind === 'http') {
-            this.setState({
-              status: 'http-error',
-              lastError: `HTTP ${err.detail.status} ${err.detail.statusText}`,
-              subscriptionType: credential.subscriptionType,
-            });
-            return;
-          }
-          if (err.detail.kind === 'network') {
-            this.setState({
-              status: 'network-error',
-              lastError: err.detail.message,
-              subscriptionType: credential.subscriptionType,
-            });
-            return;
-          }
+      this.setState({
+        status: 'read-error',
+        lastError: credResult.detail ?? credResult.reason,
+      });
+      return;
+    }
+    const { credential } = credResult;
+    if (
+      !opts.force &&
+      this.rejectedAccessToken === credential.accessToken &&
+      this.now() - this.rejectedAtMs < this.intervalMs
+    ) {
+      // The same token Anthropic already refused, asked about less than
+      // a normal poll period ago. Nothing on disk has changed, so the
+      // answer would almost certainly be the same 401 — leave the state
+      // as it is and spend no request. The next tick re-reads the
+      // credential, which is the whole point of staying armed.
+      //
+      // Two bounds, because a 401 has two possible causes:
+      //   - the token really is bad → the credential has to change
+      //     before any request could succeed, and the recheck cadence
+      //     notices that within minutes, for free;
+      //   - the token was fine and the refusal was not about it (an
+      //     auth-service blip, an org policy since reverted) → no
+      //     credential will ever change, so the `intervalMs` bound is
+      //     what eventually retries. One request per poll period is
+      //     exactly what a healthy poller spends, so this can never
+      //     cost more traffic than success does.
+      //
+      // Those two are the whole rule, deliberately: the pin plus its
+      // age, and nothing about what the chip currently reads. Keying on
+      // the displayed status as well looked safer and was not — a read
+      // that fails once moves the status off 'unauthorized' while the
+      // credential underneath is unchanged, and the skip would then
+      // release early and re-send the token it exists to withhold.
+      // Nor does the pin strand any other status: every one of them
+      // recovers by way of a *different* credential, and a different
+      // token fails this comparison on the first tick that reads it.
+      return;
+    }
+    // Past the skip, so whatever the pin was pointing at is no longer
+    // the operative credential.
+    this.clearRejection();
+    try {
+      const snapshot = await fetchUsage(credential.accessToken, this.fetchImpl);
+      if (this.isStale(generation)) return;
+      this.setState({
+        status: 'ok',
+        snapshot,
+        lastError: null,
+        subscriptionType: credential.subscriptionType,
+      });
+    } catch (err) {
+      if (this.isStale(generation)) return;
+      if (err instanceof UsageApiException) {
+        if (err.detail.kind === 'unauthorized') {
+          // Do NOT stop the interval — that used to strand the widget
+          // on "Token expired" until the user found the Settings
+          // toggle (#1012). Instead pin the token that was refused;
+          // `syncCadence` then switches to the recheck period, every
+          // tick re-reads the credential, and the guard above keeps
+          // this same bad token off the network. The moment Claude
+          // Code writes a different token, the next tick fetches with
+          // it and the status clears on its own.
+          this.rejectedAccessToken = credential.accessToken;
+          this.rejectedAtMs = this.now();
           this.setState({
-            status: 'http-error',
-            lastError: err.message,
+            status: 'unauthorized',
+            lastError: 'HTTP 401/403',
             subscriptionType: credential.subscriptionType,
           });
           return;
         }
-        // Unknown error class — treat as network for retry semantics.
-        const msg = err instanceof Error ? err.message : 'unknown';
+        if (err.detail.kind === 'http') {
+          this.setState({
+            status: 'http-error',
+            lastError: `HTTP ${err.detail.status} ${err.detail.statusText}`,
+            subscriptionType: credential.subscriptionType,
+          });
+          return;
+        }
+        if (err.detail.kind === 'network') {
+          this.setState({
+            status: 'network-error',
+            lastError: err.detail.message,
+            subscriptionType: credential.subscriptionType,
+          });
+          return;
+        }
         this.setState({
-          status: 'network-error',
-          lastError: msg,
+          status: 'http-error',
+          lastError: err.message,
           subscriptionType: credential.subscriptionType,
         });
+        return;
       }
-    } finally {
-      this.inflight = false;
+      // Unknown error class — treat as network for retry semantics.
+      const msg = err instanceof Error ? err.message : 'unknown';
+      this.setState({
+        status: 'network-error',
+        lastError: msg,
+        subscriptionType: credential.subscriptionType,
+      });
     }
+  }
+
+  /** True when the session this tick belonged to has since been stopped,
+   *  restarted or disposed. Every await in `runTick` is followed by this
+   *  check, so a fetch that outlives its own poller can neither repaint a
+   *  status the toggle already turned off nor pin a token for a session
+   *  that no longer exists. */
+  private isStale(generation: number): boolean {
+    return this.disposed || this.generation !== generation;
+  }
+
+  /** Drop the "this token is bad" verdict. The cadence is not touched
+   *  here — `syncCadence` derives it from the pin at the end of the
+   *  tick, so there is only one place that can change the interval. */
+  private clearRejection(): void {
+    this.rejectedAccessToken = null;
+    this.rejectedAtMs = 0;
+  }
+
+  /** The period the interval should be running at right now: fast while
+   *  a refusal is fresh, the ordinary poll otherwise. The fast window is
+   *  bounded by the same `intervalMs` that releases the skip, so it can
+   *  never outlive the evidence for it — and if the retry that ends it
+   *  is refused again, that re-pins and opens the next window. */
+  private cadenceMs(): number {
+    const pinned =
+      this.rejectedAccessToken !== null &&
+      this.now() - this.rejectedAtMs < this.intervalMs;
+    return pinned ? this.unauthorizedRecheckMs : this.intervalMs;
+  }
+
+  /** Re-arm to the period the current state calls for. Skipped when the
+   *  session that ran the tick is gone, so a late tick cannot resurrect
+   *  a timer or override the cadence a fresh `start()` just chose. */
+  private syncCadence(generation: number): void {
+    if (this.isStale(generation)) return;
+    if (!this.timer) return;
+    this.arm(this.cadenceMs());
   }
 
   private setState(patch: Partial<PollerState>): void {

--- a/src/main/claude/__tests__/UsagePoller.test.ts
+++ b/src/main/claude/__tests__/UsagePoller.test.ts
@@ -28,6 +28,47 @@ function makeOkFetch(): typeof fetch {
   return vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers })) as unknown as typeof fetch;
 }
 
+/** Build a credential result around a token the caller can swap, so a
+ *  test can stand in for Claude Code rewriting `.credentials.json`. */
+function credentialFor(accessToken: string): LoadResult {
+  return {
+    ok: true,
+    credential: {
+      accessToken,
+      subscriptionType: 'pro',
+      rateLimitTier: 'standard',
+      expiresAtMs: null,
+    },
+  };
+}
+
+/** Call count of an injected fetch stub. The suite types its stubs as
+ *  `typeof fetch`, which TS will not narrow back to a mock on its own. */
+function callCount(impl: typeof fetch): number {
+  return (impl as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+}
+
+/** The `authorization` header of the nth call to an injected fetch stub. */
+function bearerOf(impl: typeof fetch, callIndex: number): string {
+  const calls = (impl as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls;
+  const headers = calls[callIndex][1].headers as Record<string, string>;
+  return headers.authorization;
+}
+
+/** A fresh 200 with the rate-limit headers the parser reads. New each
+ *  call, because a Response body can only be consumed once. */
+function okUsageResponse(): Response {
+  return new Response('{}', {
+    status: 200,
+    headers: new Headers({
+      'anthropic-ratelimit-unified-5h-utilization': '0.5',
+      'anthropic-ratelimit-unified-5h-reset': '1700000000',
+      'anthropic-ratelimit-unified-7d-utilization': '0.1',
+      'anthropic-ratelimit-unified-7d-reset': '1700100000',
+    }),
+  });
+}
+
 function makeFlushPromises(): () => Promise<void> {
   // Microtask queue is drained by `await Promise.resolve()` chains; we
   // need enough chains to cover queueMicrotask → loadCredential await
@@ -61,7 +102,7 @@ describe('UsagePoller', () => {
     poller.dispose();
   });
 
-  it('fires an immediate fetch on start (queueMicrotask, not interval)', async () => {
+  it('fires an immediate fetch on start (setTimeout(0), not the interval)', async () => {
     const onState = vi.fn();
     const poller = new UsagePoller({
       intervalMs: 100_000, // way beyond test, ensures the microtask is the source
@@ -104,12 +145,13 @@ describe('UsagePoller', () => {
     poller.dispose();
   });
 
-  it('stops poller and emits unauthorized on 401', async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(
-      new Response('unauth', { status: 401 }),
-    ) as unknown as typeof fetch;
+  it('emits unauthorized on 401 and stops re-sending the refused token', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async () => new Response('unauth', { status: 401 })) as unknown as typeof fetch;
     const poller = new UsagePoller({
       intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
       loadCredential: async () => OK_CREDENTIAL,
       fetchImpl,
     });
@@ -117,11 +159,561 @@ describe('UsagePoller', () => {
     await vi.advanceTimersByTimeAsync(1);
     await flushPromises();
     expect(poller.getState().status).toBe('unauthorized');
-    // Interval should be cleared — advancing time should NOT trigger a refetch.
-    (fetchImpl as unknown as ReturnType<typeof vi.fn>).mockClear();
-    vi.advanceTimersByTime(300_000);
+    // The interval stays armed (that is what lets the status recover on
+    // its own), but every one of those recheck ticks stops at the
+    // credential read: the token on disk is the one already refused, so
+    // Anthropic still sees exactly the first 401 and no more.
+    expect(callCount(fetchImpl)).toBe(1);
+    await vi.advanceTimersByTimeAsync(10_000);
     await flushPromises();
     expect(poller.getState().status).toBe('unauthorized');
+    expect(callCount(fetchImpl)).toBe(1);
+    poller.dispose();
+  });
+
+  it('retries a still-refused token once per poll interval, not once per recheck', async () => {
+    // A 401 is not proof the token is bad — an auth outage or a policy
+    // since reverted produces one too, and no credential will ever
+    // change to release it. So the skip expires after intervalMs: the
+    // rechecks in between cost nothing, and the retry rate settles at
+    // exactly what a healthy poller spends.
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async () => new Response('unauth', { status: 401 })) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 10_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+
+    // Nine rechecks inside the poll period: credential read each time,
+    // no request.
+    await vi.advanceTimersByTimeAsync(9_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+
+    // The period elapses — exactly one retry, and it restarts the clock
+    // rather than opening the gate for every recheck after it.
+    await vi.advanceTimersByTimeAsync(2_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(2);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(2);
+
+    // A second full period behaves the same, so the rate is a steady one
+    // request per interval and not a one-off that then drifts.
+    await vi.advanceTimersByTimeAsync(6_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(3);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(3);
+    expect(poller.getState().status).toBe('unauthorized');
+    poller.dispose();
+  });
+
+  it('clears unauthorized by itself once Claude Code writes a new token (#1012)', async () => {
+    let token = 'stale-token';
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(async () => new Response('unauth', { status: 401 }))
+      .mockImplementation(
+        async () =>
+          new Response('{}', {
+            status: 200,
+            headers: new Headers({
+              'anthropic-ratelimit-unified-5h-utilization': '0.5',
+              'anthropic-ratelimit-unified-5h-reset': '1700000000',
+              'anthropic-ratelimit-unified-7d-utilization': '0.1',
+              'anthropic-ratelimit-unified-7d-reset': '1700100000',
+            }),
+          }),
+      ) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: async () => credentialFor(token),
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+    expect(bearerOf(fetchImpl, 0)).toBe('Bearer stale-token');
+
+    // The re-login. No toggle, no button, no window event — only the
+    // credential on disk changing under a poller that stayed armed.
+    token = 'fresh-token';
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(2);
+    expect(bearerOf(fetchImpl, 1)).toBe('Bearer fresh-token');
+    expect(poller.getState().status).toBe('ok');
+    expect(poller.getState().snapshot?.sessionPct).toBe(50);
+
+    // And it is back on the normal cadence, not the recheck one: the
+    // recheck interval elapsing must not, on its own, buy a new fetch.
+    await vi.advanceTimersByTimeAsync(5000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(2);
+    poller.dispose();
+  });
+
+  it('keeps re-reading the credential on every recheck while it withholds the request', async () => {
+    // The recheck is only worth arming if it actually looks. Count the
+    // credential reads as well as the requests: many of the first, one
+    // of the second.
+    let loads = 0;
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async () => new Response('unauth', { status: 401 })) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: async () => {
+        loads += 1;
+        return OK_CREDENTIAL;
+      },
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+    const loadsAfterFirst = loads;
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flushPromises();
+    expect(loads).toBeGreaterThanOrEqual(loadsAfterFirst + 9);
+    expect(callCount(fetchImpl)).toBe(1);
+    poller.dispose();
+  });
+
+  it('does not let a momentary credential miss cost a whole poll interval', async () => {
+    // Claude Code replacing .credentials.json is exactly when a read can
+    // come back empty, and it is exactly when recovery is arriving. If
+    // that one tick dropped back to the hourly cadence, the new token
+    // would sit unprobed for up to an hour — the #1012 symptom again,
+    // one state over.
+    let call = 0;
+    const load = async (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) return credentialFor('stale-token');
+      if (call === 2) return { ok: false, reason: 'not-found' };
+      return credentialFor('fresh-token');
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(async () => new Response('unauth', { status: 401 }))
+      .mockImplementation(async () => okUsageResponse()) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('token-missing');
+
+    // One more recheck period, not one more poll interval.
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('ok');
+    expect(bearerOf(fetchImpl, 1)).toBe('Bearer fresh-token');
+    poller.dispose();
+  });
+
+  it('abandons a tick whose session was stopped while it read the credential', async () => {
+    // The recheck introduced an await that runs while the poller is in
+    // its wrong state, so stop() can now land inside one. Without a
+    // lifecycle guard the tick resumes into a cleared pin, finds the
+    // skip no longer true, and sends the very credential the skip
+    // exists to withhold — after the user turned the meter off.
+    // Definite-assignment: the executor runs synchronously inside the
+    // second load(), but TS cannot see a closure assignment as a
+    // reassignment and would narrow a nullable binding to `never`.
+    let release!: (value: LoadResult) => void;
+    let call = 0;
+    const load = (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) return Promise.resolve(OK_CREDENTIAL);
+      return new Promise<LoadResult>((resolve) => {
+        release = resolve;
+      });
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async () => new Response('unauth', { status: 401 })) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+    expect(callCount(fetchImpl)).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1000); // the recheck is now awaiting the read
+    expect(typeof release).toBe('function');
+    poller.stop();
+    expect(poller.getState().status).toBe('idle');
+
+    release(OK_CREDENTIAL);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    expect(poller.getState().status).toBe('idle');
+    poller.dispose();
+  });
+
+  it('refreshNow() waits out an in-flight tick instead of being dropped by it', async () => {
+    // Before the recheck cadence existed there were no background ticks
+    // at all in the unauthorized state, so the re-entry guard could not
+    // eat a manual refresh. Now there are, and the button has to survive
+    // landing on one.
+    let release!: (value: LoadResult) => void;
+    let call = 0;
+    const load = (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<LoadResult>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(OK_CREDENTIAL);
+    };
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1); // the first tick is awaiting the read
+    expect(typeof release).toBe('function');
+    const refreshed = poller.refreshNow();
+    release(OK_CREDENTIAL);
+    await refreshed;
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(2);
+    poller.dispose();
+  });
+
+  it('abandons a tick whose session was stopped while it awaited the request', async () => {
+    // The sibling case to the credential-read one: the lifecycle guard
+    // has to hold on BOTH awaits, or a response that outlives its own
+    // session repaints a status the toggle already turned off — and,
+    // for a 401, pins a token for a poller that is no longer running.
+    let release!: (value: Response) => void;
+    const fetchImpl = vi.fn().mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          release = resolve;
+        }),
+    ) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(typeof release).toBe('function');
+
+    poller.stop();
+    expect(poller.getState().status).toBe('idle');
+    release(new Response('unauth', { status: 401 }));
+    await flushPromises();
+    // Neither the status nor the cadence may come from a session that
+    // ended: no repaint, and no interval put back by the stale finally.
+    expect(poller.getState().status).toBe('idle');
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    expect(poller.getState().status).toBe('idle');
+    poller.dispose();
+  });
+
+  it('keeps the fast cadence through an unreadable credential too, not just a missing one', async () => {
+    // Same reasoning as the not-found case: a read that fails once is
+    // not evidence that the refusal is settled, and dropping back to
+    // the hourly poll there would cost the new token an hour.
+    let call = 0;
+    const load = async (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) return credentialFor('stale-token');
+      if (call === 2) return { ok: false, reason: 'read-error', detail: 'EBUSY' };
+      return credentialFor('fresh-token');
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(async () => new Response('unauth', { status: 401 }))
+      .mockImplementation(async () => okUsageResponse()) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('read-error');
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('ok');
+    expect(bearerOf(fetchImpl, 1)).toBe('Bearer fresh-token');
+    poller.dispose();
+  });
+
+  it('gives every queued manual refresh its own pass, not just the first', async () => {
+    // Two clicks landing on one hung read used to leave the second
+    // caller with nothing: it woke up, saw the first waiter had already
+    // taken the slot, and returned as if it had been served.
+    let release!: (value: LoadResult) => void;
+    let call = 0;
+    const load = (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<LoadResult>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(OK_CREDENTIAL);
+    };
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(typeof release).toBe('function');
+    const first = poller.refreshNow();
+    const second = poller.refreshNow();
+    release(OK_CREDENTIAL);
+    await Promise.all([first, second]);
+    await flushPromises();
+    // One for the tick that was already running, one for each click.
+    expect(callCount(fetchImpl)).toBe(3);
+    poller.dispose();
+  });
+
+  it("does not let a stopped session's in-flight tick swallow the next session's first fetch", async () => {
+    // Toggling off and back on during a slow credential read leaves a
+    // tick from the dead session in flight. The new session's opening
+    // fetch must not stand down for it — that pass is going to throw
+    // its own result away, and standing down for it costs the widget a
+    // whole poll interval of emptiness.
+    let release!: (value: LoadResult) => void;
+    let call = 0;
+    const load = (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<LoadResult>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(OK_CREDENTIAL);
+    };
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1); // first tick is awaiting the read
+    expect(typeof release).toBe('function');
+    poller.stop();
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1); // the new session's immediate tick
+    release(OK_CREDENTIAL);
+    await flushPromises();
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    expect(poller.getState().status).toBe('ok');
+    poller.dispose();
+  });
+
+  it('does not run a queued tick for a session that was stopped while it waited', async () => {
+    // The wait for a busy slot is the one place a tick can outlive its
+    // own session without being inside an await of its own. If it takes
+    // the generation that happens to be current when the slot opens
+    // rather than the one it was scheduled under, a stop() in between
+    // buys a credential read and a request with the meter switched off,
+    // and a status no live timer is left to correct.
+    let release!: (value: LoadResult) => void;
+    let call = 0;
+    const load = (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<LoadResult>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(OK_CREDENTIAL);
+    };
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1); // tick A is hung on the read
+    expect(typeof release).toBe('function');
+    const refreshed = poller.refreshNow(); // queued behind A
+    poller.stop();
+    release(OK_CREDENTIAL);
+    await refreshed;
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(0);
+    expect(poller.getState().status).toBe('idle');
+    poller.dispose();
+  });
+
+  it('still withholds a refused token that reappears unchanged after a failed read', async () => {
+    // The skip is the pin and its age, and nothing else. Keying it on
+    // the displayed status too would release it here: one unreadable
+    // read moves the chip off 'unauthorized' while the credential
+    // underneath never changed, and the next tick would re-send exactly
+    // the token the skip exists to withhold.
+    let call = 0;
+    const load = async (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 2) return { ok: false, reason: 'read-error', detail: 'EBUSY' };
+      return credentialFor('stale-token');
+    };
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async () => new Response('unauth', { status: 401 })) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(poller.getState().status).toBe('unauthorized');
+    expect(callCount(fetchImpl)).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(poller.getState().status).toBe('read-error');
+
+    // The same token is back and the poll period has not elapsed, so
+    // nothing goes out — however the chip currently reads.
+    await vi.advanceTimersByTimeAsync(10_000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    expect(call).toBeGreaterThan(10);
+    poller.dispose();
+  });
+
+  it("coalesces the interval ticks that pile up behind a stopped session's read", async () => {
+    // Several firings of the new session's interval can queue on one
+    // slow read left by the old session. They are all asking the same
+    // question, so the slot opening must buy one pass, not one per
+    // firing.
+    let release!: (value: LoadResult) => void;
+    let call = 0;
+    const load = (): Promise<LoadResult> => {
+      call += 1;
+      if (call === 1) {
+        return new Promise<LoadResult>((resolve) => {
+          release = resolve;
+        });
+      }
+      return Promise.resolve(OK_CREDENTIAL);
+    };
+    const fetchImpl = makeOkFetch();
+    const poller = new UsagePoller({
+      intervalMs: 1000,
+      loadCredential: load,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1); // tick A hangs, session 1
+    expect(typeof release).toBe('function');
+    poller.stop();
+    poller.start(); // session 2; A is now a corpse the new ticks may pass
+    await vi.advanceTimersByTimeAsync(3_500); // immediate tick + 3 interval firings
+    release(OK_CREDENTIAL);
+    // Drained without advancing the clock, so anything that runs here
+    // ran because a waiter took the slot, not because a new firing did.
+    // Generous enough for four sequential passes to complete if the
+    // waiters were not coalescing.
+    for (let i = 0; i < 20; i++) await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    expect(poller.getState().status).toBe('ok');
+    poller.dispose();
+  });
+
+  it('refreshNow() re-sends even a token that was already refused', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockImplementation(async () => new Response('unauth', { status: 401 })) as unknown as typeof fetch;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      unauthorizedRecheckMs: 1000,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    // The button is an explicit user action, so it outranks the skip —
+    // the user may have fixed something the credential file cannot show.
+    await poller.refreshNow();
+    expect(callCount(fetchImpl)).toBe(2);
+    expect(bearerOf(fetchImpl, 1)).toBe(bearerOf(fetchImpl, 0));
+    expect(poller.getState().status).toBe('unauthorized');
+    poller.dispose();
+  });
+
+  it('refreshNow() is honored while the window is hidden past the skip threshold', async () => {
+    const fetchImpl = makeOkFetch();
+    let mockNow = 1_700_000_000_000;
+    const poller = new UsagePoller({
+      intervalMs: 100_000,
+      hiddenSkipThresholdMs: 5000,
+      now: () => mockNow,
+      loadCredential: async () => OK_CREDENTIAL,
+      fetchImpl,
+    });
+    poller.start();
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    poller.setWindowVisible(false);
+    mockNow += 10_000;
+    const before = callCount(fetchImpl);
+    await poller.refreshNow();
+    expect(callCount(fetchImpl)).toBe(before + 1);
     poller.dispose();
   });
 


### PR DESCRIPTION
Closes #1012.

## The bug

`UsagePoller` treats a 401/403 from the usage probe as terminal:

```ts
// src/main/claude/UsagePoller.ts (before)
if (err.detail.kind === 'unauthorized') {
  // STOP the interval — the credential is bad and pummeling
  // Anthropic with 401s helps nobody. User must re-login then
  // re-toggle.
  this.stop();
  this.setState({ status: 'unauthorized', ... });
```

The reason it gives is right — re-sending a credential Anthropic just refused
helps nobody. The instrument is what fails: `stop()` clears the interval, so
after the reporter logged back into Claude Code there was nothing left running
to notice. The titlebar chip kept reading `● Token expired — log in to Claude
Code again` indefinitely, which is what #1012 shows.

Nothing else recovers it either:

- `setWindowVisible(true)`'s catch-up kick is gated on `this.timer`, which is
  now null — so hiding and re-showing the window does nothing.
- The only ways out are the Settings toggle off/on and the manual refresh
  button, neither of which announces itself from a chip that just says the
  token expired.

The wedge is also more likely than it looks in wmux specifically: the re-login
usually happens *in a wmux pane*, so the window never hides, and this is a
long-lived app — the chip sits there for the rest of the session.

`AccountUsageService` (the per-account meter in Settings) does not have this
shape: its probes are driven by `agent.stop` past a cooldown, so an
`unauthorized` entry there re-probes on its own. Only the global poller latches.

## The fix

Keep the interval armed and pin the token that was refused.

- `rejectedAccessToken` records the `accessToken` Anthropic answered 401/403
  for. A tick that reads that same token back off disk returns *before*
  `fetchUsage`, so the property `stop()` was protecting is now enforced by
  token identity instead of by killing the loop.
- Two bounds release that skip, one for each cause a 401 can have. If the
  token really is bad, no request can succeed until the credential changes,
  and the recheck notices that within minutes for free. If the refusal was
  **not** about the token — an auth-service blip, an org policy since reverted
  — then no credential will ever change, and pinning on identity alone would
  strand the chip exactly the way `stop()` did. So the skip also expires after
  `intervalMs`: one retry per poll period, which is precisely what a healthy
  poller spends. An unauthorized poller can therefore never cost more traffic
  than a working one, and it recovers from either cause without the user doing
  anything.
- The skip is those two facts and nothing else — not what the chip currently
  reads. Keying it on the displayed status as well looked safer and was not: a
  credential read that fails once moves the status off `unauthorized` while the
  credential underneath is unchanged, and the skip would then release early and
  re-send the very token it exists to withhold. Nor does the pin strand any
  other status, because every one of them recovers by way of a *different*
  credential, and a different token fails the comparison on the first tick that
  reads it.
- `cadenceMs()` derives the interval period from that same freshness window —
  the recheck period while a refusal is fresh, the ordinary poll otherwise —
  and `syncCadence()` is the only thing that re-arms, once, at the end of a
  tick. So the fast cadence cannot outlive its evidence, and no outcome can
  leave the wrong period behind. `arm()` is the single owner of the timer;
  re-arming at the period already running is a no-op.
- A credential that reads as missing for one tick **keeps** the pin. That read
  is what a re-login looks like mid-write, and dropping the fast cadence there
  would strand the new token for a whole poll interval at the exact moment
  recovery was arriving. It would also release the skip on the tick after
  that, since a credential coming back unchanged is not a reason to re-send
  it.

The recheck means there are now background ticks in a state that previously
had none. That is what makes the lifecycle rules below load-bearing: before
this, a tick had nowhere to land except the hourly poll every other state
already ran.

- A tick captures a generation before it does anything else — including
  before any wait — and abandons its work if `start`/`stop`/`dispose` bumped it
  across an await. Without that, a `stop()` landing inside a recheck's
  credential read resumes into a cleared pin, finds the skip no longer true,
  and sends the very token the skip exists to withhold — after the user turned
  the meter off. (The same guard stops a fetch from repainting a status over
  the `idle` that `stop()` just set, which is a pre-existing race on `main`:
  both are the same missing check.)
- The re-entry guard yields to a peer but not to a corpse. Standing down for a
  pass from the current session is right — it is about to produce the same
  answer. Standing down for one left behind by a session that has since been
  stopped is not: that pass abandons its own result at its first `isStale`
  check, so a toggle off and back on during a slow read used to cost the new
  session its opening fetch and leave the widget empty for a whole interval.
- A forced tick never stands down; it waits for the slot in a loop, so several
  queued clicks each get their own pass. Ordinary ticks coalesce instead: if
  the slot was used by a pass of their own generation while they waited, that
  pass already asked their question, and N interval firings piled up behind one
  slow read stay one request rather than N.

`refreshNow()` runs its tick with `force`. An explicit click outranks both
skips: it re-sends even a pinned token (the user may have fixed something the
credential file cannot show), and it is honored while the window is hidden past
the skip threshold — which is what that skip's own comment already claimed and
the code did not do.

## What did not change

- No new status, no change to `PollerState`, no IPC or schema change. The
  renderer is untouched.
- `token-missing`, `read-error`, `http-error` and `network-error` keep their
  existing retry semantics.
- The hourly cadence, the hidden-window cost control, and the 30 minute skip
  threshold are unchanged for every state except a fresh refusal.

## Three things I looked at and deliberately left alone

- **`setState` delivers a superseded state to later subscribers** if an earlier
  subscriber calls `stop()` from inside its callback: the nested broadcast
  lands first, then the outer loop continues handing out the old value. It is
  pre-existing, unreachable with the one production subscriber (which forwards
  to the renderer over IPC), and the fix belongs to `setState` rather than to
  this change. Happy to send it separately.
- **The elapsed bound reads wall clock** (`this.now()`, like the hidden-window
  threshold above it), so a large clock correction can release the retry early
  or hold it late. The consequence is bounded at one extra probe or one delayed
  one, and the primary recovery path — the credential changing — does not
  depend on the clock at all. A second, monotonic clock for this seemed worse
  than the exposure.
- **A waiting tick blocks until the in-flight pass settles.** Both awaits it can
  block on are externally bounded — a 5s `execFile` timeout on the macOS
  credential read, a 20s abort on the request — so this is a bounded wait and
  not a barrier a wedged read could hold open forever.

## Test plan

- `src/main/claude/__tests__/UsagePoller.test.ts` — 27 cases, 14 of them new or
  rewritten. The ones that carry the argument:
  - `clears unauthorized by itself once Claude Code writes a new token (#1012)`
    — the regression test. Asserts the recovery fetch carried
    `Bearer fresh-token`, i.e. it is the new credential that went out, and that
    the poller returned to the normal cadence afterwards.
  - `keeps re-reading the credential on every recheck while it withholds the
    request` — counts credential reads as well as requests, so "it stays armed"
    is proven rather than assumed.
  - `retries a still-refused token once per poll interval, not once per
    recheck` — the second bound, from both sides, across two full periods.
  - `does not let a momentary credential miss cost a whole poll interval` and
    `keeps the fast cadence through an unreadable credential too` — the
    re-login window, which is exactly when a read is most likely to fail.
  - `still withholds a refused token that reappears unchanged after a failed
    read` — the skip is the pin and its age, not the chip's current text.
  - `abandons a tick whose session was stopped while it read the credential`
    and `... while it awaited the request` — the lifecycle guard on both awaits.
  - `does not run a queued tick for a session that was stopped while it waited`
    — the guard on the wait itself.
  - `gives every queued manual refresh its own pass, not just the first`,
    `does not let a stopped session's in-flight tick swallow the next session's
    first fetch`, and `coalesces the interval ticks that pile up behind a
    stopped session's read` — the three re-entry rules.
  - `refreshNow() re-sends even a token that was already refused` and
    `refreshNow() is honored while the window is hidden past the skip
    threshold`.
- Red/green verified by putting `origin/main`'s `UsagePoller.ts` under the new
  test file: 12 fail, the other 15 pass. With the fix, 27/27. Every behavioural
  change above was also checked red against the revision immediately before it,
  so nothing in here is passing for a reason other than the code it names.
- `npx vitest run src/main/claude src/main/account` — 120 passed.
- `npx tsc --noEmit -p tsconfig.json` — clean. `eslint` on both files — clean.
- One drive-by, called out so it is not mistaken for part of the fix: the
  pre-existing `fires an immediate fetch on start (queueMicrotask, not
  interval)` was renamed to say `setTimeout(0)`, which is what `start()`
  actually uses and has used since it was written.

## Known limit, and the follow-up it suggests

An account whose token works for Claude Code but that the usage probe is
refused for — wrong beta scope, an org restriction, a non-subscription login —
keeps the chip up. That is right, I think: it is a status readout, not a toast,
and the meter genuinely cannot read usage. But the *wording* is then wrong,
because nothing has expired.

`ClaudeCredential` already carries `expiresAtMs`, so the two are separable: a
401 on a credential whose stored expiry is still in the future is "Anthropic
refused this token", not "Token expired". I left that out of this PR on purpose
— it is a new string in 20 locales and a new `PollerStatus`, which is a
different review from this one. Happy to open it as a follow-up if you want it,
and it would be worth asking the reporter of #1012 whether their token ever
changed, since that is what tells the two cases apart.

## Stability tier impact

None. `UsagePoller` is main-process internal; `unauthorizedRecheckMs` is a new
constructor option with a default, used by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anthropic usage monitoring now continues after an unauthorized response instead of stopping.
  * Rejected credentials are temporarily withheld to prevent redundant requests.
  * Credentials are rechecked periodically and retried sooner when updated.
  * Expired-token notices clear automatically after a valid token is detected.
  * Forced refreshes continue to work even while normal polling is paused or skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->