### PR TITLE
test(daemon): stop reading the boot marker before the daemon has written it

### DIFF
--- a/src/daemon/__tests__/bootMarker.runtime.test.ts
+++ b/src/daemon/__tests__/bootMarker.runtime.test.ts
@@ -72,8 +72,17 @@ describe.skipIf(!hasBundle)('#546 boot marker lifecycle (real daemon)', () => {
     let sawMarker: string | null = null;
     for (let i = 0; i < 2000; i++) {
       try {
-        sawMarker = fs.readFileSync(markerFile, 'utf-8');
-        break;
+        const raw = fs.readFileSync(markerFile, 'utf-8');
+        // `writeFileSync` creates the file and then writes it, so a 2 ms poll
+        // can win that race and read the empty intermediate — which parsed to
+        // NaN and reddened `validate` on PRs that never touch the daemon.
+        // An empty read is not "the marker appeared"; it is the same "not yet"
+        // as ENOENT, and production agrees: parseBootMarker() rejects anything
+        // unparseable rather than treating it as a boot claim.
+        if (raw.trim() !== '') {
+          sawMarker = raw;
+          break;
+        }
       } catch { /* not yet */ }
       if (fs.existsSync(pipeFile)) break; // ready already — window closed
       await sleep(2);


### PR DESCRIPTION
Closes #1036

`validate` went red twice in an hour today on PRs that cannot touch the daemon — the Polish locale one-liner on #1029, and the 3.47.1 release commit itself — both with the same assertion:

```
AssertionError: expected NaN to be 2584
 ❯ src/daemon/__tests__/bootMarker.runtime.test.ts:93:52
```

The daemon writes its boot marker with `writeFileSync` (`src/daemon/index.ts:1175`), which creates the file and then writes it. The test polls every 2 ms and takes the first read that does not throw:

```ts
try { sawMarker = fs.readFileSync(markerFile, 'utf-8'); break; } catch { /* not yet */ }
```

so a dense poll on a loaded runner can land between the create and the write, read `''`, and then parse that as a PID at line 93. `NaN`.

An empty read carries no more information than `ENOENT`, so it now counts as "not yet" and the poll continues. That is also how production reads it: `parseBootMarker()` requires a finite PID and rejects anything unparseable rather than treating it as a boot claim, so the launcher already tolerates the same intermediate. This closes the gap between what the test accepts and what the code under test accepts — it is a test bug, not a product one, which is why the daemon side is untouched.

The witness stays honest: a daemon that never writes a non-empty marker leaves `sawMarker` null and still fails `expect(sawMarker).not.toBeNull()`, which is the assertion that stops a version with no marker at all from sailing through.

Verified: `WMUX_REQUIRE_DAEMON_BUNDLE=1 npx vitest run src/daemon/__tests__/bootMarker.runtime.test.ts` — 3/3, run repeatedly, marker observed each time.

No changelog fragment: test-only, nothing user-facing (same as #1023, which added this suite).
