### PR TITLE
Say when an install half-completed, from the two places that can still speak

### DIFF
--- a/changelog.d/1048.md
+++ b/changelog.d/1048.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **A half-completed install now says so, from the two places that can still
+  speak.** An antivirus scan holding the freshly written executable can make
+  the Windows installer abort partway, leaving an installation that either
+  never starts (a required Chromium resource was never copied) or starts but
+  can never update or uninstall (Squirrel's `Update.exe` was never written) —
+  in both cases silently, with the only diagnostic buried in the installer's
+  own log. On the update path, the install waiter now stays for the
+  installer's exit and verifies what it left behind: a broken result gets a
+  visible warning right there and a notice on the next boot that can boot.
+  An installation that runs but is missing `Update.exe` is detected at
+  startup and explained once, with reinstall guidance, instead of every
+  future update failing with no visible reason. Fresh installs run by hand
+  remain the installer's own responsibility — no process of the app exists
+  yet on such a machine. (#1048)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -93,6 +93,7 @@ import { setConfiguredFirstPartyClients } from './mcp/firstParty';
 import { readConfiguredFirstPartyClients } from './mcp/firstPartyConfig';
 import { ClaudeWorker } from './a2a/ClaudeWorker';
 import { AutoUpdater } from './updater/AutoUpdater';
+import { warnOnInstallIntegrityGap } from './updater/installIntegrity';
 import { readDaemonPid } from './updater/installTeardown';
 import { McpRegistrar } from './mcp/McpRegistrar';
 import { BrokerSupervisor, isMcpBrokerEnabled } from './mcp/BrokerSupervisor';
@@ -429,6 +430,16 @@ const autoUpdater = new AutoUpdater(() => mainWindow, {
   onInstallRequiresFullShutdown: () => { fullShutdownRequested = true; },
   getDaemonPid: () => readDaemonPid(getWmuxDir()),
 });
+
+// #1046: a Squirrel install can half-complete (an AV lock race inside the
+// installer aborts it mid-copy) and leave an installation that RUNS but can
+// never update or uninstall -- Update.exe was simply never written. Detect
+// that shape once the app is up and say so, instead of letting every later
+// update fail with no visible reason. The dead-on-arrival half of the class
+// (icudtl.dat missing) cannot reach any in-app check by definition; the
+// install waiter's post-exit verification (installTeardown.ts) covers it on
+// the update path.
+void app.whenReady().then(() => { try { warnOnInstallIntegrityGap(); } catch { /* best-effort */ } });
 
 const rpcRouter = new RpcRouter();
 markBoot('pre-pipe-server-ctor');

--- a/src/main/updater/__tests__/installIntegrity.test.ts
+++ b/src/main/updater/__tests__/installIntegrity.test.ts
@@ -1,0 +1,68 @@
+// #1046 — the boot-time half of the half-completed-install detection: an
+// installation that RUNS but never got Update.exe written can never update
+// or uninstall, and before this check nothing ever said so. Pure functions
+// only — the dialog wiring is a thin best-effort shell over these.
+import { describe, it, expect } from 'vitest';
+import { squirrelInstallRootFor, findInstallIntegrityGap } from '../installIntegrity';
+
+const SQUIRREL_EXE = 'C:\\Users\\u\\AppData\\Local\\wmux\\app-3.47.1\\wmux.exe';
+
+describe('squirrelInstallRootFor', () => {
+  it('extracts the root from the app-<version> layout', () => {
+    expect(squirrelInstallRootFor(SQUIRREL_EXE)).toBe('C:\\Users\\u\\AppData\\Local\\wmux');
+  });
+
+  it('rejects every non-Squirrel layout', () => {
+    // Dev run: electron.exe out of node_modules.
+    expect(squirrelInstallRootFor('D:\\wmux\\node_modules\\electron\\dist\\electron.exe')).toBeNull();
+    // Portable copy in an arbitrary folder.
+    expect(squirrelInstallRootFor('C:\\tools\\wmux\\wmux.exe')).toBeNull();
+    // Not an exe at all.
+    expect(squirrelInstallRootFor('C:\\x\\app-1.2.3\\wmux.dll')).toBeNull();
+    // Non-Windows layout strings never match the app-*/exe shape.
+    expect(squirrelInstallRootFor('/usr/lib/wmux/wmux')).toBeNull();
+  });
+
+  it('is case-insensitive the way NTFS is', () => {
+    expect(squirrelInstallRootFor('C:\\U\\APP-3.47.1\\WMUX.EXE')).toBe('C:\\U');
+  });
+});
+
+describe('findInstallIntegrityGap', () => {
+  it('reports Update.exe missing for a half-completed install', () => {
+    const gap = findInstallIntegrityGap(SQUIRREL_EXE, () => false);
+    expect(gap).toEqual({
+      root: 'C:\\Users\\u\\AppData\\Local\\wmux',
+      missing: ['Update.exe'],
+    });
+  });
+
+  it('checks exactly <root>\\Update.exe, nothing deeper', () => {
+    const probed: string[] = [];
+    findInstallIntegrityGap(SQUIRREL_EXE, (p) => { probed.push(p); return false; });
+    expect(probed).toEqual(['C:\\Users\\u\\AppData\\Local\\wmux\\Update.exe']);
+  });
+
+  it('is null for a complete install', () => {
+    expect(findInstallIntegrityGap(SQUIRREL_EXE, () => true)).toBeNull();
+  });
+
+  it('is null — never a probe — outside the Squirrel layout', () => {
+    const probed: string[] = [];
+    const gap = findInstallIntegrityGap('D:\\wmux\\node_modules\\electron\\dist\\electron.exe', (p) => {
+      probed.push(p);
+      return false;
+    });
+    expect(gap).toBeNull();
+    expect(probed).toEqual([]);
+  });
+
+  it('treats a throwing probe as missing-info, not as missing-file (default probe swallows)', () => {
+    // The default exists() wraps fs.existsSync in try/catch; the injected
+    // seam here documents the contract: a probe that returns false is the
+    // only way to report a gap, so an exotic fs error can at worst produce
+    // the warning, never a crash.
+    const gap = findInstallIntegrityGap(SQUIRREL_EXE, () => { throw new Error('EIO'); });
+    expect(gap).toBeNull();
+  });
+});

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -138,6 +138,16 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     }
     expect(released).toBe(true);
 
+    // #1046: the waiter now stays for Setup.exe's exit and verifies what it
+    // left behind (Update.exe at the root, icudtl.dat in the newest app-*).
+    // The fake installer installs nothing, so give the sandbox the shape of
+    // a SUCCESSFUL install up front -- this test is about the launch path,
+    // and the verification's failure branch is pinned by the script-shape
+    // tests (a live 30s corpse-poll here would spend half the test budget
+    // proving what the shape tests already prove).
+    fs.writeFileSync(path.join(root, 'Update.exe'), 'x');
+    fs.writeFileSync(path.join(root, 'app-1.0.0', 'icudtl.dat'), 'x');
+
     writeWaiter(plan([holder.pid as number], 5_000));
     expect(runWaiter(60_000).status).toBe(0);
 

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -512,3 +512,47 @@ describe('buildWaiterScript — one waiter per install root (#980, coderabbit)',
     expect(a).not.toBe(b);
   });
 });
+
+describe('buildWaiterScript — post-exit install verification (#1046)', () => {
+  const PLAN46 = {
+    pids: [4242],
+    setupExePath: 'C:/t/Setup.exe',
+    installRoot: 'C:/Users/u/AppData/Local/wmux',
+    abortMarkerPath: 'C:/t/marker.txt',
+    lockBudgetMs: 60000,
+  };
+  const script = (): string => buildWaiterScript(PLAN46) ?? '';
+
+  it('captures Setup.exe with -PassThru and only judges after a real exit', () => {
+    const s = script();
+    const start = s.indexOf('Start-Process -FilePath $setup -PassThru');
+    expect(start).toBeGreaterThan(-1);
+    const wait = s.indexOf('$setupProc.WaitForExit(600000)');
+    expect(wait).toBeGreaterThan(start);
+    // An installer still running at the deadline means "cannot judge" —
+    // exit 0, exactly the pre-#1046 behavior. The verification can only ADD
+    // a warning, never invent one about an install still in progress.
+    expect(s.indexOf('if (-not $setupDone) { exit 0 }')).toBeGreaterThan(wait);
+  });
+
+  it('checks exactly the two files whose absence is the #1046 corpse, after the launch', () => {
+    const s = script();
+    const start = s.indexOf('Start-Process -FilePath $setup');
+    expect(s.indexOf("Join-Path $root 'Update.exe'")).toBeGreaterThan(start);
+    expect(s.indexOf("'icudtl.dat'")).toBeGreaterThan(start);
+    expect(s).toContain('install-aborted: the installer exited but left an incomplete installation');
+  });
+
+  it('fails additively: guarded marker write, guarded MessageBox, its own exit code', () => {
+    const s = script();
+    // The MessageBox fires only when the Forms assembly proved loadable for
+    // the wait window, and a throw inside it is swallowed — a machine that
+    // cannot show UI still gets the marker, and one that cannot write the
+    // marker still gets the box.
+    expect(s).toMatch(/if \(\$formsLoaded\) \{ try \{ \[System\.Windows\.Forms\.MessageBox\]::Show\(/);
+    const formsTrue = s.indexOf('$formsLoaded = $true');
+    expect(formsTrue).toBeGreaterThan(s.indexOf('Add-Type -AssemblyName System.Windows.Forms'));
+    expect(formsTrue).toBeLessThan(s.indexOf('Add-Type -AssemblyName System.Drawing'));
+    expect(s.trimEnd().endsWith('exit 6')).toBe(true);
+  });
+});

--- a/src/main/updater/installIntegrity.ts
+++ b/src/main/updater/installIntegrity.ts
@@ -1,0 +1,121 @@
+/**
+ * #1046 — surface a half-completed Squirrel installation.
+ *
+ * Field log (2026-08-26): Windows Defender held a transient lock on the
+ * freshly written 213 MB wmux.exe while scanning it, a delete inside
+ * Squirrel's installer turned into UnauthorizedAccessException, and the
+ * install aborted mid-copy. What that leaves behind splits into two classes:
+ *
+ *   1. Dead on arrival — `icudtl.dat` never got copied, so Chromium's ICU
+ *      init fails before a single line of our code runs. NO in-app check can
+ *      ever fire on that machine, by definition. The update path of this
+ *      class is covered where a process of ours is still alive to look: the
+ *      install waiter's post-exit verification (installTeardown.ts). The
+ *      fresh-install path has no process of ours at all and stays open
+ *      upstream (Squirrel retry / code signing).
+ *
+ *   2. Runs, but can never update or uninstall — the app dir copied far
+ *      enough to boot, but `Update.exe` (written near the END of a
+ *      successful install, alongside shortcut/icon work) never appeared.
+ *      Every later in-app update fails, and Windows' own uninstall entry
+ *      points at the missing Update.exe. Nothing said why. THIS module is
+ *      that check: it runs on every boot, costs one stat, and turns a
+ *      forever-silent breakage into one explicit message.
+ *
+ * The path helpers use `path.win32` explicitly: the layout being detected is
+ * Windows-only, and the pure functions must behave identically under the
+ * cross-platform test matrix.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * The Squirrel install root for an executable, or null when the layout does
+ * not match. Squirrel runs the app out of `<root>\app-<version>\wmux.exe`,
+ * so the parent directory's `app-` prefix is the discriminator — a dev run
+ * (`node_modules\electron\dist\electron.exe`), a portable copy in an
+ * arbitrary folder, and every non-Windows layout all fall out here.
+ */
+export function squirrelInstallRootFor(execPath: string): string | null {
+  const w = path.win32;
+  if (!/\.exe$/i.test(w.basename(execPath))) return null;
+  const appDir = w.dirname(execPath);
+  if (!/^app-/i.test(w.basename(appDir))) return null;
+  const root = w.dirname(appDir);
+  // `app-…` directly under a drive root would make root === appDir's parent
+  // degenerate ('C:\\'); still a valid answer, so no further filtering.
+  return root;
+}
+
+export interface InstallIntegrityGap {
+  root: string;
+  missing: string[];
+}
+
+/**
+ * Pure check: given the running executable's path, is the installation it
+ * came from missing pieces a complete Squirrel install always has?
+ *
+ * Only `Update.exe` is checked. Everything the RUNNING app already proves by
+ * running (the exe itself, ICU data, resources) cannot be missing here, and
+ * probing deeper (locales, asar) would turn a one-stat boot check into a
+ * scan with its own false-positive surface.
+ */
+export function findInstallIntegrityGap(
+  execPath: string,
+  exists: (p: string) => boolean = (p) => {
+    try { return fs.existsSync(p); } catch { return false; }
+  },
+): InstallIntegrityGap | null {
+  const root = squirrelInstallRootFor(execPath);
+  if (root === null) return null;
+  const missing: string[] = [];
+  // A probe that THROWS is "cannot verify", not "missing": the only thing a
+  // gap produces is a warning, so unknown must never alarm.
+  let updateExePresent = true;
+  try {
+    updateExePresent = exists(path.win32.join(root, 'Update.exe'));
+  } catch {
+    updateExePresent = true;
+  }
+  if (!updateExePresent) missing.push('Update.exe');
+  return missing.length > 0 ? { root, missing } : null;
+}
+
+/**
+ * Boot-time wiring: warn once, loudly, when the installation is incomplete.
+ *
+ * English on purpose — this is an installer-corruption diagnostic, shown at
+ * most once per boot on a machine whose install is already broken; routing
+ * it through the locale system would add 23 files of surface (and the pl
+ * parity gate) for a message whose audience is "someone about to reinstall".
+ * `dialog.showErrorBox` follows the existing precedent for boot-path fatal
+ * notices in index.ts. Best-effort by contract: a failure to warn must never
+ * affect boot.
+ */
+export function warnOnInstallIntegrityGap(): void {
+  if (process.platform !== 'win32') return;
+  let gap: InstallIntegrityGap | null = null;
+  try {
+    gap = findInstallIntegrityGap(process.execPath);
+  } catch {
+    return;
+  }
+  if (!gap) return;
+  console.warn(
+    `[install-integrity] incomplete installation at ${gap.root}: missing ${gap.missing.join(', ')} — ` +
+    'in-app updates and uninstall will fail until wmux is reinstalled (#1046)',
+  );
+  try {
+    // Lazy so importing this module never drags electron into a test process.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { dialog } = require('electron') as typeof import('electron');
+    dialog.showErrorBox(
+      'wmux — incomplete installation',
+      `This wmux installation is missing ${gap.missing.join(', ')} — the last install did not finish ` +
+      '(an antivirus scan interrupting the installer can cause this).\n\n' +
+      'wmux itself runs, but in-app updates and uninstalling will fail until it is reinstalled. ' +
+      'Download the latest installer from github.com/openwong2kim/wmux/releases and run it to repair.',
+    );
+  } catch { /* best-effort — never block boot over a warning */ }
+}

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -350,8 +350,10 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // system dialog. Segoe UI at two weights does the rest: a bold "wmux"
     // header plus a lighter status line underneath.
     `$form = $null`,
+    `$formsLoaded = $false`,
     `try {`,
     `  Add-Type -AssemblyName System.Windows.Forms`,
+    `  $formsLoaded = $true`,
     `  Add-Type -AssemblyName System.Drawing`,
     `  $form = New-Object System.Windows.Forms.Form`,
     `  $form.Text = 'wmux update'`,
@@ -471,12 +473,55 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // and the script would exit 0, leaving a user who just watched wmux quit
     // with no update and no explanation on the next boot.
     `$started = $true`,
-    `try { Start-Process -FilePath $setup -ErrorAction Stop } catch { $started = $false }`,
+    `$setupProc = $null`,
+    `try { $setupProc = Start-Process -FilePath $setup -PassThru -ErrorAction Stop } catch { $started = $false }`,
     `if (-not $started) {`,
     `  Set-Content -LiteralPath $marker -Value 'install-aborted: the installer could not be started' -Encoding utf8`,
     `  exit 4`,
     `}`,
-    `exit 0`,
+    // #1046 -- post-exit verification. A Squirrel install can throw partway
+    // (field log: Defender's transient lock on the freshly written exe turned
+    // a delete into UnauthorizedAccessException) and abort with the app dir
+    // half-copied: wmux.exe present, icudtl.dat never written, Update.exe
+    // never created. An app without icudtl.dat dies before one line of our
+    // code runs, so no in-app check can ever fire on the machine that needs
+    // it -- this waiter is the one process of ours still alive on the update
+    // path, so it stays for the installer's exit and looks at what was left
+    // behind. (A fresh install run by hand has no waiter; that half of #1046
+    // stays open upstream.)
+    //
+    // Same fail-safe posture as the wait window above: verification can only
+    // ADD a warning. An installer still running at the deadline means
+    // "cannot judge" and exits 0 exactly like before, and so does a throw
+    // anywhere in the checks.
+    `$setupDone = $false`,
+    `try { if ($setupProc) { $setupDone = $setupProc.WaitForExit(600000) } } catch { }`,
+    `if (-not $setupDone) { exit 0 }`,
+    // Newest app-* by write time is what the root stub will launch next. The
+    // 30s poll absorbs an installer whose file work settles just after its
+    // process tree exits -- the alarm only fires once the corpse is stable.
+    `$verifyClock = [System.Diagnostics.Stopwatch]::StartNew()`,
+    `$updateExeOk = $false`,
+    `$icuOk = $false`,
+    `while ($verifyClock.ElapsedMilliseconds -lt 30000) {`,
+    `  $updateExeOk = Test-Path -LiteralPath (Join-Path $root 'Update.exe')`,
+    `  $newestApp = $null`,
+    `  try { $newestApp = Get-ChildItem -LiteralPath $root -Directory -Filter 'app-*' | Sort-Object LastWriteTime -Descending | Select-Object -First 1 } catch { }`,
+    `  $icuOk = ($null -ne $newestApp) -and (Test-Path -LiteralPath (Join-Path $newestApp.FullName 'icudtl.dat'))`,
+    `  if ($updateExeOk -and $icuOk) { exit 0 }`,
+    `  Start-Sleep -Milliseconds 1000`,
+    `}`,
+    `$missing = @()`,
+    `if (-not $updateExeOk) { $missing += 'Update.exe' }`,
+    `if (-not $icuOk) { $missing += 'icudtl.dat' }`,
+    `$reason = 'install-aborted: the installer exited but left an incomplete installation (missing ' + ($missing -join ', ') + '). Reinstall wmux from the latest Setup.exe.'`,
+    `try { Set-Content -LiteralPath $marker -Value $reason -Encoding utf8 } catch { }`,
+    // The marker only helps if the app can still boot; when icudtl.dat is
+    // what went missing, it cannot. This MessageBox is the only surface that
+    // reaches that user -- best-effort, gated on the Forms assembly having
+    // actually loaded for the wait window earlier.
+    `if ($formsLoaded) { try { [System.Windows.Forms.MessageBox]::Show('The wmux update did not complete: ' + ($missing -join ', ') + ' is missing from the installation, and wmux may no longer start. Please reinstall from the latest Setup.exe (github.com/openwong2kim/wmux/releases).', 'wmux update', [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Warning) | Out-Null } catch { } }`,
+    `exit 6`,
   ].join('\n');
 }
 


### PR DESCRIPTION
Closes #1046

A Squirrel install can throw partway — the field log shows Defender's transient lock on the freshly written 213 MB exe turning a delete into `UnauthorizedAccessException` — and abort with the app dir half-copied: `wmux.exe` present, `icudtl.dat` never written, `Update.exe` never created. Nothing in the product said anything, at install time or ever after; the only diagnostic was Squirrel's own log file.

## The constraint that shapes the fix

An installation missing `icudtl.dat` dies before one line of our code runs — Chromium's ICU init fails first, so **no in-app check can ever fire on the machine that needs it**. Whatever detects this has to be a process that is still alive when the installer finishes. There are exactly two candidates, and this PR uses both:

**1. The install waiter (update path).** It already outlives the app by design. It now captures `Setup.exe` with `-PassThru`, waits for its exit (10-minute ceiling), and verifies what was left behind: the newest `app-*` dir must contain `icudtl.dat`, and the root must contain `Update.exe`. A stable corpse gets the abort marker (read as a toast on the next boot that can boot) **and** a MessageBox (the only surface that reaches a machine that cannot), then exits with its own code (6).

Fail-safe posture mirrors #1044's wait window: verification can only *add* a warning. An installer still running at the deadline means "cannot judge" and exits 0 exactly as before; so does a throw anywhere in the checks; the 30-second settle poll means the alarm fires only on a corpse that stayed a corpse. The MessageBox is gated on the Forms assembly having actually loaded, and marker/box failures are independent — a machine that cannot show UI still gets the marker, one that cannot write the marker still gets the box.

**2. A boot-time integrity check (the runs-but-broken class).** The reported machine also had the other shape available: an install can copy far enough to *run* but never get `Update.exe` — after which every in-app update fails and Windows' own uninstall entry points at a missing file, forever, silently. `installIntegrity.ts` detects the Squirrel layout from `process.execPath` (one stat, `path.win32` so the pure functions behave identically across the CI matrix) and surfaces one `dialog.showErrorBox` with reinstall guidance. English on purpose: an installer-corruption diagnostic for someone about to reinstall does not warrant 23 locale files plus the pl parity gate.

## What this deliberately does not do

- **Fresh installs stay uncovered.** `Setup.exe` run by hand has no waiter and no bootable app — no process of ours exists on that machine. That half of #1046 needs Squirrel-side retry or code signing (which shrinks the Defender scan window), both upstream of this repo. Said in the issue rather than silently narrowed here.
- **No retry of the installer.** The reporter's option 1 targets Squirrel's internals (`Squirrel.Update.Program.Install`), which we ship as a prebuilt binary.

Reporter's options 2 and 3 from the issue are what this implements, at the two layers that can actually speak.

## Verified

- `installTeardown.test.ts` + `installIntegrity.test.ts` — 64/64. New shape tests pin the fail-safe ordering (`-PassThru` → `WaitForExit` → cannot-judge exits 0 → checks → guarded marker → guarded MessageBox → `exit 6`), and the pre-existing ordering assertions (form closed before `Start-Process`, close-site count, mutex-before-anything) pass unchanged.
- Generated script validated with PowerShell's own parser — 0 errors.
- `tsc --noEmit` clean; eslint clean on all touched files (the 4 pre-existing `no-var-requires` in `index.ts` are on untouched lines).
