### PR TITLE
Let the inline preedit track the caret while an agent streams

### DIFF
--- a/changelog.d/1034.md
+++ b/changelog.d/1034.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Korean inline composition no longer drags backwards while an agent
+  streams.** Typing a multi-syllable word into a pane with output flowing
+  painted the syllable being composed near where the word started, so
+  `정확히 어떻` read `떻확히 어` until the space committed it. The anchor added
+  for Chinese candidate windows pins both IME surfaces to the input line it
+  finds, and fluid Korean typing reaches that path too — commit echoes are
+  output — so the visible preedit was held at a column one pause stale while
+  the caret moved on. The candidate-window pin stays where it was; the inline
+  preedit now follows the caret whenever the cursor is on the anchor's own
+  row, including the continuation rows of a wrapped input box. (#1034)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1213,8 +1213,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         if (imeAnchorLogsLeft[budget] <= 0) return;
         imeAnchorLogsLeft[budget] -= 1;
         // Mirrored into the main-side log file by src/main/index.ts's
-        // console-message listener, so the user can share it. The "5" in the
-        // tag marks the input-line marker build (#1016) so a shared log is
+        // console-message listener, so the user can share it. The "6" in the
+        // tag marks the row-gated preedit-follow build (#1032) so a shared log is
         // unambiguous about which release produced it. src/held/restAge/sel
         // are the cause-3 discriminator: src=resting means the composition
         // started mid-repaint and the anchor used the last resting cell;
@@ -1225,7 +1225,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // textarea correction, preedit= the live composition-view
         // correction.
         console.info(
-          `[wmux:ime-anchor5] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
+          `[wmux:ime-anchor6] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
           `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src}${edge ? ' edge=1' : ''} held=${held.toFixed(0)}ms ` +
           `restAge=${restAge.toFixed(0)}ms gap=${outputGap.toFixed(0)}ms caretAge=${caretAge.toFixed(0)}ms ` +
           `cellHeight=${cellHeight.toFixed(2)} ` +

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1208,7 +1208,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         const id = ptyIdRef.current;
         return id ? useStore.getState().surfaceAgent[id]?.slug : undefined;
       },
-      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, outputGap, caretAge, edge, selY, selX }) => {
+      onCompositionDiagnostic: ({ phase, baseY, viewportY, cursorY, cursorX, cellHeight, dx, dy, preeditDx, preeditDy, src, held, restAge, outputGap, caretAge, edge, rowSpan, selY, selX }) => {
         const budget = phase === 'start' ? 'start' : 'mid';
         if (imeAnchorLogsLeft[budget] <= 0) return;
         imeAnchorLogsLeft[budget] -= 1;
@@ -1226,7 +1226,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // correction.
         console.info(
           `[wmux:ime-anchor6] pty=${ptyIdRef.current} composition-${phase} ybase=${baseY} ydisp=${viewportY} ` +
-          `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src}${edge ? ' edge=1' : ''} held=${held.toFixed(0)}ms ` +
+          `cursor=(${cursorX},${cursorY}) sel=(${selX},${selY}) src=${src}${edge ? ' edge=1' : ''}${rowSpan > 1 ? ` span=${rowSpan}` : ''} held=${held.toFixed(0)}ms ` +
           `restAge=${restAge.toFixed(0)}ms gap=${outputGap.toFixed(0)}ms caretAge=${caretAge.toFixed(0)}ms ` +
           `cellHeight=${cellHeight.toFixed(2)} ` +
           `pin=(${dx.toFixed(1)},${dy.toFixed(1)}) preedit=(${preeditDx.toFixed(1)},${preeditDy.toFixed(1)})` +

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -644,7 +644,7 @@ describe('#874 resting-cell tracker (cause 3, pure)', () => {
     noteCursorMove(t, 49, 113, 1100); // caret promoted, cursor parked at 49,113
     // 5ms after the park: mid-burst -> resting cell.
     const midBurst = selectFreezeCell(t, 49, 113, 1105);
-    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5, outputGap: 105, caretAge: -1, edge: false });
+    expect(midBurst).toEqual({ absRow: 30, col: 8, src: 'resting', held: 5, restAge: 5, outputGap: 105, caretAge: -1, edge: false, rowSpan: 1 });
     // 100ms after the park: the parked cell is now at rest -> trusted as-is
     // (the documented cause-3 residual: dwell cannot tell a caret from a parked
     // cell — the diagnostic fields are the field-log discriminator).
@@ -1028,12 +1028,12 @@ describe('#1016 input-line content scan (pure)', () => {
       '╰──────────────╯',
       '  ? for shortcuts',
     ];
-    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 3, col: 4 });
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 3, col: 4, rowSpan: 1 });
   });
 
   it('keeps the column honest on an indented box', () => {
     const screen = ['  ╭────╮', '  │ > x│'];
-    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 6 });
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 6, rowSpan: 1 });
   });
 
   it('the bottom-most match wins over quoted chrome in the transcript', () => {
@@ -1048,7 +1048,7 @@ describe('#1016 input-line content scan (pure)', () => {
       '│ > live     │',
       '╰────────────╯',
     ];
-    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 5, col: 4 });
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 5, col: 4, rowSpan: 1 });
   });
 
   it('a bare prompt-like line without the box top above is not matched', () => {
@@ -1063,7 +1063,7 @@ describe('#1016 input-line content scan (pure)', () => {
       '│   wrapped    │',
       '╰──────────────╯',
     ];
-    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 4 });
+    expect(scanClaudeInputLine(lines(screen), screen.length)).toEqual({ relRow: 1, col: 4, rowSpan: 2 });
   });
 
   it('bash and memory mode prompts are the same caret row', () => {
@@ -1071,9 +1071,9 @@ describe('#1016 input-line content scan (pure)', () => {
     // (bash) or `#` (memory) mode — otherwise a quoted `│ > ` in the
     // transcript above would take over.
     const bash = ['│ > quoted', '╭────╮', '│ ! ls│', '╰────╯'];
-    expect(scanClaudeInputLine(lines(bash), bash.length)).toEqual({ relRow: 2, col: 4 });
+    expect(scanClaudeInputLine(lines(bash), bash.length)).toEqual({ relRow: 2, col: 4, rowSpan: 1 });
     const memory = ['╭────╮', '│ # note│', '╰────╯'];
-    expect(scanClaudeInputLine(lines(memory), memory.length)).toEqual({ relRow: 1, col: 4 });
+    expect(scanClaudeInputLine(lines(memory), memory.length)).toEqual({ relRow: 1, col: 4, rowSpan: 1 });
   });
 
   it('returns null on an unreadable or markerless screen', () => {
@@ -1103,7 +1103,7 @@ describe('#1016 marker selection (pure)', () => {
     // With it, content wins: the park sits on the prompt row's border zone
     // (col 137 of 139), which is repaint state, not a caret.
     const sel = selectFreezeCell(t, 676, 137, 2350, { top: 640, rows: 41, cols: 139 }, 640,
-      () => ({ relRow: 36, col: 4 }));
+      () => ({ relRow: 36, col: 4, rowSpan: 1 }));
     expect(sel).toMatchObject({ absRow: 676, col: 4, src: 'marker' });
   });
 
@@ -1114,14 +1114,14 @@ describe('#1016 marker selection (pure)', () => {
     noteOutputParsed(t, 1900, 139);
     expect(t.hasCaret).toBe(false);
     const sel = selectFreezeCell(t, 676, 137, 1950, { top: 640, rows: 41, cols: 139 }, 640,
-      () => ({ relRow: 31, col: 4 }));
+      () => ({ relRow: 31, col: 4, rowSpan: 1 }));
     expect(sel).toMatchObject({ absRow: 671, col: 4, src: 'marker' });
   });
 
   it('a quiet pane ignores the marker — idle stays cursor-driven', () => {
     const t = createRestingTracker(640, 8, 1000, 30);
     noteOutputParsed(t, 1200, 139); // real output once, long quiet since
-    const scan = vi.fn(() => ({ relRow: 31, col: 4 }));
+    const scan = vi.fn(() => ({ relRow: 31, col: 4, rowSpan: 1 }));
     const sel = selectFreezeCell(t, 640, 8, 1200 + OUTPUT_QUIET_MS + 200,
       { top: 600, rows: 45, cols: 139 }, 600, scan);
     expect(sel).toMatchObject({ absRow: 640, col: 8, src: 'instant' });
@@ -1139,7 +1139,7 @@ describe('#1016 marker selection (pure)', () => {
     noteOutputParsed(t, 1900, 139);
     noteOutputParsed(t, 2300, 139);
     const sel = selectFreezeCell(t, 671, 22, 2350, { top: 640, rows: 41, cols: 139 }, 640,
-      () => ({ relRow: 31, col: 4 }));
+      () => ({ relRow: 31, col: 4, rowSpan: 1 }));
     expect(sel).toMatchObject({ absRow: 671, col: 20, src: 'caret' });
   });
 
@@ -1150,7 +1150,7 @@ describe('#1016 marker selection (pure)', () => {
     // column (edge), the branch would open on the seed alone (panel
     // finding) — hasOutput keeps it shut until real output is observed.
     const t = createRestingTracker(676, 138, 1000, 36);
-    const scan = vi.fn(() => ({ relRow: 31, col: 4 }));
+    const scan = vi.fn(() => ({ relRow: 31, col: 4, rowSpan: 1 }));
     const sel = selectFreezeCell(t, 676, 138, 1100, { top: 640, rows: 41, cols: 139 }, 640, scan);
     expect(sel).toMatchObject({ src: 'instant' });
     expect(scan).not.toHaveBeenCalled();
@@ -1566,6 +1566,112 @@ describe('#1032 row-gated preedit follow — the streaming pin never drags Korea
     // Candidate anchor at the input's start (the marker's line-level answer)…
     expect(translateOf(dom.textarea)?.dx).toBeCloseTo((4 - 10) * 10, 6);
     // …while the preedit stays on the caret (the character-level answer).
+    expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('#1032 wrapped input and scrolling streams', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('pure: the row gate spans the box interior for marker anchors', () => {
+    expect(preeditFollowsLiveCursor('marker', 31, 32, 2)).toBe(true);
+    expect(preeditFollowsLiveCursor('marker', 31, 33, 2)).toBe(false);
+    expect(preeditFollowsLiveCursor('marker', 31, 30, 2)).toBe(false);
+    // Cursor-derived anchors keep the single-row gate.
+    expect(preeditFollowsLiveCursor('caret', 34, 35, 1)).toBe(false);
+  });
+
+  it('typing on a wrapped continuation row keeps the preedit on the caret', () => {
+    // GLM review finding on the first cut: wrapped input puts the caret on
+    // the box's second row while the marker always names the first — without
+    // the rowSpan gate that read as cross-row, pinned the preedit onto the
+    // prompt row, and the #1032 drag survived exactly for multi-line
+    // messages.
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const content: string[] = [];
+    for (let i = 0; i < 45; i++) content.push(`output line ${i}`);
+    content[30] = '╭──────────────────╮';
+    content[31] = '│ > 정확히 어떻게  │';
+    content[32] = '│   할까요         │';
+    content[33] = '╰──────────────────╯';
+    t.terminal.buffer.active.getLine = (y: number) => {
+      const line = content[y - t.state.baseY];
+      return line === undefined ? undefined : { translateToString: () => line };
+    };
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'claude',
+      onCompositionDiagnostic: diag,
+    });
+    clock = 2000;
+    // The box repaint leaves the cursor mid-word on the continuation row.
+    Object.assign(t.state, { cursorY: 32, cursorX: 7 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    clock = 2400;
+    t.onWriteParsed.fire(undefined);
+    clock = 2750;
+    t.onWriteParsed.fire(undefined);
+    clock = 2800;
+    dom.textarea.style.top = `${32 * 17.6}px`;
+    dom.textarea.style.left = '70px';
+    dom.compView.style.top = `${32 * 17.6}px`;
+    dom.compView.style.left = '70px';
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'marker', selY: 31, selX: 4, cursorY: 32, cursorX: 7, rowSpan: 2,
+    });
+    // Candidate anchor pinned to the box's input start on the prompt row…
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo((31 - 32) * 17.6, 6);
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((4 - 7) * 10, 6);
+    // …while the caret on the continuation row keeps the live preedit.
+    expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
+  });
+
+  it('a stream that scrolls the buffer under the input row keeps the follow', () => {
+    // Review hardening (Grok suggestion): ybase advances during the bursts
+    // while the input line holds its screen row. The snapshot is stored
+    // screen-relative, so the row gate must keep reading "same row" — a
+    // regression here would pin, and reintroduce #1032, exactly on
+    // scrolling output.
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 34, cursorX: 11 });
+    const handle = attachImeAnchor(t.terminal, { now: () => clock, onCompositionDiagnostic: diag });
+    clock = 2000;
+    Object.assign(t.state, { baseY: 602, viewportY: 602, cursorY: 34, cursorX: 2 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    clock = 2400;
+    Object.assign(t.state, { baseY: 606, viewportY: 606, cursorY: 34, cursorX: 2 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    clock = 2750;
+    Object.assign(t.state, { baseY: 610, viewportY: 610, cursorY: 34, cursorX: 2 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    clock = 2800;
+    dom.textarea.style.top = `${34 * 17.6}px`;
+    dom.textarea.style.left = '20px';
+    dom.compView.style.top = `${34 * 17.6}px`;
+    dom.compView.style.left = '20px';
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'caret', selY: 34, selX: 11, cursorY: 34, cursorX: 2,
+    });
+    // The pin corrects along the row only; the preedit stays on the caret.
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((11 - 2) * 10, 6);
+    expect(translateOf(dom.textarea)?.dy).toBeCloseTo(0, 6);
     expect(dom.compView.style.transform).toBe('');
     handle.dispose();
   });

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -27,6 +27,7 @@ import {
   paintedCursorPosition,
   parsePxOrNull,
   pointFromCell,
+  preeditFollowsLiveCursor,
   resetRestingTracker,
   RESTING_MS,
   scanClaudeInputLine,
@@ -1405,5 +1406,167 @@ describe('#874 upstream contracts', () => {
     expect(update, 'updateCompositionElements not found — xterm internals moved').not.toBeNull();
     expect(update![0]).toContain('const cursorTop = this._bufferService.buffer.y *');
     expect(update![0]).not.toContain('ydisp');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('#1032 row-gated preedit follow — the streaming pin never drags Korean typing', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('pure: only a cross-row cursor pins a caret/marker composition', () => {
+    // Quiet-path sources always follow (the #942 contract, untouched).
+    expect(preeditFollowsLiveCursor('instant', 34, 12)).toBe(true);
+    expect(preeditFollowsLiveCursor('resting', 34, 12)).toBe(true);
+    expect(preeditFollowsLiveCursor('scrolled_out', 34, 12)).toBe(true);
+    // Streaming-path sources: same screen row = the caret, follow it;
+    // any other row = the agent's repaint cursor, pin.
+    expect(preeditFollowsLiveCursor('caret', 34, 34)).toBe(true);
+    expect(preeditFollowsLiveCursor('caret', 34, 43)).toBe(false);
+    expect(preeditFollowsLiveCursor('marker', 31, 31)).toBe(true);
+    expect(preeditFollowsLiveCursor('marker', 31, 20)).toBe(false);
+  });
+
+  /** The #1032 field geometry (2026-08-26 correction comment): the quiet
+   *  caret snapshot holds column 11 of the input row (screen row 34) while
+   *  the user types a fresh word from column 2 on that same row. Commit
+   *  echoes keep every output gap under OUTPUT_QUIET_MS for longer than
+   *  STREAM_SUSTAIN_MS, so every composition takes the streaming branch. */
+  function fluidKoreanTyping(getAgentSlug?: () => string | undefined): {
+    dom: ReturnType<typeof buildTerminalDom>;
+    t: ReturnType<typeof makeTerminal>;
+    diag: ReturnType<typeof vi.fn>;
+    handle: { dispose(): void };
+    setClock: (v: number) => void;
+    positionChildren: (r: number, c: number) => void;
+  } {
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 34, cursorX: 11 });
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug,
+      onCompositionDiagnostic: diag,
+    });
+    // The chunk at 2000 ends a 1000ms quiet span: snapshot = (11,34). The
+    // cursor moved to column 2 in the same chunk (fresh word), and the echo
+    // bursts at 2400/2750 sustain the epoch past STREAM_SUSTAIN_MS.
+    clock = 2000;
+    Object.assign(t.state, { cursorY: 34, cursorX: 2 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    clock = 2400;
+    t.onWriteParsed.fire(undefined);
+    clock = 2750;
+    t.onWriteParsed.fire(undefined);
+    clock = 2800;
+    const positionChildren = (r: number, c: number): void => {
+      dom.textarea.style.top = `${r * 17.6}px`;
+      dom.textarea.style.left = `${c * 10}px`;
+      dom.compView.style.top = `${r * 17.6}px`;
+      dom.compView.style.left = `${c * 10}px`;
+    };
+    positionChildren(34, 2);
+    return { dom, t, diag, handle, setClock: (v) => { clock = v; }, positionChildren };
+  }
+
+  it('fluid typing mid-stream: the preedit follows the caret along the input row, the textarea stays pinned', () => {
+    // The regression's exact numbers: pin.x = (sel_col - cursor_col) x 8px on
+    // every record — a correction sized to cancel the live position and glue
+    // the preedit to the stale snapshot column, so 정확히 어떻 read 떻확히 어.
+    // The pin belongs on the textarea alone (#945's split): the preedit must
+    // ride the advancing caret.
+    const { dom, t, diag, handle, positionChildren } = fluidKoreanTyping();
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'caret', selY: 34, selX: 11, cursorY: 34, cursorX: 2,
+      preeditDx: 0, preeditDy: 0,
+    });
+    // Candidate-window anchor: still frozen to the snapshot cell (#951).
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((11 - 2) * 10, 6);
+    // Inline preedit: the live cursor is ON the anchor row — it IS the caret.
+    expect(dom.compView.style.transform).toBe('');
+    // A committed syllable's echo advances the caret two cells; xterm
+    // re-anchors both children there on the next compositionupdate.
+    Object.assign(t.state, { cursorX: 4 });
+    positionChildren(34, 4);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((11 - 4) * 10, 6);
+    expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
+  });
+
+  it('a cross-row repaint cursor mid-composition pins the preedit, and the follow resumes on return', () => {
+    // The #951 tear stays fixed: an agent chunk between keystrokes parks the
+    // cursor on an output row, and following THAT cursor would drag the
+    // pinyin/preedit onto the agent's output. The pin wins for exactly that
+    // event, per-event, and the follow resumes once the cursor is back.
+    const { dom, t, handle, positionChildren } = fluidKoreanTyping();
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(dom.compView.style.transform).toBe('');
+    Object.assign(t.state, { cursorY: 20, cursorX: 100 });
+    positionChildren(20, 100);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(translateOf(dom.compView)?.dx).toBeCloseTo((11 - 100) * 10, 6);
+    expect(translateOf(dom.compView)?.dy).toBeCloseTo((34 - 20) * 17.6, 6);
+    expect(translateOf(dom.compView)).toEqual(translateOf(dom.textarea));
+    Object.assign(t.state, { cursorY: 34, cursorX: 4 });
+    positionChildren(34, 4);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(dom.compView.style.transform).toBe('');
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((11 - 4) * 10, 6);
+    handle.dispose();
+  });
+
+  it('a marker-sourced composition follows the caret inside the input box the same way', () => {
+    // Korean typing while Claude Code streams (#874 RC-C population): the
+    // content scan pins the candidate anchor to the input line's start, but
+    // the caret typing inside the box is on the marker's own row — the
+    // preedit must track it, not the box's first column.
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const content: string[] = [];
+    for (let i = 0; i < 45; i++) content.push(`output line ${i}`);
+    content[30] = '╭──────────────╮';
+    content[31] = '│ > 정확히     │';
+    content[32] = '╰──────────────╯';
+    t.terminal.buffer.active.getLine = (y: number) => {
+      const line = content[y - t.state.baseY];
+      return line === undefined ? undefined : { translateToString: () => line };
+    };
+    const handle = attachImeAnchor(t.terminal, {
+      now: () => clock,
+      getAgentSlug: () => 'claude',
+      onCompositionDiagnostic: diag,
+    });
+    clock = 2000;
+    // Claude's box repaint leaves the cursor after the typed text, ON the
+    // prompt row.
+    Object.assign(t.state, { cursorY: 31, cursorX: 10 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    clock = 2400;
+    t.onWriteParsed.fire(undefined);
+    clock = 2750;
+    t.onWriteParsed.fire(undefined);
+    clock = 2800;
+    dom.textarea.style.top = `${31 * 17.6}px`;
+    dom.textarea.style.left = `${10 * 10}px`;
+    dom.compView.style.top = `${31 * 17.6}px`;
+    dom.compView.style.left = `${10 * 10}px`;
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({
+      src: 'marker', selY: 31, selX: 4, cursorY: 31, cursorX: 10,
+    });
+    // Candidate anchor at the input's start (the marker's line-level answer)…
+    expect(translateOf(dom.textarea)?.dx).toBeCloseTo((4 - 10) * 10, 6);
+    // …while the preedit stays on the caret (the character-level answer).
+    expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
   });
 });

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -504,6 +504,11 @@ export interface AgentInputLineMarker {
    *  input's start is already on the right row, which is what field reports
    *  complain about. */
   col: number;
+  /** Rows the box interior spans — 1 plus the wrapped continuation rows
+   *  under the prompt row (#1032). Wrapped input grows the box downward and
+   *  the caret lives on whichever interior row the user is typing on, so the
+   *  preedit's row gate must treat the whole interior as caret territory. */
+  rowSpan: number;
 }
 
 // Claude Code draws its input as a rounded box; the prompt row is the first
@@ -518,6 +523,10 @@ export interface AgentInputLineMarker {
 // CJK only ever appears after it.
 const CLAUDE_PROMPT_ROW = /^(\s*)│ [>!#] /;
 const CLAUDE_BOX_TOP = /^\s*╭─/;
+const CLAUDE_BOX_BOTTOM = /^\s*╰─/;
+// Interior rows of the box below the prompt row: wrapped continuation lines.
+// They carry the side border but no prompt glyph (#1032).
+const CLAUDE_BOX_ROW = /^\s*│ /;
 
 /**
  * Find Claude Code's input line in the visible rows (#1016).
@@ -546,9 +555,22 @@ export function scanClaudeInputLine(
     if (!m) continue;
     const above = readLine(r - 1);
     if (above === undefined || !CLAUDE_BOX_TOP.test(above)) continue;
+    // Wrapped input grows the box downward: continuation rows carry the side
+    // border but no prompt glyph, and the caret lives on whichever interior
+    // row the user is typing on (#1032). Count the interior down to the
+    // bottom border so the preedit's row gate can treat all of it as caret
+    // territory. A bottom border that never appears (unreadable row, box
+    // taller than the screen) keeps the conservative single-row span.
+    let rowSpan = 1;
+    for (let d = r + 1; d < rows; d++) {
+      const below = readLine(d);
+      if (below === undefined) break;
+      if (CLAUDE_BOX_BOTTOM.test(below)) { rowSpan = d - r; break; }
+      if (!CLAUDE_BOX_ROW.test(below)) break;
+    }
     // `│ > x`: border, space, prompt, space — input begins 4 cells past the
     // border.
-    return { relRow: r, col: m[1].length + 4 };
+    return { relRow: r, col: m[1].length + 4, rowSpan };
   }
   return null;
 }
@@ -576,6 +598,10 @@ export interface FreezeCellSelection {
   /** True when the instantaneous cursor sat on the last column — a TUI
    *  line-end park (#953). Diagnostic only; the selection is not rerouted. */
   edge: boolean;
+  /** Rows the anchor's input area spans, starting at the anchor row. 1 for
+   *  every cursor-derived source; the box-interior height for `marker`
+   *  (#1032 — wrapped input puts the caret on a continuation row). */
+  rowSpan: number;
 }
 
 /**
@@ -679,24 +705,25 @@ export function selectFreezeCell(
         return {
           absRow: baseY + marker.relRow, col: marker.col,
           src: 'marker', held, restAge, outputGap, caretAge, edge,
+          rowSpan: marker.rowSpan,
         };
       }
     }
     if (state.hasCaret) {
       return {
         absRow: baseY + state.caretRelRow, col: state.caretCol,
-        src: 'caret', held, restAge, outputGap, caretAge, edge,
+        src: 'caret', held, restAge, outputGap, caretAge, edge, rowSpan: 1,
       };
     }
   }
   if (held >= RESTING_MS || !state.hasResting) {
-    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge };
+    return { absRow: instAbsRow, col: instCol, src: 'instant', held, restAge, outputGap, caretAge, edge, rowSpan: 1 };
   }
   if (viewport && (state.lastRestingAbsRow < viewport.top
     || state.lastRestingAbsRow >= viewport.top + viewport.rows)) {
-    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge, edge };
+    return { absRow: instAbsRow, col: instCol, src: 'scrolled_out', held, restAge, outputGap, caretAge, edge, rowSpan: 1 };
   }
-  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge, edge };
+  return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge, edge, rowSpan: 1 };
 }
 
 /**
@@ -713,14 +740,31 @@ export function selectFreezeCell(
  * tears the preedit away from the candidate window). Rows are compared
  * screen-relative, like the caret snapshot itself: streaming output scrolls
  * the buffer under the input line while its screen row stays put.
+ *
+ * The gate is a row RANGE, not a single row: a `marker` anchor knows the
+ * box's interior height, and wrapped input puts the caret on a continuation
+ * row that is still the user's caret (#1032 review finding — without the
+ * span, multi-line messages kept exactly the drag this gate exists to
+ * remove). Cursor-derived anchors have no box knowledge and keep a span
+ * of 1.
+ *
+ * Known, accepted residual (3-way review consensus): an agent repaint that
+ * PARKS inside this row range — the #953 line-end park landing on a box
+ * row — reads as the caret, and the preedit follows it until the next
+ * composition event. Every prior generation that tried to outsmart a park
+ * (column heuristics, hysteresis, reroutes) field-tested worse than
+ * leaving it alone (see the header history), and for Korean a same-row
+ * follow is exactly the field-clean v3.46.0 behavior. The diagnostic's
+ * pin/preedit pair discriminates it in a field log.
  */
 export function preeditFollowsLiveCursor(
   src: FreezeCellSource,
   selRelRow: number,
   cursorRelRow: number,
+  rowSpan = 1,
 ): boolean {
   if (src !== 'caret' && src !== 'marker') return true;
-  return cursorRelRow === selRelRow;
+  return cursorRelRow >= selRelRow && cursorRelRow < selRelRow + rowSpan;
 }
 
 // ---------------------------------------------------------------------------
@@ -800,6 +844,9 @@ export interface ImeAnchorOptions {
     /** True when the cursor sat on the last column — a TUI line-end park
      *  (#953). Diagnostic only; the selection is not rerouted. */
     edge: boolean;
+    /** Rows the anchor's input area spans (#1032); 1 for cursor-derived
+     *  sources, the box-interior height for `marker`. */
+    rowSpan: number;
     /** Selected cell, ybase-relative like cursorY/cursorX. */
     selY: number;
     selX: number;
@@ -1003,7 +1050,7 @@ export function attachImeAnchor(
     const b = bufferState();
     const desired = frozen !== null
       && lastSel !== null
-      && !preeditFollowsLiveCursor(lastSel.src, lastSelRelY, b.cursorY)
+      && !preeditFollowsLiveCursor(lastSel.src, lastSelRelY, b.cursorY, lastSel.rowSpan)
       ? frozen
       : paintedCursorPosition(b, geometry);
     const c = computeImeAnchorCorrection(desired, actualPreedit);
@@ -1076,6 +1123,7 @@ export function attachImeAnchor(
       outputGap: lastSel.outputGap,
       caretAge: lastSel.caretAge,
       edge: lastSel.edge,
+      rowSpan: lastSel.rowSpan,
       selY: lastSelRelY,
       selX: lastSel.col,
     });

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -159,10 +159,19 @@
  * syncPreedit) so it lands on the painted caret when the viewport is scrolled
  * (cause 1 applies to it too) without chasing mid-repaint transient cursors.
  * One exception (#951 field report on the first quiet-caret build): when the
- * freeze cell came from the quiet caret, the live cursor is the streaming
- * agent's repaint cursor, so the preedit pins to the same frozen point as the
- * textarea — otherwise the pinyin rides the agent's output rows while its
- * candidate list sits at the input line, and the two IME surfaces tear apart.
+ * freeze cell came from the quiet caret and the live cursor sits on some
+ * OTHER screen row — the streaming agent's repaint cursor — the preedit pins
+ * to the same frozen point as the textarea; otherwise the pinyin rides the
+ * agent's output rows while its candidate list sits at the input line, and
+ * the two IME surfaces tear apart. The exception is row-gated (#1032, the
+ * first ship of it was not): fluid Korean typing reaches the streaming
+ * branch too — each committed syllable's echo is output, and sub-quiet gaps
+ * sustain the epoch — and there the live cursor IS the caret advancing along
+ * the anchor's own row while the snapshot's column is one quiet-span stale.
+ * Pinning the preedit there repainted the composing syllable over text
+ * already committed (typing 정확히 어떻 read 떻확히 어) — the very drag #945
+ * removed, reintroduced on the new path. A same-row cursor is the caret; a
+ * cross-row cursor is repaint state (see preeditFollowsLiveCursor).
  *
  * The correction is computed as `desired - actual`, where `actual` is read back
  * from the styles xterm wrote rather than re-derived from the buffer. That
@@ -690,6 +699,30 @@ export function selectFreezeCell(
   return { absRow: state.lastRestingAbsRow, col: state.lastRestingCol, src: 'resting', held, restAge, outputGap, caretAge, edge };
 }
 
+/**
+ * Whether the inline preedit keeps following the live cursor for a
+ * composition whose textarea pin came from the streaming branch (#1032).
+ *
+ * `caret`/`marker` freeze cells answer a line-level question — which row the
+ * agent's input line is on — with a column that can be one quiet-span stale.
+ * The inline preedit needs the character-level answer: where in that line the
+ * user is NOW. The live cursor gives that answer exactly when it sits on the
+ * anchor's own screen row (commit echoes advance it along the input line —
+ * the field-clean v3.46.0 behavior for Korean), and is repaint state when it
+ * sits anywhere else (#951: screen corners, output rows — following it there
+ * tears the preedit away from the candidate window). Rows are compared
+ * screen-relative, like the caret snapshot itself: streaming output scrolls
+ * the buffer under the input line while its screen row stays put.
+ */
+export function preeditFollowsLiveCursor(
+  src: FreezeCellSource,
+  selRelRow: number,
+  cursorRelRow: number,
+): boolean {
+  if (src !== 'caret' && src !== 'marker') return true;
+  return cursorRelRow === selRelRow;
+}
+
 // ---------------------------------------------------------------------------
 // Runtime wiring
 // ---------------------------------------------------------------------------
@@ -929,13 +962,24 @@ export function attachImeAnchor(
    *
    * The one exception is a composition whose freeze cell came from the quiet
    * caret or the content marker (`src=caret`/`src=marker`, #951/#953/#1016
-   * field reports): there the live cursor IS the streaming agent's repaint
+   * field reports) while the live cursor sits on a DIFFERENT screen row than
+   * the frozen cell: there the cursor is the streaming agent's repaint
    * cursor, and following it split the two IME surfaces apart — the candidate
    * window pinned at the input line while the inline pinyin chased the
    * agent's output rows. Both surfaces must anchor to the same cell, so those
    * compositions pin the preedit to the same frozen point as the textarea.
-   * The quiet case is untouched: there the selection is instant/resting and
-   * the live follow stays (#942 stays fixed).
+   * A live cursor on the SAME screen row keeps the live follow (#1032): fluid
+   * Korean typing reaches the streaming branch too — commit echoes are
+   * output, and sub-quiet gaps sustain the epoch — but there the cursor is
+   * the true caret advancing along the input line while the snapshot's column
+   * is one quiet-span stale, and pinning to it painted the composing syllable
+   * over committed text (the very drag #945 removed, reintroduced on the new
+   * path). The row test is preeditFollowsLiveCursor, evaluated per
+   * composition event, so a cursor that leaves the row mid-composition (an
+   * agent chunk landing between keystrokes) pins for that event and resumes
+   * following when it returns. The quiet case is untouched: there the
+   * selection is instant/resting and the live follow stays (#942 stays
+   * fixed).
    *
    * Deliberately called only from the composition handlers, NOT from
    * onRender/onScroll: at a composition event xterm has just written the
@@ -956,9 +1000,12 @@ export function attachImeAnchor(
     if (!isUsableGeometry(geometry)) return;
     const actualPreedit = readStyledPoint(compositionView);
     if (!actualPreedit) return;
-    const desired = frozen !== null && (lastSel?.src === 'caret' || lastSel?.src === 'marker')
+    const b = bufferState();
+    const desired = frozen !== null
+      && lastSel !== null
+      && !preeditFollowsLiveCursor(lastSel.src, lastSelRelY, b.cursorY)
       ? frozen
-      : paintedCursorPosition(bufferState(), geometry);
+      : paintedCursorPosition(b, geometry);
     const c = computeImeAnchorCorrection(desired, actualPreedit);
     preeditTransform.set(c.dx, c.dy);
   };


### PR DESCRIPTION
Closes #1032

Korean inline composition is painted over text that already committed again on v3.47.0 — typing into a pane while an agent streams puts the syllable being composed near the *front* of the line, and the first syllable disappears from view until the space commits. The buffer is never wrong, only the paint, same as #942. But this is a different code path: #945's split is intact, and what broke it is the streaming anchor added for Chinese candidate windows.

## What actually happens

`src=caret` / `src=marker` exist because while an agent streams, its cursor is not reliably the input caret — so the anchor is taken from a quiet-caret snapshot or from the input line found by content. Both answer a **line-level** question: which row the input is on. #951 then pinned the inline preedit to that same cell, because following the live cursor tore the two IME surfaces apart (pinyin riding the agent's output rows while the candidate list sat at the input line).

The gap: typing into an agent's input reaches that streaming branch too. Every keystroke's echo is output, and a normal typing rhythm keeps the gaps under `OUTPUT_QUIET_MS` for longer than `STREAM_SUSTAIN_MS`. There the snapshot is one quiet-span stale, the live cursor **is** the caret, and pinning the preedit to the snapshot column drags the composing syllable backwards — further with every keystroke. The reporter's numbers show it exactly: `pin.x = (sel_col − cursor_col) × cellWidth` on every record, a correction sized to cancel the caret's real position.

## The fix

The pin reaches the preedit only when the live cursor is on a **different row** than the frozen cell — that cursor is the agent's repaint state, which is the tear #951 fixed. A cursor on the anchor's own row is the caret advancing along the input line, and the preedit follows it, which is the field-clean v3.46.0 behavior. Evaluated per composition event, so a chunk that parks the cursor off-row mid-composition pins for that event and the follow resumes when it returns.

The second commit extends the same gate to the row *range* of a wrapped input box, found by `scanClaudeInputLine`. This one is defensive rather than field-driven — see the note at the bottom.

The diagnostic tag moves to `ime-anchor6`, and logs `span=` when the box spans more than one row, so a shared field log is unambiguous about which build produced it.

## Evidence

86 unit tests pass, including the reporter's geometry (stale snapshot column, caret advancing on that row), a cross-row chunk mid-composition pinning for that event and resuming, a wrapped box, and a scrolling stream where ybase advances under a sticky input row.

Live, against a **real Claude Code pane** (v2.1.246) streaming a real turn, typing Korean into its input while it streams, and firing real composition events on xterm's helper textarea. Only the renderer module was swapped between runs.

The painted result, clipped from the input row mid-composition — `민` is the syllable being composed:

```
on main:      › 민확히어떻게해야하는지알려주
with this PR: › 정확히어떻게해야하는지알려주민
```

That is the reported symptom in pixels: the composing syllable lands on top of the first one, which vanishes.

The correction behind it, same run, caret advancing while the snapshot stays at column 2:

| caret | anchor | preedit correction on `main` | with this PR |
|---|---|---|---|
| `cursor=(8,42)` | `sel=(2,42)` | `-38.4` | `-0.06` |
| `cursor=(20,42)` | `sel=(2,42)` | `-115.2` | `-0.14` |
| `cursor=(38,42)` | `sel=(2,42)` | `-230.4` | `-0.27` |
| `cursor=(30,42)` (pixel capture) | `sel=(2,42)` | `-179.2` | `-0.2` |

The textarea pin is unchanged in both builds — the candidate window still sits where the anchor put it. Only the visible preedit stops being dragged.

A cross-row streaming cursor still pins both surfaces together, so #951 is unaffected.

## Note on the wrapped-box commit

While dogfooding I checked what current Claude Code actually draws, and it does not draw the `╭─ / │ > / ╰─` box `scanClaudeInputLine` matches — v2.1.246 renders a horizontal rule and a `›` prompt. So `src=marker` never fires against it: every record in this dogfood, and every record in the reporter's log (44 `instant`, 36 `caret`, 0 `marker`), comes from the cursor path. The rowSpan change is therefore correct but currently unexercised in the field, and the input box wrapping does not break the fix on this version anyway, because the caret keeps its screen row when the box grows (measured: column wrapped 50 → 4, row stayed 42).

The scanner being stale is its own defect and I have filed it separately rather than widening this PR.

@changinho25 — the reproduction above is yours (compose while output streams, without pausing long enough to end the composition). If you can run a build of this branch: `ime-anchor6` records should read `src=caret` with `preedit=(0.0,0.0)`; a nonzero `preedit` on a `src=caret` record means it is still wrong, and the `cursor=`/`sel=` fields on that same line will say why. Thank you for the correction comment — the first report's framing would have sent this at the wrong geometry.
