### PR TITLE
fix(terminal): label replayed PTY data at the source

### DIFF
--- a/changelog.d/1062.md
+++ b/changelog.d/1062.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **Replayed terminal history no longer relies on a timing window.** wmux now
+  labels replayed daemon PTY data at its source, so replay-only control
+  sequences are muted without suppressing live terminal behavior. (#1062)

--- a/changelog.d/1062.md
+++ b/changelog.d/1062.md
@@ -1,5 +1,6 @@
 ### Fixed
 
 - **Replayed terminal history no longer relies on a timing window.** wmux now
-  labels replayed daemon PTY data at its source, so replay-only control
-  sequences are muted without suppressing live terminal behavior. (#1062)
+  labels replayed daemon PTY data at its source, authenticates its in-band
+  boundaries, and keeps replay-only control sequences muted across pane
+  adoption without suppressing live terminal behavior. (#1062)

--- a/src/daemon/SessionPipe.ts
+++ b/src/daemon/SessionPipe.ts
@@ -5,12 +5,15 @@ import crypto from 'node:crypto';
 import { getSessionSocketPath } from '../shared/constants';
 import type { RingBuffer } from './RingBuffer';
 import { generateSnapshot, MAX_SCROLLBACK } from './HeadlessSnapshot';
-import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from './sessionPipeMarkers';
+import {
+  createSessionPipeMarkers,
+  type SessionPipeMarkers,
+} from './sessionPipeMarkers';
 
-// Re-exported for existing importers; the definitions live in the dependency-free
-// sessionPipeMarkers module so the Electron main bundle can import the markers
-// without dragging SessionPipe's @xterm/headless dependency into its Vite graph.
-export { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER };
+// Re-exported for existing importers; the factory lives in the dependency-free
+// sessionPipeMarkers module so the Electron main bundle can derive the same
+// authenticated markers without dragging @xterm/headless into its Vite graph.
+export { createSessionPipeMarkers };
 
 /**
  * TASK-10: initial-attach flushes at or above this size go through the
@@ -38,6 +41,7 @@ export class SessionPipe {
   private flushed = false;
   private reflushInFlight = false;
   private connectionRate = { count: 0, resetAt: 0 };
+  private readonly markers: SessionPipeMarkers;
 
   /**
    * Fired when the AUTHED client socket goes away (close or error) without a
@@ -62,7 +66,9 @@ export class SessionPipe {
      * the flush ships raw bytes exactly as before.
      */
     private readonly getDims?: () => { cols: number; rows: number },
-  ) {}
+  ) {
+    this.markers = createSessionPipeMarkers(authToken);
+  }
 
   /** Get the platform-specific pipe name for this session.
    * P7: Unix 소켓은 ~/.wmux{suffix}/ 하위 — shared 헬퍼가 클라이언트
@@ -276,7 +282,7 @@ export class SessionPipe {
     if (payload.length > 0) {
       socket.write(payload);
     }
-    socket.write(FLUSH_DONE_MARKER);
+    socket.write(this.markers.flushDone);
     this.flushed = true;
   }
 
@@ -437,7 +443,7 @@ export class SessionPipe {
     try {
       // T0 — one synchronous block: announce, suppress live writes, capture
       // the ring, arm the tee. Nothing can arrive between these statements.
-      socket.write(RESYNC_BEGIN_MARKER);
+      socket.write(this.markers.resyncBegin);
       this.flushed = false;
       const initial = this.ringBuffer.readAll();
       opts.bridge.on('data', tee);
@@ -477,7 +483,7 @@ export class SessionPipe {
         const tailRaw = teeQueue.length > 0 ? Buffer.concat(teeQueue.splice(0)) : null;
         socket.write(RIS);
         socket.write(outcome.payload);
-        socket.write(FLUSH_DONE_MARKER);
+        socket.write(this.markers.flushDone);
         this.flushed = true;
         if (tailRaw && tailRaw.length > 0) {
           socket.write(tailRaw);
@@ -496,7 +502,7 @@ export class SessionPipe {
       const raw = this.ringBuffer.readAll();
       socket.write(RIS);
       socket.write(raw);
-      socket.write(FLUSH_DONE_MARKER);
+      socket.write(this.markers.flushDone);
       this.flushed = true;
       // A3 rollout metric: fallback-rate by reason.
       // eslint-disable-next-line no-console

--- a/src/daemon/__tests__/DaemonPipeServer.test.ts
+++ b/src/daemon/__tests__/DaemonPipeServer.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
 import { DaemonPipeServer } from '../DaemonPipeServer';
-import { SessionPipe, FLUSH_DONE_MARKER } from '../SessionPipe';
+import { SessionPipe, createSessionPipeMarkers } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
 import {
   getDaemonAuthTokenPath,
@@ -437,6 +437,7 @@ describe('SessionPipe', () => {
   });
 
   const SESSION_AUTH_TOKEN = 'test-session-token-456';
+  const FLUSH_DONE_MARKER = createSessionPipeMarkers(SESSION_AUTH_TOKEN).flushDone;
 
   it('should start and stop without error', async () => {
     sessionPipe = new SessionPipe(sessionId + '-a', ringBuffer, SESSION_AUTH_TOKEN);

--- a/src/daemon/__tests__/SessionPipe.attachSnapshot.test.ts
+++ b/src/daemon/__tests__/SessionPipe.attachSnapshot.test.ts
@@ -16,7 +16,7 @@ import net from 'node:net';
 import crypto from 'node:crypto';
 import { Terminal } from '@xterm/headless';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
-import { SessionPipe, FLUSH_DONE_MARKER, ATTACH_SNAPSHOT_MIN_BYTES } from '../SessionPipe';
+import { SessionPipe, createSessionPipeMarkers, ATTACH_SNAPSHOT_MIN_BYTES } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
 import { waitFor } from '../../test-utils/waitFor';
 
@@ -114,6 +114,7 @@ function redrawHistory(minBytes: number): Buffer {
 }
 
 const TOKEN = 'attsnap-test-token';
+const FLUSH_DONE_MARKER = createSessionPipeMarkers(TOKEN).flushDone;
 const COLS = 100;
 const ROWS = 24;
 

--- a/src/daemon/__tests__/SessionPipe.reflush.test.ts
+++ b/src/daemon/__tests__/SessionPipe.reflush.test.ts
@@ -6,8 +6,7 @@ import { Terminal } from '@xterm/headless';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import {
   SessionPipe,
-  FLUSH_DONE_MARKER,
-  RESYNC_BEGIN_MARKER,
+  createSessionPipeMarkers,
 } from '../SessionPipe';
 import { RingBuffer } from '../RingBuffer';
 import { generateSnapshot } from '../HeadlessSnapshot';
@@ -103,6 +102,10 @@ function trimTrailingBlank(lines: string[]): string[] {
 }
 
 const TOKEN = 'reflush-session-token';
+const {
+  flushDone: FLUSH_DONE_MARKER,
+  resyncBegin: RESYNC_BEGIN_MARKER,
+} = createSessionPipeMarkers(TOKEN);
 
 // Cleanup registry — each test pushes teardown steps (LIFO).
 let cleanups: Array<() => void | Promise<void>> = [];

--- a/src/daemon/sessionPipeMarkers.ts
+++ b/src/daemon/sessionPipeMarkers.ts
@@ -8,15 +8,26 @@
  * the HeadlessSnapshot import to SessionPipe. Keep this file import-free.
  */
 
-/** Marker sent after Ring Buffer flush to signal transition to real-time mode. */
-export const FLUSH_DONE_MARKER = Buffer.from('\x00WMUX_FLUSH_DONE\x00');
+export interface SessionPipeMarkers {
+  /** Sent after a Ring Buffer flush to signal transition to real-time mode. */
+  flushDone: Buffer;
+  /** Sent immediately before a live-pipe re-flush begins. */
+  resyncBegin: Buffer;
+}
 
 /**
- * In-band announcement that a live-pipe re-flush is starting (phase 3 PR-B).
- * Written on the ALREADY-FLUSHED stream right before live output is
- * suppressed; everything after it up to the next FLUSH_DONE_MARKER is replay
- * (snapshot or raw) that the client must accumulate exactly like the initial
- * flush. Carrying the state transition in the stream itself is what makes the
- * protocol race-free: no RPC-vs-stream ordering can misclassify bytes.
+ * Build markers that only the authenticated daemon and main process can
+ * predict. PTY output shares this byte stream, so a fixed public marker would
+ * let stored output impersonate a flush boundary and regain live side-effect
+ * authority during replay. The daemon auth token is never exposed to a remote
+ * PTY producer; including it makes accidental or crafted collisions
+ * negligible while keeping this module import-free for the Vite main build.
+ * The resync marker is written on the already-flushed stream immediately
+ * before live output is suppressed; everything until flushDone is replay.
  */
-export const RESYNC_BEGIN_MARKER = Buffer.from('\x00WMUX_RESYNC_BEGIN\x00');
+export function createSessionPipeMarkers(authToken: string): SessionPipeMarkers {
+  return {
+    flushDone: Buffer.from(`\x00WMUX_FLUSH_DONE:${authToken}\x00`),
+    resyncBegin: Buffer.from(`\x00WMUX_RESYNC_BEGIN:${authToken}\x00`),
+  };
+}

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -41,7 +41,7 @@ interface PendingRequest {
  * Communicates over Named Pipe (Windows) / Unix domain socket using JSON-RPC.
  *
  * Events:
- *   'session:data'   — { sessionId: string, data: Buffer }
+ *   'session:data'   — { sessionId: string, data: Buffer, replay: boolean }
  *   'session:died'   — { sessionId: string, exitCode: number | null }
  *   'disconnected'   — daemon control pipe disconnected
  *   'event'          — DaemonEvent from daemon broadcast
@@ -810,7 +810,7 @@ export class DaemonClient extends EventEmitter {
     const drain = (events: ReturnType<SessionPipeStreamScanner['feed']>) => {
       for (const ev of events) {
         if (ev.type === 'data') {
-          this.emit('session:data', { sessionId, data: ev.data });
+          this.emit('session:data', { sessionId, data: ev.data, replay: ev.replay });
         } else {
           this.emit('session:flushComplete', { sessionId, recoveredBytes: ev.recoveredBytes });
         }
@@ -862,7 +862,7 @@ export class DaemonClient extends EventEmitter {
     const events = scanner.disarmResync();
     for (const ev of events) {
       if (ev.type === 'data') {
-        this.emit('session:data', { sessionId, data: ev.data });
+        this.emit('session:data', { sessionId, data: ev.data, replay: ev.replay });
       }
     }
   }

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -820,6 +820,11 @@ export class DaemonClient extends EventEmitter {
     };
 
     socket.on('data', (chunk: Buffer) => {
+      // A forceFresh reconnect can install a replacement before the old
+      // socket's final queued data callback runs. Only the socket that still
+      // owns this session may emit bytes; otherwise stale output could
+      // interleave with the replacement stream.
+      if (this.sessionPipes.get(sessionId) !== socket) return;
       drain(scanner.feed(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
     });
 

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -847,8 +847,7 @@ export class DaemonClient extends EventEmitter {
   armSessionResync(sessionId: string): boolean {
     const scanner = this.sessionScanners.get(sessionId);
     if (!scanner || scanner.mode !== 'live') return false;
-    scanner.armResync();
-    return true;
+    return scanner.armResync();
   }
 
   /**

--- a/src/main/DaemonClient.ts
+++ b/src/main/DaemonClient.ts
@@ -14,6 +14,7 @@ import type {
   LanLinkPeersListResult,
 } from '../shared/lanlink';
 import { stripReplayQuerySequences } from '../shared/replayQuerySanitizer';
+import { createSessionPipeMarkers } from '../daemon/sessionPipeMarkers';
 import { SessionPipeStreamScanner } from './daemon/sessionPipeStreamScanner';
 import { DAEMON_RPC_TIMEOUT_MS } from '../shared/timeouts';
 import {
@@ -803,6 +804,7 @@ export class DaemonClient extends EventEmitter {
     // scanner returns ordered events; this closure only fans them out onto the
     // EventBus, preserving the original emit signatures and ordering.
     const scanner = new SessionPipeStreamScanner({
+      markers: createSessionPipeMarkers(this.authToken),
       stripReplay: stripReplayQuerySequences,
     });
     this.sessionScanners.set(sessionId, scanner);

--- a/src/main/__tests__/DaemonClient.test.ts
+++ b/src/main/__tests__/DaemonClient.test.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import os from 'node:os';
 import path from 'node:path';
 import { DaemonClient, getDaemonPipeName, readDaemonAuthToken } from '../DaemonClient';
-import { FLUSH_DONE_MARKER } from '../../daemon/SessionPipe';
+import { createSessionPipeMarkers } from '../../daemon/SessionPipe';
 import { waitFor } from '../../test-utils/waitFor';
 
 // Helper: unique pipe name per test
@@ -106,6 +106,7 @@ function createMockSessionPipe(
       authBuffer = Buffer.concat([authBuffer, chunk]);
       const newlineIndex = authBuffer.indexOf(0x0a);
       if (newlineIndex === -1) return;
+      const presentedToken = authBuffer.subarray(0, newlineIndex).toString('utf8');
 
       // Auth token received — consume it and proceed
       authenticated = true;
@@ -113,7 +114,7 @@ function createMockSessionPipe(
       const leftover = authBuffer.subarray(newlineIndex + 1);
 
       // Flush done immediately (no ring buffer to replay)
-      socket.write(FLUSH_DONE_MARKER);
+      socket.write(createSessionPipeMarkers(presentedToken).flushDone);
 
       // Set up real data handler
       socket.on('data', (d: Buffer) => {
@@ -413,9 +414,10 @@ describe('DaemonClient', () => {
           authBuf = Buffer.concat([authBuf, chunk]);
           const nl = authBuf.indexOf(0x0a);
           if (nl === -1) return;
+          const presentedToken = authBuf.subarray(0, nl).toString('utf8');
           socket.removeListener('data', onAuth);
           const leftover = authBuf.subarray(nl + 1);
-          socket.write(FLUSH_DONE_MARKER);
+          socket.write(createSessionPipeMarkers(presentedToken).flushDone);
           socket.on('data', (d) => {
             inputReceived.push(Buffer.isBuffer(d) ? d : Buffer.from(d));
           });

--- a/src/main/__tests__/DaemonClient.test.ts
+++ b/src/main/__tests__/DaemonClient.test.ts
@@ -718,6 +718,34 @@ describe('DaemonClient', () => {
       expect(client.writeToSession(SESSION_ID, 'forced')).toBe(true);
     });
 
+    it('drops late data callbacks from a socket after its identity is replaced', async () => {
+      const staleSocket = new net.Socket();
+      const replacementSocket = new net.Socket();
+      const internals = client as unknown as {
+        sessionPipes: Map<string, net.Socket>;
+        setupSessionPipe: (sessionId: string, socket: net.Socket) => void;
+      };
+      const received: Buffer[] = [];
+      client.on('session:data', (payload: { sessionId: string; data: Buffer }) => {
+        if (payload.sessionId === SESSION_ID) received.push(payload.data);
+      });
+
+      internals.sessionPipes.set(SESSION_ID, staleSocket);
+      internals.setupSessionPipe(SESSION_ID, staleSocket);
+      internals.sessionPipes.set(SESSION_ID, replacementSocket);
+
+      staleSocket.emit('data', Buffer.concat([
+        createSessionPipeMarkers(AUTH_TOKEN).flushDone,
+        Buffer.from('stale-output'),
+      ]));
+
+      expect(received).toEqual([]);
+
+      await client.disconnect();
+      staleSocket.destroy();
+      replacementSocket.destroy();
+    });
+
     it('writeToSession returns false when the session is not connected', () => {
       expect(client.writeToSession('never-connected', 'x')).toBe(false);
     });

--- a/src/main/__tests__/DaemonClient.test.ts
+++ b/src/main/__tests__/DaemonClient.test.ts
@@ -88,6 +88,7 @@ function createMockDaemonServer(
 // Helper: create a mock session pipe server that sends FLUSH_DONE_MARKER then echoes data back
 function createMockSessionPipe(
   sessionId: string,
+  expectedToken: string,
 ): { server: net.Server; start: () => Promise<string>; stop: () => Promise<void>; writeToClient: (data: Buffer) => void } {
   const pipeName = process.platform === 'win32'
     ? `\\\\.\\pipe\\wmux-session-${sessionId}`
@@ -99,7 +100,6 @@ function createMockSessionPipe(
   const server = net.createServer((socket) => {
     clientSocket = socket;
     let authBuffer = Buffer.alloc(0);
-    let authenticated = false;
 
     const onAuthData = (data: Buffer): void => {
       const chunk = Buffer.isBuffer(data) ? data : Buffer.from(data);
@@ -107,14 +107,17 @@ function createMockSessionPipe(
       const newlineIndex = authBuffer.indexOf(0x0a);
       if (newlineIndex === -1) return;
       const presentedToken = authBuffer.subarray(0, newlineIndex).toString('utf8');
+      if (presentedToken !== expectedToken) {
+        socket.destroy();
+        return;
+      }
 
       // Auth token received — consume it and proceed
-      authenticated = true;
       socket.removeListener('data', onAuthData);
       const leftover = authBuffer.subarray(newlineIndex + 1);
 
       // Flush done immediately (no ring buffer to replay)
-      socket.write(createSessionPipeMarkers(presentedToken).flushDone);
+      socket.write(createSessionPipeMarkers(expectedToken).flushDone);
 
       // Set up real data handler
       socket.on('data', (d: Buffer) => {
@@ -357,7 +360,7 @@ describe('DaemonClient', () => {
       mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {});
       await mockServer.start();
 
-      const mockSession = createMockSessionPipe(sessionId);
+      const mockSession = createMockSessionPipe(sessionId, AUTH_TOKEN);
       await mockSession.start();
 
       client = new DaemonClient(pipeName, AUTH_TOKEN);
@@ -392,6 +395,26 @@ describe('DaemonClient', () => {
       await mockServer.stop();
     });
 
+    it('does not complete a session flush when the client presents the wrong token', async () => {
+      const sessionId = `test-sp-auth-${crypto.randomUUID().slice(0, 8)}`;
+      const mockSession = createMockSessionPipe(sessionId, AUTH_TOKEN);
+      await mockSession.start();
+
+      client = new DaemonClient(testPipeName('unused-control'), 'wrong-session-token');
+      let flushCompleted = false;
+      client.on('session:flushComplete', (payload: { sessionId: string }) => {
+        if (payload.sessionId === sessionId) flushCompleted = true;
+      });
+
+      await client.connectSessionPipe(sessionId);
+      await waitFor(() => !client.isSessionPipeWritable(sessionId), 3000);
+
+      expect(flushCompleted).toBe(false);
+
+      await client.disconnect();
+      await mockSession.stop();
+    });
+
     it('should forward client writes to session pipe', async () => {
       const pipeName = testPipeName('sp2');
       const sessionId = `test-sp-${crypto.randomUUID().slice(0, 8)}`;
@@ -415,9 +438,13 @@ describe('DaemonClient', () => {
           const nl = authBuf.indexOf(0x0a);
           if (nl === -1) return;
           const presentedToken = authBuf.subarray(0, nl).toString('utf8');
+          if (presentedToken !== AUTH_TOKEN) {
+            socket.destroy();
+            return;
+          }
           socket.removeListener('data', onAuth);
           const leftover = authBuf.subarray(nl + 1);
-          socket.write(createSessionPipeMarkers(presentedToken).flushDone);
+          socket.write(createSessionPipeMarkers(AUTH_TOKEN).flushDone);
           socket.on('data', (d) => {
             inputReceived.push(Buffer.isBuffer(d) ? d : Buffer.from(d));
           });
@@ -463,7 +490,7 @@ describe('DaemonClient', () => {
       mockServer = createMockDaemonServer(pipeName, AUTH_TOKEN, {});
       await mockServer.start();
 
-      const mockSession = createMockSessionPipe(sessionId);
+      const mockSession = createMockSessionPipe(sessionId, AUTH_TOKEN);
       await mockSession.start();
 
       client = new DaemonClient(pipeName, AUTH_TOKEN);
@@ -635,7 +662,7 @@ describe('DaemonClient', () => {
       client = new DaemonClient(pipeName, AUTH_TOKEN);
       await client.connect();
 
-      sessionPipe = createMockSessionPipe(SESSION_ID);
+      sessionPipe = createMockSessionPipe(SESSION_ID, AUTH_TOKEN);
       await sessionPipe.start();
     });
 
@@ -669,7 +696,7 @@ describe('DaemonClient', () => {
       expect(client.isSessionPipeWritable(SESSION_ID)).toBe(false);
 
       // Bring the daemon side back up at the same pipe name.
-      sessionPipe = createMockSessionPipe(SESSION_ID);
+      sessionPipe = createMockSessionPipe(SESSION_ID, AUTH_TOKEN);
       await sessionPipe.start();
 
       // Reconnect should NOT early-return — the stale entry must be

--- a/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
+++ b/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
@@ -19,18 +19,24 @@ interface Collected {
   flushes: number[];
   /** Event type sequence, e.g. ['data', 'flushComplete', 'data']. */
   order: Array<ScanEvent['type']>;
+  /** Replay provenance for each data event, in order. */
+  replay: boolean[];
 }
 
 function collect(events: ScanEvent[]): Collected {
   const parts: Buffer[] = [];
   const flushes: number[] = [];
   const order: Array<ScanEvent['type']> = [];
+  const replay: boolean[] = [];
   for (const ev of events) {
     order.push(ev.type);
-    if (ev.type === 'data') parts.push(ev.data);
+    if (ev.type === 'data') {
+      parts.push(ev.data);
+      replay.push(ev.replay);
+    }
     else flushes.push(ev.recoveredBytes);
   }
-  return { data: Buffer.concat(parts), flushes, order };
+  return { data: Buffer.concat(parts), flushes, order, replay };
 }
 
 function newScanner(opts?: { maxPendingBytes?: number; stripReplay?: (b: Buffer) => Buffer }) {
@@ -53,6 +59,7 @@ describe('initial flush', () => {
     const c = collect(events);
 
     expect(c.order).toEqual(['data', 'flushComplete', 'data']);
+    expect(c.replay).toEqual([true, false]);
     expect(c.flushes).toEqual([replay.length]);
     expect(collect([events[0]]).data.equals(replay)).toBe(true);
     expect(collect([events[2]]).data.equals(live)).toBe(true);
@@ -148,6 +155,7 @@ describe('live unarmed passthrough', () => {
     toLive(s);
     const c = collect(s.feed(b('echo output')));
     expect(c.order).toEqual(['data']);
+    expect(c.replay).toEqual([false]);
     expect(c.data.equals(b('echo output'))).toBe(true);
   });
 
@@ -242,6 +250,7 @@ describe('armed resync scan', () => {
     const c = collect(events);
 
     expect(c.order).toEqual(['data', 'data', 'flushComplete', 'data']);
+    expect(c.replay).toEqual([false, true, false]);
     // pre-marker live, then the snapshot replay, then the live tail
     expect(collect([events[0]]).data.equals(preLive)).toBe(true);
     expect(collect([events[1]]).data.equals(snapshot)).toBe(true);
@@ -308,30 +317,49 @@ describe('disarmResync', () => {
 });
 
 // ---------------------------------------------------------------------------
-// MAX_PENDING overflow — must mirror the original DaemonClient closure exactly
+// MAX_PENDING overflow — drop replay safely, resume only at FLUSH_DONE
 // ---------------------------------------------------------------------------
 
 describe('max pending overflow', () => {
-  it('drops the buffer and flips to live, emitting nothing (initial flush)', () => {
+  it('drops replay until the marker, then resumes with a live tail', () => {
     const s = newScanner({ maxPendingBytes: 10 });
     // 6 bytes, no marker — still accumulating, no events
     expect(s.feed(b('123456'))).toEqual([]);
     expect(s.mode).toBe('accumulating');
-    // +6 bytes → 12 > 10 cap → overflow: drop everything, go live, no events
+    // +6 bytes → 12 > 10 cap → drop replay and scan for the real boundary.
     expect(s.feed(b('789012'))).toEqual([]);
     expect(s.mode).toBe('live');
-    // subsequent bytes now pass straight through (buffered bytes were dropped)
-    const c = collect(s.feed(b('after')));
-    expect(c.order).toEqual(['data']);
+    // More pre-marker history is dropped, never relabelled as live.
+    expect(s.feed(b('more-history'))).toEqual([]);
+    const c = collect(s.feed(Buffer.concat([FLUSH_DONE_MARKER, b('after')])));
+    expect(c.order).toEqual(['flushComplete', 'data']);
+    expect(c.flushes).toEqual([0]);
+    expect(c.replay).toEqual([false]);
     expect(c.data.equals(b('after'))).toBe(true);
   });
 
-  it('a marker arriving in the SAME overflowing chunk is still dropped (cap wins)', () => {
+  it('settles safely when the marker arrives in the same overflowing chunk', () => {
     const s = newScanner({ maxPendingBytes: 5 });
-    // one chunk that exceeds the cap AND contains the marker — original behavior
-    // is overflow-wins: nothing emitted, straight to live.
+    // The replay is still dropped, but the marker settles the flush instead of
+    // leaking through as ordinary PTY bytes.
     const c = collect(s.feed(Buffer.concat([b('bigreplay'), FLUSH_DONE_MARKER])));
-    expect(c.order).toEqual([]);
+    expect(c.order).toEqual(['flushComplete']);
+    expect(c.flushes).toEqual([0]);
     expect(s.mode).toBe('live');
+  });
+
+  it('recognizes a flush marker split after overflow', () => {
+    const s = newScanner({ maxPendingBytes: 5 });
+    expect(s.feed(b('too-large'))).toEqual([]);
+    const cut = Math.floor(FLUSH_DONE_MARKER.length / 2);
+    expect(s.feed(FLUSH_DONE_MARKER.subarray(0, cut))).toEqual([]);
+    const c = collect(s.feed(Buffer.concat([
+      FLUSH_DONE_MARKER.subarray(cut),
+      b('live'),
+    ])));
+    expect(c.order).toEqual(['flushComplete', 'data']);
+    expect(c.flushes).toEqual([0]);
+    expect(c.replay).toEqual([false]);
+    expect(c.data.equals(b('live'))).toBe(true);
   });
 });

--- a/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
+++ b/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
@@ -3,7 +3,7 @@ import {
   SessionPipeStreamScanner,
   type ScanEvent,
 } from '../sessionPipeStreamScanner';
-import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../../daemon/SessionPipe';
+import { createSessionPipeMarkers } from '../../../daemon/SessionPipe';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -11,6 +11,9 @@ import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../../daemon/SessionP
 
 const b = (s: string): Buffer => Buffer.from(s, 'binary');
 const identityStrip = (buf: Buffer): Buffer => buf;
+const MARKERS = createSessionPipeMarkers('scanner-test-auth-token');
+const FLUSH_DONE_MARKER = MARKERS.flushDone;
+const RESYNC_BEGIN_MARKER = MARKERS.resyncBegin;
 
 interface Collected {
   /** All 'data' event payloads concatenated, in order. */
@@ -41,6 +44,7 @@ function collect(events: ScanEvent[]): Collected {
 
 function newScanner(opts?: { maxPendingBytes?: number; stripReplay?: (b: Buffer) => Buffer }) {
   return new SessionPipeStreamScanner({
+    markers: MARKERS,
     stripReplay: opts?.stripReplay ?? identityStrip,
     maxPendingBytes: opts?.maxPendingBytes,
   });
@@ -106,6 +110,18 @@ describe('initial flush', () => {
     expect(c.order).toEqual(['data', 'flushComplete', 'data']);
     expect(c.flushes).toEqual([replay.length]); // pre-strip length across the boundary
     expect(c.data.equals(b('xyL'))).toBe(true);
+  });
+
+  it('does not let PTY output forged with another token impersonate the boundary', () => {
+    const s = newScanner();
+    const forged = createSessionPipeMarkers('attacker-does-not-know-real-token').flushDone;
+    const replay = Buffer.concat([b('before'), forged, b('\x1b]52;c;Zm9yZ2Vk\x07after')]);
+    const c = collect(s.feed(Buffer.concat([replay, FLUSH_DONE_MARKER])));
+
+    expect(c.order).toEqual(['data', 'flushComplete']);
+    expect(c.replay).toEqual([true]);
+    expect(c.flushes).toEqual([replay.length]);
+    expect(c.data.equals(replay)).toBe(true);
   });
 });
 

--- a/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
+++ b/src/main/daemon/__tests__/sessionPipeStreamScanner.test.ts
@@ -329,6 +329,7 @@ describe('max pending overflow', () => {
     // +6 bytes → 12 > 10 cap → drop replay and scan for the real boundary.
     expect(s.feed(b('789012'))).toEqual([]);
     expect(s.mode).toBe('live');
+    expect(s.armResync()).toBe(false);
     // More pre-marker history is dropped, never relabelled as live.
     expect(s.feed(b('more-history'))).toEqual([]);
     const c = collect(s.feed(Buffer.concat([FLUSH_DONE_MARKER, b('after')])));
@@ -336,6 +337,8 @@ describe('max pending overflow', () => {
     expect(c.flushes).toEqual([0]);
     expect(c.replay).toEqual([false]);
     expect(c.data.equals(b('after'))).toBe(true);
+    expect(s.armResync()).toBe(true);
+    s.disarmResync();
   });
 
   it('settles safely when the marker arrives in the same overflowing chunk', () => {

--- a/src/main/daemon/sessionPipeStreamScanner.ts
+++ b/src/main/daemon/sessionPipeStreamScanner.ts
@@ -1,4 +1,4 @@
-import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../daemon/sessionPipeMarkers';
+import type { SessionPipeMarkers } from '../../daemon/sessionPipeMarkers';
 
 /**
  * Stream events produced while scanning a session pipe's byte stream.
@@ -52,8 +52,14 @@ export class SessionPipeStreamScanner {
   private carry: Buffer = EMPTY;
   private readonly maxPendingBytes: number;
   private readonly stripReplay: (b: Buffer) => Buffer;
+  private readonly markers: SessionPipeMarkers;
 
-  constructor(opts: { maxPendingBytes?: number; stripReplay: (b: Buffer) => Buffer }) {
+  constructor(opts: {
+    markers: SessionPipeMarkers;
+    maxPendingBytes?: number;
+    stripReplay: (b: Buffer) => Buffer;
+  }) {
+    this.markers = opts.markers;
     this.maxPendingBytes = opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
     this.stripReplay = opts.stripReplay;
   }
@@ -124,19 +130,19 @@ export class SessionPipeStreamScanner {
       this.armed = false;
       this.pendingChunks = [];
       this.pendingBytes = 0;
-      const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
+      const markerIndex = combined.indexOf(this.markers.flushDone);
       if (markerIndex !== -1) {
         return this.finishDiscardedOverflow(combined, markerIndex);
       }
       this.discardingOverflowReplay = true;
-      const hold = this.matchingPrefixLen(combined, FLUSH_DONE_MARKER);
+      const hold = this.matchingPrefixLen(combined, this.markers.flushDone);
       this.overflowCarry = hold > 0
         ? Buffer.from(combined.subarray(combined.length - hold))
         : EMPTY;
       return [];
     }
 
-    const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
+    const markerIndex = combined.indexOf(this.markers.flushDone);
     if (markerIndex === -1) return [];
 
     this._mode = 'live';
@@ -175,7 +181,7 @@ export class SessionPipeStreamScanner {
     // Emit data after marker (if any real-time data arrived in the same chunk).
     // After both the initial flush and a re-flush the scanner is disarmed, so
     // this tail is plain live output — passed straight through like the original.
-    const afterMarker = combined.subarray(markerIndex + FLUSH_DONE_MARKER.length);
+    const afterMarker = combined.subarray(markerIndex + this.markers.flushDone.length);
     if (afterMarker.length > 0) {
       events.push({ type: 'data', data: afterMarker, replay: false });
     }
@@ -192,11 +198,11 @@ export class SessionPipeStreamScanner {
       ? Buffer.concat([this.overflowCarry, buf])
       : buf;
     this.overflowCarry = EMPTY;
-    const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
+    const markerIndex = combined.indexOf(this.markers.flushDone);
     if (markerIndex !== -1) {
       return this.finishDiscardedOverflow(combined, markerIndex);
     }
-    const hold = this.matchingPrefixLen(combined, FLUSH_DONE_MARKER);
+    const hold = this.matchingPrefixLen(combined, this.markers.flushDone);
     if (hold > 0) {
       this.overflowCarry = Buffer.from(combined.subarray(combined.length - hold));
     }
@@ -210,7 +216,7 @@ export class SessionPipeStreamScanner {
     // No replay reached the renderer, so recoveredBytes=0 preserves any .txt
     // cache and still settles an in-flight attach/resync cleanly.
     const events: ScanEvent[] = [{ type: 'flushComplete', recoveredBytes: 0 }];
-    const afterMarker = combined.subarray(markerIndex + FLUSH_DONE_MARKER.length);
+    const afterMarker = combined.subarray(markerIndex + this.markers.flushDone.length);
     if (afterMarker.length > 0) {
       events.push({ type: 'data', data: afterMarker, replay: false });
     }
@@ -228,7 +234,7 @@ export class SessionPipeStreamScanner {
     const combined = this.carry.length > 0 ? Buffer.concat([this.carry, buf]) : buf;
     this.carry = EMPTY;
 
-    const markerIndex = combined.indexOf(RESYNC_BEGIN_MARKER);
+    const markerIndex = combined.indexOf(this.markers.resyncBegin);
     if (markerIndex !== -1) {
       const events: ScanEvent[] = [];
       if (markerIndex > 0) {
@@ -238,7 +244,7 @@ export class SessionPipeStreamScanner {
       // disarm: the resync episode is now owned by the FLUSH_DONE cycle.
       this.armed = false;
       this._mode = 'accumulating';
-      const residual = combined.subarray(markerIndex + RESYNC_BEGIN_MARKER.length);
+      const residual = combined.subarray(markerIndex + this.markers.resyncBegin.length);
       if (residual.length > 0) {
         events.push(...this.accumulate(residual));
       }
@@ -248,7 +254,7 @@ export class SessionPipeStreamScanner {
     // No full marker in this buffer. Only a tail that is a strict prefix of the
     // marker can still complete on the next chunk; everything before it is
     // definitely live data.
-    const hold = this.matchingPrefixLen(combined, RESYNC_BEGIN_MARKER);
+    const hold = this.matchingPrefixLen(combined, this.markers.resyncBegin);
     if (hold === 0) {
       return combined.length > 0 ? [{ type: 'data', data: combined, replay: false }] : [];
     }

--- a/src/main/daemon/sessionPipeStreamScanner.ts
+++ b/src/main/daemon/sessionPipeStreamScanner.ts
@@ -3,7 +3,9 @@ import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../daemon/sessionPipe
 /**
  * Stream events produced while scanning a session pipe's byte stream.
  *
- * `data`          — raw PTY bytes to forward to the renderer, in order.
+ * `data`          — raw PTY bytes to forward to the renderer, in order;
+ *                   `replay` identifies bytes recovered from the daemon's
+ *                   ring buffer rather than produced by the live PTY.
  * `flushComplete` — the ring-buffer flush (or a live re-flush) finished;
  *                   `recoveredBytes` is the PRE-STRIP length of the replayed
  *                   scrollback that preceded the FLUSH_DONE_MARKER (0 means the
@@ -11,7 +13,7 @@ import { FLUSH_DONE_MARKER, RESYNC_BEGIN_MARKER } from '../../daemon/sessionPipe
  *                   the flush-detection block below).
  */
 export type ScanEvent =
-  | { type: 'data'; data: Buffer }
+  | { type: 'data'; data: Buffer; replay: boolean }
   | { type: 'flushComplete'; recoveredBytes: number };
 
 const DEFAULT_MAX_PENDING_BYTES = 10 * 1024 * 1024; // 10 MB safety cap
@@ -40,6 +42,11 @@ export class SessionPipeStreamScanner {
   private armed = false;
   private pendingChunks: Buffer[] = [];
   private pendingBytes = 0;
+  // The replay exceeded maxPendingBytes and was dropped. Keep scanning a
+  // marker-sized tail so the remaining historical bytes never fall through as
+  // live output; normal forwarding resumes only after the real flush boundary.
+  private discardingOverflowReplay = false;
+  private overflowCarry: Buffer = EMPTY;
   // live + armed only: the longest stream tail that is a strict prefix of
   // RESYNC_BEGIN_MARKER, held back until the next chunk can confirm or deny it.
   private carry: Buffer = EMPTY;
@@ -71,7 +78,7 @@ export class SessionPipeStreamScanner {
     if (this.carry.length > 0) {
       const held = this.carry;
       this.carry = EMPTY;
-      return [{ type: 'data', data: held }];
+      return [{ type: 'data', data: held, replay: false }];
     }
     return [];
   }
@@ -84,9 +91,13 @@ export class SessionPipeStreamScanner {
       return this.accumulate(buf);
     }
 
+    if (this.discardingOverflowReplay) {
+      return this.discardOverflowReplay(buf);
+    }
+
     if (!this.armed) {
       // Steady state — no scan, no copy. Identical to the original live path.
-      return buf.length > 0 ? [{ type: 'data', data: buf }] : [];
+      return buf.length > 0 ? [{ type: 'data', data: buf, replay: false }] : [];
     }
 
     return this.scanArmed(buf);
@@ -94,24 +105,35 @@ export class SessionPipeStreamScanner {
 
   /**
    * Buffer until FLUSH_DONE_MARKER, then emit replay → flushComplete → live
-   * tail. Byte-for-byte identical to the original setupSessionPipe closure;
-   * also reused for the post-RESYNC re-flush.
+   * tail. Also reused for the post-RESYNC re-flush.
    */
   private accumulate(buf: Buffer): ScanEvent[] {
     this.pendingChunks.push(buf);
     this.pendingBytes += buf.length;
 
-    // Prevent unbounded accumulation if the flush marker never arrives. Matches
-    // the original: drop everything buffered, flip to live, emit nothing.
+    const combined = Buffer.concat(this.pendingChunks);
+
+    // Prevent unbounded accumulation if the flush marker never arrives. Drop
+    // the oversized replay, then scan without accumulating until the actual
+    // marker arrives. Treating the remainder as live would give stored control
+    // sequences live side-effect authority (#1014).
     if (this.pendingBytes > this.maxPendingBytes) {
       this._mode = 'live';
       this.armed = false;
       this.pendingChunks = [];
       this.pendingBytes = 0;
+      const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
+      if (markerIndex !== -1) {
+        return this.finishDiscardedOverflow(combined, markerIndex);
+      }
+      this.discardingOverflowReplay = true;
+      const hold = this.matchingPrefixLen(combined, FLUSH_DONE_MARKER);
+      this.overflowCarry = hold > 0
+        ? combined.subarray(combined.length - hold)
+        : EMPTY;
       return [];
     }
 
-    const combined = Buffer.concat(this.pendingChunks);
     const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
     if (markerIndex === -1) return [];
 
@@ -139,7 +161,7 @@ export class SessionPipeStreamScanner {
     if (markerIndex > 0) {
       const replay = this.stripReplay(combined.subarray(0, markerIndex));
       if (replay.length > 0) {
-        events.push({ type: 'data', data: replay });
+        events.push({ type: 'data', data: replay, replay: true });
       }
     }
 
@@ -153,9 +175,42 @@ export class SessionPipeStreamScanner {
     // this tail is plain live output — passed straight through like the original.
     const afterMarker = combined.subarray(markerIndex + FLUSH_DONE_MARKER.length);
     if (afterMarker.length > 0) {
-      events.push({ type: 'data', data: afterMarker });
+      events.push({ type: 'data', data: afterMarker, replay: false });
     }
 
+    return events;
+  }
+
+  /**
+   * Drop bytes after an accumulation overflow until FLUSH_DONE is observed.
+   * A marker-sized carry handles split markers without retaining the replay.
+   */
+  private discardOverflowReplay(buf: Buffer): ScanEvent[] {
+    const combined = this.overflowCarry.length > 0
+      ? Buffer.concat([this.overflowCarry, buf])
+      : buf;
+    this.overflowCarry = EMPTY;
+    const markerIndex = combined.indexOf(FLUSH_DONE_MARKER);
+    if (markerIndex !== -1) {
+      return this.finishDiscardedOverflow(combined, markerIndex);
+    }
+    const hold = this.matchingPrefixLen(combined, FLUSH_DONE_MARKER);
+    if (hold > 0) {
+      this.overflowCarry = combined.subarray(combined.length - hold);
+    }
+    return [];
+  }
+
+  private finishDiscardedOverflow(combined: Buffer, markerIndex: number): ScanEvent[] {
+    this.discardingOverflowReplay = false;
+    this.overflowCarry = EMPTY;
+    // No replay reached the renderer, so recoveredBytes=0 preserves any .txt
+    // cache and still settles an in-flight attach/resync cleanly.
+    const events: ScanEvent[] = [{ type: 'flushComplete', recoveredBytes: 0 }];
+    const afterMarker = combined.subarray(markerIndex + FLUSH_DONE_MARKER.length);
+    if (afterMarker.length > 0) {
+      events.push({ type: 'data', data: afterMarker, replay: false });
+    }
     return events;
   }
 
@@ -174,7 +229,7 @@ export class SessionPipeStreamScanner {
     if (markerIndex !== -1) {
       const events: ScanEvent[] = [];
       if (markerIndex > 0) {
-        events.push({ type: 'data', data: combined.subarray(0, markerIndex) });
+        events.push({ type: 'data', data: combined.subarray(0, markerIndex), replay: false });
       }
       // Consume the marker and re-enter accumulation for the re-flush. Auto
       // disarm: the resync episode is now owned by the FLUSH_DONE cycle.
@@ -190,22 +245,21 @@ export class SessionPipeStreamScanner {
     // No full marker in this buffer. Only a tail that is a strict prefix of the
     // marker can still complete on the next chunk; everything before it is
     // definitely live data.
-    const hold = this.matchingPrefixLen(combined);
+    const hold = this.matchingPrefixLen(combined, RESYNC_BEGIN_MARKER);
     if (hold === 0) {
-      return combined.length > 0 ? [{ type: 'data', data: combined }] : [];
+      return combined.length > 0 ? [{ type: 'data', data: combined, replay: false }] : [];
     }
     const emittable = combined.subarray(0, combined.length - hold);
     this.carry = combined.subarray(combined.length - hold);
-    return emittable.length > 0 ? [{ type: 'data', data: emittable }] : [];
+    return emittable.length > 0 ? [{ type: 'data', data: emittable, replay: false }] : [];
   }
 
   /**
-   * Length of the longest suffix of `buf` that equals a prefix of
-   * RESYNC_BEGIN_MARKER (in [0, marker.length - 1]). Called only when the full
-   * marker is absent, so a match can exist only at the tail.
+   * Length of the longest suffix of `buf` that equals a prefix of `marker`
+   * (in [0, marker.length - 1]). Called only when the full marker is absent,
+   * so a match can exist only at the tail.
    */
-  private matchingPrefixLen(buf: Buffer): number {
-    const marker = RESYNC_BEGIN_MARKER;
+  private matchingPrefixLen(buf: Buffer, marker: Buffer): number {
     const maxK = Math.min(marker.length - 1, buf.length);
     for (let k = maxK; k >= 1; k--) {
       if (buf.subarray(buf.length - k).equals(marker.subarray(0, k))) {

--- a/src/main/daemon/sessionPipeStreamScanner.ts
+++ b/src/main/daemon/sessionPipeStreamScanner.ts
@@ -63,8 +63,10 @@ export class SessionPipeStreamScanner {
   }
 
   /** Start watching a live stream for the in-band RESYNC_BEGIN_MARKER. */
-  armResync(): void {
+  armResync(): boolean {
+    if (this.discardingOverflowReplay) return false;
     this.armed = true;
+    return true;
   }
 
   /**
@@ -129,7 +131,7 @@ export class SessionPipeStreamScanner {
       this.discardingOverflowReplay = true;
       const hold = this.matchingPrefixLen(combined, FLUSH_DONE_MARKER);
       this.overflowCarry = hold > 0
-        ? combined.subarray(combined.length - hold)
+        ? Buffer.from(combined.subarray(combined.length - hold))
         : EMPTY;
       return [];
     }
@@ -196,7 +198,7 @@ export class SessionPipeStreamScanner {
     }
     const hold = this.matchingPrefixLen(combined, FLUSH_DONE_MARKER);
     if (hold > 0) {
-      this.overflowCarry = combined.subarray(combined.length - hold);
+      this.overflowCarry = Buffer.from(combined.subarray(combined.length - hold));
     }
     return [];
   }
@@ -204,6 +206,7 @@ export class SessionPipeStreamScanner {
   private finishDiscardedOverflow(combined: Buffer, markerIndex: number): ScanEvent[] {
     this.discardingOverflowReplay = false;
     this.overflowCarry = EMPTY;
+    this.armed = false;
     // No replay reached the renderer, so recoveredBytes=0 preserves any .txt
     // cache and still settles an in-flight attach/resync cleanly.
     const events: ScanEvent[] = [{ type: 'flushComplete', recoveredBytes: 0 }];

--- a/src/main/ipc/handlers/__tests__/sessionDataDispatcher.test.ts
+++ b/src/main/ipc/handlers/__tests__/sessionDataDispatcher.test.ts
@@ -21,7 +21,7 @@ describe('createSessionDataDispatcher', () => {
     return new EventEmitter() as EventEmitter & SessionDataEmitter;
   }
   function frame(sessionId: string, text = 'x'): SessionDataPayload {
-    return { sessionId, data: Buffer.from(text) };
+    return { sessionId, data: Buffer.from(text), replay: false };
   }
 
   it('routes each session frame to only its own handler', () => {

--- a/src/main/ipc/handlers/pty.handler.ts
+++ b/src/main/ipc/handlers/pty.handler.ts
@@ -258,6 +258,11 @@ export function registerPTYHandlers(
     return decoder.write(data);
   }
 
+  // The decoder intentionally spans replay/live provenance boundaries so a
+  // UTF-8 code point split at FLUSH_DONE remains intact. A completed code point
+  // is attributed to the frame carrying its final bytes; terminal control
+  // introducers and terminators are ASCII and never depend on this buffering.
+
   // app-weight P1-3: 8 ms micro-batching for daemon-mode PTY data (parity
   // with local-mode PTYBridge). One batcher per handler registration = per
   // daemon generation; the cleanup below disposes it, so old-generation bytes
@@ -265,10 +270,10 @@ export function registerPTYHandlers(
   // BEFORE push() (see decodeSessionData above), so batching can't split a
   // multi-byte sequence. Ordering markers (flushComplete/exit/restarted)
   // flush the session first — see each forwarder.
-  const dataBatcher = new DaemonDataBatcher((sessionId, text) => {
+  const dataBatcher = new DaemonDataBatcher((sessionId, text, replay) => {
     const win = getWindow?.();
     if (win && !win.isDestroyed()) {
-      win.webContents.send(IPC.PTY_DATA, sessionId, text);
+      win.webContents.send(IPC.PTY_DATA, sessionId, text, replay);
     }
   });
 
@@ -518,13 +523,13 @@ export function registerPTYHandlers(
       // Forward session data to renderer. Routed through the per-id helper so
       // a stale listener (from a prior create with the same id, or a reconnect)
       // is removed before the new one is attached.
-      const onSessionData = (payload: { sessionId: string; data: Buffer }) => {
+      const onSessionData = (payload: { sessionId: string; data: Buffer; replay: boolean }) => {
         if (payload.sessionId !== sessionId) return;
         initialCmd.onFirstData();
         // P1-3: decode (stateful, upstream of batching) then micro-batch —
         // the batcher's send does the window-alive check at flush time.
         const text = decodeSessionData(sessionId, payload.data);
-        if (text) dataBatcher.push(sessionId, text);
+        if (text) dataBatcher.push(sessionId, text, payload.replay);
       };
       setSessionDataListener(sessionId, onSessionData);
 
@@ -968,11 +973,11 @@ export function registerPTYHandlers(
         // stacking a duplicate. Routed through the per-id helper so a stale
         // listener (from a prior create with the same id, or an earlier
         // reconnect) is swapped, not duplicated.
-        const onSessionData = (payload: { sessionId: string; data: Buffer }) => {
+        const onSessionData = (payload: { sessionId: string; data: Buffer; replay: boolean }) => {
           if (payload.sessionId !== id) return;
           // P1-3: same decode-then-batch as the create path.
           const text = decodeSessionData(id, payload.data);
-          if (text) dataBatcher.push(id, text);
+          if (text) dataBatcher.push(id, text, payload.replay);
         };
         setSessionDataListener(id, onSessionData);
 

--- a/src/main/ipc/handlers/sessionDataDispatcher.ts
+++ b/src/main/ipc/handlers/sessionDataDispatcher.ts
@@ -24,7 +24,7 @@
  * only delegates the listener+map bookkeeping here.
  */
 
-export type SessionDataPayload = { sessionId: string; data: Buffer };
+export type SessionDataPayload = { sessionId: string; data: Buffer; replay: boolean };
 export type SessionDataHandler = (payload: SessionDataPayload) => void;
 
 /** The subset of DaemonClient (EventEmitter) this dispatcher relies on. */

--- a/src/main/pty/DaemonDataBatcher.ts
+++ b/src/main/pty/DaemonDataBatcher.ts
@@ -23,19 +23,20 @@
  */
 export class DaemonDataBatcher {
   private pending = new Map<string, string[]>();
+  private pendingReplay = new Map<string, boolean>();
   private pendingChars = new Map<string, number>();
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
   private lastSentAt = new Map<string, number>();
   private disposed = false;
 
   constructor(
-    private readonly send: (sessionId: string, text: string) => void,
+    private readonly send: (sessionId: string, text: string, replay: boolean) => void,
     private readonly intervalMs = 8,
     /** Per-session cap; exceeding it flushes synchronously (bounded memory). */
     private readonly maxBufferedChars = 4 * 1024 * 1024,
   ) {}
 
-  push(sessionId: string, text: string): void {
+  push(sessionId: string, text: string, replay = false): void {
     if (!text) return;
     if (this.disposed) {
       // Late chunk after dispose (handler swap raced a pipe read): DROP it.
@@ -54,6 +55,13 @@ export class DaemonDataBatcher {
     // full 8 ms to echoMs.p95 (13.9 → 21.5 ms) — while agent torrents still
     // coalesce: only the FIRST chunk of a burst bypasses the batch window.
     // Ordering is safe: the bypass requires an empty buffer.
+    const buffered = this.pending.get(sessionId);
+    if (buffered && this.pendingReplay.get(sessionId) !== replay) {
+      // Provenance is an ordering boundary. Never merge historical replay
+      // with live PTY output into one IPC frame: the renderer applies replay
+      // side-effect guards at the exact xterm write that parses these bytes.
+      this.flushSession(sessionId);
+    }
     const now = Date.now();
     const buf = this.pending.get(sessionId);
     if (
@@ -62,13 +70,14 @@ export class DaemonDataBatcher {
       now - (this.lastSentAt.get(sessionId) ?? 0) >= this.intervalMs
     ) {
       this.lastSentAt.set(sessionId, now);
-      this.send(sessionId, text);
+      this.send(sessionId, text, replay);
       return;
     }
     if (buf) {
       buf.push(text);
     } else {
       this.pending.set(sessionId, [text]);
+      this.pendingReplay.set(sessionId, replay);
     }
     const chars = (this.pendingChars.get(sessionId) ?? 0) + text.length;
     this.pendingChars.set(sessionId, chars);
@@ -95,9 +104,11 @@ export class DaemonDataBatcher {
     const buf = this.pending.get(sessionId);
     if (!buf || buf.length === 0) return;
     this.pending.delete(sessionId);
+    const replay = this.pendingReplay.get(sessionId) ?? false;
+    this.pendingReplay.delete(sessionId);
     this.pendingChars.delete(sessionId);
     this.lastSentAt.set(sessionId, Date.now());
-    this.send(sessionId, buf.join(''));
+    this.send(sessionId, buf.join(''), replay);
   }
 
   /** Drop a session's buffer without sending (session destroyed mid-batch). */
@@ -108,6 +119,7 @@ export class DaemonDataBatcher {
       this.timers.delete(sessionId);
     }
     this.pending.delete(sessionId);
+    this.pendingReplay.delete(sessionId);
     this.pendingChars.delete(sessionId);
     this.lastSentAt.delete(sessionId);
   }

--- a/src/main/pty/__tests__/DaemonDataBatcher.test.ts
+++ b/src/main/pty/__tests__/DaemonDataBatcher.test.ts
@@ -42,6 +42,21 @@ describe('DaemonDataBatcher', () => {
     expect(sent).toEqual([['s1', 'a'], ['s1', 'bc']]);
   });
 
+  it('keeps replay and live output in separate sends', () => {
+    const frames: Array<[string, string, boolean]> = [];
+    const b = new DaemonDataBatcher((id, text, replay) => frames.push([id, text, replay]), 8);
+    b.push('s1', 'live-leading', false);
+    b.push('s1', 'replay-a', true);
+    b.push('s1', 'replay-b', true);
+    b.push('s1', 'live-tail', false);
+    vi.runAllTimers();
+    expect(frames).toEqual([
+      ['s1', 'live-leading', false],
+      ['s1', 'replay-areplay-b', true],
+      ['s1', 'live-tail', false],
+    ]);
+  });
+
   it('keeps sessions independent (per-session buffers and timers)', () => {
     const b = new DaemonDataBatcher(send, 8);
     b.push('s1', 'x'); // leading edge each — immediate, per session

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -145,8 +145,13 @@ const electronAPI = {
         | { success: true; rows: Array<{ text: string; wrapped: boolean }>; truncated?: boolean }
         | { success: false; code: string; reason?: string }
       >,
-    onData: (callback: (id: string, data: string) => void) => {
-      const listener = (_event: Electron.IpcRendererEvent, id: string, data: string) => callback(id, data);
+    onData: (callback: (id: string, data: string, replay: boolean) => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        id: string,
+        data: string,
+        replay = false,
+      ) => callback(id, data, replay);
       ipcRenderer.on(IPC.PTY_DATA, listener);
       return () => { ipcRenderer.removeListener(IPC.PTY_DATA, listener); };
     },

--- a/src/renderer/hooks/__tests__/useTerminal.appWeightP0.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.appWeightP0.test.ts
@@ -12,10 +12,10 @@ const src = fs.readFileSync(path.join(__dirname, '..', 'useTerminal.ts'), 'utf-8
 
 describe('P0-1 — scrollback pendingData obeys retention (Codex Eng #1)', () => {
   it('both pending-data flush loops route through routePtyData, never terminal.write', () => {
-    const loops = src.match(/for \(const data of pendingData\) \{\s*\n\s*routePtyData\(data\);/g) ?? [];
+    const loops = src.match(/for \(const payload of pendingData\) \{\s*\n\s*routePtyData\(payload\);/g) ?? [];
     expect(loops.length).toBe(2);
     // The old bypass must be gone entirely.
-    expect(src).not.toMatch(/for \(const data of pendingData\) \{\s*\n\s*terminal\.write\(data\);/);
+    expect(src).not.toMatch(/for \(const payload of pendingData\) \{[\s\S]{0,80}?terminal\.write\(/);
   });
 });
 

--- a/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
@@ -43,7 +43,7 @@ describe('A6 — useTerminal async restore race cancel (source-level)', () => {
     const body = src.slice(loadIdx, loadIdx + 4000);
     // pendingData.length > 0 check happens whether or not restored ran.
     expect(body).toMatch(/scrollbackLoaded\s*=\s*true/);
-    expect(body).toMatch(/for\s*\(\s*const\s+data\s+of\s+pendingData/);
+    expect(body).toMatch(/for\s*\(\s*const\s+payload\s+of\s+pendingData/);
   });
 
   // Codex review P2 #2 (cold-start race): if `.txt` restore lands before

--- a/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
@@ -24,7 +24,7 @@ describe('Phase 3 PR-A — useTerminal hidden-pane retention wiring (source-leve
     expect(idx).toBeGreaterThan(0);
     const body = src.slice(idx, idx + 1500);
     // In-flight resync buffers bytes out of xterm entirely…
-    expect(body).toMatch(/st\.buffer\.push\(data\)/);
+    expect(body).toMatch(/st\.buffer\.push\(payload\)/);
     expect(body).toMatch(/RESYNC_BUFFER_MAX_CHARS/);
     // …otherwise the scheduler write carries the retention option (evaluated
     // per event, logged once for the first hidden pane — the dogfood gate
@@ -35,20 +35,18 @@ describe('Phase 3 PR-A — useTerminal hidden-pane retention wiring (source-leve
   });
 
   it('both pty.onData listener sites use the shared routing', () => {
-    const matches = src.match(/routePtyData\(data\)/g) ?? [];
+    const matches = src.match(/routePtyData\(payload\)/g) ?? [];
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 
   it('resync completion resets BEFORE writing the held replay (no early-parse race)', () => {
     const idx = src.indexOf('const completeResyncFromFlush');
     expect(idx).toBeGreaterThan(0);
-    // Window widened (was 1200) and the write spelling changed: #998 mutes the
-    // OSC 52 bridge for this flush, because on the raw-fallback path the
-    // reconnect replay itself lands in st.buffer. The ordering contract this
-    // test exists for — reset BEFORE the held bytes are parsed — is unchanged.
+    // The source-labelled writer mutes only replay chunks. The ordering
+    // contract this test exists for — reset BEFORE held bytes parse — remains.
     const body = src.slice(idx, idx + 2400);
     const resetIdx = body.indexOf('terminal.reset()');
-    const writeIdx = body.indexOf('for (const chunk of st.buffer) writeReplayed(terminal, chunk');
+    const writeIdx = body.indexOf('writePtyDataImmediately(terminal, chunk');
     expect(resetIdx).toBeGreaterThan(0);
     expect(writeIdx).toBeGreaterThan(resetIdx);
     // Stale retained backlog + dirty flag die with the old screen state.

--- a/src/renderer/hooks/__tests__/useTerminal.osc52.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.osc52.test.ts
@@ -76,4 +76,10 @@ describe('useTerminal OSC 52 clipboard-write wiring (source-level lock)', () => 
   it('disposes the OSC 52 handler on teardown (no leak across remounts)', () => {
     expect(SRC).toMatch(/osc52Disposable\.dispose\(\)/);
   });
+
+  it('preserves an in-flight mute across terminal parking and adoption', () => {
+    expect(SRC).toMatch(/replayMuteRef\.current\s*=\s*getTerminalReplayMute\(terminal\)/);
+    expect(SRC).toMatch(/const disposeTerminal = \(\) => \{[\s\S]{0,320}?disposeTerminalReplayMute\(terminal\)/);
+    expect(SRC).not.toMatch(/return \(\) => \{[\s\S]{0,180}?resetReplayMute/);
+  });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.osc52.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.osc52.test.ts
@@ -22,6 +22,10 @@ const SRC = readFileSync(
   path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
   'utf8',
 );
+const PRELOAD_SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/preload/preload.ts'),
+  'utf8',
+);
 
 describe('useTerminal OSC 52 clipboard-write wiring (source-level lock)', () => {
   it('registers an OSC 52 parser handler', () => {
@@ -41,18 +45,26 @@ describe('useTerminal OSC 52 clipboard-write wiring (source-level lock)', () => 
     // Replayed bytes are stored output, not a request: a reconnect, resync or
     // scrollback restore must not re-apply an old copy to the live clipboard.
     // Pinned on the predicate reaching the shared state machine, not on how the
-    // boolean is spelled — replayMute.ts owns the WHEN, and its own tests cover
-    // the windows.
+    // boolean is spelled — replayMute.ts owns the parse-scoped lifetime.
     expect(SRC).toMatch(/isReplaying:\s*\(\)\s*=>\s*isReplayMuted\(replayMuteRef\.current\)/);
     expect(SRC).toMatch(/from '\.\.\/terminal\/replayMute'/);
   });
 
-  it('opens a mute window around the reattach replay (#998)', () => {
-    // The daemon RingBuffer flush after a reattach arrives as ordinary pty:data,
-    // so there is no write of ours to hang the mute on. This is the gap the
-    // maintainer's live dogfood found; the window is what closes it.
-    expect(SRC).toMatch(/openReattachWindow\(replayMuteRef\.current\)/);
-    expect(SRC).toMatch(/noteReplayData\(replayMuteRef\.current\)/);
+  it('uses source-labelled replay writes instead of a receive-time window (#1014)', () => {
+    expect(SRC).toMatch(/onData\(\(ptyId, data, replay\)\s*=>\s*cb\(ptyId, \{[\s\S]{0,80}?replay:\s*replay\s*===\s*true/);
+    expect(SRC).toMatch(/write:\s*payload\.replay\s*\?\s*writeReplayOutput\s*:\s*undefined/);
+    expect(SRC).not.toMatch(/openReattachWindow|noteReplayData/);
+  });
+
+  it('treats legacy and local two-argument PTY data as live', () => {
+    expect(PRELOAD_SRC).toMatch(/data:\s*string,\s*\n\s*replay\s*=\s*false/);
+    expect(SRC).toMatch(/replay:\s*replay\s*===\s*true/);
+  });
+
+  it('daemon replay still proves the recovered PTY pipe is ready', () => {
+    const connect = SRC.slice(SRC.indexOf('const connectPty'), SRC.indexOf('const connectPty') + 1200);
+    expect(connect).toMatch(/routePtyData\(payload\);[\s\S]{0,120}?markPaneLive\(\);/);
+    expect(connect).not.toMatch(/if \(payload\.replay\) return/);
   });
 
   it('writes the decoded text through the clipboard IPC (1 MB cap + lock handling)', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.paneAdoption.test.ts
@@ -159,8 +159,9 @@ describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
     // The scheduler queue belongs to the instance. Discarding it on the way out
     // would drop bytes the adopting mount is the only reader of, and (unlike
     // the dispose path) no resync follows to replace them.
-    expect(mainEffect).toMatch(/if \(!canPark\) discardTerminalOutput\(terminal\);/);
-    expect(mainEffect).toMatch(/const disposeTerminal = \(\) => \{\s*\n\s*discardTerminalOutput\(terminal\);\s*\n\s*disposeWhenDragEnds\(\(\) => terminal\.dispose\(\)\);/);
+    expect(mainEffect).toMatch(/const disposeTerminal = \(\) => \{[\s\S]{0,360}?discardTerminalOutput\(terminal\);\s*\n\s*disposeWhenDragEnds\(\(\) => terminal\.dispose\(\)\);/);
+    expect(mainEffect).toMatch(/parkTerminal\(ptyId, terminal, parkElement, disposeTerminal\);/);
+    expect(mainEffect).not.toMatch(/if \(canPark\)[\s\S]{0,120}?discardTerminalOutput\(terminal\)/);
   });
 
   it('releases the addons it loaded before parking', () => {
@@ -171,6 +172,6 @@ describe('#1002 — pane-restructure terminal adoption (source-level)', () => {
   });
 
   it('still disposes directly when the terminal cannot be parked', () => {
-    expect(mainEffect).toMatch(/\} else \{\s*\n\s*disposeWhenDragEnds\(\(\) => terminal\.dispose\(\)\);\s*\n\s*\}/);
+    expect(mainEffect).toMatch(/\} else \{\s*\n\s*disposeTerminal\(\);\s*\n\s*\}/);
   });
 });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -50,6 +50,7 @@ import {
   markTerminalClean,
   getQueuedCharCount,
   promoteTerminalToPriorityDrain,
+  rebindTerminalOutputWriter,
 } from '../terminal/terminalOutputScheduler';
 import { reconnectPtyWithRetry as reconnectPtyWithRetryImpl } from './reconnectPtyWithRetry';
 import { adoptTerminal, parkTerminal, restoreParkedViewport, type ParkedTerminal } from '../terminal/terminalPark';
@@ -2085,6 +2086,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     const writeReplayOutput = (data: string) => {
       writeReplayed(terminal, data, replayMuteRef.current);
     };
+    // #1014: a parked terminal keeps its retained scheduler queue. Rebind its
+    // replay writer to this adopting mount's mute ref before that queue drains.
+    rebindTerminalOutputWriter(terminal, writeReplayOutput);
     const restingCursor = new RestingCursorGuard((seq) => {
       deliverPtyData({ data: seq, replay: false });
     });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -18,8 +18,8 @@ import { claimFit } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
 import { createOsc52Handler } from '../utils/osc52Clipboard';
 import {
-  createReplayMute, isReplayMuted, beginReplayWrite, openReattachWindow,
-  noteReplayData, resetReplayMute, type ReplayMute,
+  createReplayMute, isReplayMuted, beginReplayWrite, resetReplayMute,
+  type ReplayMute,
 } from '../terminal/replayMute';
 import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
@@ -123,8 +123,16 @@ export function createPtyDispatcher<T>(
     },
   };
 }
-const ptyDataDispatcher = createPtyDispatcher<string>((cb) =>
-  window.electronAPI.pty.onData(cb));
+interface PtyDataPayload {
+  data: string;
+  replay: boolean;
+}
+
+const ptyDataDispatcher = createPtyDispatcher<PtyDataPayload>((cb) =>
+  window.electronAPI.pty.onData((ptyId, data, replay) => cb(ptyId, {
+    data,
+    replay: replay === true,
+  })));
 const ptyExitDispatcher = createPtyDispatcher<number>((cb) =>
   window.electronAPI.pty.onExit(cb));
 const ptyFlushDispatcher = createPtyDispatcher<number>((cb) =>
@@ -348,8 +356,7 @@ export function subscribePaneSyncUi(ptyId: string, listener: (s: PaneSyncUiState
  * escape sequences are still queued, which is the bug itself.
  *
  * Live bytes must NOT come through here: a copy the user makes while a pane is
- * busy is real. The one exception is the reattach window, which has its own
- * mechanism in replayMute.ts because that replay arrives as ordinary pty:data.
+ * busy is real. Daemon replay bytes are source-labelled before they cross IPC.
  */
 function writeReplayed(term: Terminal, data: string | Uint8Array, mute: ReplayMute): void {
   const release = beginReplayWrite(mute);
@@ -361,6 +368,15 @@ function writeReplayed(term: Terminal, data: string | Uint8Array, mute: ReplayMu
     release();
     throw err;
   }
+}
+
+function writePtyDataImmediately(
+  term: Terminal,
+  payload: PtyDataPayload,
+  mute: ReplayMute,
+): void {
+  if (payload.replay) writeReplayed(term, payload.data, mute);
+  else term.write(payload.data);
 }
 
 function hiddenRetentionActive(): boolean {
@@ -405,7 +421,7 @@ interface ResyncState {
   pending: boolean;
   /** pty:data received while the resync replay is in flight — held out of
    *  xterm so the reset below cannot race half-parsed replay bytes. */
-  buffer: string[];
+  buffer: PtyDataPayload[];
   bufferedChars: number;
   resolvers: Array<() => void>;
   timer: ReturnType<typeof setTimeout> | null;
@@ -746,7 +762,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     const term = terminalRef.current;
     if (term) {
       try {
-        for (const chunk of st.buffer) term.write(chunk);
+        for (const chunk of st.buffer) {
+          writePtyDataImmediately(term, chunk, replayMuteRef.current);
+        }
       } catch { /* disposed mid-abort — teardown owns cleanup */ }
     }
     setPaneSyncUi(ptyIdRef.current ?? '', 'stale');
@@ -796,10 +814,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         writeReplayed(term, bytes, replayMuteRef.current);
         term.write(STALE_REPLAY_INPUT_MODE_RESETS);
         term.write(STALE_REPLAY_DISPLAY_RESETS);
-        // Same mixed-buffer reasoning as completeResyncFromFlush below: the
-        // renderer cannot separate held-live bytes from a replay that arrived
-        // as pty:data, so the flush is muted rather than trusted (#998).
-        for (const chunk of st.buffer) writeReplayed(term, chunk, replayMuteRef.current);
+        // Preserve the source label for bytes held alongside the snapshot:
+        // historical chunks are muted; genuinely live chunks remain trusted.
+        for (const chunk of st.buffer) {
+          writePtyDataImmediately(term, chunk, replayMuteRef.current);
+        }
         markTerminalClean(term);
       } catch { /* disposed mid-paint — teardown owns cleanup */ }
     }
@@ -2027,18 +2046,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       console.log(`[wmux:reveal] ptyId=${ptyId} mechanism=${mechanism} recoveredBytes=${recoveredBytes} buffered=${st.bufferedChars} chunks=${st.buffer.length}`);
       discardTerminalOutput(terminal); // stale retained backlog + dirty flag
       terminal.reset();
-      // #998: this buffer is MIXED. On the raw-fallback path the reconnect
-      // replay itself arrives as pty:data and lands here (hence "the held
-      // replay" in the comment above), alongside any genuinely live bytes that
-      // came in during the window. The renderer cannot tell them apart — no
-      // marker crosses the IPC boundary — so the whole flush is muted.
-      //
-      // That trades a real copy made inside a resync window (rare, ~1s, and the
-      // user can copy again) against silently replacing the clipboard with
-      // history (invisible, and the value can be days old). The first failure
-      // is a retry; the second is corruption you only notice after pasting the
-      // wrong thing somewhere.
-      for (const chunk of st.buffer) writeReplayed(terminal, chunk, replayMuteRef.current);
+      // The scanner labels every held chunk at its source. Historical bytes
+      // are muted for their exact parse lifetime; live output is not muted.
+      for (const chunk of st.buffer) {
+        writePtyDataImmediately(terminal, chunk, replayMuteRef.current);
+      }
       st.buffer.length = 0;
       st.bufferedChars = 0;
       resetStaleReplayModes(recoveredBytes);
@@ -2052,10 +2064,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         onFirstDataRef.current?.();
       }
     };
-    // X6 ②: the resume pill becomes clickable only on LIVE PTY data — NOT on
-    // restored scrollback (which also calls fireFirstData to hide overlays).
-    // Marking ready on a restore write would let the pill paste before the
-    // recovered pipe is confirmed writable (CodeRabbit #3 / eng review EI6).
+    // X6 ②: the resume pill becomes clickable only after data arrives through
+    // the PTY pipe — daemon RingBuffer replay qualifies because the recovered
+    // pipe has been health-probed as writable. A local .txt restore calls
+    // fireFirstData directly and never reaches markPaneLive.
     const markPaneLive = () => useStore.getState().markPtyReady(ptyId);
 
     // Restore scrollback from previous session, then connect PTY data listener.
@@ -2070,17 +2082,20 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // guard's own show-injection goes through `deliverPtyData` (NOT
     // routePtyData) so it is ordered with queued output but never re-enters
     // the guard.
-    const restingCursor = new RestingCursorGuard((seq) => deliverPtyData(seq));
-    const routePtyData = (data: string) => deliverPtyData(restingCursor.process(data));
-    const deliverPtyData = (data: string) => {
-      // #998: while a reattach window is open these bytes ARE the daemon
-      // RingBuffer flush, not something happening now. Each chunk extends the
-      // window; it closes when the burst goes quiet, or at the hard cap.
-      noteReplayData(replayMuteRef.current);
+    const writeReplayOutput = (data: string) => {
+      writeReplayed(terminal, data, replayMuteRef.current);
+    };
+    const restingCursor = new RestingCursorGuard((seq) => {
+      deliverPtyData({ data: seq, replay: false });
+    });
+    const routePtyData = (payload: PtyDataPayload) => {
+      deliverPtyData({ ...payload, data: restingCursor.process(payload.data) });
+    };
+    const deliverPtyData = (payload: PtyDataPayload) => {
       const st = resyncRef.current;
       if (st.pending) {
-        st.buffer.push(data);
-        st.bufferedChars += data.length;
+        st.buffer.push(payload);
+        st.bufferedChars += payload.data.length;
         if (st.bufferedChars > RESYNC_BUFFER_MAX_CHARS) abortResync('buffer-overflow');
         return;
       }
@@ -2091,10 +2106,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // "terminal.write was CALLED"), not at IPC receipt.
       const retain = hiddenRetentionActive();
       if (!isVisibleRef.current) logRetentionGateOnce(retain);
-      writeTerminalOutput(terminal, data, {
+      writeTerminalOutput(terminal, payload.data, {
         foreground: isVisibleRef.current,
         retainWhenHidden: retain,
         onWritten: (chars) => glyphRepaint.onData(chars),
+        write: payload.replay ? writeReplayOutput : undefined,
       });
     };
 
@@ -2105,8 +2121,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // would read as idle-forever. Throttled with a closure timestamp so the
       // zustand write (and its subscriber re-renders) stays off the hot path.
       let lastOutputStampAt = 0;
-      removeDataListener = ptyDataDispatcher.register(ptyId, (data) => {
-        routePtyData(data);
+      removeDataListener = ptyDataDispatcher.register(ptyId, (payload) => {
+        routePtyData(payload);
         fireFirstData();
         markPaneLive();
         const now = Date.now();
@@ -2135,16 +2151,16 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // scrollback.load() is async (IPC round-trip). If PTY sends data before it
       // resolves, connectPty() would not yet be called and data would be lost.
       // Instead, buffer incoming data and flush after scrollback is written.
-      const pendingData: string[] = [];
+      const pendingData: PtyDataPayload[] = [];
       let scrollbackLoaded = false;
 
-      removeDataListener = ptyDataDispatcher.register(ptyId, (data) => {
+      removeDataListener = ptyDataDispatcher.register(ptyId, (payload) => {
         if (!scrollbackLoaded) {
-          pendingData.push(data);
+          pendingData.push(payload);
           return;
         }
         // Same routing as connectPty (resync hold-out + scheduler).
-        routePtyData(data);
+        routePtyData(payload);
         fireFirstData();
         markPaneLive();
       });
@@ -2261,8 +2277,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // boot-restored pane obeys retention (queue, don't parse) and a
         // resync in flight keeps its hold-out ordering. Visible panes write
         // through the scheduler's foreground path, same order as before.
-        for (const data of pendingData) {
-          routePtyData(data);
+        for (const payload of pendingData) {
+          routePtyData(payload);
         }
         if (pendingData.length > 0) { fireFirstData(); markPaneLive(); }
         pendingData.length = 0;
@@ -2289,8 +2305,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         scrollbackLoaded = true;
         restoreSettled = true;
         // Same retention-aware routing as the success path above (P0-1).
-        for (const data of pendingData) {
-          routePtyData(data);
+        for (const payload of pendingData) {
+          routePtyData(payload);
         }
         if (pendingData.length > 0) { fireFirstData(); markPaneLive(); }
         pendingData.length = 0;
@@ -2568,10 +2584,6 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (inFlight) return;
       inFlight = true;
       reconnectInFlightRef.current = true;
-      // #998: the RingBuffer replay this triggers arrives as ordinary
-      // pty:data, so there is no write of ours to hang the mute on — open a
-      // window here and let the data flow close it.
-      openReattachWindow(replayMuteRef.current);
       console.log(`[useTerminal] daemon reattach ptyId=${id} (${reason})`);
       void reconnectPtyWithRetry(id, () => ptyIdRef.current === id && terminalRef.current !== null)
         .then(() => {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -18,7 +18,8 @@ import { claimFit } from '../utils/fitGuard';
 import { createAutoSelectionCopy } from '../utils/autoSelectionCopy';
 import { createOsc52Handler } from '../utils/osc52Clipboard';
 import {
-  createReplayMute, isReplayMuted, beginReplayWrite, resetReplayMute,
+  createReplayMute, getTerminalReplayMute, disposeTerminalReplayMute,
+  isReplayMuted, beginReplayWrite,
   type ReplayMute,
 } from '../terminal/replayMute';
 import { terminalFontFamilyCss } from '../utils/terminalFont';
@@ -1028,6 +1029,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         })()
         : {}),
     });
+
+    // #1014: xterm keeps parsing while the pane is parked and adopted into a
+    // new React mount. Share the mute with the terminal instance so an
+    // in-flight replay cannot become live-authorized during that handoff.
+    replayMuteRef.current = getTerminalReplayMute(terminal);
 
     const fitAddon = new FitAddon();
     const searchAddon = new SearchAddon();
@@ -2407,11 +2413,6 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     resizeObserver.observe(container);
 
     return () => {
-      // #998: a terminal disposed mid-parse never delivers its write callback,
-      // so release the replay mute here rather than leaving the next terminal
-      // that reuses this hook unable to accept a clipboard write.
-      resetReplayMute(replayMuteRef.current);
-
       // #1002: can this terminal be handed to the next mount instead of being
       // disposed? Only when every source of truth for this pane has settled on
       // it. Each rung below is a state where the adopting mount — which skips
@@ -2522,7 +2523,6 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // post-dispose drain write would throw. A PARKED terminal keeps its
       // queue: it is the same instance the next mount will drain, and there is
       // no resync behind it to replace what we would discard here (#1002).
-      if (!canPark) discardTerminalOutput(terminal);
       // #582: defer terminal.dispose() if a mouse drag is active on any
       // terminal. xterm nullifies _renderService before removing its
       // document-level mouseup/mousemove listeners — a mouseup landing on the
@@ -2532,6 +2532,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // deferring only the internal dispose is safe. See disposeWhenDragEnds
       // for the wait/force policy.
       const disposeTerminal = () => {
+        // A terminal disposed mid-parse never delivers its write callback.
+        // Invalidate this terminal's mute only at FINAL disposal, not when it
+        // is parked for adoption: its xterm write buffer survives the mount.
+        disposeTerminalReplayMute(terminal);
         discardTerminalOutput(terminal);
         disposeWhenDragEnds(() => terminal.dispose());
       };
@@ -2551,7 +2555,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // than it used to.
         parkTerminal(ptyId, terminal, parkElement, disposeTerminal);
       } else {
-        disposeWhenDragEnds(() => terminal.dispose());
+        disposeTerminal();
       }
       terminalRef.current = null;
       fitAddonRef.current = null;

--- a/src/renderer/terminal/__tests__/replayMute.test.ts
+++ b/src/renderer/terminal/__tests__/replayMute.test.ts
@@ -4,6 +4,8 @@ import {
   isReplayMuted,
   beginReplayWrite,
   resetReplayMute,
+  getTerminalReplayMute,
+  disposeTerminalReplayMute,
 } from '../replayMute';
 
 /**
@@ -69,5 +71,21 @@ describe('replayMute', () => {
     beginReplayWrite(m);
     resetReplayMute(m);
     expect(isReplayMuted(m)).toBe(false);
+  });
+
+  it('keeps an in-flight mute when the same terminal is adopted by a new mount', () => {
+    const terminal = {};
+    const originalMount = getTerminalReplayMute(terminal);
+    const release = beginReplayWrite(originalMount);
+
+    const adoptingMount = getTerminalReplayMute(terminal);
+    expect(adoptingMount).toBe(originalMount);
+    expect(isReplayMuted(adoptingMount)).toBe(true);
+
+    release();
+    expect(isReplayMuted(adoptingMount)).toBe(false);
+
+    disposeTerminalReplayMute(terminal);
+    expect(getTerminalReplayMute(terminal)).not.toBe(originalMount);
   });
 });

--- a/src/renderer/terminal/__tests__/replayMute.test.ts
+++ b/src/renderer/terminal/__tests__/replayMute.test.ts
@@ -1,187 +1,73 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   createReplayMute,
   isReplayMuted,
   beginReplayWrite,
-  openReattachWindow,
-  noteReplayData,
   resetReplayMute,
-  REATTACH_QUIET_MS,
-  REATTACH_CAP_MS,
 } from '../replayMute';
 
 /**
- * #998. The rule: while stored output is being parsed, an OSC 52 clipboard
- * write inside it must not reach the system clipboard. These pin WHEN the gate
- * is closed, which is the whole difficulty — the writes we make can hang the
- * mute on xterm's callback, while the reattach replay arrives as ordinary
- * pty:data and has to be bounded by a window instead.
+ * #998/#1014. Replay provenance is source-labelled, so only historical writes
+ * acquire the mute. Their callbacks release it; a missing callback fails shut.
  */
 describe('replayMute', () => {
-  beforeEach(() => { vi.useFakeTimers(); });
-  afterEach(() => { vi.useRealTimers(); });
-
   it('starts open', () => {
     expect(isReplayMuted(createReplayMute())).toBe(false);
   });
 
-  describe('beginReplayWrite — our own replay writes', () => {
-    it('mutes until the release runs (xterm write callback)', () => {
-      const m = createReplayMute();
-      const release = beginReplayWrite(m);
-      expect(isReplayMuted(m)).toBe(true);
-      release();
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('nests: the bridge reopens only after the LAST write settles', () => {
-      const m = createReplayMute();
-      const a = beginReplayWrite(m);
-      const b = beginReplayWrite(m);
-      a();
-      expect(isReplayMuted(m)).toBe(true); // b still parsing
-      b();
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('is idempotent — a double release cannot unmute someone else', () => {
-      const m = createReplayMute();
-      const a = beginReplayWrite(m);
-      const b = beginReplayWrite(m);
-      a();
-      a();
-      expect(isReplayMuted(m)).toBe(true);
-      b();
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('ignores a release from a previous terminal generation', () => {
-      // The hook outlives the terminal it hosts. A late callback from a disposed
-      // terminal must not unmute the terminal that replaced it — that would be
-      // the same bug wearing a different hat.
-      const m = createReplayMute();
-      const stale = beginReplayWrite(m);
-      resetReplayMute(m);
-      const fresh = beginReplayWrite(m);
-      stale();
-      expect(isReplayMuted(m)).toBe(true);
-      fresh();
-      expect(isReplayMuted(m)).toBe(false);
-    });
+  it('mutes until the xterm write completion releases it', () => {
+    const m = createReplayMute();
+    const release = beginReplayWrite(m);
+    expect(isReplayMuted(m)).toBe(true);
+    release();
+    expect(isReplayMuted(m)).toBe(false);
   });
 
-  describe('openReattachWindow — the replay that arrives as pty:data', () => {
-    it('mutes immediately, and closes after a quiet period once data has arrived', () => {
-      const m = createReplayMute();
-      openReattachWindow(m);
-      expect(isReplayMuted(m)).toBe(true);
-      noteReplayData(m);
-      vi.advanceTimersByTime(REATTACH_QUIET_MS - 1);
-      expect(isReplayMuted(m)).toBe(true);
-      vi.advanceTimersByTime(1);
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('a daemon slower than the quiet window to answer does not leak the flush (CodeRabbit #999)', () => {
-      // Before this fix, `quiet` was armed from open() — silence since the
-      // RECONNECT REQUEST, not since the replay. A daemon slower than
-      // REATTACH_QUIET_MS to send its first byte closed the window before the
-      // flush landed, and the flush then went through unmuted: the same
-      // clipboard leak the module exists to prevent, just moved later.
-      const m = createReplayMute();
-      openReattachWindow(m);
-      vi.advanceTimersByTime(REATTACH_QUIET_MS + 50); // no data yet — must still be muted
-      expect(isReplayMuted(m)).toBe(true);
-      noteReplayData(m); // the flush finally lands
-      expect(isReplayMuted(m)).toBe(true);
-      vi.advanceTimersByTime(REATTACH_QUIET_MS - 1);
-      expect(isReplayMuted(m)).toBe(true);
-      vi.advanceTimersByTime(1);
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('stays muted while the burst keeps arriving', () => {
-      const m = createReplayMute();
-      openReattachWindow(m);
-      for (let i = 0; i < 10; i += 1) {
-        vi.advanceTimersByTime(REATTACH_QUIET_MS - 50);
-        noteReplayData(m);
-      }
-      expect(isReplayMuted(m)).toBe(true);
-      vi.advanceTimersByTime(REATTACH_QUIET_MS);
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('a pane that never stops printing cannot hold the bridge shut', () => {
-      // The hard cap is why this is safe to hang on a heuristic: worst case the
-      // mute lasts REATTACH_CAP_MS, not forever.
-      const m = createReplayMute();
-      openReattachWindow(m);
-      for (let i = 0; i < 200; i += 1) {
-        vi.advanceTimersByTime(100);
-        noteReplayData(m);
-      }
-      expect(isReplayMuted(m)).toBe(false);
-      expect(200 * 100).toBeGreaterThan(REATTACH_CAP_MS);
-    });
-
-    it('opens at most one window (a doubled reattach does not double the depth)', () => {
-      const m = createReplayMute();
-      openReattachWindow(m);
-      openReattachWindow(m);
-      vi.advanceTimersByTime(REATTACH_CAP_MS);
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('noteReplayData is inert when no window is open (the common case)', () => {
-      const m = createReplayMute();
-      noteReplayData(m);
-      expect(isReplayMuted(m)).toBe(false);
-      vi.advanceTimersByTime(REATTACH_CAP_MS * 2);
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('closes on the hard cap when the replay never arrives (failed reconnect, empty ring)', () => {
-      // No noteReplayData call at all: the quiet timer never arms, so only
-      // the cap can end this window.
-      const m = createReplayMute();
-      openReattachWindow(m);
-      vi.advanceTimersByTime(REATTACH_CAP_MS - 1);
-      expect(isReplayMuted(m)).toBe(true);
-      vi.advanceTimersByTime(1);
-      expect(isReplayMuted(m)).toBe(false);
-    });
-
-    it('coexists with a write mute: both must clear', () => {
-      const m = createReplayMute();
-      openReattachWindow(m);
-      noteReplayData(m);
-      const release = beginReplayWrite(m);
-      vi.advanceTimersByTime(REATTACH_QUIET_MS);
-      expect(isReplayMuted(m)).toBe(true); // window closed, write still parsing
-      release();
-      expect(isReplayMuted(m)).toBe(false);
-    });
+  it('nests: the bridge reopens only after the last write settles', () => {
+    const m = createReplayMute();
+    const a = beginReplayWrite(m);
+    const b = beginReplayWrite(m);
+    a();
+    expect(isReplayMuted(m)).toBe(true);
+    b();
+    expect(isReplayMuted(m)).toBe(false);
   });
 
-  describe('resetReplayMute — teardown', () => {
-    it('drops everything, so a disposed terminal cannot leave the bridge muted', () => {
-      const m = createReplayMute();
-      openReattachWindow(m);
-      beginReplayWrite(m);
-      resetReplayMute(m);
-      expect(isReplayMuted(m)).toBe(false);
-    });
+  it('fails closed if xterm strands an earlier replay callback', () => {
+    const m = createReplayMute();
+    beginReplayWrite(m); // deliberately never released
+    const later = beginReplayWrite(m);
+    later();
+    expect(isReplayMuted(m)).toBe(true);
+  });
 
-    it('cancels the window timers (no late close touching the successor)', () => {
-      const m = createReplayMute();
-      openReattachWindow(m);
-      resetReplayMute(m);
-      const release = beginReplayWrite(m); // next terminal starts a replay
-      vi.advanceTimersByTime(REATTACH_CAP_MS * 2);
-      expect(isReplayMuted(m)).toBe(true); // stale timers must not have fired
-      release();
-      expect(isReplayMuted(m)).toBe(false);
-    });
+  it('is idempotent — a double release cannot unmute another write', () => {
+    const m = createReplayMute();
+    const a = beginReplayWrite(m);
+    const b = beginReplayWrite(m);
+    a();
+    a();
+    expect(isReplayMuted(m)).toBe(true);
+    b();
+    expect(isReplayMuted(m)).toBe(false);
+  });
+
+  it('ignores a release from a previous terminal generation', () => {
+    const m = createReplayMute();
+    const stale = beginReplayWrite(m);
+    resetReplayMute(m);
+    const fresh = beginReplayWrite(m);
+    stale();
+    expect(isReplayMuted(m)).toBe(true);
+    fresh();
+    expect(isReplayMuted(m)).toBe(false);
+  });
+
+  it('teardown drops all writes from the disposed terminal', () => {
+    const m = createReplayMute();
+    beginReplayWrite(m);
+    beginReplayWrite(m);
+    resetReplayMute(m);
+    expect(isReplayMuted(m)).toBe(false);
   });
 });

--- a/src/renderer/terminal/__tests__/terminalOutputScheduler.test.ts
+++ b/src/renderer/terminal/__tests__/terminalOutputScheduler.test.ts
@@ -132,6 +132,34 @@ describe('terminalOutputScheduler', () => {
     expect(written).toEqual([4, 2]);
   });
 
+  it('preserves each queued segment writer across replay/live boundaries', () => {
+    const writes: Array<[string, string]> = [];
+    const t: SchedulableTerminal = {
+      write: (data) => writes.push(['live', data]),
+    };
+    const replayWrite = (data: string) => writes.push(['replay', data]);
+    writeTerminalOutput(t, 'old-a', { foreground: false, write: replayWrite });
+    writeTerminalOutput(t, 'old-b', { foreground: false, write: replayWrite });
+    writeTerminalOutput(t, 'new', { foreground: false });
+    vi.runAllTimers();
+    expect(writes).toEqual([
+      ['replay', 'old-aold-b'],
+      ['live', 'new'],
+    ]);
+  });
+
+  it('uses the supplied writer on the direct foreground path', () => {
+    const t = makeTerminal();
+    const replayWrites: string[] = [];
+    noteTerminalInput(t);
+    writeTerminalOutput(t, 'history', {
+      foreground: true,
+      write: (data) => replayWrites.push(data),
+    });
+    expect(replayWrites).toEqual(['history']);
+    expect(t.writes).toEqual([]);
+  });
+
   it('drains large backlogs in bounded chunks across ticks, order preserved', () => {
     const t = makeTerminal();
     const big = 'x'.repeat(100 * 1024) + 'END';

--- a/src/renderer/terminal/__tests__/terminalOutputScheduler.test.ts
+++ b/src/renderer/terminal/__tests__/terminalOutputScheduler.test.ts
@@ -6,6 +6,7 @@ import {
   discardTerminalOutput,
   getQueuedCharCount,
   promoteTerminalToPriorityDrain,
+  rebindTerminalOutputWriter,
   __resetTerminalOutputSchedulerForTests,
   type SchedulableTerminal,
 } from '../terminalOutputScheduler';
@@ -157,6 +158,22 @@ describe('terminalOutputScheduler', () => {
       write: (data) => replayWrites.push(data),
     });
     expect(replayWrites).toEqual(['history']);
+    expect(t.writes).toEqual([]);
+  });
+
+  it('rebinds retained custom writes when a parked terminal is adopted', () => {
+    const t = makeTerminal();
+    const oldMount: string[] = [];
+    const newMount: string[] = [];
+    writeTerminalOutput(t, 'history', {
+      foreground: false,
+      retainWhenHidden: true,
+      write: (data) => oldMount.push(data),
+    });
+    rebindTerminalOutputWriter(t, (data) => newMount.push(data));
+    flushTerminalOutput(t);
+    expect(oldMount).toEqual([]);
+    expect(newMount).toEqual(['history']);
     expect(t.writes).toEqual([]);
   });
 

--- a/src/renderer/terminal/replayMute.ts
+++ b/src/renderer/terminal/replayMute.ts
@@ -1,60 +1,26 @@
-// === OSC 52 replay mute (#998) — pure state machine, DOM-free ===
+// === OSC 52 replay mute (#998/#1014) — pure state machine, DOM-free ===
 //
 // A copy is an act, and an act cannot be replayed. Stored output written back
-// into xterm — a dead-pane snapshot, a resync payload, restored scrollback, or
-// the daemon RingBuffer flush after a reattach — may contain an OSC 52
-// clipboard write. Re-executing it silently replaces the live clipboard with
-// whatever was copied when those bytes were first produced, and since the ring
-// buffer outlives the session that produced it, that value can be days old.
-//
-// This module owns WHEN the bridge is closed. Two shapes, because the two kinds
-// of replay arrive differently:
-//
-//   • writes we make ourselves        -> beginWrite(), released in xterm's
-//     (snapshot / resync / scrollback)   write callback, so the mute lasts
-//                                        exactly as long as the parse
-//   • the reattach replay             -> openReattachWindow(), released when the
-//     (arrives as ordinary pty:data)     burst goes quiet, or at a hard cap
-//
-// The reattach window is the one that needs a heuristic: nothing in the data
-// event says "this is a replay", so the window opens when we ask the daemon to
-// reconnect and closes when the output it sends back stops arriving. A live copy
-// made inside that window is swallowed — deliberate, and the lesser evil: a lost
-// copy is a retry the user notices immediately, a resurrected one is corruption
-// they discover after pasting the wrong thing somewhere.
-//
-// The quiet timer tracks silence in the REPLAY, not silence since the window
-// opened: it only starts once the first chunk arrives (noteReplayData). A
-// daemon that takes longer than REATTACH_QUIET_MS to answer the reconnect
-// request would otherwise let a quiet-from-open timer close the window before
-// its own flush landed — the leak this module exists to prevent, just moved
-// later. The cap timer alone covers "the replay never came at all".
-
-/** No data for this long ends the reattach window (the flush arrives as a burst). */
-export const REATTACH_QUIET_MS = 250;
-/** Hard cap, so a pane that keeps printing can never hold the bridge shut. */
-export const REATTACH_CAP_MS = 5_000;
-
-type Timer = ReturnType<typeof setTimeout>;
+// into xterm may contain an OSC 52 clipboard write; re-executing it must not
+// replace the live clipboard. Replay provenance now comes from the daemon's
+// session-pipe scanner, so every stored write can use xterm's completion
+// callback as its mute lifetime. No receive-time window or timer is needed.
+// The counter deliberately fails closed: if xterm strands a callback, later
+// replay remains muted instead of silently regaining side-effect authority.
 
 export interface ReplayMute {
-  /** In-flight replay writes plus (at most one) open reattach window. */
+  /** Replay writes handed to xterm but not yet confirmed parsed. */
   depth: number;
   /**
    * Terminal generation. This hook outlives the terminal it hosts, so a write
-   * callback or timer from a disposed terminal must not release the mute of the
-   * one that replaced it.
+   * callback from a disposed terminal must not release the mute of the one
+   * that replaced it.
    */
   gen: number;
-  reattachOpen: boolean;
-  quiet: Timer | null;
-  /** Release for the open reattach window, so `noteReplayData` can re-arm it. */
-  closeReattach?: () => void;
-  cap: Timer | null;
 }
 
 export function createReplayMute(): ReplayMute {
-  return { depth: 0, gen: 0, reattachOpen: false, quiet: null, cap: null };
+  return { depth: 0, gen: 0 };
 }
 
 /** True while stored bytes are being parsed — the OSC 52 handler reads this. */
@@ -63,10 +29,9 @@ export function isReplayMuted(m: ReplayMute): boolean {
 }
 
 /**
- * Mute for one write we are about to make. Returns the release, which the caller
- * hands to xterm's write callback: releasing synchronously would unmute while
- * the escape sequences are still queued, which is the bug itself. Idempotent,
- * and inert once the generation has moved on.
+ * Mute for one replay write. Returns the release that the caller hands to
+ * xterm's write callback: releasing synchronously would unmute while escape
+ * sequences are still queued. Idempotent and generation-scoped.
  */
 export function beginReplayWrite(m: ReplayMute): () => void {
   const gen = m.gen;
@@ -79,53 +44,8 @@ export function beginReplayWrite(m: ReplayMute): () => void {
   };
 }
 
-/**
- * Mute the window around a reattach: the daemon replays its RingBuffer as
- * ordinary pty:data, so there is no write of ours to hang the mute on. Opens at
- * most one window; `noteData` extends it while the burst is arriving.
- */
-export function openReattachWindow(m: ReplayMute): void {
-  if (m.reattachOpen) return;
-  const gen = m.gen;
-  m.reattachOpen = true;
-  m.depth += 1;
-  const close = (): void => {
-    if (!m.reattachOpen || m.gen !== gen) return;
-    m.reattachOpen = false;
-    clearTimers(m);
-    m.depth = Math.max(0, m.depth - 1);
-  };
-  // Only `cap` is armed here — the backstop for "the replay never came"
-  // (failed reconnect, empty ring), which would otherwise hold the bridge
-  // shut indefinitely. `quiet` is NOT armed until the first chunk actually
-  // arrives (see noteReplayData): arming it from open() measured silence
-  // from the RECONNECT REQUEST, not from the replay, so a daemon slower than
-  // REATTACH_QUIET_MS to answer closed the window before its own flush
-  // landed — the exact leak this module exists to prevent, just moved later.
-  m.cap = setTimeout(close, REATTACH_CAP_MS);
-  m.closeReattach = close;
-}
-
-/** Extend an open reattach window: more bytes are still arriving. */
-export function noteReplayData(m: ReplayMute): void {
-  if (!m.reattachOpen) return;
-  if (m.quiet) clearTimeout(m.quiet);
-  m.quiet = setTimeout(() => m.closeReattach?.(), REATTACH_QUIET_MS);
-}
-
-/**
- * Teardown. Bumps the generation so late callbacks and timers cannot touch the
- * successor's state, and drops everything this generation was holding.
- */
+/** Teardown: invalidate late callbacks and drop this generation's writes. */
 export function resetReplayMute(m: ReplayMute): void {
   m.gen += 1;
   m.depth = 0;
-  m.reattachOpen = false;
-  clearTimers(m);
-  m.closeReattach = undefined;
-}
-
-function clearTimers(m: ReplayMute): void {
-  if (m.quiet) { clearTimeout(m.quiet); m.quiet = null; }
-  if (m.cap) { clearTimeout(m.cap); m.cap = null; }
 }

--- a/src/renderer/terminal/replayMute.ts
+++ b/src/renderer/terminal/replayMute.ts
@@ -19,8 +19,23 @@ export interface ReplayMute {
   gen: number;
 }
 
+// A parked xterm instance crosses React mount boundaries while its write
+// buffer keeps parsing. The mute therefore belongs to the terminal object, not
+// to the hook mount that currently renders it.
+const terminalMutes = new WeakMap<object, ReplayMute>();
+
 export function createReplayMute(): ReplayMute {
   return { depth: 0, gen: 0 };
+}
+
+/** Return the replay mute owned by one terminal, preserving it across adopt. */
+export function getTerminalReplayMute(terminal: object): ReplayMute {
+  let mute = terminalMutes.get(terminal);
+  if (!mute) {
+    mute = createReplayMute();
+    terminalMutes.set(terminal, mute);
+  }
+  return mute;
 }
 
 /** True while stored bytes are being parsed — the OSC 52 handler reads this. */
@@ -48,4 +63,12 @@ export function beginReplayWrite(m: ReplayMute): () => void {
 export function resetReplayMute(m: ReplayMute): void {
   m.gen += 1;
   m.depth = 0;
+}
+
+/** Final terminal disposal: invalidate callbacks and release the WeakMap entry. */
+export function disposeTerminalReplayMute(terminal: object): void {
+  const mute = terminalMutes.get(terminal);
+  if (!mute) return;
+  resetReplayMute(mute);
+  terminalMutes.delete(terminal);
 }

--- a/src/renderer/terminal/terminalOutputScheduler.ts
+++ b/src/renderer/terminal/terminalOutputScheduler.ts
@@ -63,7 +63,8 @@ interface WriteOptions {
   /** Optional hand-off used when these bytes need parse-scoped behavior.
    *  Queued chunks retain whether they need this writer, while the queue entry
    *  keeps the latest mount's function so parked terminals can be adopted
-   *  without retaining a stale closure. */
+   *  without retaining a stale closure. For replay-provenance bytes, this
+   *  writer MUST apply replay-scoped control-sequence muting. */
   write?: (data: string) => void;
 }
 
@@ -235,7 +236,9 @@ function getOrCreateEntry(
   return entry;
 }
 
-/** Rebind retained custom chunks to the mount that currently owns `terminal`. */
+/** Rebind retained custom chunks to the mount that currently owns `terminal`.
+ *  Replay-provenance chunks depend on this writer applying replay-scoped
+ *  control-sequence muting; callers must not bind a plain terminal writer. */
 export function rebindTerminalOutputWriter(
   terminal: SchedulableTerminal,
   write: (data: string) => void,
@@ -294,10 +297,22 @@ function hasQueuedChunks(entry: QueueEntry): boolean {
 function writeQueuedChunk(entry: QueueEntry): boolean {
   const chunk = takeQueuedChunk(entry, CHUNK_CHARS);
   if (!chunk) return true;
+  const customWrite = chunk.customWrite ? entry.customWrite : undefined;
+  if (chunk.customWrite && !customWrite) {
+    // This is an internal invariant failure, not the routine dispose race
+    // below. Fail closed: replay bytes must never fall back to an unmuted
+    // terminal.write, and make the dropped backlog visible in dogfood logs.
+    console.error(
+      `[wmux:terminal-output] custom replay writer is unbound; dropping ${entry.queuedChars + chunk.data.length} queued chars`,
+    );
+    entry.chunks.length = 0;
+    entry.chunkIndex = 0;
+    entry.queuedChars = 0;
+    return false;
+  }
   try {
-    if (chunk.customWrite) {
-      if (!entry.customWrite) throw new Error('custom terminal writer is not bound');
-      entry.customWrite(chunk.data);
+    if (customWrite) {
+      customWrite(chunk.data);
     } else {
       entry.terminal.write(chunk.data);
     }

--- a/src/renderer/terminal/terminalOutputScheduler.ts
+++ b/src/renderer/terminal/terminalOutputScheduler.ts
@@ -60,13 +60,22 @@ interface WriteOptions {
    *  terminal.write (glyph-repaint cadence tracks WRITE calls, not IPC
    *  receipt — see glyphRepaint.ts header). */
   onWritten?: (chars: number) => void;
+  /** Optional hand-off used when these bytes need parse-scoped behavior.
+   *  Queued chunks retain the writer they arrived with, so replay and live
+   *  output can share a terminal queue without losing provenance. */
+  write?: (data: string) => void;
+}
+
+interface QueuedChunk {
+  data: string;
+  write?: (data: string) => void;
 }
 
 interface QueueEntry {
   terminal: SchedulableTerminal;
   /** Queued segments in arrival order. Consumed via chunkIndex to avoid
    *  O(n²) shift() on long queues; compacted periodically. */
-  chunks: string[];
+  chunks: QueuedChunk[];
   chunkIndex: number;
   queuedChars: number;
   /** True when foreground bytes are queued (visible pane briefly behind) —
@@ -238,25 +247,28 @@ function compactConsumedChunks(entry: QueueEntry): void {
 }
 
 /** Take up to `limit` chars off the head of the queue, preserving order. */
-function takeQueuedChunk(entry: QueueEntry, limit: number): string {
+function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedChunk | null {
   let data = '';
   let remaining = limit;
+  let write: QueuedChunk['write'];
   while (remaining > 0 && entry.chunkIndex < entry.chunks.length) {
     const chunk = entry.chunks[entry.chunkIndex];
-    if (chunk.length <= remaining) {
-      data += chunk;
-      remaining -= chunk.length;
-      entry.queuedChars -= chunk.length;
+    if (data && chunk.write !== write) break;
+    write = chunk.write;
+    if (chunk.data.length <= remaining) {
+      data += chunk.data;
+      remaining -= chunk.data.length;
+      entry.queuedChars -= chunk.data.length;
       entry.chunkIndex += 1;
     } else {
-      data += chunk.slice(0, remaining);
-      entry.chunks[entry.chunkIndex] = chunk.slice(remaining);
+      data += chunk.data.slice(0, remaining);
+      chunk.data = chunk.data.slice(remaining);
       entry.queuedChars -= remaining;
       remaining = 0;
     }
   }
   compactConsumedChunks(entry);
-  return data;
+  return data ? { data, write } : null;
 }
 
 /** True when this entry still holds unconsumed output. Reads the cursor rather
@@ -268,11 +280,12 @@ function hasQueuedChunks(entry: QueueEntry): boolean {
 /** Hand one bounded chunk to xterm. Returns false when the terminal is gone
  *  (disposed mid-flight) and the entry should be abandoned. */
 function writeQueuedChunk(entry: QueueEntry): boolean {
-  const data = takeQueuedChunk(entry, CHUNK_CHARS);
-  if (!data) return true;
+  const chunk = takeQueuedChunk(entry, CHUNK_CHARS);
+  if (!chunk) return true;
   try {
-    entry.terminal.write(data);
-    entry.onWritten?.(data.length);
+    if (chunk.write) chunk.write(chunk.data);
+    else entry.terminal.write(chunk.data);
+    entry.onWritten?.(chunk.data.length);
     return true;
   } catch {
     // terminal.dispose() raced a queued late chunk. Drop this entry only —
@@ -411,7 +424,10 @@ function releaseHeldWithSyntheticEnd(terminal: SchedulableTerminal, entry: Queue
   clearSyncFrame(terminal);
   entry.heldForSync = false;
   entry.priority = true;
-  entry.chunks.push(SYNC_OUTPUT_END);
+  entry.chunks.push({
+    data: SYNC_OUTPUT_END,
+    write: entry.chunks[entry.chunks.length - 1]?.write,
+  });
   entry.queuedChars += SYNC_OUTPUT_END.length;
   scheduleDrain(0);
 }
@@ -458,7 +474,7 @@ function holdForSyncFrame(
   entry.retained = false;
   entry.priority = true;
   entry.heldForSync = true;
-  entry.chunks.push(data);
+  entry.chunks.push({ data, write: options.write });
   entry.queuedChars += data.length;
   if (entry.queuedChars > MAX_QUEUE_CHARS) {
     // A single frame ballooned past the cap (never-closing frame / runaway
@@ -484,7 +500,7 @@ function releaseSyncFrame(
   entry.retained = false;
   entry.heldForSync = false;
   entry.priority = true;
-  entry.chunks.push(data);
+  entry.chunks.push({ data, write: options.write });
   entry.queuedChars += data.length;
   if (entry.queuedChars > MAX_QUEUE_CHARS) {
     flushTerminalOutput(terminal);
@@ -532,7 +548,7 @@ export function writeTerminalOutput(
         console.log('[wmux:hidden-retention] engaged — hidden pane output retained without parsing');
       }
     }
-    entry.chunks.push(data);
+    entry.chunks.push({ data, write: options.write });
     entry.queuedChars += data.length;
     if (entry.queuedChars > MAX_QUEUE_CHARS) {
       queue.delete(terminal);
@@ -585,7 +601,8 @@ export function writeTerminalOutput(
     withinInteractiveWindow(terminal)
   ) {
     try {
-      terminal.write(data);
+      if (options.write) options.write(data);
+      else terminal.write(data);
       options.onWritten?.(data.length);
     } catch {
       // Disposed-terminal race — nothing to clean up on the direct path.
@@ -599,7 +616,7 @@ export function writeTerminalOutput(
   // ahead of it, order preserved); a background write without retainWhenHidden
   // means retention was turned off mid-flight.
   entry.retained = false;
-  entry.chunks.push(data);
+  entry.chunks.push({ data, write: options.write });
   entry.queuedChars += data.length;
 
   if (entry.queuedChars > MAX_QUEUE_CHARS) {
@@ -643,7 +660,10 @@ export function flushTerminalOutput(terminal: SchedulableTerminal): void {
   if (hadOpenFrame) {
     // The held bytes carry an unmatched BEGIN; close xterm's sync mode so the
     // handed-over frame paints (twin of the safety-timeout release).
-    entry.chunks.push(SYNC_OUTPUT_END);
+    entry.chunks.push({
+      data: SYNC_OUTPUT_END,
+      write: entry.chunks[entry.chunks.length - 1]?.write,
+    });
     entry.queuedChars += SYNC_OUTPUT_END.length;
   }
   queue.delete(terminal);

--- a/src/renderer/terminal/terminalOutputScheduler.ts
+++ b/src/renderer/terminal/terminalOutputScheduler.ts
@@ -61,14 +61,15 @@ interface WriteOptions {
    *  receipt — see glyphRepaint.ts header). */
   onWritten?: (chars: number) => void;
   /** Optional hand-off used when these bytes need parse-scoped behavior.
-   *  Queued chunks retain the writer they arrived with, so replay and live
-   *  output can share a terminal queue without losing provenance. */
+   *  Queued chunks retain whether they need this writer, while the queue entry
+   *  keeps the latest mount's function so parked terminals can be adopted
+   *  without retaining a stale closure. */
   write?: (data: string) => void;
 }
 
 interface QueuedChunk {
   data: string;
-  write?: (data: string) => void;
+  customWrite: boolean;
 }
 
 interface QueueEntry {
@@ -91,6 +92,8 @@ interface QueueEntry {
    *  marker or the hold safety timeout, never by another terminal's drain. */
   heldForSync: boolean;
   onWritten?: (chars: number) => void;
+  /** Latest mount's custom writer. Retained chunks store only a boolean tag. */
+  customWrite?: (data: string) => void;
 }
 
 // Cadence: hidden output is invisible, so its first hand-off can wait a
@@ -215,9 +218,8 @@ function scheduleDrain(delayMs: number): void {
 }
 
 /** Fetch this terminal's queue entry, creating an empty one on first write.
- *  `onWritten` is re-bound on every call because the latest registration belongs
- *  to the current mount — a stale closure from a previous mount would notify a
- *  component that is already gone. */
+ *  Mount-owned callbacks are re-bound on every applicable call so a parked
+ *  terminal never drains through stale closures after adoption. */
 function getOrCreateEntry(
   terminal: SchedulableTerminal,
   options: WriteOptions,
@@ -229,7 +231,17 @@ function getOrCreateEntry(
   }
   // Latest registration wins — the hook closure belongs to the current mount.
   entry.onWritten = options.onWritten;
+  if (options.write) entry.customWrite = options.write;
   return entry;
+}
+
+/** Rebind retained custom chunks to the mount that currently owns `terminal`. */
+export function rebindTerminalOutputWriter(
+  terminal: SchedulableTerminal,
+  write: (data: string) => void,
+): void {
+  const entry = queue.get(terminal);
+  if (entry) entry.customWrite = write;
 }
 
 /** Drop already-consumed chunks so a long-lived queue doesn't grow without
@@ -250,11 +262,11 @@ function compactConsumedChunks(entry: QueueEntry): void {
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedChunk | null {
   let data = '';
   let remaining = limit;
-  let write: QueuedChunk['write'];
+  let customWrite: boolean | undefined;
   while (remaining > 0 && entry.chunkIndex < entry.chunks.length) {
     const chunk = entry.chunks[entry.chunkIndex];
-    if (data && chunk.write !== write) break;
-    write = chunk.write;
+    if (data && chunk.customWrite !== customWrite) break;
+    customWrite = chunk.customWrite;
     if (chunk.data.length <= remaining) {
       data += chunk.data;
       remaining -= chunk.data.length;
@@ -268,7 +280,7 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedChunk | null {
     }
   }
   compactConsumedChunks(entry);
-  return data ? { data, write } : null;
+  return data ? { data, customWrite: customWrite ?? false } : null;
 }
 
 /** True when this entry still holds unconsumed output. Reads the cursor rather
@@ -283,8 +295,12 @@ function writeQueuedChunk(entry: QueueEntry): boolean {
   const chunk = takeQueuedChunk(entry, CHUNK_CHARS);
   if (!chunk) return true;
   try {
-    if (chunk.write) chunk.write(chunk.data);
-    else entry.terminal.write(chunk.data);
+    if (chunk.customWrite) {
+      if (!entry.customWrite) throw new Error('custom terminal writer is not bound');
+      entry.customWrite(chunk.data);
+    } else {
+      entry.terminal.write(chunk.data);
+    }
     entry.onWritten?.(chunk.data.length);
     return true;
   } catch {
@@ -426,7 +442,7 @@ function releaseHeldWithSyntheticEnd(terminal: SchedulableTerminal, entry: Queue
   entry.priority = true;
   entry.chunks.push({
     data: SYNC_OUTPUT_END,
-    write: entry.chunks[entry.chunks.length - 1]?.write,
+    customWrite: entry.chunks[entry.chunks.length - 1]?.customWrite ?? false,
   });
   entry.queuedChars += SYNC_OUTPUT_END.length;
   scheduleDrain(0);
@@ -474,7 +490,7 @@ function holdForSyncFrame(
   entry.retained = false;
   entry.priority = true;
   entry.heldForSync = true;
-  entry.chunks.push({ data, write: options.write });
+  entry.chunks.push({ data, customWrite: options.write !== undefined });
   entry.queuedChars += data.length;
   if (entry.queuedChars > MAX_QUEUE_CHARS) {
     // A single frame ballooned past the cap (never-closing frame / runaway
@@ -500,7 +516,7 @@ function releaseSyncFrame(
   entry.retained = false;
   entry.heldForSync = false;
   entry.priority = true;
-  entry.chunks.push({ data, write: options.write });
+  entry.chunks.push({ data, customWrite: options.write !== undefined });
   entry.queuedChars += data.length;
   if (entry.queuedChars > MAX_QUEUE_CHARS) {
     flushTerminalOutput(terminal);
@@ -548,7 +564,7 @@ export function writeTerminalOutput(
         console.log('[wmux:hidden-retention] engaged — hidden pane output retained without parsing');
       }
     }
-    entry.chunks.push({ data, write: options.write });
+    entry.chunks.push({ data, customWrite: options.write !== undefined });
     entry.queuedChars += data.length;
     if (entry.queuedChars > MAX_QUEUE_CHARS) {
       queue.delete(terminal);
@@ -616,7 +632,7 @@ export function writeTerminalOutput(
   // ahead of it, order preserved); a background write without retainWhenHidden
   // means retention was turned off mid-flight.
   entry.retained = false;
-  entry.chunks.push({ data, write: options.write });
+  entry.chunks.push({ data, customWrite: options.write !== undefined });
   entry.queuedChars += data.length;
 
   if (entry.queuedChars > MAX_QUEUE_CHARS) {
@@ -662,7 +678,7 @@ export function flushTerminalOutput(terminal: SchedulableTerminal): void {
     // handed-over frame paints (twin of the safety-timeout release).
     entry.chunks.push({
       data: SYNC_OUTPUT_END,
-      write: entry.chunks[entry.chunks.length - 1]?.write,
+      customWrite: entry.chunks[entry.chunks.length - 1]?.customWrite ?? false,
     });
     entry.queuedChars += SYNC_OUTPUT_END.length;
   }


### PR DESCRIPTION
## Summary

Replace renderer timing guesses with daemon-source replay provenance so only replayed PTY history receives replay-scoped control-sequence muting. Authenticate the in-band replay boundaries and preserve mute state across terminal adoption so PTY output and mount churn cannot bypass that provenance.

## Changes

- Label ring-buffer and resync bytes in the session-pipe scanner, then preserve replay provenance through batching, IPC, decoding, and terminal scheduling.
- Derive flush/resync markers from the daemon auth token so stored PTY output cannot impersonate a replay boundary.
- Bind replay mute state to the xterm instance so an in-flight replay stays muted while a parked terminal moves between React mounts.
- Keep live readiness behavior intact while failing closed for oversized replay, nested mute scopes, and parked-terminal writer adoption.
- Add regression coverage for authenticated marker boundaries, overflow recovery, batching separation, OSC 52 muting, and scheduler retention/adoption.

## CHANGELOG entry

### Fixed

- **Replayed terminal history no longer relies on a timing window.** wmux now labels replayed daemon PTY data at its source, authenticates its in-band boundaries, and keeps replay-only control sequences muted across pane adoption without suppressing live terminal behavior. (#1062)

## Stability tier impact

- [ ] No external surface touched (internal refactor / docs / tests / CI).
- [ ] Additive change to a `stable` surface (new optional param, new field, new event type).
- [ ] Breaking change to a `stable` surface (requires major bump — block until release planning is in scope).
- [ ] Change to an `experimental` surface (note in release notes).
- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — the replay flag and authenticated markers stay inside the daemon/main/preload/renderer PTY pipeline and do not change a documented Substrate 3.0 surface.

## Test plan

- Focused marker/scanner/SessionPipe/replay-mute/adoption suite: 132 passed.
- Broader daemon/main/renderer run: 2,256 passed, 5 skipped; two affected source locks were updated and rerun green, while the remaining WebGL patch and Windows worktree timeout failures are unrelated baseline/environment failures.
- TypeScript: npx tsc --noEmit -p tsconfig.json passed.
- Daemon bundle and web CSP gate: npm run build:daemon passed.
- Changelog collector: node scripts/collect-changelog.mjs --check passed.
- ESLint on changed files reported only the repository's existing diagnostics on unchanged legacy lines; no new-line diagnostic was introduced.
- Hosted CI on final head `26fcb3ae`: validate, perf/artifact contract, and Windows/macOS/Ubuntu baselines passed.
- Manual UI verification: n/a; the behavior is exercised at the socket, scanner, IPC, hook, mute, parking, and scheduler seams.

## Related issues / PRs

Closes #1014

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Replayed terminal data is now clearly distinguished from live output, keeping replay-only control sequences muted.
  - Improved recovery when replay buffers become oversized, preventing historical data from appearing as live output.
  - Preserved correct ordering and separation when replay and live data arrive together.
  - Secured replay boundaries against forged synchronization markers.
  - Preserved replay muting and queued terminal output during pane adoption.
  - Improved handling of incomplete or interrupted session resynchronization.

- **Tests**
  - Added coverage for replay labeling, overflow recovery, authentication, scheduling, and replay/live output boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->