### PR TITLE
fix(terminal): don't anchor the preedit to the previous composition at start

### DIFF
--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -519,6 +519,13 @@ describe('#942 inline preedit (Korean IME) — the pin never drags the preedit',
     dom.compView.style.left = '120px';
     dom.textarea.dispatchEvent(new Event('compositionstart'));
     expect(translateOf(dom.textarea)?.dy).toBeCloseTo(8 * 17.6, 6);
+    // The preedit's correction lands on the first compositionupdate, not at
+    // start: xterm's compositionstart writes only textContent and the `active`
+    // class, so at start the element holds no position for this composition
+    // (nothing is painted there either — an empty view is zero-width). This
+    // used to assert at start against coordinates the test had placed itself,
+    // a state xterm never produces (#1032 field follow-up).
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
     expect(translateOf(dom.compView)?.dy).toBeCloseTo(8 * 17.6, 6);
     handle.dispose();
   });
@@ -1673,6 +1680,93 @@ describe('#1032 wrapped input and scrolling streams', () => {
     expect(translateOf(dom.textarea)?.dx).toBeCloseTo((11 - 2) * 10, 6);
     expect(translateOf(dom.textarea)?.dy).toBeCloseTo(0, 6);
     expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('#1032 field follow-up — compositionstart never corrects against the previous composition', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('a second composition starts with a zero preedit correction, not one measured off the first', () => {
+    // Field report on v3.47.1 (#1032, after the fix landed): a
+    // composition-start record carried `preedit=(24.0,0.0)` next to
+    // `pin=(-72.0,0.0)` — unrelated values, and the same 24.0 recurred on
+    // unrelated compositions. Cause: xterm's compositionstart handler sets
+    // only `textContent`/`active`; `style.left/top` are written in
+    // updateCompositionElements on the FIRST compositionupdate. So at start
+    // the element still carries the previous composition's coordinates.
+    const dom = buildTerminalDom();
+    const t = makeTerminal(dom);
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 0, viewportY: 0, cursorY: 30, cursorX: 20 });
+    const place = (r: number, c: number): void => {
+      dom.textarea.style.top = `${r * 17.6}px`;
+      dom.textarea.style.left = `${c * 10}px`;
+      dom.compView.style.top = `${r * 17.6}px`;
+      dom.compView.style.left = `${c * 10}px`;
+    };
+    place(30, 20);
+    const handle = attachImeAnchor(t.terminal, { onCompositionDiagnostic: diag });
+
+    // First composition, at column 20, runs and ends. xterm leaves the
+    // preedit's style.left/top on the element afterwards.
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    dom.textarea.dispatchEvent(new Event('compositionend'));
+
+    // The caret has since moved well down the line; xterm repositions the
+    // TEXTAREA on its own (_syncTextArea), but the preedit keeps the stale
+    // coordinates until the next update.
+    Object.assign(t.state, { cursorX: 26 });
+    dom.textarea.style.left = `${26 * 10}px`;
+
+    diag.mockClear();
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    // The start record must not report a correction derived from the previous
+    // composition's position.
+    expect(diag.mock.calls[0][0]).toMatchObject({ phase: 'start', preeditDx: 0, preeditDy: 0 });
+    expect(dom.compView.style.transform).toBe('');
+
+    // Once xterm gives the preedit a real position, the correction resumes
+    // exactly as before — the caret is followed, nothing is pinned.
+    place(30, 26);
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(dom.compView.style.transform).toBe('');
+    handle.dispose();
+  });
+
+  it('a caret-sourced pin still lands on the first update after the start is skipped', () => {
+    // Skipping the start must not cost the streaming pin: the first
+    // compositionupdate is where xterm positions the preedit, and that is
+    // where the pin has to reach it.
+    const dom = buildTerminalDom(10, 17.6, 45, 128);
+    const t = makeTerminal(dom, 45, 128);
+    let clock = 1000;
+    const diag = vi.fn();
+    Object.assign(t.state, { baseY: 600, viewportY: 600, cursorY: 40, cursorX: 5 });
+    const handle = attachImeAnchor(t.terminal, { now: () => clock, onCompositionDiagnostic: diag });
+    clock = 2000;
+    Object.assign(t.state, { cursorY: 43, cursorX: 127 });
+    t.onCursorMove.fire(undefined);
+    t.onWriteParsed.fire(undefined);
+    dom.textarea.style.top = `${43 * 17.6}px`;
+    dom.textarea.style.left = `${127 * 10}px`;
+    clock = 2400;
+    t.onWriteParsed.fire(undefined);
+    clock = 2750;
+    t.onWriteParsed.fire(undefined);
+    clock = 2800;
+    dom.textarea.dispatchEvent(new Event('compositionstart'));
+    expect(diag.mock.calls[0][0]).toMatchObject({ src: 'caret', preeditDx: 0, preeditDy: 0 });
+    // xterm positions the preedit on the live (repaint) cursor at the first
+    // update; the cross-row pin pulls it back to the frozen cell.
+    dom.compView.style.top = `${43 * 17.6}px`;
+    dom.compView.style.left = `${127 * 10}px`;
+    dom.textarea.dispatchEvent(new Event('compositionupdate'));
+    expect(translateOf(dom.compView)?.dy).toBeCloseTo((40 - 43) * 17.6, 6);
+    expect(translateOf(dom.compView)?.dx).toBeCloseTo((5 - 127) * 10, 6);
     handle.dispose();
   });
 });

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -173,6 +173,18 @@
  * removed, reintroduced on the new path. A same-row cursor is the caret; a
  * cross-row cursor is repaint state (see preeditFollowsLiveCursor).
  *
+ * Timing note, learned from the #1032 field log: xterm positions the preedit
+ * ONLY in `updateCompositionElements`, which it calls from `compositionupdate`.
+ * Its `compositionstart` handler sets `textContent = ''` and the `active`
+ * class and nothing else, so at start the element still carries the PREVIOUS
+ * composition's `style.left/top`. Correcting against those produced a
+ * start-record `preedit` offset that recurred identically across unrelated
+ * compositions — inert on screen (an empty view has no padding or min-width,
+ * so it is zero-width until the first update fills it) but indistinguishable
+ * in a log from a real drag, which defeats the point of a diagnostic that
+ * exists to be read by reporters. The preedit correction therefore begins at
+ * the first update, where the position is real.
+ *
  * The correction is computed as `desired - actual`, where `actual` is read back
  * from the styles xterm wrote rather than re-derived from the buffer. That
  * matters for three reasons: `_syncTextArea` early-returns while composing (so
@@ -1038,9 +1050,21 @@ export function attachImeAnchor(
    * follow would drag the composing syllable around the screen (2-model
    * panel finding on the first cut of this fix).
    */
-  const syncPreedit = (): void => {
+  const syncPreedit = (atStart = false): void => {
     if (!preeditTransform || !compositionView) return;
-    if (!composing) {
+    // `atStart`: xterm has not positioned the preedit for THIS composition yet.
+    // Its compositionstart handler only sets `textContent = ''` and the
+    // `active` class; `style.left/top` are written in updateCompositionElements,
+    // which runs on the first compositionupdate. So the coordinates still on
+    // the element belong to the PREVIOUS composition, and a correction measured
+    // against them is meaningless — field-reported on #1032 as a
+    // composition-start record carrying `preedit=(24.0,0.0)` that recurred
+    // identically across unrelated compositions, which reads like a live drag
+    // and is not one. Nothing is painted either: an empty `.composition-view`
+    // has no padding or min-width in xterm's stylesheet, so it is zero-width
+    // until the first update fills it. Clear the transform and wait for the
+    // update that gives the preedit a real position.
+    if (!composing || atStart) {
       preeditTransform.set(0, 0);
       return;
     }
@@ -1163,7 +1187,7 @@ export function attachImeAnchor(
       ? pointFromCell(sel.absRow, sel.col, b, geometry)
       : null;
     sync();
-    syncPreedit();
+    syncPreedit(true);
     emitDiagnostic('start');
   };
 


### PR DESCRIPTION
Field follow-up on #1032. The reporter verified v3.47.1 fixes the drag, and flagged the one record that did not match the healthy signature:

```
composition-start … src=caret pin=(-72.0,0.0) preedit=(24.0,0.0)
```

with the same `24.0` recurring on unrelated `src=instant` composition-start records. Their read was right — it is not the old `pin == preedit` coupling — and it is worth chasing, because the cause is real even though the symptom is not visible.

## Cause

xterm positions the preedit only in `updateCompositionElements`, called from `compositionupdate`. Its `compositionstart` handler does this and nothing else:

```ts
public compositionstart(): void {
  this._isComposing = true;
  this._compositionPosition.start = this._textarea.value.length;
  this._compositionView.textContent = '';
  this._dataAlreadySent = '';
  this._compositionView.classList.add('active');
}
```

So at `compositionstart` the element still carries the **previous** composition's `style.left/top`, and `syncPreedit` computed `desired - actual` against those. A stale anchor gives a stale delta, and since the leftover position is the same each time, so is the number — which is exactly the recurrence the reporter noticed.

Nothing is painted there: an empty `.composition-view` has no padding or `min-width` in xterm's stylesheet, so it is zero-width until the first update fills it. That is why this never reached the screen in either the dogfood or the field.

## Why fix a cosmetically inert record

The diagnostic exists to be read by reporters — it is the whole reason `#874`/`#942`/`#951`/`#1032` were diagnosable from a shared log rather than a repro none of us can run. A record that reports an offset nobody can see is indistinguishable in a log from a real drag, and it already cost a reporter time on a build that was working correctly.

## The change

The preedit correction begins at the first update, where the position is real. The streaming pin is unaffected — the first update is also where xterm gives the preedit a position for the pin to correct — and a test now pins that specifically.

One existing test moved with it. #942's scrolled-viewport case asserted the preedit correction immediately after `compositionstart`, against coordinates the test had placed on the element itself, which is a state xterm never produces at start. It now asserts after the update, so it still guards what it was written to guard (the ydisp term reaches the preedit) without encoding a timing that does not exist. Calling that out explicitly rather than letting an existing green assertion quietly change meaning.

## Verified

`npx vitest run src/renderer/terminal/__tests__/imeAnchor.test.ts` — 88/88, including two new cases: a second composition starting with a zero preedit correction instead of one measured off the first, and a caret-sourced pin still landing on the first update.

`tsc --noEmit` and `eslint` clean.

No changelog fragment: the user-visible behaviour does not change, only what the diagnostic reports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text input behavior for IME compositions by deferring preedit positioning until the first update.
  - Prevented stale positioning from previous compositions from affecting new input sessions.
  - Preserved accurate caret alignment when composition text spans multiple rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->