### PR TITLE
Close the two review-round findings on the IME sync timer and the boot-marker poll

### DIFF
--- a/src/daemon/__tests__/bootMarker.runtime.test.ts
+++ b/src/daemon/__tests__/bootMarker.runtime.test.ts
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import net from 'node:net';
+import { parseBootMarker } from '../../shared/daemon/daemonLauncherCore';
 
 const SUFFIX = '-i546-test';
 const dir = path.join(os.homedir(), `.wmux${SUFFIX}`);
@@ -61,6 +62,8 @@ describe.skipIf(!hasBundle)('#546 boot marker lifecycle (real daemon)', () => {
       env: { ...process.env, WMUX_DATA_SUFFIX: SUFFIX },
       stdio: ['ignore', 'ignore', 'ignore'],
     });
+    const spawnedPid = child.pid;
+    expect(spawnedPid, 'spawn returned no pid').toBeDefined();
 
     // (1) The marker appears, and names the daemon's own PID. Poll densely —
     // boot with zero sessions to recover is ~300 ms, and the marker is written
@@ -74,12 +77,15 @@ describe.skipIf(!hasBundle)('#546 boot marker lifecycle (real daemon)', () => {
       try {
         const raw = fs.readFileSync(markerFile, 'utf-8');
         // `writeFileSync` creates the file and then writes it, so a 2 ms poll
-        // can win that race and read the empty intermediate — which parsed to
-        // NaN and reddened `validate` on PRs that never touch the daemon.
-        // An empty read is not "the marker appeared"; it is the same "not yet"
-        // as ENOENT, and production agrees: parseBootMarker() rejects anything
-        // unparseable rather than treating it as a boot claim.
-        if (raw.trim() !== '') {
+        // can win that race and read a not-yet-complete intermediate — which
+        // parsed to NaN and reddened `validate` on PRs that never touch the
+        // daemon. The production parser is the predicate here, not an
+        // approximation of it: an empty read AND a torn one ("90" of "9052")
+        // are equally unparseable boot claims, and both re-poll as "not yet",
+        // exactly the way parseBootMarker() refuses them in the launcher.
+        // (3-way review consensus on the first cut, which skipped only empty
+        // reads and let a torn read through to the PID assertion below.)
+        if (spawnedPid !== undefined && parseBootMarker(raw, spawnedPid)) {
           sawMarker = raw;
           break;
         }

--- a/src/renderer/terminal/__tests__/imeAnchor.test.ts
+++ b/src/renderer/terminal/__tests__/imeAnchor.test.ts
@@ -1770,3 +1770,53 @@ describe('#1032 field follow-up — compositionstart never corrects against the 
     handle.dispose();
   });
 });
+
+// ---------------------------------------------------------------------------
+
+describe('#1040 follow-up — the deferred sync is disarmed at compositionstart', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('a deferred sync from a composition that never ended cannot fire into the next one', () => {
+    // Review finding on the #1040 round: compositionupdate schedules a
+    // setTimeout(0) re-sync (mirroring xterm's own recursive reposition), and
+    // only compositionEND cleared it. A composition that ends without its
+    // compositionend event (focus loss mid-composition) leaves that timer
+    // armed, and it would fire during the NEXT composition's pre-update
+    // window — correcting against coordinates xterm wrote for the PREVIOUS
+    // composition, the exact stale-anchor class this file exists to prevent.
+    // compositionstart now disarms it, symmetric with the end handler.
+    vi.useFakeTimers();
+    try {
+      const dom = buildTerminalDom();
+      const t = makeTerminal(dom);
+      Object.assign(t.state, { baseY: 0, viewportY: 0, cursorY: 30, cursorX: 20 });
+      const place = (r: number, c: number): void => {
+        dom.textarea.style.top = `${r * 17.6}px`;
+        dom.textarea.style.left = `${c * 10}px`;
+        dom.compView.style.top = `${r * 17.6}px`;
+        dom.compView.style.left = `${c * 10}px`;
+      };
+      place(30, 20);
+      const handle = attachImeAnchor(t.terminal);
+
+      // Composition 1: the update arms the deferred re-sync. No compositionend.
+      dom.textarea.dispatchEvent(new Event('compositionstart'));
+      dom.textarea.dispatchEvent(new Event('compositionupdate'));
+
+      // Composition 2 begins; the caret has moved on, and xterm has not yet
+      // positioned the preedit for it (that happens on its first update).
+      Object.assign(t.state, { cursorX: 26 });
+      dom.textarea.style.left = `${26 * 10}px`;
+      dom.textarea.dispatchEvent(new Event('compositionstart'));
+
+      // The stale timer must be gone. If it fired here, it would compute
+      // desired(col 26) - actual(col 20) against the previous composition's
+      // coordinates and paint a correction xterm never asked for.
+      vi.runOnlyPendingTimers();
+      expect(dom.compView.style.transform).toBe('');
+      handle.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/renderer/terminal/imeAnchor.ts
+++ b/src/renderer/terminal/imeAnchor.ts
@@ -1160,6 +1160,18 @@ export function attachImeAnchor(
     // the cursor. The cell it pins to is the resting-tracker selection: the
     // instantaneous cursor when it is at rest, the last resting cell when the
     // composition starts inside a repaint burst (cause 3).
+    //
+    // First, disarm a deferred update-sync left over from the PREVIOUS
+    // composition (review finding on the #1040 round): its closure would
+    // correct against coordinates xterm has not yet rewritten for this
+    // composition — the stale-anchor class this module exists to prevent.
+    // The end handler already disarms it, but a composition that dies
+    // without a compositionend event (focus loss mid-composition) leaves it
+    // armed, and start is then the only remaining gate.
+    if (pendingCompositionSync !== null) {
+      clearTimeout(pendingCompositionSync);
+      pendingCompositionSync = null;
+    }
     composing = true;
     const b = bufferState();
     // #1016: while output flows, the cursor never visits the input caret

--- a/src/shared/daemon/__tests__/bootMarkerParse.test.ts
+++ b/src/shared/daemon/__tests__/bootMarkerParse.test.ts
@@ -1,0 +1,47 @@
+// #546 / #1036 — parseBootMarker is the launcher's whole safety predicate for
+// "a live daemon claims to be booting", and (since #1041) also the predicate
+// the boot-marker runtime test polls with. Its rejection set is therefore a
+// contract two places rely on, and until now it had no direct test: the
+// review round on #1041 justified the test-side poll by claiming equivalence
+// with this function, so the claim gets pinned here rather than staying an
+// assertion in a comment.
+import { describe, it, expect } from 'vitest';
+import { parseBootMarker } from '../daemonLauncherCore';
+
+describe('#546 parseBootMarker — the boot-claim predicate', () => {
+  const PID = 9052;
+
+  it('accepts exactly a marker naming the expected PID', () => {
+    expect(parseBootMarker('9052', PID)).toBe(true);
+    // The daemon writes String(process.pid) with no newline, but a trailing
+    // newline must not defeat the claim if that ever changes.
+    expect(parseBootMarker('9052\n', PID)).toBe(true);
+    expect(parseBootMarker('  9052  ', PID)).toBe(true);
+  });
+
+  it('rejects the create-then-write intermediate: the empty file', () => {
+    // The #1036 flake: writeFileSync creates the file before writing it, and
+    // a dense poll can read the empty middle state.
+    expect(parseBootMarker('', PID)).toBe(false);
+    expect(parseBootMarker('   ', PID)).toBe(false);
+    expect(parseBootMarker(null, PID)).toBe(false);
+  });
+
+  it('rejects a torn read: a strict prefix of the PID parses but must not claim', () => {
+    // "90" of "9052" — parseInt succeeds, so Number.isFinite alone would let
+    // it through; only the equality with the verified PID refuses it. This is
+    // the case the #1041 review round found the test-side poll still passing.
+    expect(parseBootMarker('90', PID)).toBe(false);
+    expect(parseBootMarker('905', PID)).toBe(false);
+  });
+
+  it('rejects a different live PID: a predecessor\'s leftover is not our claim', () => {
+    expect(parseBootMarker('1234', PID)).toBe(false);
+  });
+
+  it('rejects garbage without throwing', () => {
+    expect(parseBootMarker('not-a-pid', PID)).toBe(false);
+    expect(parseBootMarker('NaN', PID)).toBe(false);
+    expect(parseBootMarker('Infinity', PID)).toBe(false);
+  });
+});


### PR DESCRIPTION
Post-merge 3-way review round (Claude / GLM-5.3 / Grok) on #1039 and #1040 — both had merged without independent review. No P1s; two findings survived verification and this PR closes both.

## 1. The deferred sync outlives a composition that never ends (`imeAnchor.ts`)

`compositionupdate` arms a `setTimeout(0)` re-sync, mirroring xterm's own recursive reposition. Only compositionEND disarmed it. A composition that dies without its `compositionend` event — focus loss mid-composition — leaves the timer armed, and it fires during the **next** composition's pre-update window, correcting against coordinates xterm wrote for the previous composition. That is precisely the stale-anchor class #1040 fixed at `compositionstart`, surviving through a side door.

The reviewer who found it proposed a latch; the disarm-at-start is simpler and closes the same hole, because `syncPreedit` has no callers outside the composition handlers (`onRender`/`onScroll` touch only the textarea path) — so the leftover timer was the *only* thing that could fire in that window. It is also symmetric with the end handler, which already disarms for the mirror-image reason.

The regression test is proven non-vacuous: with the disarm removed it fails (`translate(60px, 0px)` where `''` is expected), with it it passes.

Narrow trigger, invisible result (the transform lands on a zero-width empty view and self-heals on the first update) — but the module's whole diagnostic story depends on the log not lying, and this was a path where it could.

## 2. The boot-marker poll accepted torn reads (`bootMarker.runtime.test.ts`)

All three reviewers converged on this one independently, each from the same observation: #1039 skipped only **empty** reads, so a torn read (`"90"` of `"9052"`) still escaped the poll and reached the PID assertion as the same NaN-class flake — while the comment justified the check by claiming equivalence with `parseBootMarker()`, which rejects *anything* unparseable. The claimed equivalence was not the implemented one.

The poll now uses the production parser itself as its predicate, against the spawned child's PID: empty and torn reads alike re-poll as "not yet", and the comment's claim is now literally true. A daemon that never writes a valid marker still fails `expect(sawMarker).not.toBeNull()`, so the witness keeps its teeth.

## Review-round claims that did *not* survive verification, for the record

- "Re-syncs between start and first update reapply stale corrections via cursor/write/render/scroll" — those paths call `sync()` (textarea only), never `syncPreedit`. The defect above is real but its mechanism is the leftover timer, not those callers.
- "The test can pass without ever observing a marker" — `expect(sawMarker).not.toBeNull()` fails that case.

## Verified

- `imeAnchor.test.ts` 89/89 (new straddle test included), fails-without-fix proven.
- `WMUX_REQUIRE_DAEMON_BUNDLE=1` boot-marker runtime suite 3/3 against the real bundle.
- `tsc --noEmit`, `eslint` clean.

No changelog fragments: a test-only change and a not-user-observable timer disarm, same standing as #1039/#1040.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input-method editor behavior when a composition loses focus unexpectedly, preventing stale positioning from affecting subsequent text input.
  * Improved daemon startup marker handling to reject incomplete or invalid reads and confirm the marker matches the active daemon process.

* **Tests**
  * Added regression coverage for interrupted text compositions and daemon boot-marker validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->