### PR TITLE
feat(i18n): detect system locale on first run, fall back to English

### DIFF
--- a/changelog.d/1047.md
+++ b/changelog.d/1047.md
@@ -1,0 +1,3 @@
+### Added
+
+- **First-run system-locale detection.** A session that has never had a language chosen (fresh install, or a `session.json` from before the `locale` field existed) now picks up the OS locale via `navigator.language` and maps it to one of the 23 shipped languages — a region variant like `pl-PL` or `de-AT` matches its base language, and Traditional-vs-Simplified Chinese is routed by script/region rather than defaulting to one. A language nobody ships (or a locale string that doesn't parse) falls back to English, same as today. Detection runs exactly once: any explicit choice already on record in `session.json` — the user's own pick, or a previous run's detection — is left untouched.

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -66,6 +66,16 @@ const electronAPI = {
       typeof process.getSystemVersion === 'function' ? process.getSystemVersion() : null,
     )
     : null,
+  // Raw OS locale (e.g. 'pl-PL', 'zh-Hant-TW') for first-run language
+  // detection (workspaceSlice's loadSession). `navigator.language` and not an
+  // IPC round-trip to `app.getLocale()`: sandboxed preload keeps the full Web
+  // platform surface (only Node builtins are restricted — see the
+  // getSystemVersion comment above), and Electron already seeds
+  // `navigator.language` from the OS locale, so this is available
+  // synchronously with no main-process hop. Static like the two fields above:
+  // the OS locale cannot change mid-session, so there is nothing to keep in
+  // sync.
+  systemLocale: typeof navigator !== 'undefined' && navigator.language ? navigator.language : 'en',
   pty: {
     // `exec`/`supervision` (X8): set by the AppLayout funnel for a supervised
     // wmux.json leaf — `exec` runs the command as the pane's ROOT process and

--- a/src/renderer/i18n/__tests__/detectSupportedLocale.test.ts
+++ b/src/renderer/i18n/__tests__/detectSupportedLocale.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { detectSupportedLocale, LOCALE_OPTIONS } from '../index';
+
+describe('detectSupportedLocale', () => {
+  it('matches a plain supported code exactly', () => {
+    expect(detectSupportedLocale('pl')).toBe('pl');
+    expect(detectSupportedLocale('en')).toBe('en');
+  });
+
+  it('strips a region subtag when the base language is supported', () => {
+    expect(detectSupportedLocale('pl-PL')).toBe('pl');
+    expect(detectSupportedLocale('de-AT')).toBe('de');
+    expect(detectSupportedLocale('fr-CA')).toBe('fr');
+  });
+
+  it('matches case-insensitively', () => {
+    expect(detectSupportedLocale('PL-pl')).toBe('pl');
+    expect(detectSupportedLocale('DE')).toBe('de');
+  });
+
+  it('matches the exact region-qualified ids we ship (zh-TW, pt-BR)', () => {
+    expect(detectSupportedLocale('zh-TW')).toBe('zh-TW');
+    expect(detectSupportedLocale('pt-BR')).toBe('pt-BR');
+  });
+
+  it('routes zh by script/region: Traditional-leaning signals go to zh-TW, everything else to zh', () => {
+    expect(detectSupportedLocale('zh-Hant-TW')).toBe('zh-TW');
+    expect(detectSupportedLocale('zh-HK')).toBe('zh-TW');
+    expect(detectSupportedLocale('zh-MO')).toBe('zh-TW');
+    expect(detectSupportedLocale('zh-CN')).toBe('zh');
+    expect(detectSupportedLocale('zh-Hans')).toBe('zh');
+    expect(detectSupportedLocale('zh')).toBe('zh');
+  });
+
+  it('falls back to English for a language we do not ship', () => {
+    // Swedish is not in LOCALE_OPTIONS today — if that ever changes, swap the
+    // fixture for another genuinely unsupported code rather than deleting
+    // the assertion.
+    expect(LOCALE_OPTIONS.some((o) => (o.value as string) === 'sv')).toBe(false);
+    expect(detectSupportedLocale('sv-SE')).toBe('en');
+    expect(detectSupportedLocale('sv')).toBe('en');
+  });
+
+  it('falls back to English for empty, whitespace, or garbage input — never throws', () => {
+    expect(detectSupportedLocale('')).toBe('en');
+    expect(detectSupportedLocale('   ')).toBe('en');
+    expect(detectSupportedLocale('not-a-locale-at-all')).toBe('en');
+    expect(detectSupportedLocale(undefined as unknown as string)).toBe('en');
+  });
+
+  it('respects an injected supported-locale list instead of the module default', () => {
+    expect(detectSupportedLocale('pl-PL', ['en', 'de'])).toBe('en');
+    expect(detectSupportedLocale('de-DE', ['en', 'de'])).toBe('de');
+  });
+});

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -153,3 +153,52 @@ export const LOCALE_OPTIONS: Array<{ value: Locale; label: string }> = [
   { value: 'uk', label: 'Українська' },
   { value: 'vi', label: 'Tiếng Việt' },
 ];
+
+const SUPPORTED_LOCALES = LOCALE_OPTIONS.map((o) => o.value);
+
+/**
+ * Map a raw OS/BCP-47 locale string (`navigator.language`, e.g. `'pl-PL'`,
+ * `'zh-Hant-TW'`, `'pt-BR'`) to one of our 23 supported locales, falling back
+ * to `'en'` when nothing reasonable matches.
+ *
+ * Pure and total — never throws on garbage input, since the caller is
+ * first-run session load and a bad OS locale string must not be able to
+ * block the app from opening.
+ *
+ * Two passes:
+ *   1. Exact match, case-insensitive, against the full tag — catches the two
+ *      locales whose OWN id carries a region (`zh-TW`, `pt-BR`) when the OS
+ *      reports that exact region back.
+ *   2. Primary-subtag match — `'pl-PL'` -> `'pl'`, `'de-AT'` -> `'de'`. `zh`
+ *      gets special handling here: a Traditional-script/Taiwan/HK/Macau
+ *      signal (`Hant`, `-TW`, `-HK`, `-MO`) maps to `'zh-TW'` and everything
+ *      else that starts with `zh` maps to `'zh'` — those two are NOT mutually
+ *      readable, so guessing wrong is worse than the generic English
+ *      fallback would be for most other locales.
+ *
+ * Anything that matches neither pass — including a locale we simply don't
+ * ship a translation for — returns `'en'`.
+ */
+export function detectSupportedLocale(
+  systemLocale: string,
+  supported: readonly Locale[] = SUPPORTED_LOCALES,
+): Locale {
+  const tag = (systemLocale || '').trim().toLowerCase();
+  if (!tag) return 'en';
+
+  const supportedLower = new Map<string, Locale>(supported.map((l) => [l.toLowerCase(), l]));
+
+  const exact = supportedLower.get(tag);
+  if (exact) return exact;
+
+  const primary = tag.split('-')[0];
+
+  if (primary === 'zh') {
+    const isTraditional = /(^|-)(hant|tw|hk|mo)(-|$)/.test(tag);
+    const zhVariant: Locale = isTraditional ? 'zh-TW' : 'zh';
+    return supported.includes(zhVariant) ? zhVariant : 'en';
+  }
+
+  const byPrimary = supported.find((l) => l.toLowerCase().split('-')[0] === primary);
+  return byPrimary ?? 'en';
+}

--- a/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
+++ b/src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts
@@ -135,6 +135,11 @@ beforeAll(() => {
     usage: {
       setEnabled: setUsageEnabled,
     },
+    // First-run locale detection reads this (see detectSupportedLocale tests
+    // below) — default to English here so every OTHER test in this file
+    // keeps behaving as if the OS locale were English, unless a test
+    // overrides it.
+    systemLocale: 'en-US',
   };
   // document is provided by jsdom in vitest; safe to call setAttribute.
 });
@@ -1289,5 +1294,73 @@ describe('WorkspaceSlice.loadSession — stashedPanes guards (#977 review)', () 
 
     const ws = store.getState().workspaces[0];
     expect(ws.stashedPanes![0].pane.ordinal).toBe(9);
+  });
+});
+
+describe('WorkspaceSlice.loadSession — first-run system locale detection', () => {
+  // loadSession early-returns for an empty workspaces array (line ~682,
+  // before the theme/locale restoration code ever runs), so this needs at
+  // least one well-formed workspace to reach the branch under test.
+  const minimalData = (): SessionData =>
+    ({
+      workspaces: [{
+        id: 'ws-1',
+        name: 'WS',
+        rootPane: { id: 'pane-root', type: 'leaf', surfaces: [], activeSurfaceId: '' },
+        activePaneId: 'pane-root',
+      }],
+      activeWorkspaceId: 'ws-1',
+      sidebarVisible: true,
+    }) as unknown as SessionData;
+
+  function withSystemLocale<T>(systemLocale: string, run: () => T): T {
+    const api = (globalThis.window as unknown as { electronAPI: { systemLocale?: string } }).electronAPI;
+    const prev = api.systemLocale;
+    api.systemLocale = systemLocale;
+    try {
+      return run();
+    } finally {
+      api.systemLocale = prev;
+    }
+  }
+
+  it('detects a supported OS locale when session.json has no locale yet (fresh/legacy session)', () => {
+    withSystemLocale('pl-PL', () => {
+      const store = createTestStore();
+      store.getState().loadSession(minimalData());
+      expect(store.getState().locale).toBe('pl');
+    });
+  });
+
+  it('falls back to English when the OS locale is not one we ship', () => {
+    withSystemLocale('xx-XX', () => {
+      const store = createTestStore();
+      store.getState().loadSession(minimalData());
+      expect(store.getState().locale).toBe('en');
+    });
+  });
+
+  it('does NOT override a locale the user (or a prior load) already set — no data.locale means detect ONLY on a truly empty field', () => {
+    withSystemLocale('pl-PL', () => {
+      const store = createTestStore();
+      const data = { ...minimalData(), locale: 'de' } as unknown as SessionData;
+      store.getState().loadSession(data);
+      // The explicit 'de' in session.json wins over the OS locale entirely —
+      // detection must never fire once a real choice is on record.
+      expect(store.getState().locale).toBe('de');
+    });
+  });
+
+  it('is inert when window.electronAPI is unavailable (e.g. a race before preload finishes)', () => {
+    const api = (globalThis.window as unknown as { electronAPI?: { systemLocale?: string } }).electronAPI;
+    const saved = api;
+    (globalThis.window as unknown as { electronAPI?: unknown }).electronAPI = undefined;
+    try {
+      const store = createTestStore();
+      expect(() => store.getState().loadSession(minimalData())).not.toThrow();
+      expect(store.getState().locale).toBe('en');
+    } finally {
+      (globalThis.window as unknown as { electronAPI?: unknown }).electronAPI = saved;
+    }
   });
 });

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -5,7 +5,7 @@ import { normalizeWorkspaceProfile } from '../../../shared/workspaceProfile';
 import { normalizeWorkspaceColor, type WorkspaceColorId } from '../../../shared/workspaceColors';
 import { normalizeRoleBindings } from '../../../shared/orchestratorRole';
 import { getPresetById } from '../../../shared/layoutPresets';
-import { setLocale as i18nSetLocale, t as i18nT, type Locale } from '../../i18n';
+import { setLocale as i18nSetLocale, t as i18nT, detectSupportedLocale, type Locale } from '../../i18n';
 import { applyCustomCssVars, migrateThemeId, migrateCustomThemeColors } from '../../themes';
 import { resetInspectState } from './uiSlice';
 import { sanitizeFontFamily } from '../../utils/terminalFont';
@@ -949,6 +949,17 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       if (data.locale) {
         state.locale = data.locale as Locale;
         i18nSetLocale(data.locale as Locale);
+      } else {
+        // No locale in session.json: either a genuinely first-ever run, or a
+        // session.json written before this field existed. Either way the
+        // user has never made an explicit choice, so detect once from the
+        // OS locale (falling back to English) rather than silently sitting
+        // on the hardcoded 'en' default. A user who DOES pick a language in
+        // Settings gets `data.locale` populated from then on (setLocale
+        // writes it), so this branch never re-fires for them.
+        const detected = detectSupportedLocale(window.electronAPI?.systemLocale ?? '');
+        state.locale = detected;
+        i18nSetLocale(detected);
       }
       if (data.terminalFontSize != null) state.terminalFontSize = data.terminalFontSize;
       // UI scale: clamp on load so a hand-edited session.json (e.g. uiScale: 5)

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -957,7 +957,14 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         // on the hardcoded 'en' default. A user who DOES pick a language in
         // Settings gets `data.locale` populated from then on (setLocale
         // writes it), so this branch never re-fires for them.
-        const detected = detectSupportedLocale(window.electronAPI?.systemLocale ?? '');
+        // `typeof window` guard, not a bare reference: loadSession also runs
+        // under node-environment suites (workspaceColor, workspaceProjections,
+        // paneOrdinal, remoteWorkspacesSlice) where `window` does not exist at
+        // all, so a bare read is a ReferenceError — the same reason the
+        // preload half of this feature guards `typeof navigator`.
+        const detected = detectSupportedLocale(
+          (typeof window !== 'undefined' ? window.electronAPI?.systemLocale : undefined) ?? '',
+        );
         state.locale = detected;
         i18nSetLocale(detected);
       }


### PR DESCRIPTION
## Summary

Feature request from Simply.IN HQ (not a filed bug): a fresh install/session should default to the OS's own language when it's one of the 23 we ship, instead of always opening in English until the user finds Settings.

## What's there today

`workspaceSlice.loadSession` only ever sets `state.locale` when `data.locale` is present in `session.json` — and the only writer of that field is `setLocale` (Settings panel), so a user's explicit choice was the only thing that ever set it. Nothing read `app.getLocale()`/`navigator.language` anywhere in the codebase before this PR — confirmed by grep, not assumed.

## Changes

- **`src/renderer/i18n/index.ts`** — `detectSupportedLocale(systemLocale, supported = SUPPORTED_LOCALES)`: pure, total, never throws. Exact match first (catches `zh-TW`/`pt-BR`, the two ids that carry a region themselves), then primary-subtag match ignoring region (`pl-PL` → `pl`, `de-AT` → `de`). `zh` gets dedicated handling: a Traditional/Taiwan/HK/Macau signal (`Hant`, `-TW`, `-HK`, `-MO`) routes to `zh-TW`, everything else starting `zh` routes to `zh` — those two scripts aren't mutually readable, so a wrong guess is worse than falling back to English would be for any other language. No match at all → `'en'`.
- **`src/preload/preload.ts`** — `systemLocale: navigator.language` added as a static field on `electronAPI`, same pattern as the existing `platform`/`windowsBuildNumber` fields right above it (sandboxed preload keeps the full Web platform surface even though most Node builtins are restricted — see that block's own comment). No IPC round-trip to `app.getLocale()` needed; Electron already seeds `navigator.language` from the OS locale, and it can't change mid-session so there's nothing to keep in sync.
- **`src/renderer/stores/slices/workspaceSlice.ts`** — `loadSession`'s existing `if (data.locale) { ... }` gained an `else` branch: only reached when `data.locale` was never written (a genuinely first-ever run, or a `session.json` predating this field), calls `detectSupportedLocale(window.electronAPI?.systemLocale ?? '')` and applies the result. An explicit choice already on record — the user's own pick, or a previous run's detection result, both get written back to `session.json` by `setLocale` — always wins; this branch cannot re-fire for a session that's already been through it once.

## Test plan

- New `src/renderer/i18n/__tests__/detectSupportedLocale.test.ts` — exact/region/case-insensitive matching, the zh-TW vs zh script routing, English fallback for both an unsupported language and garbage/empty input, and that an injected `supported` list is respected (used to keep the fixture stable if we ever add/drop a locale).
- New tests in `workspaceSlice.loadSession.test.ts`: detects a supported OS locale on a session with no `locale` field, falls back to English for an unsupported OS locale, does **not** override an explicit `data.locale` even when the OS locale would map to something else, and is inert (defaults to English, never throws) if `window.electronAPI` isn't available yet.
- `npm run test:parallel -- src/renderer/i18n src/renderer/stores/slices/__tests__/workspaceSlice.loadSession.test.ts` — **217/217 passed**. (Used `test:parallel`, not a bare `vitest run` — this repo also has real-execution `*.runtime.test.ts` files elsewhere under `src/main/updater` that a bare `vitest run` would pick up and that visibly launch PowerShell/WinForms windows on a real Windows box; irrelevant to this PR's files, but worth the right command out of habit.)
- `npx tsc --noEmit` — clean.
- `npx eslint` on all five touched files — 1 pre-existing error + 22 pre-existing warnings, all confirmed present in the identical, untouched lines of `upstream/main` before this PR (checked via `git show upstream/main:<file> | eslint --stdin`) — none introduced by this change.

## Not in this PR

Region-to-region nuance beyond the `zh`/`zh-TW` split (e.g. `pt-PT` maps to `pt-BR` via the generic primary-subtag pass, since `pt-BR` is the only Portuguese we ship) — flagging it here rather than silently deciding it's fine: happy to special-case it out to English instead if that's preferred, but `pt-BR` read as closer to a Portugal user than English felt like the more useful default.

`changelog.d/1047.md` — guessed the PR number from the latest open PR at filing time; happy to rename if it lands differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The app now detects your system language during first launch and selects the closest supported language automatically.
  - Regional and Chinese script variants are recognized, including Traditional Chinese locales.
  - Unsupported, invalid, or unavailable language settings fall back to English.
  - Previously saved or explicitly selected language preferences remain unchanged.
  - Language detection works reliably even when system information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->