### PR TITLE
feat(pane): fold the auto label on single-tab panes, rename from the menu

### DIFF
--- a/changelog.d/1026.md
+++ b/changelog.d/1026.md
@@ -1,0 +1,7 @@
+### Changed
+
+- The pane header no longer shows the auto label (`w2-1`) on a pane with a single tab and no custom name — the tab title already says it. Naming the pane, adding a second tab, or opening the rename editor brings it back. (#1021, #1026)
+
+### Added
+
+- **Rename pane** in the pane-actions menu (right-click the pane header) — pane renaming no longer requires knowing the double-click gesture. (#1026)

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -12,7 +12,7 @@ import { computePaneAutoName, paneDisplayName } from '../../utils/paneNaming';
 import { findPane } from '../../../shared/paneUtils';
 import PaneDragGrip from './PaneDragGrip';
 import { FOCUS_RING } from '../focusRing';
-import { IconSplitRight, IconSplitDown, IconBrowser, IconEyeOff } from '../icons';
+import { IconSplitRight, IconSplitDown, IconBrowser, IconEyeOff, IconPencil } from '../icons';
 import { displayPath } from '../../utils/displayPath';
 import { workspaceColorHex } from '../../../shared/workspaceColors';
 import PaneActionsMenu, { PANE_ACTIONS_MENU_WIDTH, type PaneActionItem } from './PaneActionsMenu';
@@ -402,12 +402,7 @@ export default function SurfaceTabs({
     {
       key: 'rename-pane',
       label: t('pane.rename'),
-      // Zoom's precedent: a mono glyph span where no drawn icon exists yet.
-      icon: (
-        <span aria-hidden="true" className="font-mono text-[13px] leading-none">
-          ✎
-        </span>
-      ),
+      icon: <IconPencil size={14} />,
       onSelect: startPaneRename,
     },
     {

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -273,53 +273,6 @@ export default function SurfaceTabs({
     setMenuOpen(true);
   }, []);
 
-  const menuItems: PaneActionItem[] = useMemo(() => [
-    {
-      key: 'split-right',
-      label: t('pane.splitRight'),
-      shortcut: SC_SPLIT_RIGHT,
-      icon: <IconSplitRight size={14} />,
-      onSelect: onSplitHorizontal,
-    },
-    {
-      key: 'split-down',
-      label: t('pane.splitDown'),
-      shortcut: SC_SPLIT_DOWN,
-      icon: <IconSplitDown size={14} />,
-      onSelect: onSplitVertical,
-    },
-    {
-      key: 'new-browser',
-      label: t('pane.newBrowser'),
-      icon: <IconBrowser size={14} />,
-      onSelect: onAddBrowser,
-    },
-    {
-      key: 'stash',
-      label: t('pane.stash'),
-      shortcut: stashChord ?? undefined,
-      icon: <IconEyeOff size={14} />,
-      disabled: stashDisabled,
-      title: stashTooltip,
-      onSelect: stashThisPane,
-    },
-    {
-      key: 'zoom',
-      label: t('settings.prefix.toggleZoom'),
-      icon: (
-        <span aria-hidden="true" className="font-mono text-[13px] leading-none">
-          {isZoomed ? '⤡' : '⤢'}
-        </span>
-      ),
-      active: isZoomed,
-      separatorBefore: true,
-      onSelect: toggleZoom,
-    },
-  ], [
-    t, onSplitHorizontal, onSplitVertical, onAddBrowser,
-    stashChord, stashDisabled, stashTooltip, stashThisPane, isZoomed, toggleZoom,
-  ]);
-
   // Right-click anywhere on the header — tabs included — opens the same menu
   // at any width. Suppressed when the operator turned pane actions OFF in
   // Settings: that is a deliberate no-pane-chrome choice.
@@ -400,6 +353,9 @@ export default function SurfaceTabs({
   const paneOrdinal = leaf && leaf.type === 'leaf' ? (leaf.ordinal ?? 0) : 0;
   const paneAutoName = computePaneAutoName(workspace.wsOrdinal ?? 0, paneOrdinal, activeSlug);
   const paneDisplay = paneDisplayName(paneLabel, paneAutoName);
+  // Mirrors paneDisplayName's own blank-label rule, so "named" here means
+  // exactly "the display name is the user's, not the auto coordinate".
+  const hasUserLabel = !!paneLabel && paneLabel.trim().length > 0;
   // Purely visual (shared/workspaceColors.ts) — undefined for the untagged
   // majority, so an untagged workspace's header renders exactly as before.
   // Rendered as ONE dot at the strip's start (same idiom as the multiview
@@ -410,7 +366,7 @@ export default function SurfaceTabs({
   // repeating it per tab adds nothing.
   const tabTagColor = workspaceColorHex(workspace.color);
 
-  const startPaneRename = () => {
+  const startPaneRename = useCallback(() => {
     // Suppress the rename a double-click triggers right after a tab drag.
     if (Date.now() - dragStartTimeRef.current < 300) return;
     // Clear any stale cancel flag from a prior edit whose unmount-blur didn't
@@ -418,7 +374,68 @@ export default function SurfaceTabs({
     paneRenameCancelRef.current = false;
     setPaneEditName(paneLabel ?? '');
     setPaneEditing(true);
-  };
+  }, [paneLabel]);
+
+  // Below startPaneRename (not with the other useCallbacks above) because the
+  // rename item needs it in scope — a const arrow is TDZ-dead until defined.
+  const menuItems: PaneActionItem[] = useMemo(() => [
+    {
+      key: 'split-right',
+      label: t('pane.splitRight'),
+      shortcut: SC_SPLIT_RIGHT,
+      icon: <IconSplitRight size={14} />,
+      onSelect: onSplitHorizontal,
+    },
+    {
+      key: 'split-down',
+      label: t('pane.splitDown'),
+      shortcut: SC_SPLIT_DOWN,
+      icon: <IconSplitDown size={14} />,
+      onSelect: onSplitVertical,
+    },
+    {
+      key: 'new-browser',
+      label: t('pane.newBrowser'),
+      icon: <IconBrowser size={14} />,
+      onSelect: onAddBrowser,
+    },
+    {
+      key: 'rename-pane',
+      label: t('pane.rename'),
+      // Zoom's precedent: a mono glyph span where no drawn icon exists yet.
+      icon: (
+        <span aria-hidden="true" className="font-mono text-[13px] leading-none">
+          ✎
+        </span>
+      ),
+      onSelect: startPaneRename,
+    },
+    {
+      key: 'stash',
+      label: t('pane.stash'),
+      shortcut: stashChord ?? undefined,
+      icon: <IconEyeOff size={14} />,
+      disabled: stashDisabled,
+      title: stashTooltip,
+      onSelect: stashThisPane,
+    },
+    {
+      key: 'zoom',
+      label: t('settings.prefix.toggleZoom'),
+      icon: (
+        <span aria-hidden="true" className="font-mono text-[13px] leading-none">
+          {isZoomed ? '⤡' : '⤢'}
+        </span>
+      ),
+      active: isZoomed,
+      separatorBefore: true,
+      onSelect: toggleZoom,
+    },
+  ], [
+    t, onSplitHorizontal, onSplitVertical, onAddBrowser, startPaneRename,
+    stashChord, stashDisabled, stashTooltip, stashThisPane, isZoomed, toggleZoom,
+  ]);
+
   const commitPaneRename = () => {
     // Escape set the cancel flag — discard without persisting and reset it.
     if (paneRenameCancelRef.current) {
@@ -510,7 +527,15 @@ export default function SurfaceTabs({
       {/* P2 — pane identity + double-click rename. A distinct element/handler
           from the surface tabs (different store: pane label via MetadataStore vs
           surface.title), so the two renames never collide. */}
-      {paneEditing ? (
+      {/* #1021 — with exactly one tab and no user rename, the auto label
+          (`w{ws}-{ordinal}`) is a second name for the thing the tab already
+          names, on a segment that owns reserved width and answers only
+          double-click. Fold it away in that case; it comes back the moment
+          the pane gains a second tab (a deliberate structural act, so the
+          layout shift lands on an interaction, not on idle chrome), when the
+          user names the pane (explicit intent to see it), or while the rename
+          editor is open (reachable from the pane-actions menu). */}
+      {(paneEditing || hasUserLabel || surfaces.length > 1) && (paneEditing ? (
         <input
           ref={paneInputRef}
           data-pane-label-input
@@ -543,7 +568,7 @@ export default function SurfaceTabs({
         >
           {paneDisplay}
         </span>
-      )}
+      ))}
       {surfaces.map((s) => (
         <div
           key={s.id}

--- a/src/renderer/components/Pane/__tests__/SurfaceTabs.actions.test.tsx
+++ b/src/renderer/components/Pane/__tests__/SurfaceTabs.actions.test.tsx
@@ -381,7 +381,10 @@ describe('SurfaceTabs — the ⋮ overflow menu', () => {
     const keys = Array.from(menu!.querySelectorAll('[data-pane-menu-action]')).map((el) =>
       el.getAttribute('data-pane-menu-action'),
     );
-    expect(keys.sort()).toEqual(['new-browser', 'split-down', 'split-right', 'stash', 'zoom']);
+    // rename-pane is menu-only by design (#1021): the fold removed the
+    // label's double-click in the single-tab case, and the menu is the
+    // affordance that replaces it — the cluster stays icon-sized actions.
+    expect(keys.sort()).toEqual(['new-browser', 'rename-pane', 'split-down', 'split-right', 'stash', 'zoom']);
   });
 
   it('splits this pane from the menu', () => {
@@ -452,6 +455,9 @@ describe('SurfaceTabs — the ⋮ overflow menu', () => {
   });
 
   it('leaves the native context menu alone on a rename input', () => {
+    // #1021 folds the label away on an unnamed single-tab pane, so name it
+    // first — a labelled pane still renames the way it always did.
+    useStore.getState().setPaneLabel(rootLeafId(), 'named');
     mount(rootLeafId(), { actionsMode: 'overflow' });
     // Enter pane-rename mode the way a user does: double-click the label.
     act(() => {
@@ -521,7 +527,7 @@ describe('SurfaceTabs — the ⋮ overflow menu', () => {
     mount(rootLeafId(), { actionsMode: 'overflow' });
     openOverflowMenu();
     const items = [...document.querySelectorAll<HTMLButtonElement>('[data-pane-menu-action]')];
-    expect(items.length).toBe(5);
+    expect(items.length).toBe(6);
     const press = (key: string) => act(() => {
       document.activeElement!.dispatchEvent(
         new KeyboardEvent('keydown', { key, bubbles: true }),
@@ -533,11 +539,11 @@ describe('SurfaceTabs — the ⋮ overflow menu', () => {
     expect(document.activeElement).toBe(items[1]);
     press('ArrowUp');
     press('ArrowUp'); // wraps 0 → last
-    expect(document.activeElement).toBe(items[4]);
+    expect(document.activeElement).toBe(items[5]);
     press('ArrowDown'); // wraps last → 0
     expect(document.activeElement).toBe(items[0]);
     press('End');
-    expect(document.activeElement).toBe(items[4]);
+    expect(document.activeElement).toBe(items[5]);
     press('Home');
     expect(document.activeElement).toBe(items[0]);
   });

--- a/src/renderer/components/Pane/__tests__/SurfaceTabs.paneLabel.test.tsx
+++ b/src/renderer/components/Pane/__tests__/SurfaceTabs.paneLabel.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+//
+// #1021 — the pane label is a second name for the same thing the single
+// surface tab already names, so it folds away when a pane has exactly one
+// tab and no user rename. This pins the three visibility states (hidden /
+// user-named / multi-tab) and the affordance that makes the fold safe: the
+// pane-actions menu carries a Rename item, so a label-less pane can still be
+// named without the double-click target the fold removed.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import SurfaceTabs from '../SurfaceTabs';
+import { useStore } from '../../../stores';
+import type { Surface, Workspace } from '../../../../shared/types';
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function activeWs(): Workspace {
+  return useStore
+    .getState()
+    .workspaces.find((w) => w.id === useStore.getState().activeWorkspaceId)!;
+}
+
+function surface(id: string, title: string): Surface {
+  return { id, ptyId: `pty-${id}`, title, shell: 'bash', cwd: '/tmp' };
+}
+
+function mount(surfaces: Surface[]): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const ws = activeWs();
+  act(() => {
+    root.render(
+      React.createElement(SurfaceTabs, {
+        surfaces,
+        activeSurfaceId: surfaces[0]!.id,
+        workspace: ws,
+        paneId: ws.rootPane.id,
+        paneActive: true,
+        onSelect: () => undefined,
+        onClose: () => undefined,
+        onSplitHorizontal: () => undefined,
+        onSplitVertical: () => undefined,
+        onAddTerminal: () => undefined,
+        onAddBrowser: () => undefined,
+      }),
+    );
+  });
+}
+
+function paneLabelEl(): HTMLElement | null {
+  return container.querySelector('[data-pane-label]');
+}
+
+describe('SurfaceTabs — single-surface pane label fold (#1021)', () => {
+  beforeEach(() => {
+    useStore.getState().setPaneLabel(activeWs().rootPane.id, '');
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    useStore.getState().setPaneLabel(activeWs().rootPane.id, '');
+  });
+
+  it('hides the auto label when the pane has exactly one tab and no user rename', () => {
+    mount([surface('s1', 'WMUX')]);
+    expect(paneLabelEl()).toBeNull();
+  });
+
+  it('keeps showing a user-set label on a single-tab pane', () => {
+    useStore.getState().setPaneLabel(activeWs().rootPane.id, 'build watcher');
+    mount([surface('s1', 'WMUX')]);
+    const el = paneLabelEl();
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toBe('build watcher');
+  });
+
+  it('keeps the auto label once the pane holds a second tab', () => {
+    mount([surface('s1', 'WMUX'), surface('s2', 'logs')]);
+    const el = paneLabelEl();
+    expect(el).not.toBeNull();
+    // Auto coordinate shape (w{ws}-{ordinal}, optionally with an agent slug).
+    expect(el!.textContent).toMatch(/^w\d+-\d+/);
+  });
+
+  it('the pane-actions menu opens the rename editor on a label-less pane', () => {
+    mount([surface('s1', 'WMUX')]);
+    expect(paneLabelEl()).toBeNull();
+
+    // Right-click the header to open the pane-actions menu.
+    act(() => {
+      container.firstElementChild!.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 10, clientY: 10 }),
+      );
+    });
+    const items = Array.from(document.querySelectorAll('button, [role="menuitem"]'));
+    const rename = items.find((el) => el.textContent?.includes('Rename pane'));
+    expect(rename).toBeTruthy();
+
+    act(() => {
+      (rename as HTMLElement).click();
+    });
+    // The fold's visibility condition includes paneEditing, so the editor
+    // renders even though the label span it replaces was hidden.
+    expect(container.querySelector('[data-pane-label-input]')).not.toBeNull();
+  });
+});

--- a/src/renderer/components/Pane/__tests__/paneClusterWidth.test.ts
+++ b/src/renderer/components/Pane/__tests__/paneClusterWidth.test.ts
@@ -211,9 +211,19 @@ describe('the ⋮ menu offers exactly what the cluster does', () => {
     return [...region.matchAll(/key: '([a-z-]+)'/g)].map((m) => m[1]).sort();
   }
 
-  it('names the same actions in both places', () => {
+  it('offers every cluster action in the menu, and pins the menu-only set', () => {
     const cluster = clusterActions();
     expect(cluster.length).toBeGreaterThan(0);
-    expect(menuActions()).toEqual(cluster);
+    const menu = menuActions();
+    // The failure this guards is directional: the menu is the surface that
+    // must never LOSE an action, because at a width where only the ⋮ (or the
+    // header right-click) fits, the menu is all the user has. The menu may
+    // carry more — pinned exactly, so a menu-only addition is a deliberate
+    // decision here rather than silent drift. rename-pane is menu-only by
+    // design (#1021): the label fold removed the double-click target on
+    // unnamed single-tab panes, and the menu replaces that affordance; the
+    // cluster keeps to icon-sized layout actions.
+    for (const key of cluster) expect(menu).toContain(key);
+    expect(menu.filter((k) => !cluster.includes(k))).toEqual(['rename-pane']);
   });
 });

--- a/src/renderer/components/icons.tsx
+++ b/src/renderer/components/icons.tsx
@@ -112,6 +112,17 @@ export function IconEyeOff({ size = 14 }: { size?: number }) {
   );
 }
 
+export function IconPencil({ size = 14 }: { size?: number }) {
+  // Nib + shaft + baseline, drawn on the same 14px stroked grid as the rest of
+  // the set — a filled glyph (✎) next to these reads as a different weight.
+  return (
+    <Icon size={size}>
+      <path d="M9.4 2.6 a1.4 1.4 0 0 1 2 2 L5 11 L2.5 11.5 L3 9 Z" />
+      <line x1="8.6" y1="3.4" x2="10.6" y2="5.4" />
+    </Icon>
+  );
+}
+
 export function IconChevron({ size = 14 }: { size?: number }) {
   // Points right; rotate 90° via transform for an expanded/down state.
   return <Icon size={size}><polyline points="5.5,3 9.5,7 5.5,11" /></Icon>;

--- a/src/renderer/i18n/locales/ar.ts
+++ b/src/renderer/i18n/locales/ar.ts
@@ -39,6 +39,7 @@ export const ar = {
   'pane.maxLeavesReachedWithStash': 'تم بلوغ حد الأجزاء ({count})، منها {stashed} موضوعة جانبًا. أعد واحدًا وأغلقه، أو أغلق جزءًا ظاهرًا.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'إعادة تسمية الجزء',
   'pane.stash': 'وضع الجزء جانبًا',
   'pane.stashHint': 'يُزال من التخطيط — تستمر الجلسة في العمل',
   'pane.unstash': 'إعادة',

--- a/src/renderer/i18n/locales/bs.ts
+++ b/src/renderer/i18n/locales/bs.ts
@@ -39,6 +39,7 @@ export const bs = {
   'pane.maxLeavesReachedWithStash': 'Dostignut limit panela ({count}), uključujući {stashed} sklonjenih. Vratite jedan i zatvorite ga ili zatvorite vidljivi panel.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Preimenuj panel',
   'pane.stash': 'Skloni panel',
   'pane.stashHint': 'Uklanja se iz izgleda — sesija nastavlja raditi',
   'pane.unstash': 'Vrati nazad',

--- a/src/renderer/i18n/locales/da.ts
+++ b/src/renderer/i18n/locales/da.ts
@@ -39,6 +39,7 @@ export const da = {
   'pane.maxLeavesReachedWithStash': 'Panelgrænsen er nået ({count}), heraf {stashed} lagt til side. Hent ét tilbage og luk det, eller luk et synligt panel.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Omdøb panel',
   'pane.stash': 'Læg panelet til side',
   'pane.stashHint': 'Fjernes fra layoutet — sessionen kører videre',
   'pane.unstash': 'Hent tilbage',

--- a/src/renderer/i18n/locales/de.ts
+++ b/src/renderer/i18n/locales/de.ts
@@ -39,6 +39,7 @@ export const de = {
   'pane.maxLeavesReachedWithStash': 'Bereichslimit erreicht ({count}), davon {stashed} beiseitegelegt. Holen Sie einen zurück und schließen Sie ihn, oder schließen Sie einen sichtbaren Bereich.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Bereich umbenennen',
   'pane.stash': 'Bereich beiseitelegen',
   'pane.stashHint': 'Aus dem Layout entfernen — die Sitzung läuft weiter',
   'pane.unstash': 'Zurückholen',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -302,6 +302,7 @@ export const en = {
   // Pane stash (#977) — taking a pane out of the layout WITHOUT killing it.
   // The wording carries the whole promise: "stash" removes, "close" destroys,
   // and every string here says which one is happening.
+  'pane.rename': 'Rename pane',
   'pane.stash': 'Stash pane',
   'pane.stashHint': 'Remove from layout — the session keeps running',
   'pane.unstash': 'Bring back',

--- a/src/renderer/i18n/locales/es.ts
+++ b/src/renderer/i18n/locales/es.ts
@@ -39,6 +39,7 @@ export const es = {
   'pane.maxLeavesReachedWithStash': 'Límite de paneles alcanzado ({count}), incluidos {stashed} apartados. Recupera uno y ciérralo, o cierra un panel visible.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Renombrar panel',
   'pane.stash': 'Apartar panel',
   'pane.stashHint': 'Se quita del diseño — la sesión sigue en ejecución',
   'pane.unstash': 'Recuperar',

--- a/src/renderer/i18n/locales/fr.ts
+++ b/src/renderer/i18n/locales/fr.ts
@@ -39,6 +39,7 @@ export const fr = {
   'pane.maxLeavesReachedWithStash': 'Limite de panneaux atteinte ({count}), dont {stashed} mis de côté. Ramenez-en un et fermez-le, ou fermez un panneau visible.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Renommer le panneau',
   'pane.stash': 'Mettre le panneau de côté',
   'pane.stashHint': 'Retiré de la disposition — la session continue de tourner',
   'pane.unstash': 'Ramener',

--- a/src/renderer/i18n/locales/hi.ts
+++ b/src/renderer/i18n/locales/hi.ts
@@ -39,6 +39,7 @@ export const hi = {
   'pane.maxLeavesReachedWithStash': 'पैनल की सीमा पूरी हो गई ({count}), जिसमें {stashed} किनारे रखे हुए हैं। एक को वापस लाकर बंद करें, या कोई दिखने वाला पैनल बंद करें।',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'पैनल का नाम बदलें',
   'pane.stash': 'पैनल किनारे रखें',
   'pane.stashHint': 'लेआउट से हटता है — सेशन चलता रहता है',
   'pane.unstash': 'वापस लाएँ',

--- a/src/renderer/i18n/locales/id.ts
+++ b/src/renderer/i18n/locales/id.ts
@@ -39,6 +39,7 @@ export const id = {
   'pane.maxLeavesReachedWithStash': 'Batas panel tercapai ({count}), termasuk {stashed} yang disisihkan. Kembalikan satu lalu tutup, atau tutup panel yang terlihat.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Ubah nama panel',
   'pane.stash': 'Sisihkan panel',
   'pane.stashHint': 'Dikeluarkan dari tata letak — sesi tetap berjalan',
   'pane.unstash': 'Kembalikan',

--- a/src/renderer/i18n/locales/it.ts
+++ b/src/renderer/i18n/locales/it.ts
@@ -39,6 +39,7 @@ export const it = {
   'pane.maxLeavesReachedWithStash': 'Limite di pannelli raggiunto ({count}), inclusi {stashed} messi da parte. Riportane indietro uno e chiudilo, oppure chiudi un pannello visibile.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Rinomina pannello',
   'pane.stash': 'Metti da parte il pannello',
   'pane.stashHint': 'Rimosso dal layout — la sessione resta in esecuzione',
   'pane.unstash': 'Riporta indietro',

--- a/src/renderer/i18n/locales/ja.ts
+++ b/src/renderer/i18n/locales/ja.ts
@@ -39,6 +39,7 @@ export const ja = {
   'pane.maxLeavesReachedWithStash': 'ペイン数の上限に達しました（{count}、うち退避 {stashed}）。退避中のペインを戻して閉じるか、表示中のペインを閉じてください。',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'ペインの名前を変更',
   'pane.stash': 'ペインを退避',
   'pane.stashHint': 'レイアウトから外します — セッションは動き続けます',
   'pane.unstash': '戻す',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -51,6 +51,8 @@ export const ko = {
   'pane.maxLeavesReached': '창 분할 한도 도달 ({count}개). 창을 닫고 다시 시도하세요.',
   'pane.maxLeavesReachedWithStash': '페인 한도 도달 ({count}개, 보관 {stashed}개 포함). 보관함에서 꺼내 닫거나, 보이는 페인을 닫으세요.',
 
+  'pane.rename': '페인 이름 바꾸기',
+
   'pane.stash': '페인 치우기',
   'pane.stashHint': '레이아웃에서 치웁니다 — 세션은 계속 실행됩니다',
   'pane.unstash': '꺼내기',

--- a/src/renderer/i18n/locales/ms.ts
+++ b/src/renderer/i18n/locales/ms.ts
@@ -39,6 +39,7 @@ export const ms = {
   'pane.maxLeavesReachedWithStash': 'Had panel dicapai ({count}), termasuk {stashed} yang diketepikan. Bawa satu kembali dan tutupnya, atau tutup panel yang kelihatan.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Namakan semula panel',
   'pane.stash': 'Ketepikan panel',
   'pane.stashHint': 'Dikeluarkan dari susun atur — sesi terus berjalan',
   'pane.unstash': 'Bawa kembali',

--- a/src/renderer/i18n/locales/nb.ts
+++ b/src/renderer/i18n/locales/nb.ts
@@ -39,6 +39,7 @@ export const nb = {
   'pane.maxLeavesReachedWithStash': 'Panelgrensen er nådd ({count}), inkludert {stashed} lagt til side. Hent ett tilbake og lukk det, eller lukk et synlig panel.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Gi panelet nytt navn',
   'pane.stash': 'Legg panelet til side',
   'pane.stashHint': 'Fjernes fra oppsettet — økten fortsetter å kjøre',
   'pane.unstash': 'Hent tilbake',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -44,6 +44,7 @@ export const pl = {
   'pane.maxLeavesReachedWithStash': 'Osiągnięto limit paneli ({count}), w tym {stashed} odłożonych. Przywróć jeden i zamknij go albo zamknij widoczny panel.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Zmień nazwę panelu',
   'pane.stash': 'Odłóż panel',
   'pane.stashHint': 'Znika z układu — sesja działa dalej',
   'pane.unstash': 'Przywróć',

--- a/src/renderer/i18n/locales/pt-BR.ts
+++ b/src/renderer/i18n/locales/pt-BR.ts
@@ -39,6 +39,7 @@ export const ptBR = {
   'pane.maxLeavesReachedWithStash': 'Limite de painéis atingido ({count}), incluindo {stashed} guardado(s). Traga um de volta e feche-o, ou feche um painel visível.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Renomear painel',
   'pane.stash': 'Guardar painel',
   'pane.stashHint': 'Sai do layout — a sessão continua rodando',
   'pane.unstash': 'Trazer de volta',

--- a/src/renderer/i18n/locales/ru.ts
+++ b/src/renderer/i18n/locales/ru.ts
@@ -39,6 +39,7 @@ export const ru = {
   'pane.maxLeavesReachedWithStash': 'Достигнут лимит панелей ({count}), включая отложенные: {stashed}. Верните одну и закройте её либо закройте видимую панель.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Переименовать панель',
   'pane.stash': 'Отложить панель',
   'pane.stashHint': 'Убрать из макета — сессия продолжит работать',
   'pane.unstash': 'Вернуть',

--- a/src/renderer/i18n/locales/th.ts
+++ b/src/renderer/i18n/locales/th.ts
@@ -39,6 +39,7 @@ export const th = {
   'pane.maxLeavesReachedWithStash': 'ถึงขีดจำกัดจำนวนพาเนลแล้ว ({count}) รวมที่เก็บไว้ {stashed} นำกลับมาหนึ่งพาเนลแล้วปิด หรือปิดพาเนลที่แสดงอยู่',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'เปลี่ยนชื่อพาเนล',
   'pane.stash': 'เก็บพาเนลไว้ก่อน',
   'pane.stashHint': 'นำออกจากเลย์เอาต์ — เซสชันยังทำงานต่อ',
   'pane.unstash': 'นำกลับมา',

--- a/src/renderer/i18n/locales/tr.ts
+++ b/src/renderer/i18n/locales/tr.ts
@@ -39,6 +39,7 @@ export const tr = {
   'pane.maxLeavesReachedWithStash': 'Bölme sınırına ulaşıldı ({count}); bunların {stashed} tanesi kenara alınmış. Birini geri getirip kapatın ya da görünen bir bölmeyi kapatın.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Bölmeyi yeniden adlandır',
   'pane.stash': 'Bölmeyi kenara al',
   'pane.stashHint': 'Düzenden çıkarılır — oturum çalışmaya devam eder',
   'pane.unstash': 'Geri getir',

--- a/src/renderer/i18n/locales/uk.ts
+++ b/src/renderer/i18n/locales/uk.ts
@@ -39,6 +39,7 @@ export const uk = {
   'pane.maxLeavesReachedWithStash': 'Досягнуто ліміт панелей ({count}), зокрема відкладених: {stashed}. Поверніть одну й закрийте її або закрийте видиму панель.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Перейменувати панель',
   'pane.stash': 'Відкласти панель',
   'pane.stashHint': 'Прибрати з макета — сесія продовжить працювати',
   'pane.unstash': 'Повернути',

--- a/src/renderer/i18n/locales/vi.ts
+++ b/src/renderer/i18n/locales/vi.ts
@@ -39,6 +39,7 @@ export const vi = {
   'pane.maxLeavesReachedWithStash': 'Đã đạt giới hạn khung ({count}), bao gồm {stashed} khung đã cất. Hãy đưa một khung trở lại rồi đóng, hoặc đóng một khung đang hiển thị.',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': 'Đổi tên khung',
   'pane.stash': 'Cất khung',
   'pane.stashHint': 'Gỡ khỏi bố cục — phiên vẫn tiếp tục chạy',
   'pane.unstash': 'Đưa trở lại',

--- a/src/renderer/i18n/locales/zh-TW.ts
+++ b/src/renderer/i18n/locales/zh-TW.ts
@@ -39,6 +39,7 @@ export const zhTW = {
   'pane.maxLeavesReachedWithStash': '已達面板數量上限（{count}，其中已收起 {stashed}）。請取回一個並關閉，或關閉一個可見的面板。',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': '重新命名面板',
   'pane.stash': '收起面板',
   'pane.stashHint': '從版面移除 — 工作階段會繼續執行',
   'pane.unstash': '取回',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -757,6 +757,7 @@ export const zh = {
   'pane.maxLeavesReachedWithStash': '已达到面板数量上限（{count}，其中已收起 {stashed}）。请取回一个并关闭，或关闭一个可见面板。',
 
   // Pane stash (#977) — the pane leaves the layout, its session keeps running.
+  'pane.rename': '重命名面板',
   'pane.stash': '收起面板',
   'pane.stashHint': '从布局中移除 — 会话继续运行',
   'pane.unstash': '取回',


### PR DESCRIPTION
Closes #1021 (item 1; item 2 was confirmed no-change in the issue).

## What

With exactly one surface tab and no user rename, the pane label now folds away. It comes back the moment any of these hold:

- the pane gains a second tab (the layout shift lands on a deliberate structural act, not on idle chrome — the concern raised in the issue),
- the user names the pane (explicit intent to see it),
- the rename editor is open.

## The affordance the fold removes, and its replacement

Double-click-on-label was the *only* way to name a pane — folding the label on unnamed single-tab panes would have made them permanently unnameable. The pane-actions menu now carries a **Rename pane** item (`startPaneRename`, same editor), which is reachable at any width via the header right-click and arguably more discoverable than the double-click ever was. New `pane.rename` key added to all 23 locales, following the full-coverage convention of the other `pane.*` menu keys.

## Test contract changes

- New `SurfaceTabs.paneLabel.test.tsx` (4 tests): hidden / user-named / multi-tab visibility states, plus menu-rename opening the editor on a label-less pane.
- The cluster/menu parity test (`paneClusterWidth.test.ts`) becomes directional: every cluster action must exist in the menu — the menu is the surface that must never lose an action, since at ⋮-only widths it is all the user has — and the menu-only set is pinned to exactly `['rename-pane']` so future menu-only additions are a decision, not drift.
- `SurfaceTabs.actions.test.tsx`: menu key list and arrow-walk indices updated for the sixth item; the native-context-menu-on-rename test names the pane first, since an unnamed single-tab pane no longer renders the label it double-clicks.

## Test plan

- `npx tsc --noEmit` — clean
- Pane `__tests__` + i18n suites: 22 files, 312 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Rename pane** action to the pane-header context menu.
  * Pane names can now be edited even when the pane label is hidden.
  * Automatic labels are hidden for unnamed, single-tab panes and remain visible for named or multi-tab panes.
  * Added localized rename controls across supported languages.

* **Tests**
  * Added coverage for pane-label visibility, renaming, and menu navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->