### PR TITLE
fix(updater): confirm the waiter actually started before quitting

### DIFF
--- a/changelog.d/1057.md
+++ b/changelog.d/1057.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **An update that quits and never installs no longer fails silently.** The
+  install waiter's detached PowerShell process could die before running a
+  single line of its own script — event-log evidence on a real machine showed
+  it starting the same second the app called `app.quit()` and never getting
+  further, consistent with Windows Job Object cleanup catching a "detached"
+  child that never requested breakaway. The waiter now writes a heartbeat as
+  its first act, and the app waits (up to 3s) to see it before tearing
+  anything down. A waiter that never signals costs nothing — no daemon
+  shutdown, no quit, no install — instead of the app disappearing into an
+  unexplainable hang. (#1057)

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -35,10 +35,12 @@ import {
   clearAbortMarker,
   freeSpaceShortfall,
   INSTALL_ABORT_MARKER,
+  INSTALL_READY_MARKER,
   probeVolume,
   readAbortMarker,
   spawnInstallWaiter,
   terminatePids,
+  waitForWaiterHeartbeat,
 } from './installTeardown';
 
 const REPO = 'openwong2kim/wmux';
@@ -82,6 +84,12 @@ const INSTALL_LOCK_BUDGET_MS = 60_000;
 // exists for the paths where it is NOT armed — a quit that never reaches a
 // before-quit handler at all leaves nothing else to notice.
 const INSTALL_QUIT_WATCHDOG_MS = 30_000;
+// #1056 — how long to wait for the waiter's heartbeat before concluding the
+// spawn itself did not survive (see waitForWaiterHeartbeat). Short on purpose:
+// unlike the lock budget, this is not waiting on anything that legitimately
+// takes time — a live process writes one file in well under a second, so a
+// few seconds of silence already means it is gone, not just busy.
+const WAITER_HEARTBEAT_BUDGET_MS = 3_000;
 // Squirrel downloading and unpacking a ~120 MB bundle before it reports
 // 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
 // makes this minutes, and aborting a healthy update is worse than waiting.
@@ -887,6 +895,12 @@ export class AutoUpdater {
 
     const installRoot = resolve(dirname(process.execPath), '..');
     const abortMarkerPath = join(app.getPath('userData'), INSTALL_ABORT_MARKER);
+    const readyMarkerPath = join(app.getPath('userData'), INSTALL_READY_MARKER);
+    // A stale heartbeat from a previous attempt would make the check below
+    // pass without the new waiter ever having run. Best-effort: an unlink
+    // failure just means the poll might see a false positive from stale
+    // state, same as if we had never added this check.
+    try { await unlink(readyMarkerPath); } catch { /* nothing to clear */ }
 
     // Pre-flight: refuse BEFORE anything is written rather than dying halfway.
     // Budgeted per volume — the staging download and the install root can live
@@ -951,6 +965,7 @@ export class AutoUpdater {
       setupExePath: tempPath,
       installRoot,
       abortMarkerPath,
+      readyMarkerPath,
       lockBudgetMs: INSTALL_LOCK_BUDGET_MS,
     });
     if (!waiterPath) {
@@ -961,6 +976,24 @@ export class AutoUpdater {
       this.sendToRenderer(IPC.UPDATE_ERROR, {
         status: 'error',
         message: 'Could not prepare the installer safely. The update was not started and your installation is unchanged.',
+      });
+      return;
+    }
+
+    // #1056 — confirm the waiter's PowerShell process actually ran its first
+    // line before doing anything that cannot be walked back. A real machine
+    // showed the spawned process go completely silent, with none of the abort
+    // paths in the script ever reached — nothing here proves WHY (see
+    // installTeardown.ts for the leading theory), only THAT it happened, which
+    // is enough to stop before the daemon shutdown and the force-kill below
+    // instead of quitting into a hang nothing can explain afterward.
+    const waiterAlive = await waitForWaiterHeartbeat(readyMarkerPath, WAITER_HEARTBEAT_BUDGET_MS);
+    if (!waiterAlive) {
+      this.isInstalling = false;
+      console.error(`[AutoUpdater] waiter=${waiterPath} never signaled it started — refusing to quit`);
+      this.sendToRenderer(IPC.UPDATE_ERROR, {
+        status: 'error',
+        message: 'The installer did not start. The update was not started and your installation is unchanged. Please try again.',
       });
       return;
     }

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -897,10 +897,25 @@ export class AutoUpdater {
     const abortMarkerPath = join(app.getPath('userData'), INSTALL_ABORT_MARKER);
     const readyMarkerPath = join(app.getPath('userData'), INSTALL_READY_MARKER);
     // A stale heartbeat from a previous attempt would make the check below
-    // pass without the new waiter ever having run. Best-effort: an unlink
-    // failure just means the poll might see a false positive from stale
-    // state, same as if we had never added this check.
-    try { await unlink(readyMarkerPath); } catch { /* nothing to clear */ }
+    // pass without the new waiter ever having run. ENOENT — nothing there to
+    // clear — is the expected, common case. Anything else means we cannot
+    // prove the marker is gone, so a stale heartbeat could go on to authorize
+    // the daemon shutdown and force-kill below for a waiter that never ran
+    // this time. That is exactly the failure #1056 exists to catch, so this
+    // fails closed instead of falling back to "same as if we had never added
+    // the check" (coderabbit, #1057).
+    try {
+      await unlink(readyMarkerPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.isInstalling = false;
+        this.sendToRenderer(IPC.UPDATE_ERROR, {
+          status: 'error',
+          message: 'Could not prepare the installer safely. The update was not started and your installation is unchanged.',
+        });
+        return;
+      }
+    }
 
     // Pre-flight: refuse BEFORE anything is written rather than dying halfway.
     // Budgeted per volume — the staging download and the install root can live

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -176,7 +176,9 @@ async function loadWin32(
     // never leaks an UPDATE_ERROR into tests about other flows.
     readAbortMarker: vi.fn((): string | null => null),
     clearAbortMarker: vi.fn(),
+    waitForWaiterHeartbeat: vi.fn(async (): Promise<boolean> => true),
     INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
+    INSTALL_READY_MARKER: 'update-install-ready.tmp',
   };
   vi.doMock('../installTeardown', () => teardown);
 

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -18,7 +18,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createHash } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { IPC } from '../../../shared/constants';
@@ -185,7 +185,7 @@ async function loadForPlatform(
   }));
 
   const mod = await import('../AutoUpdater');
-  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, ipcListeners, request, appQuit, shellOpenPath, nativeUpdater, teardown };
+  return { AutoUpdater: mod.AutoUpdater, requestUrls, ipcHandlers, ipcListeners, request, appQuit, shellOpenPath, nativeUpdater, teardown, tempPathDir };
 }
 
 describe('AutoUpdater platform gating', () => {
@@ -529,7 +529,8 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
     // heartbeat check runs BEFORE the daemon shutdown and the force-kill, so a
     // dead-on-arrival waiter costs nothing instead of quitting into a hang.
     const loaded = await loadForPlatform('win32', downloadRoutes);
-    const { installHandler, sent } = await downloadUpdateFor(loaded);
+    const hooks = quitHooks();
+    const { installHandler, sent } = await downloadUpdateFor(loaded, hooks);
 
     loaded.teardown.waitForWaiterHeartbeat.mockResolvedValueOnce(false);
     await installHandler();
@@ -541,7 +542,32 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
     expect(loaded.shellOpenPath).not.toHaveBeenCalled();
     // Nothing irreversible ran: no daemon shutdown, no force-kill. Order is
     // the whole point -- this check sits between spawning the waiter and
-    // committing to either.
+    // committing to either. A regression that called onInstallRequiresFullShutdown
+    // before this check would pass every assertion above (coderabbit, #1057).
+    expect(loaded.teardown.terminatePids).not.toHaveBeenCalled();
+    expect(hooks.onInstallRequiresFullShutdown).not.toHaveBeenCalled();
+  });
+
+  it('win32 (#1057, coderabbit): a stale ready-marker that cannot be cleared refuses instead of risking a false "waiter is alive"', async () => {
+    // waitForWaiterHeartbeat is mocked in this suite, so it cannot itself prove
+    // the fail-closed path -- the real risk is upstream, in the best-effort
+    // unlink that is supposed to clear a previous attempt's marker before the
+    // real heartbeat check ever runs. A directory at that exact path makes the
+    // unlink fail with a real, non-ENOENT error (EPERM/EISDIR) with no mocking
+    // of fs itself.
+    const loaded = await loadForPlatform('win32', downloadRoutes);
+    const readyMarkerPath = join(loaded.tempPathDir, loaded.teardown.INSTALL_READY_MARKER);
+    mkdirSync(readyMarkerPath);
+    const { installHandler, sent } = await downloadUpdateFor(loaded);
+
+    await installHandler();
+
+    const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
+    expect(err).toBeDefined();
+    expect(loaded.appQuit).not.toHaveBeenCalled();
+    expect(loaded.shellOpenPath).not.toHaveBeenCalled();
+    // The heartbeat check must never even run against an unproven marker.
+    expect(loaded.teardown.waitForWaiterHeartbeat).not.toHaveBeenCalled();
     expect(loaded.teardown.terminatePids).not.toHaveBeenCalled();
   });
 

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -162,7 +162,12 @@ async function loadForPlatform(
     readDaemonPid: vi.fn((): number | null => null),
     readAbortMarker: vi.fn((): string | null => null),
     clearAbortMarker: vi.fn(),
+    // #1056 — resolves true by default so existing tests exercise the same
+    // happy path as before this check existed; the dedicated test below
+    // overrides it to prove the refusal branch.
+    waitForWaiterHeartbeat: vi.fn(async (): Promise<boolean> => true),
     INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
+    INSTALL_READY_MARKER: 'update-install-ready.tmp',
   };
   vi.doMock('../installTeardown', () => teardown);
 
@@ -513,6 +518,31 @@ describe('AutoUpdater #502 — quit after launching the installer', () => {
     // untouched when the safe path is unavailable.
     expect(loaded.appQuit).not.toHaveBeenCalled();
     expect(loaded.shellOpenPath).not.toHaveBeenCalled();
+  });
+
+  it('win32 (#1056): a waiter that never signals it started reports UPDATE_ERROR and does NOT quit or tear anything down', async () => {
+    // Event-log evidence from a real machine: the waiter's PowerShell engine
+    // started and then went silent forever, in the same second the app called
+    // app.quit() -- consistent with a detached child dying with an outer Job
+    // Object the parent belongs to (Node's `detached: true` on Windows never
+    // requests CREATE_BREAKAWAY_FROM_JOB). This proves the app-side half: the
+    // heartbeat check runs BEFORE the daemon shutdown and the force-kill, so a
+    // dead-on-arrival waiter costs nothing instead of quitting into a hang.
+    const loaded = await loadForPlatform('win32', downloadRoutes);
+    const { installHandler, sent } = await downloadUpdateFor(loaded);
+
+    loaded.teardown.waitForWaiterHeartbeat.mockResolvedValueOnce(false);
+    await installHandler();
+
+    const err = sent.find((m) => m.channel === IPC.UPDATE_ERROR);
+    expect(err).toBeDefined();
+    expect(String(err?.data.message)).toContain('did not start');
+    expect(loaded.appQuit).not.toHaveBeenCalled();
+    expect(loaded.shellOpenPath).not.toHaveBeenCalled();
+    // Nothing irreversible ran: no daemon shutdown, no force-kill. Order is
+    // the whole point -- this check sits between spawning the waiter and
+    // committing to either.
+    expect(loaded.teardown.terminatePids).not.toHaveBeenCalled();
   });
 
   it('win32: refuses to install from an unpackaged build instead of killing stray processes', async () => {

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -43,6 +43,7 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
   let setupStamp: string;
   let fakeSetup: string;
   let abortMarker: string;
+  let readyMarker: string;
   let scriptPath: string;
   const children: ChildProcess[] = [];
 
@@ -54,6 +55,7 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     fs.writeFileSync(heldExe, 'x');
     setupStamp = path.join(sandbox, 'setup-ran.txt');
     abortMarker = path.join(sandbox, 'abort.txt');
+    readyMarker = path.join(sandbox, 'ready.tmp');
     fakeSetup = path.join(sandbox, 'fake-setup.cmd');
     // Stand-in for Setup.exe: proves it ran without installing anything.
     fs.writeFileSync(fakeSetup, `@echo off\r\necho ran > "${setupStamp}"\r\n`);
@@ -89,7 +91,8 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
   }
 
   const plan = (pids: number[], lockBudgetMs: number): WaiterPlan => ({
-    pids, setupExePath: fakeSetup, installRoot: root, abortMarkerPath: abortMarker, lockBudgetMs,
+    pids, setupExePath: fakeSetup, installRoot: root, abortMarkerPath: abortMarker,
+    readyMarkerPath: readyMarker, lockBudgetMs,
   });
 
   function runWaiter(timeoutMs: number): { status: number | null; timedOut: boolean } {
@@ -291,6 +294,7 @@ describe.skipIf(!onWindows)('concurrent waiters (#980)', () => {
       setupExePath: fakeSetup,
       installRoot: root,
       abortMarkerPath: marker,
+      readyMarkerPath: marker.replace(/\.txt$/, '-ready.tmp'),
       lockBudgetMs: 90_000,
     });
 

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -5,7 +5,7 @@
 //   2. a still-locked root aborts instead of launching.
 //
 // Everything else (enumeration, volume budgeting, quoting) feeds those two.
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -21,6 +21,7 @@ import {
   terminatePids,
   readAbortMarker,
   clearAbortMarker,
+  waitForWaiterHeartbeat,
   INSTALL_ABORT_MARKER,
   type WaiterPlan,
 } from '../installTeardown';
@@ -30,6 +31,7 @@ const PLAN: WaiterPlan = {
   setupExePath: 'C:\\Temp\\wmux-3.41.0.Setup.exe',
   installRoot: 'C:\\Users\\u\\AppData\\Local\\wmux',
   abortMarkerPath: 'C:\\Users\\u\\AppData\\Roaming\\wmux\\install-abort.txt',
+  readyMarkerPath: 'C:\\Users\\u\\AppData\\Roaming\\wmux\\install-ready.tmp',
   lockBudgetMs: 30_000,
 };
 
@@ -428,6 +430,7 @@ describe('buildWaiterScript — the clock has to survive a long uptime (#980)', 
     setupExePath: 'C:/Temp/Setup.exe',
     installRoot: 'C:/Root',
     abortMarkerPath: 'C:/Data/aborted.txt',
+    readyMarkerPath: 'C:/Data/ready.tmp',
     lockBudgetMs: 60_000,
   };
 
@@ -462,6 +465,7 @@ describe('buildWaiterScript — one waiter per install root (#980, coderabbit)',
     setupExePath: 'C:/Temp/Setup.exe',
     installRoot: 'C:/Root',
     abortMarkerPath: 'C:/Data/aborted.txt',
+    readyMarkerPath: 'C:/Data/ready.tmp',
     lockBudgetMs: 60_000,
   };
   const script = () => buildWaiterScript(plan)!;
@@ -483,9 +487,13 @@ describe('buildWaiterScript — one waiter per install root (#980, coderabbit)',
     const s = script();
     const yieldAt = s.indexOf('exit 5');
     expect(yieldAt).toBeGreaterThan(-1);
-    // No marker write on this path: a "refused" marker from the loser would
-    // overwrite or pre-empt whatever the incumbent has to report.
-    expect(s.slice(0, yieldAt)).not.toContain('Set-Content');
+    // No ABORT marker write on this path: a "refused" marker from the loser
+    // would overwrite or pre-empt whatever the incumbent has to report. The
+    // #1056 heartbeat write IS expected before this point — it says "a
+    // process ran," not "the install was refused," and every waiter
+    // (incumbent or newcomer) writes its own regardless of the mutex outcome.
+    expect(s.slice(0, yieldAt)).not.toContain('-LiteralPath $marker');
+    expect(s.slice(0, yieldAt)).toContain('-LiteralPath $ready');
   });
 
   it('derives the mutex name from a SHA256 hash of $root, not a lossy character replace', () => {
@@ -519,6 +527,7 @@ describe('buildWaiterScript — post-exit install verification (#1046)', () => {
     setupExePath: 'C:/t/Setup.exe',
     installRoot: 'C:/Users/u/AppData/Local/wmux',
     abortMarkerPath: 'C:/t/marker.txt',
+    readyMarkerPath: 'C:/t/ready.tmp',
     lockBudgetMs: 60000,
   };
   const script = (): string => buildWaiterScript(PLAN46) ?? '';
@@ -554,5 +563,76 @@ describe('buildWaiterScript — post-exit install verification (#1046)', () => {
     expect(formsTrue).toBeGreaterThan(s.indexOf('Add-Type -AssemblyName System.Windows.Forms'));
     expect(formsTrue).toBeLessThan(s.indexOf('Add-Type -AssemblyName System.Drawing'));
     expect(s.trimEnd().endsWith('exit 6')).toBe(true);
+  });
+});
+
+describe('buildWaiterScript — the #1056 heartbeat is the very first thing it does', () => {
+  it('writes the ready marker before the mutex, before the wait window, before everything', () => {
+    const s = buildWaiterScript(PLAN)!;
+    const heartbeatAt = s.indexOf(`-LiteralPath $ready`);
+    const mutexAt = s.indexOf('System.Threading.Mutex');
+    const formsAt = s.indexOf('Add-Type -AssemblyName System.Windows.Forms');
+    expect(heartbeatAt).toBeGreaterThan(-1);
+    // Only the three path/budget assignments and $ErrorActionPreference may
+    // precede it -- nothing that could itself throw or block.
+    expect(s.indexOf('$ErrorActionPreference')).toBeLessThan(heartbeatAt);
+    expect(heartbeatAt).toBeLessThan(mutexAt);
+    expect(heartbeatAt).toBeLessThan(formsAt);
+  });
+
+  it('guards the write so a failure here cannot abort the rest of the script', () => {
+    const s = buildWaiterScript(PLAN)!;
+    expect(s).toContain(
+      `try { Set-Content -LiteralPath $ready -Value 'alive' -Encoding utf8 } catch { }`,
+    );
+  });
+
+  it('rejects a plan whose readyMarkerPath is not a safe PowerShell literal', () => {
+    expect(buildWaiterScript({ ...PLAN, readyMarkerPath: 'C:\\bad\npath.txt' })).toBeNull();
+  });
+});
+
+describe('waitForWaiterHeartbeat (#1056)', () => {
+  it('returns true immediately when the marker already exists, without sleeping', async () => {
+    const sleeps: number[] = [];
+    const alive = await waitForWaiterHeartbeat(
+      '/fake/ready.tmp', 3000, 100,
+      () => true,
+      async (ms) => { sleeps.push(ms); },
+    );
+    expect(alive).toBe(true);
+    expect(sleeps).toEqual([]);
+  });
+
+  it('polls until the marker appears, then stops', async () => {
+    let calls = 0;
+    const exists = () => { calls += 1; return calls >= 3; };
+    const sleeps: number[] = [];
+    const alive = await waitForWaiterHeartbeat(
+      '/fake/ready.tmp', 3000, 100,
+      exists,
+      async (ms) => { sleeps.push(ms); },
+    );
+    expect(alive).toBe(true);
+    expect(calls).toBe(3);
+    expect(sleeps).toEqual([100, 100]);
+  });
+
+  it('gives up once the budget is exhausted and the marker never appeared', async () => {
+    // Real timers, driven by vitest's fake clock so the budget elapses without
+    // the test actually burning wall-clock time -- the default sleepFn is a
+    // genuine setTimeout, and Date.now() (also faked) is what the function's
+    // own deadline math reads.
+    vi.useFakeTimers();
+    try {
+      const existsFn = vi.fn(() => false);
+      const resultP = waitForWaiterHeartbeat('/fake/ready.tmp', 250, 100, existsFn);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(await resultP).toBe(false);
+      // Checked at least at the start and once more after the budget ran out.
+      expect(existsFn.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -68,6 +68,14 @@ import { spawn, execFileSync } from 'child_process';
  */
 export const INSTALL_ABORT_MARKER = 'update-install-aborted.txt';
 
+/**
+ * #1056 — heartbeat the waiter writes as its first act, relative to userData.
+ * Not the abort marker: this says "the process ran at all," not "it refused."
+ * Cleared before each attempt so a stale one from a prior run cannot pass the
+ * check for a waiter that never started this time.
+ */
+export const INSTALL_READY_MARKER = 'update-install-ready.tmp';
+
 /** Result of the pre-flight space check. `null` when there is enough room. */
 export interface SpaceShortfall {
   volume: string;
@@ -82,6 +90,16 @@ export interface WaiterPlan {
   installRoot: string;
   /** Marker written when the waiter refuses to launch. Read on next boot. */
   abortMarkerPath: string;
+  /**
+   * #1056 — written as the waiter's very first act, before anything else
+   * (even the mutex). The caller polls for it before committing to the
+   * daemon shutdown and the force-kill: its absence after a short budget
+   * means the process died before running a single line of the script, which
+   * every other signal (the abort marker, a Squirrel log) requires reaching
+   * further than that to produce. See spawnInstallWaiter / AutoUpdater for
+   * why this can happen even though the process is spawned `detached`.
+   */
+  readyMarkerPath: string;
   /** How long to keep re-checking the root for locks before giving up. */
   lockBudgetMs: number;
 }
@@ -275,7 +293,7 @@ export function selectOwnTreePids(
  * handle waits and the lock probe have passed.
  */
 export function buildWaiterScript(plan: WaiterPlan): string | null {
-  const paths = [plan.setupExePath, plan.installRoot, plan.abortMarkerPath];
+  const paths = [plan.setupExePath, plan.installRoot, plan.abortMarkerPath, plan.readyMarkerPath];
   if (!paths.every(isSafePsPathLiteral)) return null;
   if (!plan.pids.every((p) => Number.isInteger(p) && p > 0)) return null;
   // Same check the pids get. A zero, negative or NaN budget would put the
@@ -289,7 +307,21 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `$root = ${psQuote(plan.installRoot)}`,
     `$setup = ${psQuote(plan.setupExePath)}`,
     `$marker = ${psQuote(plan.abortMarkerPath)}`,
+    `$ready = ${psQuote(plan.readyMarkerPath)}`,
     `$budget = ${plan.lockBudgetMs}`,
+    // #1056 — the very first thing this script does, before even the mutex.
+    // A real machine showed the waiter's PowerShell engine starting and then
+    // going silent forever, in the same second the app called app.quit(), with
+    // none of the abort paths below ever reached (no marker, no Squirrel log).
+    // Node's `detached: true` on Windows only requests DETACHED_PROCESS |
+    // CREATE_NEW_PROCESS_GROUP — never CREATE_BREAKAWAY_FROM_JOB (confirmed in
+    // libuv's win/process.c, which says so in its own comment) — so a parent
+    // that is itself a member of an outer Job Object with KILL_ON_JOB_CLOSE can
+    // still take a "detached" child down with it. This can't fix that
+    // mechanism from here; it only proves whether the engine got far enough to
+    // run a line of script at all, which is exactly the fact the caller is
+    // missing when the whole update goes silent.
+    `try { Set-Content -LiteralPath $ready -Value 'alive' -Encoding utf8 } catch { }`,
     // Single-instance gate, FIRST — before a handle is captured or anything
     // else happens. The quit watchdog unlatches `isInstalling` after 30 s so a
     // refused quit stays retryable, but the waiter it spawned can still be
@@ -579,6 +611,32 @@ export function collectInstallRootProcesses(installRoot: string): InstallRootSur
  *  the ownership split. */
 export function collectInstallRootPids(installRoot: string): number[] {
   return collectInstallRootProcesses(installRoot).pids;
+}
+
+/**
+ * #1056 — bounded poll for the waiter's heartbeat, written as the first line
+ * of the script (see buildWaiterScript). The caller awaits this BEFORE
+ * `onInstallRequiresFullShutdown()` and the force-kill, so a waiter that never
+ * ran costs nothing: nothing has been torn down yet and the old install is
+ * untouched.
+ *
+ * `existsFn` and `sleepFn` are injected so the unit suite can resolve this in
+ * milliseconds instead of burning the real budget.
+ */
+export async function waitForWaiterHeartbeat(
+  markerPath: string,
+  budgetMs: number,
+  pollMs = 100,
+  existsFn: (p: string) => boolean = fs.existsSync,
+  sleepFn: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+): Promise<boolean> {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    if (existsFn(markerPath)) return true;
+    const left = deadline - Date.now();
+    if (left <= 0) return existsFn(markerPath);
+    await sleepFn(Math.min(pollMs, left));
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses #1056: on a real Windows machine, clicking "Update" quit the app and then nothing happened — no install, no marker on next boot, stuck on the old version, and zero trace anywhere.

## What the evidence showed

`Microsoft-Windows-PowerShell/Operational` on the affected machine: the waiter's PowerShell engine starts (`40961`, "starting up") in the same second the app calls `app.quit()`, and then never reaches "ready for user input" (`40962`) — compared with two unrelated short-lived PowerShell calls four seconds earlier that both completed their whole start→ready cycle in ~1s. No abort marker was written, no Squirrel log exists, `Update.exe` was never touched. Every explicit abort path in `buildWaiterScript` (`exit 2/3/4`, all preceded by `Set-Content $marker`) requires reaching at least the mutex line — even the marker-less `exit 5` requires evaluating `New-Object System.Threading.Mutex`. None of that happened. The process died before executing a single line of the script.

## What's confirmed vs. still a theory

**Confirmed** (read directly from libuv's `src/win/process.c`, which Node's `child_process.spawn` sits on top of): a Windows `detached: true` spawn requests `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` — never `CREATE_BREAKAWAY_FROM_JOB`. libuv's own comment on that exact line says so explicitly:

> Note that we're not setting the CREATE_BREAKAWAY_FROM_JOB flag. That means that libuv might not let you create a fully daemonized process when run under job control.

**Still a theory** (not independently confirmed on the affected machine): that wmux's own main process is itself a member of an outer Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, and that this is specifically what killed the waiter. The timing fits exactly, but I don't have a way to verify Job Object membership on a machine I don't have access to. I did not chase this further with a speculative native-API fix — see "What I didn't do" below.

## The fix

The waiter script's very first act — before the mutex, before the wait window, before anything else that could throw — is now to write a heartbeat file:

```powershell
$ready = '<path>'
try { Set-Content -LiteralPath $ready -Value 'alive' -Encoding utf8 } catch { }
```

`AutoUpdater.performInstall` now awaits `waitForWaiterHeartbeat(readyMarkerPath, 3000)` **between** `spawnInstallWaiter` and `onInstallRequiresFullShutdown()` / the force-kill — i.e. before anything irreversible. If the heartbeat never appears, nothing is torn down: no daemon shutdown, nothing killed, no `app.quit()`. The user gets an immediate `UPDATE_ERROR` ("The installer did not start...") instead of the app silently disappearing.

This fixes the *symptom* regardless of the underlying mechanism — Job Object, AV, or something else entirely — because it only asks "did the process run at all," not "why did it die."

## What I didn't do

I did not attempt a native-API workaround (`CREATE_BREAKAWAY_FROM_JOB` isn't exposed by Node's public `child_process` API — reaching it would mean a native addon or an unverified hack like re-launching through `cmd /c start`). Given the mechanism itself is still a theory, I'd rather ship the fail-safe heartbeat now and let a confirmed root cause (if someone can reproduce with Process Explorer / `handle.exe` showing Job Object membership) drive a more targeted fix later.

## Test plan

- `installTeardown.test.ts`: heartbeat write is the first script statement (before the mutex, before `Add-Type`), guarded by try/catch, survives the existing `exit 5` marker-less-bailout test (updated to distinguish the heartbeat write from the abort-marker write). New `waitForWaiterHeartbeat` unit tests: resolves immediately when the marker exists, polls until it appears, gives up cleanly at the budget (driven by fake timers, no real wall-clock burn).
- `AutoUpdater.platform.test.ts`: new test proving that when the heartbeat never arrives, `UPDATE_ERROR` fires and `app.quit()` / `terminatePids` are never called — mirrors the existing "waiter could not be prepared" test.
- `installTeardown.runtime.test.ts` (real PowerShell, real file locks, run separately via `--config vitest.runtime.config.ts`, not part of `npm run test:parallel`): all 9 existing tests still pass unmodified in behavior — the heartbeat write doesn't disturb the lock-wait/mutex/launch ordering the whole module exists to guarantee.
- `npx tsc --noEmit` and `npx eslint` on all changed files: clean (0 errors).

No version bump. Changelog fragment added once this PR number is known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows updates by verifying the installer process starts before shutting down or terminating the app.
  - Prevented silent installation failures when the installer process exits before execution.
  - Updates now report an error if the installer does not start within the verification window.
  - Added safeguards to prevent stale installation signals from authorizing shutdown when the installer has not launched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->