### PR TITLE
fix(updater): give the install wait some feedback

### DIFF
--- a/changelog.d/1044.md
+++ b/changelog.d/1044.md
@@ -1,7 +1,3 @@
-### Fixed
-
-- **A repeat "Install now" click while an update was already installing used to do nothing at all.** The single-instance guard in the install waiter (#980) is correct — a second Squirrel install racing the first is exactly the corruption it exists to prevent — but it refused silently: no marker, so nothing to report on the next boot. It now writes a marker before refusing, so the existing "why was my update refused" notice (#866) picks it up like any other refusal instead of leaving the click looking like the button did nothing. (#1043)
-
 ### Added
 
 - **A best-effort "installing the update, please wait" window during the install handoff.** Clicking "install now" used to close the app and go silent for up to ~1-2 minutes while the install waiter confirmed every process had actually let go of the install root — indistinguishable, from the outside, from the update having failed. The waiter (which already has to run outside the install root it is watching) now shows a small always-on-top window for that wait, and closes it right before Squirrel's own installer UI takes over. Failing to show it (a locked-down machine, no display subsystem) degrades to today's silent-but-correct behavior — it can never block or fail the install itself. (#1043)

--- a/changelog.d/1044.md
+++ b/changelog.d/1044.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **A repeat "Install now" click while an update was already installing used to do nothing at all.** The single-instance guard in the install waiter (#980) is correct — a second Squirrel install racing the first is exactly the corruption it exists to prevent — but it refused silently: no marker, so nothing to report on the next boot. It now writes a marker before refusing, so the existing "why was my update refused" notice (#866) picks it up like any other refusal instead of leaving the click looking like the button did nothing. (#1043)
+
+### Added
+
+- **A best-effort "installing the update, please wait" window during the install handoff.** Clicking "install now" used to close the app and go silent for up to ~1-2 minutes while the install waiter confirmed every process had actually let go of the install root — indistinguishable, from the outside, from the update having failed. The waiter (which already has to run outside the install root it is watching) now shows a small always-on-top window for that wait, and closes it right before Squirrel's own installer UI takes over. Failing to show it (a locked-down machine, no display subsystem) degrades to today's silent-but-correct behavior — it can never block or fail the install itself. (#1043)

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -17,6 +17,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { spawn, spawnSync, execFileSync, type ChildProcess } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   buildWaiterScript,
   spawnInstallWaiter,
@@ -295,7 +296,13 @@ describe.skipIf(!onWindows)('concurrent waiters (#980)', () => {
 
     // Deterministic gate, not a sleep: proceed only once A actually HOLDS the
     // mutex — otherwise B could win the race and this test would invert.
-    const mtxName = 'wmux-install-waiter-' + root.replace(/[^A-Za-z0-9]/g, '_');
+    // #1044, coderabbit: the real script now hashes $root with SHA256 instead
+    // of the old lossy character replace. Node's crypto computes the same
+    // digest over the same bytes — .toUpperCase() to match PowerShell's
+    // BitConverter.ToString output, which the real script also strips dashes
+    // from.
+    const mtxHash = createHash('sha256').update(root, 'utf8').digest('hex').toUpperCase();
+    const mtxName = 'wmux-install-waiter-' + mtxHash;
     const deadline = Date.now() + 15_000;
     let held = false;
     while (Date.now() < deadline) {

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -87,21 +87,6 @@ describe('buildWaiterScript — ordering is the whole contract', () => {
     expect(buildWaiterScript({ ...PLAN, pids: [1.5] })).toBeNull();
   });
 
-  // #1043 — a live earlier waiter used to make a repeat click a silent no-op:
-  // `exit 5` fired before the marker path was ever reached, so the boot that
-  // followed had nothing to report. The mutex still has to win the race (a
-  // second Squirrel install against the same root is the #866 corruption this
-  // whole module exists to prevent) — only the silence was the bug.
-  it('writes a marker before refusing a second concurrent waiter', () => {
-    const s = buildWaiterScript(PLAN) ?? '';
-    const mutexCheck = s.indexOf('if (-not $mtxCreated)');
-    const marker = s.indexOf('another install is already in progress');
-    const exit5 = s.indexOf('exit 5');
-    expect(mutexCheck).toBeGreaterThan(-1);
-    expect(marker).toBeGreaterThan(mutexCheck);
-    expect(exit5).toBeGreaterThan(marker);
-  });
-
   // #1043 — a best-effort "please wait" indicator for the otherwise-silent
   // 1-2 minute window. Structural lock only: the WinForms message loop and
   // its interaction with a real Windows desktop cannot run on CI regardless
@@ -462,7 +447,10 @@ describe('buildWaiterScript — the clock has to survive a long uptime (#980)', 
   });
 
   it('hands WaitForExit an int, so a widened remainder cannot throw the wait away', () => {
-    expect(buildWaiterScript(plan)!).toContain('$h.WaitForExit([int]$left)');
+    // #1043 sliced the single blocking WaitForExit into a poll (so the wait
+    // screen can pump DoEvents between slices) — the value handed to
+    // WaitForExit is now the per-slice remainder, still explicitly cast.
+    expect(buildWaiterScript(plan)!).toContain('$exited = $h.WaitForExit([int]$slice)');
   });
 });
 

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -86,6 +86,65 @@ describe('buildWaiterScript — ordering is the whole contract', () => {
     expect(buildWaiterScript({ ...PLAN, pids: [-3] })).toBeNull();
     expect(buildWaiterScript({ ...PLAN, pids: [1.5] })).toBeNull();
   });
+
+  // #1043 — a live earlier waiter used to make a repeat click a silent no-op:
+  // `exit 5` fired before the marker path was ever reached, so the boot that
+  // followed had nothing to report. The mutex still has to win the race (a
+  // second Squirrel install against the same root is the #866 corruption this
+  // whole module exists to prevent) — only the silence was the bug.
+  it('writes a marker before refusing a second concurrent waiter', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const mutexCheck = s.indexOf('if (-not $mtxCreated)');
+    const marker = s.indexOf('another install is already in progress');
+    const exit5 = s.indexOf('exit 5');
+    expect(mutexCheck).toBeGreaterThan(-1);
+    expect(marker).toBeGreaterThan(mutexCheck);
+    expect(exit5).toBeGreaterThan(marker);
+  });
+
+  // #1043 — a best-effort "please wait" indicator for the otherwise-silent
+  // 1-2 minute window. Structural lock only: the WinForms message loop and
+  // its interaction with a real Windows desktop cannot run on CI regardless
+  // of platform (there is no display), so this pins the CODE SHAPE — that a
+  // failure to build the form can never block the wait/probe logic, and that
+  // the window is gone before Setup.exe (which brings its own UI) starts.
+  it('shows a best-effort wait indicator that never gates the wait itself', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const formTry = s.indexOf('Add-Type -AssemblyName System.Windows.Forms');
+    const formCatch = s.indexOf('} catch { $form = $null }');
+    const handleWait = s.indexOf('WaitForExit');
+    const closeBeforeStart = s.lastIndexOf('$form.Close()');
+    const start = s.indexOf('Start-Process -FilePath $setup');
+
+    expect(formTry).toBeGreaterThan(-1);
+    // The form build is wrapped so any failure (Add-Type refused, no display
+    // subsystem) degrades to $form = $null rather than an unhandled error
+    // that would abort the whole waiter and silently cancel the update.
+    expect(formCatch).toBeGreaterThan(formTry);
+    expect(formCatch).toBeLessThan(handleWait);
+    // Every DoEvents/Close call is null-checked, so a null $form is inert —
+    // the wait/probe/launch sequence behaves exactly as it did before this
+    // indicator existed.
+    expect(s).toMatch(/if \(\$form\) \{ try \{ \[System\.Windows\.Forms\.Application\]::DoEvents\(\) \} catch \{ \} \}/);
+    // Closed before Setup.exe starts — Squirrel has its own UI from here.
+    expect(closeBeforeStart).toBeGreaterThan(handleWait);
+    expect(closeBeforeStart).toBeLessThan(start);
+  });
+
+  it('closes the wait indicator on every abort path too, not just success', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const stuckAbort = s.indexOf("'install-aborted: a process under the install root would not exit'");
+    const lockedAbort = s.indexOf("'install-aborted: install root still locked'");
+    // Each abort's own Set-Content is preceded (a few lines up) by a
+    // form-close guard — assert the guard is present at all, since a leaked
+    // topmost window after a refused install would be its own, smaller
+    // version of this same issue.
+    const closeCount = (s.match(/if \(\$form\) \{ try \{ \$form\.Close\(\) \} catch \{ \} \}/g) ?? []).length;
+    expect(stuckAbort).toBeGreaterThan(-1);
+    expect(lockedAbort).toBeGreaterThan(-1);
+    // success path + stuck-handle abort + locked-root abort = 3 close sites.
+    expect(closeCount).toBe(3);
+  });
 });
 
 describe('selectInstallRootPids', () => {

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { createHash } from 'node:crypto';
 import {
   isSafePsPathLiteral,
   freeSpaceShortfall,
@@ -96,7 +97,7 @@ describe('buildWaiterScript — ordering is the whole contract', () => {
   it('shows a best-effort wait indicator that never gates the wait itself', () => {
     const s = buildWaiterScript(PLAN) ?? '';
     const formTry = s.indexOf('Add-Type -AssemblyName System.Windows.Forms');
-    const formCatch = s.indexOf('} catch { $form = $null }');
+    const formCatch = s.indexOf('} catch { if ($form) { try { $form.Close() } catch { } }; $form = $null }');
     const handleWait = s.indexOf('WaitForExit');
     const closeBeforeStart = s.lastIndexOf('$form.Close()');
     const start = s.indexOf('Start-Process -FilePath $setup');
@@ -127,8 +128,9 @@ describe('buildWaiterScript — ordering is the whole contract', () => {
     const closeCount = (s.match(/if \(\$form\) \{ try \{ \$form\.Close\(\) \} catch \{ \} \}/g) ?? []).length;
     expect(stuckAbort).toBeGreaterThan(-1);
     expect(lockedAbort).toBeGreaterThan(-1);
-    // success path + stuck-handle abort + locked-root abort = 3 close sites.
-    expect(closeCount).toBe(3);
+    // success path + stuck-handle abort + locked-root abort + the
+    // form-setup catch block (coderabbit, #1044) = 4 close sites.
+    expect(closeCount).toBe(4);
   });
 });
 
@@ -486,7 +488,27 @@ describe('buildWaiterScript — one waiter per install root (#980, coderabbit)',
     expect(s.slice(0, yieldAt)).not.toContain('Set-Content');
   });
 
-  it('scopes the mutex to the install root, so two installations never collide', () => {
-    expect(script()).toContain(`'wmux-install-waiter-' + ($root -replace '[^A-Za-z0-9]', '_')`);
+  it('derives the mutex name from a SHA256 hash of $root, not a lossy character replace', () => {
+    const s = script();
+    expect(s).toContain(
+      '[System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($root))',
+    );
+    expect(s).toContain(`'wmux-install-waiter-' + $mtxHash`);
+    // The regression this replaces: '[^A-Za-z0-9]' -> '_' collapses any root
+    // whose only difference is which non-alphanumeric character it uses.
+    expect(s).not.toContain(`-replace '[^A-Za-z0-9]', '_'`);
+  });
+
+  it('two roots the old regex-replace would have collided on now hash differently (#1043, coderabbit)', () => {
+    // C:\wmux-a and C:\wmux_a both replace their one non-alnum character with
+    // '_' and land on the identical mutex name under the old scheme — two
+    // genuinely different installations would then block each other's
+    // update. This is PowerShell's own SHA256 at runtime; Node's `crypto`
+    // computes the same algorithm over the same bytes, so equality here would
+    // mean the new scheme collides too, not just that the two happen to
+    // differ today.
+    const a = createHash('sha256').update('C:\\wmux-a', 'utf8').digest('hex');
+    const b = createHash('sha256').update('C:\\wmux_a', 'utf8').digest('hex');
+    expect(a).not.toBe(b);
   });
 });

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -302,15 +302,56 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     //
     // A named mutex gives exactly the wanted semantics for free: it exists
     // only while some process holds a handle to it, so a LIVE earlier waiter
-    // blocks the newcomer (exit 5, silently — the incumbent owns the install
-    // and the marker), while a dead or finished one leaves nothing behind and
-    // the newcomer proceeds. No state file to go stale, nothing to clean up.
-    // The name embeds the install root so two different installations (per
-    // user, portable copies) can never block each other.
+    // blocks the newcomer (exit 5 — the incumbent owns the install; the
+    // newcomer writes the marker for whichever boot reads it next, #1043),
+    // while a dead or finished one leaves nothing behind and the newcomer
+    // proceeds. No state file to go stale, nothing to clean up. The name
+    // embeds the install root so two different installations (per user,
+    // portable copies) can never block each other.
     `$mtxName = 'wmux-install-waiter-' + ($root -replace '[^A-Za-z0-9]', '_')`,
     `$mtxCreated = $false`,
     `$mtx = New-Object System.Threading.Mutex -ArgumentList $true, $mtxName, ([ref]$mtxCreated)`,
-    `if (-not $mtxCreated) { exit 5 }`,
+    // #1043 — this used to be a bare `exit 5`: correct (it stops a second
+    // Squirrel install from racing the first), but silent. A repeat click
+    // while an earlier waiter is still alive produced literally nothing —
+    // no marker, so nothing for the app to report on the boot that follows —
+    // which reads exactly like "the button did nothing" even though the
+    // mutex did its job. Writing the marker here reuses the SAME pull-based
+    // notice AppLayout's useRefusedInstallNotice already shows at every boot
+    // (#866) instead of inventing a second reporting path for one branch.
+    `if (-not $mtxCreated) {`,
+    `  Set-Content -LiteralPath $marker -Value 'install-aborted: another install is already in progress' -Encoding utf8`,
+    `  exit 5`,
+    `}`,
+    // #1043 — best-effort "please wait" indicator for the whole silent
+    // window below. Deliberately outside every correctness path: every use
+    // of $form is null-checked and wrapped in its own try/catch, so a
+    // machine where Add-Type/WinForms misbehaves (a locked-down policy, a
+    // server SKU with no display subsystem) degrades to exactly today's
+    // silent-but-correct wait, never to a failed install. It lives here and
+    // not in the Electron app for the same reason the waiter itself does
+    // (see spawnInstallWaiter): the app's own process tree is precisely what
+    // has to fully let go of the install root, so anything meant to render
+    // for the whole wait has to run outside that tree.
+    `$form = $null`,
+    `try {`,
+    `  Add-Type -AssemblyName System.Windows.Forms`,
+    `  Add-Type -AssemblyName System.Drawing`,
+    `  $form = New-Object System.Windows.Forms.Form`,
+    `  $form.Text = 'wmux update'`,
+    `  $form.FormBorderStyle = 'FixedToolWindow'`,
+    `  $form.StartPosition = 'CenterScreen'`,
+    `  $form.TopMost = $true`,
+    `  $form.ShowInTaskbar = $false`,
+    `  $form.ClientSize = New-Object System.Drawing.Size(360, 90)`,
+    `  $label = New-Object System.Windows.Forms.Label`,
+    `  $label.Text = "Installing the wmux update...\`nThis window closes on its own."`,
+    `  $label.Dock = 'Fill'`,
+    `  $label.TextAlign = 'MiddleCenter'`,
+    `  $form.Controls.Add($label)`,
+    `  $form.Show()`,
+    `  [System.Windows.Forms.Application]::DoEvents()`,
+    `} catch { $form = $null }`,
     // Capture HANDLES first. GetProcessById opens a handle now, so a later pid
     // recycle cannot make an exited process look alive (or a stranger's
     // process look like ours).
@@ -329,14 +370,30 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // below swallows it, and every handle is skipped without ever setting
     // $stuck. The wait silently becomes a no-op on exactly the long-uptime
     // machines that most need it. A Stopwatch is monotonic and 64-bit (#980).
+    //
+    // #1043 — sliced into a poll instead of one long WaitForExit so the form
+    // above can stay responsive (DoEvents needs to run periodically on THIS
+    // thread; a single multi-second blocking wait would freeze it for the
+    // whole slice). Same deadline, same "did every handle exit in budget"
+    // contract as before — only the granularity changed. A WaitForExit
+    // exception still reads as "this handle is not the blocker" ($exited
+    // stays true), matching the original catch-and-continue.
     `$clock = [System.Diagnostics.Stopwatch]::StartNew()`,
     `$stuck = $false`,
     `foreach ($h in $handles) {`,
-    `  $left = $budget - $clock.ElapsedMilliseconds`,
-    `  if ($left -le 0) { $stuck = $true; break }`,
-    `  try { if (-not $h.WaitForExit([int]$left)) { $stuck = $true; break } } catch { }`,
+    `  while ($true) {`,
+    `    $left = $budget - $clock.ElapsedMilliseconds`,
+    `    if ($left -le 0) { $stuck = $true; break }`,
+    `    $slice = [Math]::Min(200, $left)`,
+    `    $exited = $true`,
+    `    try { $exited = $h.WaitForExit([int]$slice) } catch { }`,
+    `    if ($exited) { break }`,
+    `    if ($form) { try { [System.Windows.Forms.Application]::DoEvents() } catch { } }`,
+    `  }`,
+    `  if ($stuck) { break }`,
     `}`,
     `if ($stuck) {`,
+    `  if ($form) { try { $form.Close() } catch { } }`,
     `  Set-Content -LiteralPath $marker -Value 'install-aborted: a process under the install root would not exit' -Encoding utf8`,
     `  exit 3`,
     `}`,
@@ -362,13 +419,20 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // installer runs at all, so a wrapped counter here does not merely mistime
     // it — it collapses the whole budget into a single pass.
     `$lockClock = [System.Diagnostics.Stopwatch]::StartNew()`,
-    `while ((Test-RootLocked) -and ($lockClock.ElapsedMilliseconds -lt $budget)) { Start-Sleep -Milliseconds 500 }`,
+    `while ((Test-RootLocked) -and ($lockClock.ElapsedMilliseconds -lt $budget)) {`,
+    `  if ($form) { try { [System.Windows.Forms.Application]::DoEvents() } catch { } }`,
+    `  Start-Sleep -Milliseconds 500`,
+    `}`,
     `if (Test-RootLocked) {`,
     // Refusing leaves a working old version. Launching anyway is precisely the
     // failure this module exists to prevent, so there is no "best effort" here.
+    `  if ($form) { try { $form.Close() } catch { } }`,
     `  Set-Content -LiteralPath $marker -Value 'install-aborted: install root still locked' -Encoding utf8`,
     `  exit 2`,
     `}`,
+    // The wait is over — Squirrel's own UI takes it from here once
+    // Start-Process below succeeds, so ours has nothing left to say.
+    `if ($form) { try { $form.Close() } catch { } }`,
     // A verified installer can still be gone by now — quarantined by AV,
     // swept by a temp cleaner. Under SilentlyContinue that failure is invisible
     // and the script would exit 0, leaving a user who just watched wmux quit

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -302,27 +302,29 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     //
     // A named mutex gives exactly the wanted semantics for free: it exists
     // only while some process holds a handle to it, so a LIVE earlier waiter
-    // blocks the newcomer (exit 5 — the incumbent owns the install; the
-    // newcomer writes the marker for whichever boot reads it next, #1043),
-    // while a dead or finished one leaves nothing behind and the newcomer
-    // proceeds. No state file to go stale, nothing to clean up. The name
-    // embeds the install root so two different installations (per user,
-    // portable copies) can never block each other.
+    // blocks the newcomer (exit 5, silently — the incumbent owns the install
+    // and the marker), while a dead or finished one leaves nothing behind and
+    // the newcomer proceeds. No state file to go stale, nothing to clean up.
+    // The name embeds the install root so two different installations (per
+    // user, portable copies) can never block each other.
+    //
+    // #1043 considered having the newcomer write its own marker here, so a
+    // repeat click that hits this branch is not silent on the next boot.
+    // Reverted: the incumbent is the one still deciding the real outcome, up
+    // to a further ~120s out. If it goes on to SUCCEED, it writes no marker at
+    // all — and a marker the newcomer left behind here would sit there
+    // unclaimed and get read on the next boot as "your update was refused,"
+    // which is false. If the incumbent later fails, it overwrites whatever
+    // this branch wrote anyway, so the newcomer's write only ever matters in
+    // the narrow window where it is wrong. The #1043 fix for this branch's
+    // silence lives in the "please wait" window below instead: that window is
+    // owned by the INCUMBENT and stays on screen (topmost) for the whole wait,
+    // so a user who reopens wmux and clicks "update" again sees it still
+    // there rather than a second silent close.
     `$mtxName = 'wmux-install-waiter-' + ($root -replace '[^A-Za-z0-9]', '_')`,
     `$mtxCreated = $false`,
     `$mtx = New-Object System.Threading.Mutex -ArgumentList $true, $mtxName, ([ref]$mtxCreated)`,
-    // #1043 — this used to be a bare `exit 5`: correct (it stops a second
-    // Squirrel install from racing the first), but silent. A repeat click
-    // while an earlier waiter is still alive produced literally nothing —
-    // no marker, so nothing for the app to report on the boot that follows —
-    // which reads exactly like "the button did nothing" even though the
-    // mutex did its job. Writing the marker here reuses the SAME pull-based
-    // notice AppLayout's useRefusedInstallNotice already shows at every boot
-    // (#866) instead of inventing a second reporting path for one branch.
-    `if (-not $mtxCreated) {`,
-    `  Set-Content -LiteralPath $marker -Value 'install-aborted: another install is already in progress' -Encoding utf8`,
-    `  exit 5`,
-    `}`,
+    `if (-not $mtxCreated) { exit 5 }`,
     // #1043 — best-effort "please wait" indicator for the whole silent
     // window below. Deliberately outside every correctness path: every use
     // of $form is null-checked and wrapped in its own try/catch, so a

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -321,7 +321,14 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // owned by the INCUMBENT and stays on screen (topmost) for the whole wait,
     // so a user who reopens wmux and clicks "update" again sees it still
     // there rather than a second silent close.
-    `$mtxName = 'wmux-install-waiter-' + ($root -replace '[^A-Za-z0-9]', '_')`,
+    // #1043, coderabbit: the old name was 'wmux-install-waiter-' + ($root
+    // -replace '[^A-Za-z0-9]', '_') — lossy character replacement, so two
+    // DISTINCT roots that only differ in a replaced character (C:\wmux-a vs
+    // C:\wmux_a) collapse onto the same mutex name and would block each
+    // other's install. A SHA256 of the root is collision-resistant instead of
+    // merely "usually fine."
+    `$mtxHash = [System.BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash([System.Text.Encoding]::UTF8.GetBytes($root))) -replace '-', ''`,
+    `$mtxName = 'wmux-install-waiter-' + $mtxHash`,
     `$mtxCreated = $false`,
     `$mtx = New-Object System.Threading.Mutex -ArgumentList $true, $mtxName, ([ref]$mtxCreated)`,
     `if (-not $mtxCreated) { exit 5 }`,
@@ -335,6 +342,13 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // (see spawnInstallWaiter): the app's own process tree is precisely what
     // has to fully let go of the install root, so anything meant to render
     // for the whole wait has to run outside that tree.
+    // Colors match the app's own default dark chrome (the 'amber' theme in
+    // themes.ts: bgMantle for panel surfaces, textMain for body text,
+    // accentSecondary — steel-blue, the app's own "navigation/informational"
+    // accent, not the amber "attention" one — for the header) rather than
+    // stock Windows gray, so this reads as wmux's own UI and not a random
+    // system dialog. Segoe UI at two weights does the rest: a bold "wmux"
+    // header plus a lighter status line underneath.
     `$form = $null`,
     `try {`,
     `  Add-Type -AssemblyName System.Windows.Forms`,
@@ -345,15 +359,32 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `  $form.StartPosition = 'CenterScreen'`,
     `  $form.TopMost = $true`,
     `  $form.ShowInTaskbar = $false`,
-    `  $form.ClientSize = New-Object System.Drawing.Size(360, 90)`,
+    `  $form.BackColor = [System.Drawing.ColorTranslator]::FromHtml('#19191C')`,
+    `  $form.ClientSize = New-Object System.Drawing.Size(380, 110)`,
+    `  $headerLabel = New-Object System.Windows.Forms.Label`,
+    `  $headerLabel.Text = 'wmux'`,
+    `  $headerLabel.ForeColor = [System.Drawing.ColorTranslator]::FromHtml('#6E9BC4')`,
+    `  $headerLabel.Font = New-Object System.Drawing.Font('Segoe UI', 13, [System.Drawing.FontStyle]::Bold)`,
+    `  $headerLabel.Dock = 'Top'`,
+    `  $headerLabel.Height = 40`,
+    `  $headerLabel.TextAlign = 'MiddleCenter'`,
     `  $label = New-Object System.Windows.Forms.Label`,
-    `  $label.Text = "Installing the wmux update...\`nThis window closes on its own."`,
+    `  $label.Text = "Installing the update...\`nThis window closes on its own."`,
+    `  $label.ForeColor = [System.Drawing.ColorTranslator]::FromHtml('#EFEEEC')`,
+    `  $label.Font = New-Object System.Drawing.Font('Segoe UI', 9)`,
     `  $label.Dock = 'Fill'`,
     `  $label.TextAlign = 'MiddleCenter'`,
     `  $form.Controls.Add($label)`,
+    `  $form.Controls.Add($headerLabel)`,
     `  $form.Show()`,
     `  [System.Windows.Forms.Application]::DoEvents()`,
-    `} catch { $form = $null }`,
+    // #1043, coderabbit: a throw partway through this block — after
+    // .Show() but before the try finishes — used to leave a visible form
+    // orphaned: the catch cleared $form to null, so every later `if ($form)`
+    // cleanup treated it as never having existed and the window sat there,
+    // topmost, until the waiter process itself exited. Close it first if it
+    // got far enough to exist, THEN null the reference.
+    `} catch { if ($form) { try { $form.Close() } catch { } }; $form = $null }`,
     // Capture HANDLES first. GetProcessById opens a handle now, so a later pid
     // recycle cannot make an exited process look alive (or a stranger's
     // process look like ours).


### PR DESCRIPTION
## Summary

Addresses one of the three parts of #1043 — the other two turned out to already be handled (see below). The install-teardown mechanism from #866/#980 (`installTeardown.ts`, the detached PowerShell waiter that confirms every process has actually released the install root before letting Squirrel run) is correct — it fails safe by refusing rather than risking a half-deleted install. The gap #1043 reported was entirely in feedback around it.

## Changes

**A best-effort "installing the update, please wait" window for the wait itself.**

Between quit and `Setup.exe` actually launching, the waiter spends up to ~1-2 minutes (60s handle-wait + up to 60s lock-probe, both generous on purpose — see the comments on `INSTALL_LOCK_BUDGET_MS`) with zero UI. From the outside that's indistinguishable from a failed update, which is what triggered the report behind #1043: a manual reopen of the app mid-wait re-locked the install root, and a subsequent click hit the single-instance mutex refusal (see "considered and reverted" below).

The window can't live in the Electron app's own process — that process is precisely what has to fully release the install root, so anything meant to render for the whole wait has to run outside that tree, same reasoning as why the waiter script itself already lives outside the install root (see the comment on `spawnInstallWaiter`). So it's built into the waiter: a minimal always-on-top WinForms window, shown non-modally right after the mutex check, kept responsive via `Application.DoEvents()` woven into the existing wait loops (the handle-wait loop is now a short poll instead of one long blocking `WaitForExit`, same deadline/contract, just finer-grained so the form doesn't freeze for the whole slice), and closed right before `Start-Process` (Squirrel has its own UI from there).

**Safety property:** every use of `$form` is null-checked and wrapped in its own `try`/`catch`. A machine where `Add-Type -AssemblyName System.Windows.Forms` fails (locked-down policy, no display subsystem) degrades to exactly today's silent-but-correct wait — the indicator can never gate, delay, or fail the install itself. Verified the generated script parses with `[System.Management.Automation.Language.Parser]::ParseFile` (not just eyeballed).

Because this window is owned by the still-running *incumbent* waiter and stays on screen (topmost) for its whole lifetime, it also covers the reopen case from the report: a user who closes-and-reopens wmux while a waiter is still alive sees it still sitting there, rather than a closed window and no explanation.

## Considered and reverted: writing a marker on the mutex refusal

First pass at this PR made `buildWaiterScript`'s single-instance guard (`if (-not $mtxCreated) { exit 5 }`) write an abort marker before exiting, so a repeat click while a waiter was already live would have *something* to report on the next boot, via the existing pull-based notice (`AppLayout.useRefusedInstallNotice`, #866).

Reverted after checking it against what the *incumbent* waiter can still do: it has up to another ~120s to decide the real outcome. If it goes on to **succeed**, it writes no marker at all — the newcomer's "another install is already in progress" marker would then sit there unclaimed and get read on the next boot as "your update was refused," which would be false. If the incumbent later fails, it overwrites whatever the newcomer wrote anyway, so the newcomer's write only ever mattered in the one case where it was wrong. This exact tradeoff is why the mutex branch was silent by design in the first place (see the pre-existing comment above it) — the wait window above is the right fix for the visibility gap instead, since it doesn't require guessing at an outcome that isn't decided yet.

## Part 2 of #1043's ask — already fixed, not touched here

`AutoUpdater` already tracks `isInstalling` in-process and answers a repeat "install now" with an immediate `UPDATE_ERROR` ("An update install is already in progress...") instead of re-running the quit/waiter cycle — this already covers a fast double-click within the same running session. It does *not* cover the report's actual scenario (the app was fully closed and manually reopened between clicks, which drops all in-memory state) — that gap is what the wait window above closes instead, from the waiter side rather than the app side.

## Part 3 of #1043 (proactive refusal notice) — already fixed, not touched here

The issue's diagnosis leaned on `AutoUpdater.takeRefusedInstall()`'s doc comment, which says the only listener lives in the Settings panel (mounted only while Settings is open). That's stale documentation: `AppLayout.useRefusedInstallNotice` already pulls and surfaces this on every boot, unconditionally, as an error toast — the same fix already applied to `getPendingInstall()` for #897. Flagging this rather than silently no-op'ing it: didn't want to claim credit for something that was already working, and didn't want to touch the doc comment's historical framing without being sure that's welcome scope for this PR.

## Test plan

- `installTeardown.test.ts`: 2 new tests for the wait indicator (code shape — build wrapped in try/catch, closed before `Start-Process` on every exit path including both abort branches, never gates the wait/probe loop). All pre-existing tests in the same file, including the two that pin the mutex branch's silence (`yields silently (exit 5) — the incumbent owns the install AND the marker`) and the `WaitForExit` int-cast guarantee (updated to match the new per-slice call), pass unchanged in intent.
- Full suite run for real this time: `npm install` + `npx vitest run src/main/updater` — **137 passed**, `installTeardown.test.ts` alone **52/52**. `npx tsc --noEmit` clean. `npx eslint` on both touched files — 0 errors, 4 pre-existing warnings (`no-non-null-assertion`, same pattern the rest of the file already uses).
- Generated the actual script with the real function and validated it with PowerShell's own parser (`[System.Management.Automation.Language.Parser]::ParseFile`) — 0 syntax errors.

## Not in this PR

The budget sizes themselves (60s + 60s) aren't touched — they're already documented as deliberately generous (a daemon flushing large scrollback buffers can hold files a while, and waiting is free while refusing costs the update), and #1043 didn't ask to shrink them, just to make the wait visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an always-on-top installation progress window during Windows handoff.
  * The window remains responsive while installation processes and file locks are checked.
  * Updated the progress window with branded dark styling and improved readability.

* **Bug Fixes**
  * Ensured the window closes after successful, aborted, timed-out, or interrupted installation attempts.
  * Improved graceful fallback when the window cannot be displayed.
  * Prevented distinct installation locations from being incorrectly treated as the same concurrent installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->