### PR TITLE
fix(updater): make the install waiter's launch provable, and survivable

### DIFF
--- a/changelog.d/1059.md
+++ b/changelog.d/1059.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Clicking Install can no longer quit wmux into a silent no-op.** On
+  current Windows builds the helper process that runs the installer after
+  wmux quits could die before executing a single line, leaving the old
+  version in place with no error and no trace anywhere. The helper's launch
+  is now verified before wmux commits to quitting — if it cannot be proven
+  to run, the update is refused on the spot with the app still open — and a
+  helper that dies partway through now leaves a note that wmux shows on the
+  next start. (#1059)

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -113,7 +113,10 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     const { timedOut } = runWaiter(12_000);
     expect(timedOut).toBe(true);
     expect(fs.existsSync(setupStamp)).toBe(false);
-    expect(fs.existsSync(abortMarker)).toBe(false);
+    // #1056 — mid-wait the incumbent's interrupted sentinel is ON DISK by
+    // design (it is what reports a waiter killed before any terminal); the
+    // pin here is that no TERMINAL reason has been written yet.
+    expect(fs.readFileSync(abortMarker, 'utf-8')).toContain('interrupted before it could report');
   }, 120_000);
 
   it('gives up instead of waiting forever on a process that will not die', () => {
@@ -225,7 +228,17 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     const written = spawnInstallWaiter(plan([process.pid], 1_000));
     expect(written).not.toBeNull();
     expect((written as string).toLowerCase().startsWith(root.toLowerCase())).toBe(false);
-  }, 30_000);
+    // #1056/P2-6 — this call now really launches a waiter (it terminates
+    // itself in ~1s: its handle wait is against our own live pid on a 1s
+    // budget). Reap the temp dir this test used to leak every run; retried
+    // briefly because the dying waiter can hold its script file a moment.
+    const leaked = path.dirname(written as string);
+    const rmDeadline = Date.now() + 10_000;
+    for (;;) {
+      try { fs.rmSync(leaked, { recursive: true, force: true }); break; }
+      catch { if (Date.now() > rmDeadline) break; execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 500'], { windowsHide: true }); }
+    }
+  }, 60_000);
 
   it('enumerates nothing for a root no process runs from', () => {
     expect(collectInstallRootPids(root)).toEqual([]);
@@ -343,5 +356,107 @@ describe.skipIf(!onWindows)('concurrent waiters (#980)', () => {
     expect(resB.status).toBe(5);
     expect(fs.existsSync(markerB)).toBe(false);
     expect(fs.existsSync(setupStamp)).toBe(false);
+  }, 120_000);
+});
+
+describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWaiter)', () => {
+  // Smoke coverage, billed honestly: on CI runners the direct detached spawn
+  // still works, so this suite is green before AND after the transport change
+  // and cannot regress-pin #1056 itself. What it closes is the older hole
+  // that let #1056 ship: no test anywhere ran the waiter through the real
+  // spawnInstallWaiter transport. The env assertion is the part that would
+  // go red if a future transport stopped inheriting the caller's environment
+  // — Setup.exe resolves its install target from %LOCALAPPDATA%.
+  let sandbox: string;
+  let root: string;
+  let envStamp: string;
+  let fakeSetup: string;
+  let marker: string;
+  let launchedDir: string | null = null;
+
+  beforeEach(() => {
+    sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-transport-')));
+    root = path.join(sandbox, 'wmux');
+    fs.mkdirSync(path.join(root, 'app-1.0.0'), { recursive: true });
+    // The shape of a SUCCESSFUL install, so the waiter's post-exit
+    // verification passes, removes its sentinel and exits 0 — the failure
+    // branches are pinned by the script-shape tests, and an exit-6
+    // MessageBox here would hang a headless runner.
+    fs.writeFileSync(path.join(root, 'Update.exe'), 'x');
+    fs.writeFileSync(path.join(root, 'app-1.0.0', 'icudtl.dat'), 'x');
+    envStamp = path.join(sandbox, 'env.txt');
+    marker = path.join(sandbox, 'abort.txt');
+    fakeSetup = path.join(sandbox, 'fake-setup.cmd');
+    // Redirect-first, so a username ending in a digit cannot turn `%USERNAME%>`
+    // into a stream redirect.
+    fs.writeFileSync(fakeSetup, `@echo off\r\n>"${envStamp}" echo %LOCALAPPDATA%^|%USERPROFILE%^|%USERNAME%\r\n`);
+  });
+
+  afterEach(() => {
+    // The waiter is NOT our child (that is the whole point of the trampoline)
+    // — reap by command line before dropping the directories.
+    if (launchedDir !== null) {
+      const dirLike = launchedDir.replace(/'/g, "''");
+      try {
+        execFileSync(PS, ['-NoProfile', '-NonInteractive', '-Command',
+          `Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='cmd.exe'" | Where-Object { $_.CommandLine -like '*${dirLike}*' } | ForEach-Object { taskkill /PID $_.ProcessId /T /F } | Out-Null`,
+        ], { windowsHide: true, timeout: 20_000 });
+      } catch { /* nothing left to reap */ }
+      try { fs.rmSync(launchedDir, { recursive: true, force: true }); } catch { /* lock lingers */ }
+      launchedDir = null;
+    }
+    try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch { /* lock lingers */ }
+  });
+
+  const mkPlan = (): WaiterPlan => ({
+    pids: [], setupExePath: fakeSetup, installRoot: root,
+    abortMarkerPath: marker, readyMarkerPath: path.join(sandbox, 'ready-transport.tmp'),
+    lockBudgetMs: 2_000,
+  });
+
+  function sleep200(): void {
+    execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 200'], { windowsHide: true });
+  }
+
+  it('a verified transport runs the waiter with the caller environment intact', () => {
+    const written = spawnInstallWaiter(mkPlan());
+    // The launch-stamp gate passed — a real process executed our first line.
+    expect(written).not.toBeNull();
+    launchedDir = path.dirname(written as string);
+
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline && !fs.existsSync(envStamp)) sleep200();
+    expect(fs.existsSync(envStamp)).toBe(true);
+    const [la, up, un] = fs.readFileSync(envStamp, 'utf-8').trim().split('|');
+    expect(la).toBe(process.env.LOCALAPPDATA);
+    expect(up).toBe(process.env.USERPROFILE);
+    expect(un).toBe(process.env.USERNAME);
+
+    // Success path: the interrupted sentinel must be GONE once the waiter's
+    // post-exit verification passes.
+    const markerDeadline = Date.now() + 45_000;
+    while (Date.now() < markerDeadline && fs.existsSync(marker)) sleep200();
+    expect(fs.existsSync(marker)).toBe(false);
+  }, 120_000);
+
+  it("survives a TEMP with spaces and an apostrophe (the cmd /c quoting pin)", () => {
+    // cmd /c re-parses its tail with its own rules; today's safety rests on
+    // the FIRST token (the System32 powershell path) being space-free and
+    // unquoted. The script path is the token that inherits the user's TEMP,
+    // so this pins the one quoting risk left in the transport.
+    const weird = path.join(sandbox, "tmp o'brien");
+    fs.mkdirSync(weird);
+    const saved = { TEMP: process.env.TEMP, TMP: process.env.TMP };
+    process.env.TEMP = weird;
+    process.env.TMP = weird;
+    try {
+      const written = spawnInstallWaiter(mkPlan());
+      expect(written).not.toBeNull();
+      expect((written as string).toLowerCase().startsWith(weird.toLowerCase())).toBe(true);
+      launchedDir = path.dirname(written as string);
+    } finally {
+      process.env.TEMP = saved.TEMP;
+      process.env.TMP = saved.TMP;
+    }
   }, 120_000);
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -90,6 +90,58 @@ describe('buildWaiterScript — ordering is the whole contract', () => {
     expect(buildWaiterScript({ ...PLAN, pids: [1.5] })).toBeNull();
   });
 
+  // #1056 — the launch stamp is the transport's execution proof. FIRST, and
+  // before the mutex: a newcomer that yields with exit 5 still proves the
+  // transport works.
+  it('writes the launch stamp before anything else when asked to', () => {
+    const s = buildWaiterScript(PLAN, 'C:\\Temp\\wmux-w\\launched-a.txt') ?? '';
+    const stamp = s.indexOf('launched-a.txt');
+    expect(stamp).toBeGreaterThan(-1);
+    expect(stamp).toBeLessThan(s.indexOf('$mtxHash'));
+    // Best-effort: a stamp that cannot be written degrades to "transport
+    // unverified", never to a broken waiter.
+    expect(s).toMatch(/try \{ Set-Content -LiteralPath \$stampPath[^\n]*\} catch \{ \}/);
+  });
+
+  it('emits no stamp machinery when not asked', () => {
+    // "No stamp" is a legal shape — the suites' single-argument call sites
+    // and any future caller that only needs the script.
+    const s = buildWaiterScript(PLAN) ?? '';
+    expect(s).not.toContain('$stampPath');
+  });
+
+  it('refuses a stamp path a double quote could break out of', () => {
+    // Deliberate divergence from isSafePsPathLiteral (which accepts `"` as a
+    // legal path character for single-quoted PS literals): the stamp path
+    // also rides through a cmd.exe trampoline command line, where `"` is
+    // structural.
+    expect(buildWaiterScript(PLAN, 'C:\\Temp\\a"b\\launched.txt')).toBeNull();
+    expect(buildWaiterScript(PLAN, 'C:\\Temp\\a\nb.txt')).toBeNull();
+  });
+
+  // #1056 — the interrupted sentinel: incumbent-only, and placed where a
+  // WinForms/Add-Type failure cannot eat it.
+  it('writes the interrupted sentinel after the mutex gate and before the wait window', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const gate = s.indexOf('exit 5');
+    const sentinel = s.indexOf('interrupted before it could report');
+    const form = s.indexOf('$form = $null');
+    expect(gate).toBeGreaterThan(-1);
+    expect(sentinel).toBeGreaterThan(gate);
+    expect(sentinel).toBeLessThan(form);
+  });
+
+  it('removes the sentinel on both success exits', () => {
+    const s = buildWaiterScript(PLAN) ?? '';
+    const removals = s.match(/Remove-Item -LiteralPath \$marker -ErrorAction SilentlyContinue/g) ?? [];
+    // One for the verified-ok exit, one for the cannot-judge exit: an
+    // installer demonstrably launched and still running at the 10-minute
+    // deadline makes "interrupted" a false refusal (the #1043 newcomer-marker
+    // reasoning).
+    expect(removals).toHaveLength(2);
+    expect(s).toContain('{ Remove-Item -LiteralPath $marker -ErrorAction SilentlyContinue; exit 0 }');
+  });
+
   // #1043 — a best-effort "please wait" indicator for the otherwise-silent
   // 1-2 minute window. Structural lock only: the WinForms message loop and
   // its interaction with a real Windows desktop cannot run on CI regardless
@@ -541,7 +593,7 @@ describe('buildWaiterScript — post-exit install verification (#1046)', () => {
     // An installer still running at the deadline means "cannot judge" —
     // exit 0, exactly the pre-#1046 behavior. The verification can only ADD
     // a warning, never invent one about an install still in progress.
-    expect(s.indexOf('if (-not $setupDone) { exit 0 }')).toBeGreaterThan(wait);
+    expect(s.indexOf('if (-not $setupDone) { Remove-Item -LiteralPath $marker -ErrorAction SilentlyContinue; exit 0 }')).toBeGreaterThan(wait);
   });
 
   it('checks exactly the two files whose absence is the #1046 corpse, after the launch', () => {

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -292,7 +292,7 @@ export function selectOwnTreePids(
  * one property that matters is that Setup.exe is never started before both the
  * handle waits and the lock probe have passed.
  */
-export function buildWaiterScript(plan: WaiterPlan): string | null {
+export function buildWaiterScript(plan: WaiterPlan, launchStampPath?: string): string | null {
   const paths = [plan.setupExePath, plan.installRoot, plan.abortMarkerPath, plan.readyMarkerPath];
   if (!paths.every(isSafePsPathLiteral)) return null;
   if (!plan.pids.every((p) => Number.isInteger(p) && p > 0)) return null;
@@ -300,6 +300,23 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
   // deadline in the past, so the lock loop would fall through on its first
   // pass — turning the gate that makes this whole change work into a no-op.
   if (!Number.isInteger(plan.lockBudgetMs) || plan.lockBudgetMs <= 0) return null;
+  // #1056 — optional execution-proof stamp. Stricter than isSafePsPathLiteral
+  // on purpose: this path also rides through a cmd.exe trampoline command
+  // line, where a double quote is structural. Optional, so the suites'
+  // existing single-argument call sites stay legal — "no stamp" is a shape.
+  if (launchStampPath !== undefined &&
+    (!isSafePsPathLiteral(launchStampPath) || launchStampPath.includes('"'))) {
+    return null;
+  }
+  const stampLines = launchStampPath === undefined ? [] : [
+    // Immediately after the $ready heartbeat, still before the mutex: the
+    // transport gate in spawnInstallWaiter polls for this file (a distinct
+    // one per transport), and a newcomer that yields with exit 5 still
+    // proves the transport works. Best-effort: a stamp that cannot be
+    // written degrades to "transport unverified", never to a broken waiter.
+    `$stampPath = ${psQuote(launchStampPath)}`,
+    `try { Set-Content -LiteralPath $stampPath -Value 'launched' -Encoding utf8 } catch { }`,
+  ];
 
   const pidList = plan.pids.join(',');
   return [
@@ -322,6 +339,7 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // run a line of script at all, which is exactly the fact the caller is
     // missing when the whole update goes silent.
     `try { Set-Content -LiteralPath $ready -Value 'alive' -Encoding utf8 } catch { }`,
+    ...stampLines,
     // Single-instance gate, FIRST — before a handle is captured or anything
     // else happens. The quit watchdog unlatches `isInstalling` after 30 s so a
     // refused quit stays retryable, but the waiter it spawned can still be
@@ -364,6 +382,17 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `$mtxCreated = $false`,
     `$mtx = New-Object System.Threading.Mutex -ArgumentList $true, $mtxName, ([ref]$mtxCreated)`,
     `if (-not $mtxCreated) { exit 5 }`,
+    // #1056 — incumbent-only "interrupted" sentinel. From here this waiter
+    // owns the outcome; if it dies without reaching a terminal (the app's
+    // death tears down a containing job, a reboot mid-wait), the next boot
+    // must not be silent. Every abort terminal below overwrites it, and both
+    // success exits remove it — the cannot-judge exit included, since an
+    // installer demonstrably launched and still running at the deadline makes
+    // "interrupted" a false refusal (the same false-positive reasoning as the
+    // #1043 newcomer-marker note above). Written BEFORE the WinForms block so
+    // an Add-Type failure cannot eat it, and only AFTER the mutex so a
+    // yielding newcomer (exit 5) cannot clobber the incumbent's outcome.
+    `try { Set-Content -LiteralPath $marker -Value 'install-aborted: wmux quit to install the update, but the installer step was interrupted before it could report an outcome. Try again, or run the installer from the releases page.' -Encoding utf8 } catch { }`,
     // #1043 — best-effort "please wait" indicator for the whole silent
     // window below. Deliberately outside every correctness path: every use
     // of $form is null-checked and wrapped in its own try/catch, so a
@@ -528,7 +557,7 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     // anywhere in the checks.
     `$setupDone = $false`,
     `try { if ($setupProc) { $setupDone = $setupProc.WaitForExit(600000) } } catch { }`,
-    `if (-not $setupDone) { exit 0 }`,
+    `if (-not $setupDone) { Remove-Item -LiteralPath $marker -ErrorAction SilentlyContinue; exit 0 }`,
     // Newest app-* by write time is what the root stub will launch next. The
     // 30s poll absorbs an installer whose file work settles just after its
     // process tree exits -- the alarm only fires once the corpse is stable.
@@ -540,7 +569,7 @@ export function buildWaiterScript(plan: WaiterPlan): string | null {
     `  $newestApp = $null`,
     `  try { $newestApp = Get-ChildItem -LiteralPath $root -Directory -Filter 'app-*' | Sort-Object LastWriteTime -Descending | Select-Object -First 1 } catch { }`,
     `  $icuOk = ($null -ne $newestApp) -and (Test-Path -LiteralPath (Join-Path $newestApp.FullName 'icudtl.dat'))`,
-    `  if ($updateExeOk -and $icuOk) { exit 0 }`,
+    `  if ($updateExeOk -and $icuOk) { Remove-Item -LiteralPath $marker -ErrorAction SilentlyContinue; exit 0 }`,
     `  Start-Sleep -Milliseconds 1000`,
     `}`,
     `$missing = @()`,
@@ -640,39 +669,143 @@ export async function waitForWaiterHeartbeat(
 }
 
 /**
- * Write the waiter to a temp directory and start it detached.
+ * Sync sleep for the launch-stamp gate below. Atomics.wait cannot be assumed
+ * blockable on every agent — a TypeError here would land in
+ * spawnInstallWaiter's outer catch and turn into a UNIVERSAL install refusal,
+ * a worse bug than the one this file fixes — so each step degrades to a
+ * bounded busy-wait instead of propagating (#1056 review P1-A).
+ */
+function sleepStepMs(ms: number): void {
+  try {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+  } catch {
+    const end = Date.now() + ms;
+    while (Date.now() < end) { /* bounded busy-wait fallback */ }
+  }
+}
+
+/** True once `stampPath` exists, polling every 50ms up to `budgetMs`. */
+function waitForLaunchStamp(stampPath: string, budgetMs: number): boolean {
+  const deadline = Date.now() + budgetMs;
+  for (;;) {
+    try { if (fs.existsSync(stampPath)) return true; } catch { /* probe again */ }
+    if (Date.now() >= deadline) return false;
+    sleepStepMs(50);
+  }
+}
+
+// #1056 launch-verification budgets. A is generous on purpose: its critical
+// path is cmd.exe start + a PS 5.1 engine cold start + AMSI/Defender scanning
+// a freshly written .ps1 in TEMP — and the AV-heavy machines where that is
+// slow are exactly the machines this transport exists for; misreading a
+// working trampoline as dead falls through to a transport known to die on
+// those same machines. B is short: same engine init, no cmd, and it only
+// runs after A already burned its window. Total ≤8s of synchronous wait, and
+// nothing is armed yet — the 20s before-quit deadline only exists once the
+// caller reaches app.quit().
+const LAUNCH_STAMP_BUDGET_A_MS = 6_000;
+const LAUNCH_STAMP_BUDGET_B_MS = 2_000;
+
+/**
+ * Write the waiter to a temp directory and start it so that it PROVABLY runs.
  *
  * The script deliberately does NOT live under the install root: Setup.exe
  * deletes that root, and a waiter inside it would be deleting itself while
- * running. Returns the script path on success, null when it could not start —
- * and a null MUST make the caller abandon the install rather than fall back to
- * launching Setup.exe directly.
+ * running. Returns the launched script's path on success, null when no
+ * transport could be verified — and a null MUST make the caller abandon the
+ * install rather than fall back to launching Setup.exe directly.
+ *
+ * #1056 — "started" is not something a spawn can promise here. On current
+ * Windows builds (measured on two real machines: the reporter's and this
+ * one), a PowerShell spawned DIRECTLY with `detached: true` dies before
+ * executing its first line — engine event 40961 with no 40962, exit 0,
+ * nothing on stderr, no AV detection — while the same PowerShell created by
+ * a detached cmd.exe survives and runs to completion. So:
+ *
+ *   transport A — cmd.exe trampoline. argv-array: libuv does the CRT
+ *       quoting, and cmd /c's strip-first-and-last-quote rule cannot fire
+ *       because the first token after /c (the System32 powershell path)
+ *       carries no spaces and is unquoted.
+ *   transport B — today's direct detached spawn, kept for machines where A
+ *       is somehow unavailable but the direct spawn still works.
+ *   Both with cwd pinned OUTSIDE the install root — an inherited cwd inside
+ *       it would hold the directory open in a way the lock probe (file locks
+ *       only) can never see.
+ *
+ * Each transport must PROVE execution: the waiter's first statement writes a
+ * launch stamp — a distinct file per transport, so a late A stamp can never
+ * be misattributed to B and the transport log cannot lie — and the gate
+ * polls for it. The trampoline's cost is one idle cmd.exe parked as the
+ * waiter's parent for its lifetime (up to ~11 min); it lives in System32 and
+ * holds nothing under the install root.
  */
 export function spawnInstallWaiter(plan: WaiterPlan): string | null {
   if (process.platform !== 'win32') return null;
-  const script = buildWaiterScript(plan);
-  if (!script) return null;
   try {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-install-waiter-'));
-    const scriptPath = path.join(dir, 'wait-and-install.ps1');
+    const stampA = path.join(dir, 'launched-a.txt');
+    const stampB = path.join(dir, 'launched-b.txt');
+    const scriptA = buildWaiterScript(plan, stampA);
+    const scriptB = buildWaiterScript(plan, stampB);
+    if (!scriptA || !scriptB) return null;
+    const scriptPathA = path.join(dir, 'wait-and-install.ps1');
+    const scriptPathB = path.join(dir, 'wait-and-install-b.ps1');
     // The BOM is load-bearing. Windows PowerShell 5.1 decodes a BOM-less file
     // as the system ANSI code page, so on a Korean install every path we
     // embedded — all of them under the user profile — comes back mangled.
     // Measured: with `C:\Users\홍길동\...` the BOM-less script still exits 0
     // while writing to the wrong path, which is the worst shape a failure can
     // take here (silent success). With the BOM it behaves.
-    fs.writeFileSync(scriptPath, '\uFEFF' + script, 'utf-8');
+    fs.writeFileSync(scriptPathA, '\uFEFF' + scriptA, 'utf-8');
+    fs.writeFileSync(scriptPathB, '\uFEFF' + scriptB, 'utf-8');
+
     const systemRoot = process.env.SystemRoot || 'C:\\Windows';
     const powershell = path.join(
       systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
     );
-    const child = spawn(
-      powershell,
-      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptPath],
-      { detached: true, stdio: 'ignore', windowsHide: true },
-    );
-    child.unref();
-    return scriptPath;
+    const psArgs = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File'];
+    const spawnedPids: number[] = [];
+
+    try {
+      const a = spawn(
+        'cmd.exe',
+        ['/d', '/c', powershell, ...psArgs, scriptPathA],
+        { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
+      );
+      a.unref();
+      if (typeof a.pid === 'number') spawnedPids.push(a.pid);
+    } catch { /* transport A unavailable — B still gets its window */ }
+    if (waitForLaunchStamp(stampA, LAUNCH_STAMP_BUDGET_A_MS)) {
+      console.log(`[installTeardown] waiter verified via cmd trampoline (pid ${spawnedPids[0] ?? '?'}): ${scriptPathA}`);
+      return scriptPathA;
+    }
+
+    try {
+      const b = spawn(
+        powershell,
+        [...psArgs, scriptPathB],
+        { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
+      );
+      b.unref();
+      if (typeof b.pid === 'number') spawnedPids.push(b.pid);
+    } catch { /* fall through to the refusal below */ }
+    if (waitForLaunchStamp(stampB, LAUNCH_STAMP_BUDGET_B_MS)) {
+      console.log(`[installTeardown] waiter verified via direct spawn (pid ${spawnedPids[spawnedPids.length - 1] ?? '?'}): ${scriptPathB}`);
+      return scriptPathB;
+    }
+
+    // Neither transport proved execution — refuse. P1-B: a slow-but-alive
+    // waiter left behind now would double-report (its interrupted sentinel
+    // plus a later exit-3 marker) and park a TopMost wait window over a wmux
+    // the user is still using, so both attempts are tree-killed (the /T
+    // reaches the PS under the cmd parent) and whatever they already wrote
+    // is cleared. Kill before clear: a residual race is acceptable, a
+    // guaranteed double-report is not.
+    console.warn('[installTeardown] no waiter transport proved execution — refusing the install handoff (#1056)');
+    terminatePids(spawnedPids);
+    clearAbortMarker(plan.abortMarkerPath);
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
Rebased onto #1057 (the heartbeat fail-safe) — the two changes now layer instead of overlapping:

- **#1057 (merged)** owns the outer gate: `performInstall` refuses to tear anything down until the waiter's `$ready` heartbeat proves a process ran.
- **This PR** owns the transport underneath: making a waiter exist for that heartbeat to come from, on the machines where today's spawn dies.

## The transport problem

On current Windows builds a PowerShell spawned directly with `detached: true` dies before executing its first line — measured on two real machines (the reporter's event log in #1056 and a second machine): engine event 40961 with no 40962, exit 0, empty stderr, no AV detection, parent lifetime and Job Objects irrelevant; pwsh 7 dies identically; detached node.exe/cmd.exe children survive. With #1057 alone those machines get a *correct refusal* forever — updates still can't complete. This PR makes them complete:

- **Transport A — cmd.exe trampoline.** A PowerShell created by a detached cmd survives where a directly-detached one dies (measured, including under a deliberate `KILL_ON_JOB_CLOSE` job). argv-array spawn: libuv does the CRT quoting, and `cmd /c`'s strip-first-quote rule cannot fire because the System32 powershell path carries no spaces.
- **Transport B** — the direct detached spawn, kept for machines where A is unavailable but B still works.
- Each transport proves itself via a **per-transport launch stamp** (written right after the `$ready` heartbeat, still before the mutex — so a transport verified inside `spawnInstallWaiter` has already written `$ready`, and #1057's outer check passes instantly). Distinct stamp files per transport, so the log can never misattribute which one worked.
- **No stamp from either → tree-kill both attempts, clear what they wrote, return null** — `performInstall`'s existing refusal fires with nothing killed and no quit armed. This closes #1060: the slow-but-alive waiter that #1057's 3s outer budget could strand (later writing a contradictory exit-3 marker under a TopMost window) is now killed on the refusal path, and the inner gate gives transport A a 6s budget sized for AV cold starts.
- Once the mutex is held, the waiter writes an **"interrupted" sentinel** over the abort-marker path and removes it on both success exits — a waiter killed mid-wait reports on the next boot instead of vanishing.
- Both transports pin `cwd` outside the install root; the `Atomics.wait` sync sleep degrades per-step to a bounded busy-wait.

Alternatives measured and rejected: WMI `Win32_Process.Create` passed every gate (user env/session/token intact, WinForms renders under `ShowWindow=0`) but adds an ASR-blockable LOLBin pattern for zero benefit over the trampoline; a one-shot scheduled task also survives but needs lifecycle management; a conhost wrapper dies like the bare spawn.

## Tests

Script-shape pins for the stamp (after the heartbeat, before the mutex; best-effort; absent when not requested; double-quote paths refused) and the sentinel (after the mutex gate, removed on both success exits); the updated #1046 pin; and a runtime smoke suite that runs the **real `spawnInstallWaiter`** end to end — asserting the waiter executes with the caller's environment intact (`Setup.exe` resolves its target from `%LOCALAPPDATA%`) and survives a TEMP containing spaces and an apostrophe, plus the mid-wait sentinel pin and the temp-dir leak fix in the script-placement test. Billed honestly: on runners where the detached spawn works this suite is green either way; what it closes is that no test anywhere ran the real transport.

Unit + platform suites and the full runtime suite green on a real Windows box after the rebase; tsc and eslint clean. Plan reviewed twice (initial + delta) before implementation.

The notice layer that surfaces these failures is #1058. Closes #1056. Closes #1060.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows installer reliability by verifying that the post-quit update helper launches successfully before proceeding.
  - Updates are now refused when the helper cannot be confirmed, preventing incomplete or unsafe installations.
  - Interrupted updates are detected and reported the next time the app starts.
  - Added improved handling for installer completion, timeouts, temporary paths, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->