### PR TITLE
fix(daemon): identify the daemon by its script path, not a generic marker

### DIFF
--- a/changelog.d/1027.md
+++ b/changelog.d/1027.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- wmux could SIGKILL an unrelated program that happened to be running a script at `.../daemon/index.js`, if the operating system had recycled the daemon's process id onto it. The daemon is now identified by the exact script path wmux itself launches, rather than by a path shape that any project can have. (#1025, #1027)

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -15,8 +15,8 @@ import {
   pollDaemonReady,
   isDaemonPipeGone,
   ensureDaemon as ensureDaemonCore,
-  killDaemonByPidFile,
-  killVerifiedDaemonPid,
+  killDaemonByPidFile as killDaemonByPidFileCore,
+  killVerifiedDaemonPid as killVerifiedDaemonPidCore,
   type DaemonInfo,
   type DaemonLauncherDeps,
   type ProcessLiveness,
@@ -48,8 +48,6 @@ export {
   DAEMON_READY_HARD_CEILING_MS,
   pollDaemonReady,
   isDaemonPipeGone,
-  killDaemonByPidFile,
-  killVerifiedDaemonPid,
 };
 export type {
   DaemonInfo,
@@ -152,6 +150,28 @@ const electronDeps: DaemonLauncherDeps = {
   isElectronHost: () => true,
   markBoot,
 };
+
+/**
+ * #1025 — the kill gate identifies a PID by comparing its command line
+ * against the exact daemon scripts this host would spawn, so both entry
+ * points have to hand the resolver's answer down. Wrapping here (rather than
+ * at each of main/index.ts's four call sites) keeps the Electron-specific
+ * knowledge in the Electron seam, which is what this module is for.
+ */
+export function killDaemonByPidFile(): boolean {
+  return killDaemonByPidFileCore(resolveDaemonScriptCandidates());
+}
+
+export function killVerifiedDaemonPid(
+  pid: number,
+  opts: { definitiveOnly: boolean },
+): boolean {
+  return killVerifiedDaemonPidCore(pid, {
+    ...opts,
+    scriptCandidates: resolveDaemonScriptCandidates(),
+  });
+}
+
 
 /**
  * `ensureDaemon()` — same zero-argument signature every existing caller

--- a/src/shared/daemon/__tests__/killVerifiedDaemonPid.scriptIdentity.test.ts
+++ b/src/shared/daemon/__tests__/killVerifiedDaemonPid.scriptIdentity.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn, type ChildProcess } from 'child_process';
+import { killVerifiedDaemonPid } from '../daemonLauncherCore';
+
+/**
+ * #1025 — reproduced by execution before this fix: an unrelated program
+ * whose argv carries `<anything>/daemon/index.js` was verified as wmux's
+ * daemon and SIGKILLed on a recycled PID. `daemon/index.js` is an extremely
+ * common layout, so that marker was never evidence of anything; identity
+ * against the scripts this host would actually spawn is.
+ *
+ * These spawn real processes and assert on the real OS probes, the way the
+ * cross-host suite does — the bug was in what the probes were compared
+ * against, so a mocked cmdline would test the wrong half.
+ */
+describe('killVerifiedDaemonPid — daemon-script identity (#1025)', () => {
+  let tmpDir = '';
+  let child: ChildProcess | null = null;
+
+  afterEach(async () => {
+    if (child && child.pid && child.exitCode === null) {
+      try { process.kill(child.pid, 'SIGKILL'); } catch { /* already gone */ }
+      await new Promise<void>((resolve) => {
+        if (!child) return resolve();
+        child.once('exit', () => resolve());
+        setTimeout(resolve, 2000);
+      });
+    }
+    child = null;
+    if (tmpDir) {
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); break; }
+        catch { await new Promise((resolve) => setTimeout(resolve, 200)); }
+      }
+      tmpDir = '';
+    }
+  });
+
+  async function spawnSleeper(scriptPath: string): Promise<number> {
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, 'setTimeout(() => {}, 30000);\n');
+    child = spawn(process.execPath, [scriptPath], { stdio: 'ignore' });
+    expect(child.pid).toBeTruthy();
+    // Let the OS register the PID before tasklist/ps is asked about it.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return child.pid as number;
+  }
+
+  it("refuses an unrelated process whose argv merely ends in daemon/index.js", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-innocent-'));
+    // Somebody else's program, using the same everyday layout. Note the image
+    // matches too (both are plain `node`), so the cmdline gate is the ONLY
+    // thing standing between this process and a SIGKILL.
+    const pid = await spawnSleeper(path.join(tmpDir, 'someone-elses-app', 'daemon', 'index.js'));
+
+    const killed = killVerifiedDaemonPid(pid, { definitiveOnly: false });
+    expect(killed).toBe(false);
+
+    let alive = true;
+    try { process.kill(pid, 0); } catch { alive = false; }
+    expect(alive).toBe(true);
+  }, 15_000);
+
+  it('kills a process running exactly one of this host\'s resolved daemon scripts', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-ours-'));
+    // The same everyday layout as the case above — the ONLY difference is
+    // that this path is what the resolver says we spawn, which is the whole
+    // point: identity, not shape.
+    const scriptPath = path.join(tmpDir, 'dist', 'daemon', 'index.js');
+    const pid = await spawnSleeper(scriptPath);
+
+    const killed = killVerifiedDaemonPid(pid, {
+      definitiveOnly: false,
+      scriptCandidates: [path.join(tmpDir, 'dist', 'daemon-bundle', 'index.js'), scriptPath],
+    });
+    expect(killed).toBe(true);
+  }, 15_000);
+});

--- a/src/shared/daemon/daemonLauncherCore.ts
+++ b/src/shared/daemon/daemonLauncherCore.ts
@@ -249,39 +249,54 @@ function tokenizeCommandLine(cmdline: string): string[] {
 /**
  * Does this command line invoke one of wmux's daemon entry-script paths?
  *
- * #1019 review: `.includes()` on the whole raw string has no path-boundary
- * awareness, so the bare `'daemon-bundle'` marker matches an unrelated
- * `/srv/my-daemon-bundle-backup/index.js` (that string genuinely contains
- * `daemon-bundle` as a substring) on a recycled PID. Segment-based matching
- * fixes exactly that: tokenize the cmdline (quote-aware, so a Windows path
- * with spaces in one argument isn't split apart), split each token on `/`
- * or `\`, and require the KNOWN marker to occupy its own path segment(s) —
- * `my-daemon-bundle-backup` is one segment, not two, so it can never equal
- * the segment `'daemon-bundle'` no matter what substring it contains.
+ * Two signals, strongest first.
  *
- * This does not (and cannot) resolve the adjacent, fuzzier case of a
- * genuinely unrelated program that happens to be installed at a path whose
- * LAST TWO segments are literally `daemon/index.js` — that is a real path
- * shape collision, not a substring artifact, and is accepted as a residual
- * false-positive risk the way it always has been (this marker was never the
- * only signal; image-name checks and `definitiveOnly` gate what a match is
- * allowed to authorize).
+ * **Identity (#1025).** `scriptCandidates` are the exact paths THIS host
+ * would spawn (`deps.resolveDaemonScriptCandidates()`). If a cmdline token
+ * equals one of them, the process is running the very script we launch —
+ * that is proof, not a pattern. Marker matching cannot reach this bar: the
+ * previous generic markers accepted any argv carrying `<anything>/daemon/
+ * index.js`, an extremely common project layout, so an unrelated
+ * `node /srv/app/daemon/index.js` inheriting a recycled PID was verified as
+ * ours and SIGKILLed (reproduced by execution in #1025). Those markers are
+ * gone; the dev-checkout layouts they existed for (`dist/daemon/daemon/
+ * index.js`, `dist/daemon/index.js`) are candidates, so identity covers them.
+ *
+ * **Cross-host fallback.** Since #1001 a daemon may have been spawned by a
+ * different host than the one asking — Electron killing a CLI-spawned
+ * daemon, or the reverse — and the two resolve their scripts from different
+ * roots, so the asking host's candidate list will not contain the other's
+ * path. A path segment beginning `daemon-bundle` keeps that case working:
+ * the name is wmux's own (package.json's `build:daemon` esbuild outfile),
+ * not a generic layout, and it is what every packaged install runs. The
+ * segment must BEGIN with it (a build/test variant may suffix it), which is
+ * what keeps `/srv/my-daemon-bundle-backup/index.js` out — there the marker
+ * is not at the segment's start.
+ *
+ * Callers that cannot supply candidates get the fallback alone. That is a
+ * deliberate narrowing: refusing to kill degrades to the respawn budget and
+ * a manual-recovery message, while a false positive kills a stranger's
+ * process, so the asymmetry belongs on the refusing side.
  */
-function cmdlineMatchesDaemonScript(cmdline: string): boolean {
-  for (const token of tokenizeCommandLine(cmdline)) {
-    const segments = token.replace(/\\/g, '/').split('/').filter(Boolean);
-    for (let i = 0; i < segments.length; i++) {
-      // 'daemon-bundle' needs to START this segment, not equal it exactly —
-      // a build/test variant may suffix it (`daemon-bundle-fake-index.js`,
-      // a hashed hot-reload dir, etc), and `startsWith` still accepts that.
-      // It still rejects the false positive this fix exists for: a `my-`
-      // PREFIX before the marker (`my-daemon-bundle-backup`) fails
-      // `startsWith('daemon-bundle')`, because the marker isn't at the
-      // segment's start there — that's the actual boundary that matters,
-      // not "is this the ENTIRE segment".
-      if (segments[i].startsWith('daemon-bundle')) return true;
-      if (segments[i] === 'daemon' && segments[i + 1] === 'daemon' && segments[i + 2] === 'index.js') return true;
-      if (segments[i] === 'daemon' && segments[i + 1] === 'index.js') return true;
+function cmdlineMatchesDaemonScript(cmdline: string, scriptCandidates: string[] = []): boolean {
+  const tokens = tokenizeCommandLine(cmdline);
+  // Windows path comparison is case-insensitive; POSIX is not, and folding
+  // case there would accept a genuinely different file.
+  const normalize = (raw: string): string => {
+    const slashed = raw.replace(/\\/g, '/');
+    return process.platform === 'win32' ? slashed.toLowerCase() : slashed;
+  };
+
+  if (scriptCandidates.length > 0) {
+    const wanted = new Set(scriptCandidates.map(normalize));
+    for (const token of tokens) {
+      if (wanted.has(normalize(token))) return true;
+    }
+  }
+
+  for (const token of tokens) {
+    for (const segment of normalize(token).split('/')) {
+      if (segment.startsWith('daemon-bundle')) return true;
     }
   }
   return false;
@@ -1071,7 +1086,7 @@ export async function ensureDaemon(deps: DaemonLauncherDeps): Promise<DaemonInfo
             `[launcher] user approved cleanup of unverified PID ${existingPid} (cmdline lookup failed)`,
           );
         } else {
-          const cmdlineMatches = cmdlineMatchesDaemonScript(cmdline);
+          const cmdlineMatches = cmdlineMatchesDaemonScript(cmdline, deps.resolveDaemonScriptCandidates());
           if (!cmdlineMatches) {
             // (b) Same image but different app (e.g. another Electron
             // tool). Don't kill, but the cleanup path below is safe.
@@ -1285,7 +1300,7 @@ export async function ensureDaemon(deps: DaemonLauncherDeps): Promise<DaemonInfo
  * Best-effort: never throws. Returns true only when a verified daemon was
  * signalled.
  */
-export function killDaemonByPidFile(): boolean {
+export function killDaemonByPidFile(scriptCandidates: string[] = []): boolean {
   try {
     const wmuxDir = getWmuxDir();
     const pidStr = fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim();
@@ -1293,7 +1308,7 @@ export function killDaemonByPidFile(): boolean {
     // Before-quit mode: indeterminate verification still proceeds — this
     // path runs seconds after we were actively talking to that PID, so
     // reuse is near-impossible and an orphan is the worse outcome.
-    return killVerifiedDaemonPid(pid, { definitiveOnly: false });
+    return killVerifiedDaemonPid(pid, { definitiveOnly: false, scriptCandidates });
   } catch {
     return false;
   }
@@ -1320,7 +1335,7 @@ export function killDaemonByPidFile(): boolean {
  */
 export function killVerifiedDaemonPid(
   pid: number,
-  opts: { definitiveOnly: boolean },
+  opts: { definitiveOnly: boolean; scriptCandidates?: string[] },
 ): boolean {
   try {
     if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return false;
@@ -1354,7 +1369,7 @@ export function killVerifiedDaemonPid(
       // mismatch blocks the kill — it just needs the second, cmdline signal
       // to also fail to clear it, rather than mismatch alone.
       if (opts.definitiveOnly || imageDefinitivelyMismatched) return false;
-    } else if (!cmdlineMatchesDaemonScript(cmdline)) {
+    } else if (!cmdlineMatchesDaemonScript(cmdline, opts.scriptCandidates ?? [])) {
       return false; // definitive: same image but not our daemon script
     }
 


### PR DESCRIPTION
Closes #1025.

## The hole

`killVerifiedDaemonPid` proved a PID was wmux's daemon by looking for markers in its command line, and one of them was a bare `daemon` + `index.js` path-segment pair. That shape is an ordinary project layout, so the marker was never evidence of anything — an unrelated `node <anything>/daemon/index.js` inheriting a recycled PID passed the gate. The image check does not save it either: a plain-`node` daemon and a plain-`node` third-party process share an image basename.

Reproduced by execution, not by reading: spawning such a sleeper and calling `killVerifiedDaemonPid(pid, { definitiveOnly: false })` returned `true`, and the innocent process was gone afterwards.

Not a regression — #1019 narrowed the substring matching to path segments, which removed the `my-daemon-bundle-backup` shape, but the generic pair survived that pass and the pre-#1019 `.includes()` matched it too. It needs PID reuse to fire in production, which is why this was filed rather than treated as urgent.

## The fix

Identity instead of pattern. `deps.resolveDaemonScriptCandidates()` already holds the exact paths this host would spawn, so the gate compares command-line tokens against those — running the very script we launch is proof, and no marker can reach that bar. The dev-checkout layouts the generic markers existed for (`dist/daemon/daemon/index.js`, `dist/daemon/index.js`) are themselves candidates, so nothing loses coverage; those markers are gone.

A path segment beginning `daemon-bundle` stays as the cross-host fallback. Since #1001 an Electron host may kill a CLI-spawned daemon or the reverse, and neither can name the other's install root, so identity alone would refuse exactly the case #1019 enabled. That directory name is wmux's own `build:daemon` esbuild output rather than a generic layout, and the segment must *begin* with it, which is what keeps the `my-daemon-bundle-backup` shape out.

Callers that cannot supply candidates get the fallback alone. That is deliberate: refusing to kill degrades to the respawn budget and a manual-recovery message, while a false positive kills a stranger's process, so the asymmetry belongs on the refusing side.

Threading: `killDaemonByPidFile(candidates?)` and `killVerifiedDaemonPid(pid, { definitiveOnly, scriptCandidates? })` take them; `ensureDaemon`'s own call site passes `deps.resolveDaemonScriptCandidates()`; and `main/daemon/launcher.ts` — the Electron seam — wraps both entry points so `main/index.ts`'s four call sites are untouched.

Case is folded, since Windows path comparison is case-insensitive and POSIX is not — folding there would accept a genuinely different file.

## Test plan

- [x] New `killVerifiedDaemonPid.scriptIdentity.test.ts` (2 tests), spawning real processes and asserting on the real OS probes — the bug was in what the probes were compared against, so a mocked command line would test the wrong half. One asserts the innocent `daemon/index.js` process is refused *and still alive*; the other kills a process running a path that is byte-identical to a supplied candidate, which is the same everyday shape — the only difference being identity.
- [x] Confirmed the first test is not vacuous: restoring the generic marker makes it fail, removing it again makes it pass.
- [x] The three existing `killVerifiedDaemonPid.crossHost.test.ts` cases pass unchanged, including the one that relies on the bare `daemon-bundle` marker.
- [x] `npx tsc --noEmit` clean; `src/shared/daemon` + `src/main/daemon` + `src/cli/commands` — 23 files, 348 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented wmux from terminating unrelated processes that happen to use a similarly named daemon script.
  * Improved daemon identification by verifying the exact script launched by wmux.
  * Added safeguards for cross-host Electron and CLI scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->