### PR TITLE
feat(browser): snapshot auto-diff, selector scoping, inline lifecycle events

### DIFF
--- a/changelog.d/1063.md
+++ b/changelog.d/1063.md
@@ -1,0 +1,4 @@
+### Added
+
+- `browser_snapshot` now returns a compact diff against the previous snapshot of the same page when that is smaller (`full:true` forces the complete tree), and accepts `selector` to scope the snapshot to a subtree and `filter:"interactive"` to strip non-interactive nodes.
+- Browser tool results now report page lifecycle changes inline — navigations (including SPA route changes), page loads, and tab closure that happened since the last tool call — so agents no longer need to poll for page state.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **151** methods (`ALL_RPC_METHODS` in
+Total: **152** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -139,6 +139,7 @@ Total: **151** methods (`ALL_RPC_METHODS` in
 | `browser.screenshot` | `browser.screenshot` | `browser` |
 | `browser.evaluate` | `browser.evaluate` | `browser` |
 | `browser.console.get` | `browser.read` | `browser` |
+| `browser.lifecycle.get` | `browser.read` | `browser` |
 | `browser.network.get` | `browser.read` | `browser` |
 | `browser.responseBody.get` | `browser.read` | `browser` |
 | `browser.type.cdp` | `browser.type` | `browser` |

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 80000,
-      "wireResultSha256": "9ffa0f077647435fd41855d7d0d8d28a7ca94acbbdc27bcf58fc2d4256134969",
+      "wireResultSha256": "d2a28f9455afd75a7c92c050863084e373746bd7ece5c132ab47603c4eb8a407",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/main/browser-session/BrowserCaptureManager.ts
+++ b/src/main/browser-session/BrowserCaptureManager.ts
@@ -56,6 +56,21 @@ interface NetEntry extends NetworkEntry {
   bodyBytes?: number;
 }
 
+// Browser lifecycle events surfaced inline in MCP tool results (act→verify
+// loop compression): main-frame navigations, load completion, guest closure.
+export interface LifecycleEntry {
+  type: 'navigated' | 'loaded' | 'closed';
+  url?: string;
+  ts: number;
+}
+
+// Lifecycle ring bound: these are drained on nearly every browser_* tool call,
+// so a small cap suffices — anything older than 20 events is stale context.
+const MAX_LIFECYCLE_ENTRIES = 20;
+// Closure records for already-dropped guests, kept so a `closed` event can
+// still be drained once after the per-webContents state is gone.
+const MAX_PENDING_CLOSURES = 8;
+
 interface CaptureState {
   dbg: Electron.Debugger;
   onMessage: (event: Electron.Event, method: string, params: unknown, sessionId?: string) => void;
@@ -63,6 +78,7 @@ interface CaptureState {
   console: ConsoleEntry[];
   network: NetEntry[];
   byRequestId: Map<string, NetEntry>;
+  lifecycle: LifecycleEntry[];
   totalBodyBytes: number;
   enabled: boolean;
 }
@@ -119,6 +135,10 @@ export class BrowserCaptureManager {
   // Singleflight: concurrent first calls share one enable Promise so the
   // listener is never attached twice (which would double-buffer every event).
   private ensuring = new Map<number, Promise<CaptureState | null>>();
+  // Lifecycle entries that must outlive their CaptureState: drop({closed:true})
+  // moves undrained events plus a synthesized `closed` record here, keyed by
+  // the departed webContentsId, so the next drain can still report the close.
+  private pendingClosures = new Map<number, LifecycleEntry[]>();
 
   /**
    * Ensure capture is active for a guest webContents, enabling the CDP domains
@@ -164,6 +184,7 @@ export class BrowserCaptureManager {
       console: [],
       network: [],
       byRequestId: new Map(),
+      lifecycle: [],
       totalBodyBytes: 0,
       enabled: false,
     };
@@ -187,6 +208,7 @@ export class BrowserCaptureManager {
         maxResourceBufferSize: MAX_RESPONSE_BODY_BYTES,
         maxTotalBufferSize: MAX_TOTAL_BODY_BYTES,
       });
+      await dbg.sendCommand('Page.enable');
     } catch (err) {
       console.error('[BrowserCaptureManager] domain enable failed:', err);
       this.drop(webContentsId);
@@ -194,7 +216,7 @@ export class BrowserCaptureManager {
     }
 
     state.enabled = true;
-    wc.once('destroyed', () => this.drop(webContentsId));
+    wc.once('destroyed', () => this.drop(webContentsId, { closed: true }));
     return state;
   }
 
@@ -247,6 +269,22 @@ export class BrowserCaptureManager {
         if (isTextualContentType(ct)) {
           void this.fetchBody(state, entry);
         }
+        break;
+      }
+      case 'Page.frameNavigated': {
+        // Main frame only — subframe churn (ads, embeds) is noise here.
+        const frame = (params.frame ?? {}) as { parentId?: string; url?: string };
+        if (frame.parentId !== undefined) break;
+        const url = frame.url ?? '';
+        // Collapse consecutive same-URL navigations (SPA replaceState churn,
+        // redirect hops that settle on the same URL).
+        const last = state.lifecycle[state.lifecycle.length - 1];
+        if (last?.type === 'navigated' && last.url === url) break;
+        this.pushLifecycle(state, { type: 'navigated', url, ts: Date.now() });
+        break;
+      }
+      case 'Page.loadEventFired': {
+        this.pushLifecycle(state, { type: 'loaded', ts: Date.now() });
         break;
       }
       default:
@@ -306,6 +344,13 @@ export class BrowserCaptureManager {
     state.console.push(entry);
     if (state.console.length > MAX_CAPTURE_ENTRIES) {
       state.console.splice(0, state.console.length - MAX_CAPTURE_ENTRIES);
+    }
+  }
+
+  private pushLifecycle(state: CaptureState, entry: LifecycleEntry): void {
+    state.lifecycle.push(entry);
+    if (state.lifecycle.length > MAX_LIFECYCLE_ENTRIES) {
+      state.lifecycle.splice(0, state.lifecycle.length - MAX_LIFECYCLE_ENTRIES);
     }
   }
 
@@ -378,8 +423,36 @@ export class BrowserCaptureManager {
     state.totalBodyBytes = 0;
   }
 
-  /** Stop capturing for a webContents and remove all listeners. */
-  drop(webContentsId: number): void {
+  /**
+   * Drain lifecycle events, destructively: each event is reported to exactly
+   * one consumer (the browser.console.get clear semantics, but in one call —
+   * lifecycle is inlined into every tool result, so a non-destructive read
+   * would repeat the same events forever). Falls back to pending closure
+   * records when the guest's state is already gone.
+   */
+  drainLifecycle(webContentsId: number): LifecycleEntry[] {
+    const state = this.states.get(webContentsId);
+    if (state) {
+      const entries = state.lifecycle;
+      state.lifecycle = [];
+      return entries;
+    }
+    const pending = this.pendingClosures.get(webContentsId);
+    if (pending) {
+      this.pendingClosures.delete(webContentsId);
+      return pending;
+    }
+    return [];
+  }
+
+  /**
+   * Stop capturing for a webContents and remove all listeners.
+   * `closed: true` marks a real guest departure (destroyed / unregistered):
+   * undrained lifecycle events plus a synthesized `closed` record survive in
+   * pendingClosures. A plain drop (DevTools stealing the debugger, enable
+   * failure) must NOT report a close — the guest is still there.
+   */
+  drop(webContentsId: number, opts?: { closed?: boolean }): void {
     const state = this.states.get(webContentsId);
     if (!state) return;
     try {
@@ -390,6 +463,18 @@ export class BrowserCaptureManager {
       // debugger already gone
     }
     this.states.delete(webContentsId);
+    if (opts?.closed) {
+      this.pendingClosures.set(webContentsId, [
+        ...state.lifecycle,
+        { type: 'closed', ts: Date.now() },
+      ]);
+      // Bound the map: evict the oldest closure record (insertion order).
+      while (this.pendingClosures.size > MAX_PENDING_CLOSURES) {
+        const oldest = this.pendingClosures.keys().next().value;
+        if (oldest === undefined) break;
+        this.pendingClosures.delete(oldest);
+      }
+    }
   }
 
   dropAll(): void {

--- a/src/main/browser-session/BrowserCaptureManager.ts
+++ b/src/main/browser-session/BrowserCaptureManager.ts
@@ -208,11 +208,18 @@ export class BrowserCaptureManager {
         maxResourceBufferSize: MAX_RESPONSE_BODY_BYTES,
         maxTotalBufferSize: MAX_TOTAL_BODY_BYTES,
       });
-      await dbg.sendCommand('Page.enable');
     } catch (err) {
       console.error('[BrowserCaptureManager] domain enable failed:', err);
       this.drop(webContentsId);
       return null;
+    }
+
+    // Page domain is lifecycle-only: a failure here must not take down the
+    // working console/network capture above (review: regression risk).
+    try {
+      await dbg.sendCommand('Page.enable');
+    } catch (err) {
+      console.warn('[BrowserCaptureManager] Page.enable failed (lifecycle capture off):', err);
     }
 
     state.enabled = true;
@@ -278,6 +285,15 @@ export class BrowserCaptureManager {
         const url = frame.url ?? '';
         // Collapse consecutive same-URL navigations (SPA replaceState churn,
         // redirect hops that settle on the same URL).
+        const last = state.lifecycle[state.lifecycle.length - 1];
+        if (last?.type === 'navigated' && last.url === url) break;
+        this.pushLifecycle(state, { type: 'navigated', url, ts: Date.now() });
+        break;
+      }
+      case 'Page.navigatedWithinDocument': {
+        // SPA route change (history.pushState) — the page content can change
+        // completely without a frameNavigated, so record it as a navigation.
+        const url = typeof params.url === 'string' ? params.url : '';
         const last = state.lifecycle[state.lifecycle.length - 1];
         if (last?.type === 'navigated' && last.url === url) break;
         this.pushLifecycle(state, { type: 'navigated', url, ts: Date.now() });

--- a/src/main/browser-session/__tests__/BrowserCaptureManager.test.ts
+++ b/src/main/browser-session/__tests__/BrowserCaptureManager.test.ts
@@ -225,3 +225,67 @@ describe('BrowserCaptureManager', () => {
     expect(c[c.length - 1].text).toBe('1099');
   });
 });
+
+// Lifecycle capture + drain (Phase 1 browser events). Reuses the same fake
+// webContents/debugger harness as the suites above.
+describe('BrowserCaptureManager lifecycle', () => {
+  let mgr: BrowserCaptureManager;
+
+  beforeEach(() => {
+    fakeWc = makeFakeWc();
+    mgr = new BrowserCaptureManager();
+  });
+
+  it('enables the Page domain alongside Runtime + Network', async () => {
+    await mgr.ensure(1);
+    const cmds = fakeWc!.debugger.sendCommand.mock.calls.map((c) => c[0]);
+    expect(cmds).toContain('Page.enable');
+    // Order guard: Page.enable must not displace the existing enables.
+    expect(cmds).toContain('Runtime.enable');
+    expect(cmds).toContain('Network.enable');
+  });
+
+  it('records main-frame navigations only, collapses consecutive dupes, and drains destructively', async () => {
+    await mgr.ensure(1);
+    emit(fakeWc!, 'Page.frameNavigated', { frame: { url: 'https://a.test/' } });
+    emit(fakeWc!, 'Page.frameNavigated', { frame: { url: 'https://a.test/' } }); // dupe → collapsed
+    emit(fakeWc!, 'Page.frameNavigated', { frame: { parentId: 'f1', url: 'https://ad.test/' } }); // subframe → ignored
+    emit(fakeWc!, 'Page.loadEventFired', {});
+    emit(fakeWc!, 'Page.frameNavigated', { frame: { url: 'https://b.test/' } });
+
+    const drained = mgr.drainLifecycle(1);
+    expect(drained.map((e) => [e.type, e.url])).toEqual([
+      ['navigated', 'https://a.test/'],
+      ['loaded', undefined],
+      ['navigated', 'https://b.test/'],
+    ]);
+    // Destructive: a second drain reports nothing.
+    expect(mgr.drainLifecycle(1)).toEqual([]);
+  });
+
+  it('caps the lifecycle ring', async () => {
+    await mgr.ensure(1);
+    for (let i = 0; i < 30; i++) {
+      emit(fakeWc!, 'Page.frameNavigated', { frame: { url: `https://x.test/${i}` } });
+    }
+    const drained = mgr.drainLifecycle(1);
+    expect(drained.length).toBe(20);
+    expect(drained[0].url).toBe('https://x.test/10');
+  });
+
+  it('drop({closed:true}) preserves undrained events plus a closed record, drained exactly once', async () => {
+    await mgr.ensure(1);
+    emit(fakeWc!, 'Page.frameNavigated', { frame: { url: 'https://a.test/' } });
+    fakeWc!.emit('destroyed'); // wc destroyed → drop with closed:true
+
+    const drained = mgr.drainLifecycle(1);
+    expect(drained.map((e) => e.type)).toEqual(['navigated', 'closed']);
+    expect(mgr.drainLifecycle(1)).toEqual([]);
+  });
+
+  it('a plain drop (debugger detach) does NOT synthesize a closed record', async () => {
+    await mgr.ensure(1);
+    fakeWc!.debugger.emit('detach'); // DevTools stole the session — guest still alive
+    expect(mgr.drainLifecycle(1)).toEqual([]);
+  });
+});

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -296,6 +296,7 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   'browser.screenshot':        { capability: 'browser.screenshot', riskClass: 'browser' },
   'browser.evaluate':          { capability: 'browser.evaluate',   riskClass: 'browser' },
   'browser.console.get':       { capability: 'browser.read',       riskClass: 'browser' },
+  'browser.lifecycle.get':     { capability: 'browser.read',       riskClass: 'browser' },
   'browser.network.get':       { capability: 'browser.read',       riskClass: 'browser' },
   'browser.responseBody.get':  { capability: 'browser.read',       riskClass: 'browser' },
   'browser.type.cdp':          { capability: 'browser.type',  riskClass: 'browser' },

--- a/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.test.ts
@@ -1272,6 +1272,40 @@ describe('registerBrowserRpc', () => {
     }
   });
 
+  it('browser.lifecycle.get drains lifecycle events destructively (Phase 1)', async () => {
+    const router = register();
+    const response = await router.dispatch({ id: '7b', method: 'browser.lifecycle.get', params: {} });
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.result).toHaveProperty('entries');
+      expect(Array.isArray((response.result as { entries: unknown[] }).entries)).toBe(true);
+    }
+  });
+
+  it('browser.lifecycle.get answers a missing target with empty entries, not an error (Phase 1)', async () => {
+    const router = new RpcRouter();
+    const webviewCdpManager = {
+      getTarget: vi.fn(() => null),
+      listTargets: vi.fn(() => []),
+      getCdpPort: vi.fn(() => 18800),
+      waitForTarget: vi.fn(),
+      ensureAwake: vi.fn(async () => null),
+      setCaptureCleanup: vi.fn(),
+      withAutomationLease: vi.fn(async (_surfaceId: string, fn: () => Promise<unknown>) => fn()),
+      acquireRpcLease: vi.fn(() => 'lease-1'),
+      renewRpcLease: vi.fn(() => true),
+      releaseRpcLease: vi.fn(() => true),
+    };
+    registerBrowserRpc(router, () => null, webviewCdpManager as never);
+    const response = await router.dispatch({ id: '11b', method: 'browser.lifecycle.get', params: {} });
+    // Unlike console.get, a gone target is a reportable state here (the tab may
+    // have just closed) — never an error, and empty when nothing is pending.
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect((response.result as { entries: unknown[] }).entries).toEqual([]);
+    }
+  });
+
   it('browser.network.get drains the capture buffer (#106)', async () => {
     const router = register();
     const response = await router.dispatch({ id: '8', method: 'browser.network.get', params: {} });

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -514,7 +514,18 @@ export function registerBrowserRpc(
   };
 
   // Tear down capture listeners whenever a surface's CDP session is unregistered.
-  webviewCdpManager.setCaptureCleanup((webContentsId) => captureManager.drop(webContentsId));
+  // unregister() fires only on real guest departure (destroyed / different-guest
+  // replacement — same-guest re-register skips it), so record it as a close for
+  // the lifecycle drain.
+  webviewCdpManager.setCaptureCleanup((webContentsId) =>
+    captureManager.drop(webContentsId, { closed: true }),
+  );
+
+  // browser.lifecycle.get target-tolerance: remember the last webContentsId a
+  // scope drained from, so a close can still be reported after the target is
+  // gone (getTarget() then returns null and pendingClosures is keyed by the
+  // departed webContentsId).
+  const lastLifecycleTarget = new Map<string, number>();
 
   // #517 lightweight mode: every automation op that drives the guest must hold
   // an AutomationLease for its duration so a hidden, throttled guest runs
@@ -1238,6 +1249,32 @@ export function registerBrowserRpc(
     const entries = captureManager.getConsole(target.webContentsId);
     if (clear) captureManager.clearConsole(target.webContentsId);
     return { entries };
+  });
+
+  /**
+   * browser.lifecycle.get
+   * Destructively drain browser lifecycle events (navigated/loaded/closed) for
+   * inline injection into MCP tool results. Target-tolerant: a gone target is
+   * answered from the pending-closure records of the scope's last-known guest
+   * instead of erroring — a closed tab is exactly the case this must report.
+   * params: { surfaceId?: string }
+   */
+  registerLeased('browser.lifecycle.get', async (params, scope) => {
+    const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
+    const scopeKey = `${scope ?? ''}|${surfaceId ?? ''}`;
+
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) {
+      const lastId = lastLifecycleTarget.get(scopeKey);
+      if (lastId === undefined) return { entries: [] };
+      lastLifecycleTarget.delete(scopeKey);
+      return { entries: captureManager.drainLifecycle(lastId) };
+    }
+
+    lastLifecycleTarget.set(scopeKey, target.webContentsId);
+    const state = await captureManager.ensure(target.webContentsId);
+    if (!state) return { entries: [] };
+    return { entries: captureManager.drainLifecycle(target.webContentsId) };
   });
 
   /**

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -526,6 +526,7 @@ export function registerBrowserRpc(
   // gone (getTarget() then returns null and pendingClosures is keyed by the
   // departed webContentsId).
   const lastLifecycleTarget = new Map<string, number>();
+  const MAX_LIFECYCLE_TARGETS = 64; // scope keys are per caller×surface — bound the map (review)
 
   // #517 lightweight mode: every automation op that drives the guest must hold
   // an AutomationLease for its duration so a hidden, throttled guest runs
@@ -1271,7 +1272,13 @@ export function registerBrowserRpc(
       return { entries: captureManager.drainLifecycle(lastId) };
     }
 
+    lastLifecycleTarget.delete(scopeKey);
     lastLifecycleTarget.set(scopeKey, target.webContentsId);
+    while (lastLifecycleTarget.size > MAX_LIFECYCLE_TARGETS) {
+      const oldest = lastLifecycleTarget.keys().next().value;
+      if (oldest === undefined) break;
+      lastLifecycleTarget.delete(oldest);
+    }
     const state = await captureManager.ensure(target.webContentsId);
     if (!state) return { entries: [] };
     return { entries: captureManager.drainLifecycle(target.webContentsId) };

--- a/src/mcp/connectionScope.ts
+++ b/src/mcp/connectionScope.ts
@@ -47,6 +47,12 @@ export interface ConnectionScope {
    * an import cycle (dom-intelligence imports this module); it owns the cast.
    */
   elementCache?: unknown[];
+  /**
+   * browser_snapshot auto-diff baselines (surface key → last snapshot), per
+   * connection for the same reason as elementCache. Typed as unknown to avoid
+   * an import cycle (snapshotCache imports this module); it owns the cast.
+   */
+  snapshotCache?: unknown;
 }
 
 const storage = new AsyncLocalStorage<ConnectionScope>();

--- a/src/mcp/playwright/__tests__/automationLease.events.test.ts
+++ b/src/mcp/playwright/__tests__/automationLease.events.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Inline lifecycle events (Phase 1): withAutomationLease drains
+// browser.lifecycle.get before the tool body, prepends drained events to a
+// content-shaped result, and invalidates the snapshot baseline on
+// navigated/closed. Mock idiom follows automationLease.test.ts.
+
+const { mockSendRpc } = vi.hoisted(() => ({ mockSendRpc: vi.fn() }));
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (...args: unknown[]) => mockSendRpc(...args),
+}));
+
+import { withAutomationLease } from '../automationLease';
+import { getSnapshotBaseline, setSnapshotBaseline, snapshotSurfaceKey } from '../snapshotCache';
+
+const deps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
+function rpcRouter(lifecycleEntries: unknown) {
+  return (method: string) => {
+    if (method === 'browser.lease.acquire') return Promise.resolve({ token: 'lease-1' });
+    if (method === 'browser.lifecycle.get') {
+      return lifecycleEntries instanceof Error
+        ? Promise.reject(lifecycleEntries)
+        : Promise.resolve({ entries: lifecycleEntries });
+    }
+    return Promise.resolve({});
+  };
+}
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  deps.resolveWorkspaceId.mockReset();
+  deps.resolveWorkspaceId.mockResolvedValue('ws-test');
+});
+
+describe('withAutomationLease lifecycle injection', () => {
+  it('prepends drained events to a content-shaped result', async () => {
+    mockSendRpc.mockImplementation(
+      rpcRouter([{ type: 'navigated', url: 'https://a.test/', ts: Date.now() - 3000 }]),
+    );
+    const body = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'tool output' }],
+    }));
+
+    const result = await withAutomationLease(deps, 's1', body);
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].text).toContain('[browser events since last tool call]');
+    expect(result.content[0].text).toContain('navigated: https://a.test/');
+    expect(result.content[1].text).toBe('tool output');
+  });
+
+  it('leaves non-content results and drain failures untouched', async () => {
+    mockSendRpc.mockImplementation(rpcRouter(new Error('unknown method')));
+    const plain = await withAutomationLease(deps, 's1', async () => 'plain-string');
+    expect(plain).toBe('plain-string');
+
+    mockSendRpc.mockImplementation(
+      rpcRouter([{ type: 'loaded', ts: Date.now() }]),
+    );
+    const nonContent = await withAutomationLease(deps, 's1', async () => ({ value: 1 }));
+    expect(nonContent).toEqual({ value: 1 });
+  });
+
+  it('invalidates the snapshot baseline on a navigated event', async () => {
+    const key = snapshotSurfaceKey('ws-test', 's1');
+    setSnapshotBaseline(key, 'ai||', 'old snapshot');
+    expect(getSnapshotBaseline(key, 'ai||')).not.toBeNull();
+
+    mockSendRpc.mockImplementation(
+      rpcRouter([{ type: 'navigated', url: 'https://b.test/', ts: Date.now() }]),
+    );
+    await withAutomationLease(deps, 's1', async () => ({ content: [] }));
+
+    expect(getSnapshotBaseline(key, 'ai||')).toBeNull();
+  });
+
+  it('a loaded-only drain does not invalidate the baseline', async () => {
+    const key = snapshotSurfaceKey('ws-test', 's1');
+    setSnapshotBaseline(key, 'ai||', 'old snapshot');
+
+    mockSendRpc.mockImplementation(rpcRouter([{ type: 'loaded', ts: Date.now() }]));
+    await withAutomationLease(deps, 's1', async () => ({ content: [] }));
+
+    expect(getSnapshotBaseline(key, 'ai||')).not.toBeNull();
+  });
+});

--- a/src/mcp/playwright/__tests__/automationLease.test.ts
+++ b/src/mcp/playwright/__tests__/automationLease.test.ts
@@ -32,6 +32,8 @@ describe('automation lease workspace scope', () => {
     expect(body).toHaveBeenCalledWith({ workspaceId: 'ws-test', surfaceId: 'surface-1' });
     expect(mockSendRpc.mock.calls).toEqual([
       ['browser.lease.acquire', { workspaceId: 'ws-test', surfaceId: 'surface-1' }],
+      // Lifecycle drain rides inside the lease bracket, before the body.
+      ['browser.lifecycle.get', { workspaceId: 'ws-test', surfaceId: 'surface-1' }],
       ['browser.lease.release', { token: 'lease-1' }],
     ]);
   });

--- a/src/mcp/playwright/__tests__/dom-intelligence.selector.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.selector.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { buildDomSnapshotExpression } from '../dom-intelligence';
+
+// Selector-scoped DOM snapshot (Phase 1): the expression runs against jsdom
+// (document/location are globals there), the same way the markdown-extractor
+// dom tests execute in-page code.
+
+function run(expr: string): string {
+  // Indirect eval → runs in global scope where jsdom's document lives.
+  return (0, eval)(expr) as string;
+}
+
+describe('buildDomSnapshotExpression(rootSelector)', () => {
+  it('tags and lists only interactive elements under the scope root', () => {
+    document.body.innerHTML =
+      '<main><h2>Inside</h2><button id="b1">In</button></main>' +
+      '<h2>Outside</h2><button id="b2">Out</button>';
+
+    const out = run(buildDomSnapshotExpression('main'));
+
+    expect(out).toContain('Scope: main');
+    expect(out).toContain('"In"');
+    expect(out).not.toContain('"Out"');
+    expect(out).toContain('H2: Inside');
+    expect(out).not.toContain('H2: Outside');
+    expect(document.getElementById('b1')?.getAttribute('data-wmux-ref')).toBe('0');
+    expect(document.getElementById('b2')?.hasAttribute('data-wmux-ref')).toBe(false);
+  });
+
+  it('wipes stale refs document-wide even when they fall outside the scope', () => {
+    document.body.innerHTML =
+      '<main><button id="b1">In</button></main><button id="b2" data-wmux-ref="7">Out</button>';
+
+    run(buildDomSnapshotExpression('main'));
+
+    // The out-of-scope stale ref must not survive to collide with fresh 0-based numbering.
+    expect(document.getElementById('b2')?.hasAttribute('data-wmux-ref')).toBe(false);
+  });
+
+  it('reports a non-matching selector instead of throwing', () => {
+    document.body.innerHTML = '<button>x</button>';
+    const out = run(buildDomSnapshotExpression('#nope'));
+    expect(out).toBe('No element matches selector: #nope');
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.fallback.test.ts
@@ -7,7 +7,7 @@ const { mockSendRpc, getPage } = vi.hoisted(() => ({
 
 vi.mock('../../wmux-client', () => ({
   sendRpc: (method: string, ...args: unknown[]) =>
-    method.startsWith('browser.lease.')
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
       ? Promise.resolve({ token: null })
       : mockSendRpc(method, ...args),
 }));

--- a/src/mcp/playwright/__tests__/snapshot.filter.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.filter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateSnapshot } from '../snapshot';
+
+// filter:'interactive' (Phase 1): strip non-interactive nodes up front, not
+// just on maxLength overflow — the measured-dominant agent usage. Same fake
+// Page harness as snapshot.fallthrough.test.ts.
+
+interface CdpNode {
+  nodeId: string;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+const TREE: CdpNode[] = [
+  { nodeId: '1', role: { type: 'role', value: 'RootWebArea' }, name: { type: 'name', value: 'Page' }, childIds: ['2', '3', '4'] },
+  { nodeId: '2', role: { type: 'role', value: 'paragraph' }, name: { type: 'name', value: 'Some prose' }, childIds: [] },
+  { nodeId: '3', role: { type: 'role', value: 'button' }, name: { type: 'name', value: 'OK' }, childIds: [] },
+  { nodeId: '4', role: { type: 'role', value: 'link' }, name: { type: 'name', value: 'Docs' }, childIds: [] },
+];
+
+function makePage(nodes: CdpNode[]) {
+  const client = {
+    send: vi.fn(async (method: string) =>
+      method === 'Accessibility.getFullAXTree' ? { nodes } : {},
+    ),
+    detach: vi.fn(() => Promise.resolve()),
+  };
+  return {
+    context: () => ({ newCDPSession: async () => client }),
+    evaluate: vi.fn(async () => ''),
+    getByRole: vi.fn(),
+    locator: vi.fn(),
+  };
+}
+
+describe('generateSnapshot filter:"interactive"', () => {
+  it('strips non-interactive nodes and keeps sequential refs', async () => {
+    const page = makePage(TREE);
+    const out = await generateSnapshot(page as never, { format: 'ai', filter: 'interactive' });
+
+    expect(out).not.toContain('paragraph');
+    expect(out).toContain('button');
+    expect(out).toContain('ref="0"');
+    expect(out).toContain('link');
+    expect(out).toContain('ref="1"');
+  });
+
+  it('without the filter, non-interactive nodes remain', async () => {
+    const page = makePage(TREE);
+    const out = await generateSnapshot(page as never, { format: 'ai' });
+    expect(out).toContain('paragraph');
+    expect(out).toContain('button');
+  });
+});

--- a/src/mcp/playwright/__tests__/snapshotCache.test.ts
+++ b/src/mcp/playwright/__tests__/snapshotCache.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getSnapshotBaseline,
+  invalidateSnapshotBaseline,
+  setSnapshotBaseline,
+  snapshotSurfaceKey,
+} from '../snapshotCache';
+
+// Baseline store for browser_snapshot auto-diff. The URL guard is the 3-model
+// review consensus: a diff across different page URLs is never valid, whatever
+// lifecycle events were missed.
+
+const key = snapshotSurfaceKey('ws-1', 'surf-1');
+
+beforeEach(() => {
+  invalidateSnapshotBaseline('ws-1', 'surf-1');
+});
+
+describe('snapshot baseline URL guard', () => {
+  it('returns the baseline when attrs and url match', () => {
+    setSnapshotBaseline(key, 'ai||', 'tree', 'https://a.test/');
+    expect(getSnapshotBaseline(key, 'ai||', 'https://a.test/')?.text).toBe('tree');
+  });
+
+  it('drops the baseline on url mismatch', () => {
+    setSnapshotBaseline(key, 'ai||', 'tree', 'https://a.test/');
+    expect(getSnapshotBaseline(key, 'ai||', 'https://b.test/')).toBeNull();
+    // And it is gone for good, not merely hidden.
+    expect(getSnapshotBaseline(key, 'ai||', 'https://a.test/')).toBeNull();
+  });
+
+  it('drops the baseline on attrs mismatch', () => {
+    setSnapshotBaseline(key, 'ai||', 'tree', 'https://a.test/');
+    expect(getSnapshotBaseline(key, 'ai|main|', 'https://a.test/')).toBeNull();
+  });
+
+  it('keeps legacy behavior when neither side knows a url', () => {
+    setSnapshotBaseline(key, 'ai||', 'tree');
+    expect(getSnapshotBaseline(key, 'ai||')?.text).toBe('tree');
+  });
+});

--- a/src/mcp/playwright/__tests__/snapshotDiff.test.ts
+++ b/src/mcp/playwright/__tests__/snapshotDiff.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { diffSnapshotLines, formatSnapshotResult } from '../snapshotDiff';
+
+// browser_snapshot auto-diff (Phase 1): line-LCS over the line-oriented
+// snapshot text, with a full-snapshot fallback whenever a diff would not be a
+// real savings. The first line of every result declares which was returned.
+
+function lines(n: number, prefix = 'line'): string {
+  return Array.from({ length: n }, (_, i) => `- ${prefix} ${i} [ref=${i}]`).join('\n');
+}
+
+describe('diffSnapshotLines', () => {
+  it('reports only the changed region with @ line markers and 1 context line', () => {
+    const prev = lines(30);
+    const next = prev.replace('- line 12 [ref=12]', '- line 12 CHANGED [ref=12]');
+
+    const diff = diffSnapshotLines(prev, next);
+    expect(diff).not.toBeNull();
+    expect(diff!.changedLines).toBe(2); // one removed + one added
+    expect(diff!.text).toContain('@ line');
+    expect(diff!.text).toContain('- - line 12 [ref=12]');
+    expect(diff!.text).toContain('+ - line 12 CHANGED [ref=12]');
+    // Distant unchanged lines are omitted.
+    expect(diff!.text).not.toContain('line 0 ');
+    expect(diff!.text).not.toContain('line 29');
+  });
+
+  it('returns a zero-change marker for identical inputs', () => {
+    const text = lines(5);
+    expect(diffSnapshotLines(text, text)).toEqual({
+      text: '(no changes since previous snapshot)',
+      changedLines: 0,
+    });
+  });
+
+  it('bails (null) when the changed region exceeds the DP bound', () => {
+    const prev = lines(2100, 'old');
+    const next = lines(2100, 'new');
+    expect(diffSnapshotLines(prev, next)).toBeNull();
+  });
+});
+
+describe('formatSnapshotResult', () => {
+  it('returns full with header when no baseline exists', () => {
+    const out = formatSnapshotResult(null, 'a\nb');
+    expect(out.usedDiff).toBe(false);
+    expect(out.text.startsWith('[snapshot: full]\n')).toBe(true);
+    expect(out.text).toContain('a\nb');
+  });
+
+  it('returns a diff with header when the change is small', () => {
+    const prev = lines(40);
+    const next = prev.replace('- line 3 [ref=3]', '- line 3 NEW [ref=3]');
+    const out = formatSnapshotResult(prev, next);
+    expect(out.usedDiff).toBe(true);
+    expect(out.text.split('\n')[0]).toContain('[snapshot: diff vs previous');
+    expect(out.text).toContain('full:true');
+    expect(out.text).toContain('+ - line 3 NEW [ref=3]');
+  });
+
+  it('falls back to full when the diff is not a real savings (>50%)', () => {
+    const prev = lines(10, 'old');
+    const next = lines(10, 'new');
+    const out = formatSnapshotResult(prev, next);
+    expect(out.usedDiff).toBe(false);
+    expect(out.text.startsWith('[snapshot: full]\n')).toBe(true);
+  });
+});

--- a/src/mcp/playwright/__tests__/snapshotDiff.test.ts
+++ b/src/mcp/playwright/__tests__/snapshotDiff.test.ts
@@ -34,8 +34,8 @@ describe('diffSnapshotLines', () => {
   });
 
   it('bails (null) when the changed region exceeds the DP bound', () => {
-    const prev = lines(2100, 'old');
-    const next = lines(2100, 'new');
+    const prev = lines(900, 'old');
+    const next = lines(900, 'new');
     expect(diffSnapshotLines(prev, next)).toBeNull();
   });
 });

--- a/src/mcp/playwright/__tests__/state.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/state.fallback.test.ts
@@ -15,7 +15,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 const { mockSendRpc } = vi.hoisted(() => ({ mockSendRpc: vi.fn() }));
 vi.mock('../../wmux-client', () => ({
   sendRpc: (method: string, ...args: unknown[]) =>
-    typeof method === 'string' && method.startsWith('browser.lease.')
+    typeof method === 'string' && (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
       ? Promise.resolve({ token: null })
       : mockSendRpc(method, ...args),
 }));

--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -5,7 +5,8 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 // browser.evaluate RPC channel instead of throwing "No browser page available".
 
 // #517: tool handlers are wrapped in withAutomationLease, which issues
-// browser.lease.* RPCs around the real operation. Record that traffic
+// browser.lease.* RPCs around the real operation, plus a browser.lifecycle.get
+// drain before the body. Record that infrastructure traffic
 // separately so ordinary fallback assertions see only browser.evaluate calls.
 const { mockSendRpc, mockLeaseRpc, getPage, getInstance } = vi.hoisted(() => {
   const getPage = vi.fn();
@@ -18,7 +19,7 @@ const { mockSendRpc, mockLeaseRpc, getPage, getInstance } = vi.hoisted(() => {
 });
 vi.mock('../../wmux-client', () => ({
   sendRpc: (method: string, ...args: unknown[]) =>
-    typeof method === 'string' && method.startsWith('browser.lease.')
+    typeof method === 'string' && (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
       ? mockLeaseRpc(method, ...args)
       : mockSendRpc(method, ...args),
 }));
@@ -277,7 +278,12 @@ describe('browser_wait RPC fallback', () => {
 
     await wait({ selector: '#app', surfaceId: 'surface-1' });
 
-    expect(mockLeaseRpc.mock.calls).toEqual([
+    // The lifecycle drain rides between acquire and the body — filter it out:
+    // this test is about the lease bracket, not the drain.
+    const leaseCalls = mockLeaseRpc.mock.calls.filter(
+      (c) => c[0] !== 'browser.lifecycle.get',
+    );
+    expect(leaseCalls).toEqual([
       ['browser.lease.acquire', { workspaceId: 'ws-test', surfaceId: 'surface-1' }],
       ['browser.lease.release', { token: 'lease-1' }],
     ]);

--- a/src/mcp/playwright/automationLease.ts
+++ b/src/mcp/playwright/automationLease.ts
@@ -6,9 +6,67 @@ import {
   type BrowserToolDeps,
 } from './browserScope';
 
+import { invalidateSnapshotBaseline } from './snapshotCache';
+
 // Renew well inside main's 30s RPC-lease TTL so a long-running tool op
 // (browser_wait_for, slow page interactions) never lapses mid-flight.
 const RENEW_INTERVAL_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Inline lifecycle events: before each tool body runs, drain the browser
+// lifecycle ring (navigations / loads / closes since the last tool call) from
+// main and prepend them to the tool's result, so the agent never needs a
+// polling round-trip to learn the page moved underneath it. Drain failure is
+// silent — older mains without browser.lifecycle.get must not break tools.
+// ---------------------------------------------------------------------------
+
+interface LifecycleEventWire {
+  type: 'navigated' | 'loaded' | 'closed';
+  url?: string;
+  ts: number;
+}
+
+async function drainLifecycleEvents(scope: BrowserTargetScope): Promise<LifecycleEventWire[]> {
+  try {
+    const res = await sendScopedBrowserRpc<{ entries?: LifecycleEventWire[] }>(
+      'browser.lifecycle.get',
+      scope,
+    );
+    const entries = Array.isArray(res?.entries) ? res.entries : [];
+    // A navigation or close means any cached snapshot baseline for this
+    // surface describes a page that no longer exists.
+    if (entries.some((e) => e.type === 'navigated' || e.type === 'closed')) {
+      invalidateSnapshotBaseline(scope.workspaceId, scope.surfaceId);
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+function formatAgo(ts: number): string {
+  const s = Math.max(0, Math.round((Date.now() - ts) / 1000));
+  return s < 60 ? `${s}s ago` : `${Math.round(s / 60)}m ago`;
+}
+
+/**
+ * Prepend drained events to an MCP tool result. Only results that duck-type
+ * as { content: [...] } are touched (isError results included) — anything
+ * else passes through unchanged.
+ */
+function prependBrowserEvents<T>(result: T, events: LifecycleEventWire[]): T {
+  if (events.length === 0) return result;
+  const shaped = result as { content?: Array<{ type: string; text?: string }> } | null | undefined;
+  if (!shaped || !Array.isArray(shaped.content)) return result;
+  const lines = events.map(
+    (e) => `- ${e.type}${e.url ? `: ${e.url}` : ''} (${formatAgo(e.ts)})`,
+  );
+  shaped.content.unshift({
+    type: 'text',
+    text: `[browser events since last tool call]\n${lines.join('\n')}`,
+  });
+  return result;
+}
 
 /**
  * Automation lease for Playwright-direct operations (#517 lightweight mode).
@@ -71,8 +129,9 @@ export async function withAutomationLease<T>(
       if (lateToken) sendRpc('browser.lease.renew', { token: lateToken }).catch(() => {});
     }, RENEW_INTERVAL_MS);
     (lateRenew as { unref?: () => void }).unref?.();
+    const lateEvents = await drainLifecycleEvents(scope);
     try {
-      return await fn(scope);
+      return prependBrowserEvents(await fn(scope), lateEvents);
     } finally {
       done = true;
       clearInterval(lateTimer);
@@ -92,8 +151,9 @@ export async function withAutomationLease<T>(
   // Do not keep the MCP process alive just to renew a lease.
   (renewTimer as { unref?: () => void }).unref?.();
 
+  const events = await drainLifecycleEvents(scope);
   try {
-    return await fn(scope);
+    return prependBrowserEvents(await fn(scope), events);
   } finally {
     clearInterval(renewTimer);
     sendRpc('browser.lease.release', { token: heldToken }).catch(() => {

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -31,21 +31,32 @@ export const INTERACTIVE_SELECTOR =
  * documents), which is exactly why it covers background surfaces where the
  * CDP accessibility tree returns root-only.
  *
+ * `rootSelector` (optional) scopes the interactive query and heading listing
+ * to the first matching element — the 100-element cap then applies within that
+ * scope, which is the point: a scoped snapshot of a busy page surfaces the
+ * region the agent cares about instead of the first 100 elements site-wide.
+ * The stale-ref wipe stays document-wide so an out-of-scope element can never
+ * retain a stale ref that collides with the fresh numbering.
+ *
  * Stale-tag hygiene: prior `data-wmux-ref` attributes are removed before
  * re-numbering from 0. Without this, a shrunk interactive set between two
  * snapshots would leave two elements sharing one ref, and resolveRef's
  * `.first()` data-attr fallback (snapshot.ts) could pick the wrong one.
  */
-export function buildDomSnapshotExpression(): string {
+export function buildDomSnapshotExpression(rootSelector?: string): string {
   return `(() => {
     const sel = ${JSON.stringify(INTERACTIVE_SELECTOR)};
+    const rootSel = ${JSON.stringify(rootSelector ?? null)};
+    const root = rootSel ? document.querySelector(rootSel) : document;
+    if (!root) return 'No element matches selector: ' + rootSel;
     document.querySelectorAll('[data-wmux-ref]').forEach(el => el.removeAttribute('data-wmux-ref'));
-    const interactives = [...document.querySelectorAll(sel)].slice(0, 100);
+    const interactives = [...root.querySelectorAll(sel)].slice(0, 100);
     interactives.forEach((el, i) => el.setAttribute('data-wmux-ref', String(i)));
     const title = document.title;
     const url = location.href;
     const lines = ['Page: ' + title, 'URL: ' + url, ''];
-    document.querySelectorAll('h1,h2,h3').forEach(h => {
+    if (rootSel) lines.push('Scope: ' + rootSel, '');
+    root.querySelectorAll('h1,h2,h3').forEach(h => {
       lines.push(h.tagName + ': ' + (h.textContent || '').trim().substring(0, 80));
     });
     lines.push('', 'Interactive elements (use ref number for click/fill/type):');

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -12,6 +12,9 @@ export interface SnapshotOptions {
   depth?: number;
   /** Maximum output length in characters (default 50000) */
   maxLength?: number;
+  /** 'interactive' = strip non-interactive nodes up front ('ai' format only),
+   *  not just on overflow — the measured-dominant agent usage. */
+  filter?: 'interactive';
 }
 
 /** CDP Accessibility.AXNode shape (subset of fields we use) */
@@ -152,6 +155,18 @@ export interface RefEntry {
 
 /** Per-page storage of the last generated refMap to avoid concurrency issues */
 const pageRefMaps = new WeakMap<Page, RefEntry[]>();
+
+/**
+ * Mark a page's refs as DOM-attribute-based: an empty a11y refMap makes
+ * resolveRef fall through to the `[data-wmux-ref]` locator. Used by the
+ * selector-scoped snapshot path in inspection.ts, which tags refs via the DOM
+ * expression while a live Page (and possibly a stale a11y refMap from an
+ * earlier unscoped snapshot) exists.
+ */
+export function markDomRefsActive(page: Page): void {
+  pageRefMaps.set(page, []);
+}
+
 
 function isInteractive(role: string): boolean {
   return INTERACTIVE_ROLES.has(role);
@@ -342,8 +357,15 @@ export async function generateSnapshot(
     }
   }
 
+  // Opt-in interactive-only filter: same strip as the overflow retry below,
+  // but unconditional — the agent asked for only actionable nodes.
+  let effectiveTree = tree;
+  if (options?.filter === 'interactive' && format === 'ai') {
+    effectiveTree = stripNonInteractive(tree) ?? tree;
+  }
+
   let refs: RefEntry[] = [];
-  let output = serializeTree(tree, format, depth, refs);
+  let output = serializeTree(effectiveTree, format, depth, refs);
 
   // If the output exceeds maxLength AND we are in 'ai' mode, strip
   // non-interactive nodes and regenerate.

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -358,10 +358,17 @@ export async function generateSnapshot(
   }
 
   // Opt-in interactive-only filter: same strip as the overflow retry below,
-  // but unconditional — the agent asked for only actionable nodes.
+  // but unconditional — the agent asked for only actionable nodes. Zero
+  // interactive nodes must NOT fall back to the full tree (review consensus:
+  // the filter would silently invert into maximum output) — say so instead.
   let effectiveTree = tree;
   if (options?.filter === 'interactive' && format === 'ai') {
-    effectiveTree = stripNonInteractive(tree) ?? tree;
+    const stripped = stripNonInteractive(tree);
+    if (!stripped) {
+      pageRefMaps.set(page, []);
+      return '(no interactive elements on this page)';
+    }
+    effectiveTree = stripped;
   }
 
   let refs: RefEntry[] = [];

--- a/src/mcp/playwright/snapshotCache.ts
+++ b/src/mcp/playwright/snapshotCache.ts
@@ -15,6 +15,12 @@ export interface SnapshotBaseline {
   /** Attribute key: a diff is only valid against a baseline produced with the
    *  same format/selector/filter — mismatches replace, never diff. */
   attrs: string;
+  /** Page URL at capture time. Diffing across different URLs is never valid:
+   *  a missed navigation event (destructive drain won by another consumer,
+   *  in-surface tab switch, drain response lost) must degrade to a full
+   *  snapshot, not a diff against a page that no longer exists (3-model
+   *  review consensus). */
+  url?: string;
   ts: number;
 }
 
@@ -44,22 +50,35 @@ export function snapshotSurfaceKey(workspaceId: string | undefined, surfaceId: s
   return `ws:${workspaceId ?? ''}:surf:${surfaceId ?? ''}`;
 }
 
-export function getSnapshotBaseline(surfaceKey: string, attrs: string): SnapshotBaseline | null {
+export function getSnapshotBaseline(
+  surfaceKey: string,
+  attrs: string,
+  url?: string,
+): SnapshotBaseline | null {
   const store = getStore();
   const entry = store.get(surfaceKey);
   if (!entry) return null;
-  if (entry.attrs !== attrs || Date.now() - entry.ts > BASELINE_TTL_MS) {
+  // URL guard: when both sides know their URL and they differ, the baseline
+  // describes another page — drop it. (Both undefined keeps legacy behavior
+  // for callers that cannot determine a URL.)
+  const urlMismatch = entry.url !== undefined && url !== undefined && entry.url !== url;
+  if (entry.attrs !== attrs || urlMismatch || Date.now() - entry.ts > BASELINE_TTL_MS) {
     store.delete(surfaceKey);
     return null;
   }
   return entry;
 }
 
-export function setSnapshotBaseline(surfaceKey: string, attrs: string, text: string): void {
+export function setSnapshotBaseline(
+  surfaceKey: string,
+  attrs: string,
+  text: string,
+  url?: string,
+): void {
   const store = getStore();
   // Refresh insertion order so eviction below is LRU-ish.
   store.delete(surfaceKey);
-  store.set(surfaceKey, { text, attrs, ts: Date.now() });
+  store.set(surfaceKey, { text, attrs, ...(url !== undefined && { url }), ts: Date.now() });
   while (store.size > MAX_BASELINES) {
     const oldest = store.keys().next().value;
     if (oldest === undefined) break;

--- a/src/mcp/playwright/snapshotCache.ts
+++ b/src/mcp/playwright/snapshotCache.ts
@@ -1,0 +1,73 @@
+import { getConnectionScope } from '../connectionScope';
+
+// ---------------------------------------------------------------------------
+// Per-surface snapshot baselines for browser_snapshot's auto-diff mode.
+//
+// A baseline is the last full snapshot text a caller produced for a surface;
+// the next snapshot with matching attributes returns a diff against it instead
+// of the full tree. Stored per connection (broker) with a module-global
+// fallback (single-child) — the elementCache idiom in dom-intelligence.ts —
+// so two agents on the same surface never diff against each other's baseline.
+// ---------------------------------------------------------------------------
+
+export interface SnapshotBaseline {
+  text: string;
+  /** Attribute key: a diff is only valid against a baseline produced with the
+   *  same format/selector/filter — mismatches replace, never diff. */
+  attrs: string;
+  ts: number;
+}
+
+// Bounds: a handful of surfaces per agent is the realistic ceiling; TTL is a
+// backstop against diffing a snapshot from a long-abandoned page state when a
+// navigation event was missed (e.g. main lacked browser.lifecycle.get).
+const MAX_BASELINES = 8;
+const BASELINE_TTL_MS = 5 * 60 * 1000;
+
+let moduleBaselines: Map<string, SnapshotBaseline> | undefined;
+
+function getStore(): Map<string, SnapshotBaseline> {
+  const scope = getConnectionScope();
+  if (scope) {
+    const existing = scope.snapshotCache as Map<string, SnapshotBaseline> | undefined;
+    if (existing) return existing;
+    const fresh = new Map<string, SnapshotBaseline>();
+    scope.snapshotCache = fresh;
+    return fresh;
+  }
+  if (!moduleBaselines) moduleBaselines = new Map();
+  return moduleBaselines;
+}
+
+/** Surface key mirroring PlaywrightEngine.resolveSelectionContext. */
+export function snapshotSurfaceKey(workspaceId: string | undefined, surfaceId: string | undefined): string {
+  return `ws:${workspaceId ?? ''}:surf:${surfaceId ?? ''}`;
+}
+
+export function getSnapshotBaseline(surfaceKey: string, attrs: string): SnapshotBaseline | null {
+  const store = getStore();
+  const entry = store.get(surfaceKey);
+  if (!entry) return null;
+  if (entry.attrs !== attrs || Date.now() - entry.ts > BASELINE_TTL_MS) {
+    store.delete(surfaceKey);
+    return null;
+  }
+  return entry;
+}
+
+export function setSnapshotBaseline(surfaceKey: string, attrs: string, text: string): void {
+  const store = getStore();
+  // Refresh insertion order so eviction below is LRU-ish.
+  store.delete(surfaceKey);
+  store.set(surfaceKey, { text, attrs, ts: Date.now() });
+  while (store.size > MAX_BASELINES) {
+    const oldest = store.keys().next().value;
+    if (oldest === undefined) break;
+    store.delete(oldest);
+  }
+}
+
+/** Drop the baseline for a surface (drained `navigated`/`closed` event). */
+export function invalidateSnapshotBaseline(workspaceId: string | undefined, surfaceId: string | undefined): void {
+  getStore().delete(snapshotSurfaceKey(workspaceId, surfaceId));
+}

--- a/src/mcp/playwright/snapshotDiff.ts
+++ b/src/mcp/playwright/snapshotDiff.ts
@@ -9,8 +9,10 @@
 // ---------------------------------------------------------------------------
 
 // Bail out of the O(n·m) DP beyond this many lines per side (after common
-// prefix/suffix trimming) — the caller then returns the full snapshot.
-const MAX_DIFF_LINES = 2000;
+// prefix/suffix trimming) — the caller then returns the full snapshot. Kept
+// small: the DP is synchronous on the MCP event loop (review: 2000 lines was
+// an 8MB table + 4M-iteration stall per snapshot).
+const MAX_DIFF_LINES = 800;
 // A diff at least this fraction of the full snapshot's size stops being a
 // savings and starts being a harder-to-read full snapshot.
 const DIFF_WORTHWHILE_RATIO = 0.5;

--- a/src/mcp/playwright/snapshotDiff.ts
+++ b/src/mcp/playwright/snapshotDiff.ts
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------------
+// Line-level snapshot diff for browser_snapshot's auto-diff mode.
+//
+// Snapshots are one-line-per-node text (both the a11y serializer and the DOM
+// listing), so a plain line LCS is sufficient — no dependency needed. Ref
+// numbers are embedded in the line text, which is what makes diffing over
+// renumber-prone refs sound: any renumbering surfaces as changed lines, and a
+// small diff means the surviving refs are byte-identical and resolve the same.
+// ---------------------------------------------------------------------------
+
+// Bail out of the O(n·m) DP beyond this many lines per side (after common
+// prefix/suffix trimming) — the caller then returns the full snapshot.
+const MAX_DIFF_LINES = 2000;
+// A diff at least this fraction of the full snapshot's size stops being a
+// savings and starts being a harder-to-read full snapshot.
+const DIFF_WORTHWHILE_RATIO = 0.5;
+
+interface LineDiff {
+  text: string;
+  changedLines: number;
+}
+
+/**
+ * Unified-style diff of two line-oriented texts, 1 context line per hunk.
+ * Returns null when either side (after trimming the common prefix/suffix)
+ * exceeds MAX_DIFF_LINES — the caller falls back to the full snapshot.
+ */
+export function diffSnapshotLines(prevText: string, nextText: string): LineDiff | null {
+  const prev = prevText.split('\n');
+  const next = nextText.split('\n');
+
+  // Trim common prefix/suffix before the DP — typical act→verify snapshots
+  // share almost everything, so this collapses the quadratic core to the
+  // changed region.
+  let start = 0;
+  while (start < prev.length && start < next.length && prev[start] === next[start]) start++;
+  let endP = prev.length;
+  let endN = next.length;
+  while (endP > start && endN > start && prev[endP - 1] === next[endN - 1]) {
+    endP--;
+    endN--;
+  }
+
+  const a = prev.slice(start, endP);
+  const b = next.slice(start, endN);
+  if (a.length === 0 && b.length === 0) {
+    return { text: '(no changes since previous snapshot)', changedLines: 0 };
+  }
+  if (a.length > MAX_DIFF_LINES || b.length > MAX_DIFF_LINES) return null;
+
+  // LCS DP over the trimmed middle.
+  const n = a.length;
+  const m = b.length;
+  const width = m + 1;
+  const dp = new Uint16Array((n + 1) * width);
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i * width + j] =
+        a[i] === b[j]
+          ? dp[(i + 1) * width + j + 1] + 1
+          : Math.max(dp[(i + 1) * width + j], dp[i * width + j + 1]);
+    }
+  }
+
+  // Walk the table into (-, +, ' ') ops over the trimmed region.
+  type Op = { kind: '-' | '+' | ' '; line: string };
+  const ops: Op[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      ops.push({ kind: ' ', line: a[i] });
+      i++;
+      j++;
+    } else if (dp[(i + 1) * width + j] >= dp[i * width + j + 1]) {
+      ops.push({ kind: '-', line: a[i] });
+      i++;
+    } else {
+      ops.push({ kind: '+', line: b[j] });
+      j++;
+    }
+  }
+  while (i < n) ops.push({ kind: '-', line: a[i++] });
+  while (j < m) ops.push({ kind: '+', line: b[j++] });
+
+  // Group into hunks with 1 context line on each side. `start` offsets hunk
+  // positions back into full-text line numbers (1-based, next-side).
+  const out: string[] = [];
+  let changedLines = 0;
+  let k = 0;
+  // Position in the NEXT text of the op at index k (advances on '+'/' ').
+  let nextLine = start;
+  while (k < ops.length) {
+    if (ops[k].kind === ' ') {
+      nextLine++;
+      k++;
+      continue;
+    }
+    // Hunk starts at the change; include one preceding context line if present.
+    const hunkStartIdx = k > 0 && ops[k - 1].kind === ' ' ? k - 1 : k;
+    const hunkHeaderLine = nextLine - (hunkStartIdx === k - 1 ? 1 : 0) + 1;
+    const hunk: string[] = [];
+    if (hunkStartIdx === k - 1) hunk.push(`  ${ops[k - 1].line}`);
+    // Consume until we see 2 consecutive context lines (1 kept as trailing
+    // context, the rest ends the hunk).
+    while (k < ops.length) {
+      const op = ops[k];
+      if (op.kind === ' ') {
+        const nextIsChange = ops[k + 1] && ops[k + 1].kind !== ' ';
+        if (!nextIsChange) {
+          hunk.push(`  ${op.line}`);
+          nextLine++;
+          k++;
+          break;
+        }
+        hunk.push(`  ${op.line}`);
+        nextLine++;
+        k++;
+        continue;
+      }
+      hunk.push(`${op.kind} ${op.line}`);
+      changedLines++;
+      if (op.kind !== '-') nextLine++;
+      k++;
+    }
+    out.push(`@ line ${hunkHeaderLine}`);
+    out.push(...hunk);
+  }
+
+  return { text: out.join('\n'), changedLines };
+}
+
+export interface FormattedSnapshot {
+  text: string;
+  usedDiff: boolean;
+}
+
+/**
+ * Render a snapshot result: a diff against the baseline when one exists and
+ * the diff is genuinely smaller (< DIFF_WORTHWHILE_RATIO of the full text),
+ * else the full snapshot. The first line always declares which was returned.
+ */
+export function formatSnapshotResult(baseline: string | null, nextText: string): FormattedSnapshot {
+  const full = { text: `[snapshot: full]\n${nextText}`, usedDiff: false };
+  if (baseline === null || baseline === '') return full;
+  const diff = diffSnapshotLines(baseline, nextText);
+  if (!diff) return full;
+  if (diff.changedLines > 0 && diff.text.length >= nextText.length * DIFF_WORTHWHILE_RATIO) {
+    return full;
+  }
+  return {
+    text:
+      `[snapshot: diff vs previous — unchanged lines omitted; pass full:true for the complete tree]\n` +
+      diff.text,
+    usedDiff: true,
+  };
+}

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -3,8 +3,11 @@ import type { Page } from 'playwright-core';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
-import { generateSnapshot, resolveRef } from '../snapshot';
+import { generateSnapshot, markDomRefsActive, resolveRef } from '../snapshot';
 import { buildDomSnapshotExpression } from '../dom-intelligence';
+import { pageEvaluator, rpcEvaluator } from '../page-eval';
+import { formatSnapshotResult } from '../snapshotDiff';
+import { getSnapshotBaseline, setSnapshotBaseline, snapshotSurfaceKey } from '../snapshotCache';
 import { evaluateWithGesture } from '../anti-detection';
 import { detectDangerousPatterns } from '../security';
 import { sanitizeRef } from './interaction';
@@ -33,6 +36,22 @@ const BROWSER_SNAPSHOT_SHAPE = {
     .string()
     .optional()
     .describe('Reserved for future use: ref number to scope the snapshot to a subtree.'),
+  selector: z
+    .string()
+    .optional()
+    .describe(
+      'CSS selector to scope the snapshot to the first matching element (e.g. "main", "[role=dialog]"). Returns a DOM listing of interactive elements within that subtree.',
+    ),
+  filter: z
+    .enum(['interactive'])
+    .optional()
+    .describe('"interactive" strips non-interactive nodes from the tree — much smaller output.'),
+  full: z
+    .boolean()
+    .optional()
+    .describe(
+      'Force the complete snapshot. By default a repeat snapshot of the same page returns a diff against the previous one when that is smaller.',
+    ),
   surfaceId: optionalSurfaceId,
 };
 
@@ -305,29 +324,47 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
   // -----------------------------------------------------------------------
   server.tool(
     'browser_snapshot',
-    'Take an accessibility tree snapshot of the current page. Returns a text representation of the page structure with interactive elements annotated with ref numbers.',
+    'Take an accessibility tree snapshot of the current page. Returns a text representation of the page structure with interactive elements annotated with ref numbers. A repeat snapshot of the same page returns a diff against the previous one when that is smaller (pass full:true to force the complete tree); selector scopes to a subtree, filter:"interactive" strips non-interactive nodes.',
     BROWSER_SNAPSHOT_SHAPE,
-    async ({ format, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ format, selector, filter, full, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        // Try Playwright for full snapshot
+        let text: string;
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
-        if (page) {
-          const snapshot = await generateSnapshot(page, { format: format ?? 'ai' });
-          return {
-            content: [{ type: 'text' as const, text: snapshot }],
-          };
+        if (selector) {
+          // Selector scoping runs DOM-side on BOTH transports (one code path):
+          // the expression tags data-wmux-ref within the subtree, so refs
+          // resolve via the data-attr locator — mark any live Page's a11y
+          // refMap stale so resolveRef cannot use it.
+          const evaluate = page ? pageEvaluator(page) : rpcEvaluator(scope);
+          text = String(await evaluate(buildDomSnapshotExpression(selector)));
+          if (page) markDomRefsActive(page);
+        } else if (page) {
+          text = await generateSnapshot(page, {
+            format: format ?? 'ai',
+            ...(filter && { filter }),
+          });
+        } else {
+          // Fallback: extract page structure via RPC evaluation. Tags interactive
+          // elements with data-wmux-ref so interaction tools can resolve them.
+          // Same expression the page-mode root-only fallthrough runs (snapshot.ts),
+          // via the shared buildDomSnapshotExpression() helper.
+          const result = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
+            expression: buildDomSnapshotExpression(),
+          });
+          text = result.value;
         }
 
-        // Fallback: extract page structure via RPC evaluation. Tags interactive
-        // elements with data-wmux-ref so interaction tools can resolve them.
-        // Same expression the page-mode root-only fallthrough runs (snapshot.ts),
-        // via the shared buildDomSnapshotExpression() helper.
-        const result = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
-          expression: buildDomSnapshotExpression(),
-        });
+        // Auto-diff: a repeat snapshot with the same attributes returns a diff
+        // against the previous one when that is genuinely smaller (D1). The
+        // fresh text always becomes the new baseline — including on full:true.
+        const key = snapshotSurfaceKey(scope.workspaceId, scope.surfaceId);
+        const attrs = `${format ?? 'ai'}|${selector ?? ''}|${filter ?? ''}`;
+        const baseline = full ? null : getSnapshotBaseline(key, attrs);
+        const rendered = formatSnapshotResult(baseline?.text ?? null, text);
+        setSnapshotBaseline(key, attrs, text);
 
         return {
-          content: [{ type: 'text' as const, text: result.value }],
+          content: [{ type: 'text' as const, text: rendered.text }],
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -337,7 +337,20 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
           // refMap stale so resolveRef cannot use it.
           const evaluate = page ? pageEvaluator(page) : rpcEvaluator(scope);
           text = String(await evaluate(buildDomSnapshotExpression(selector)));
+          if (text.startsWith('No element matches selector:')) {
+            // A miss is an error, not a snapshot — and must never become the
+            // diff baseline for the next call (review consensus).
+            return {
+              content: [{ type: 'text' as const, text }],
+              isError: true,
+            };
+          }
           if (page) markDomRefsActive(page);
+          // The DOM listing has no format/filter concept — be honest about it
+          // instead of silently ignoring the params (review consensus).
+          if (format || filter) {
+            text = `(note: format/filter are ignored when selector is given)\n${text}`;
+          }
         } else if (page) {
           text = await generateSnapshot(page, {
             format: format ?? 'ai',
@@ -357,11 +370,20 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
         // Auto-diff: a repeat snapshot with the same attributes returns a diff
         // against the previous one when that is genuinely smaller (D1). The
         // fresh text always becomes the new baseline — including on full:true.
+        // URL guard (3-model review): never diff across different page URLs —
+        // Playwright pages report url() directly, the DOM listing embeds a
+        // "URL: …" line to parse.
+        let currentUrl: string | undefined;
+        if (page && typeof (page as { url?: () => string }).url === 'function') {
+          currentUrl = page.url();
+        } else {
+          currentUrl = /^URL: (.+)$/m.exec(text)?.[1];
+        }
         const key = snapshotSurfaceKey(scope.workspaceId, scope.surfaceId);
         const attrs = `${format ?? 'ai'}|${selector ?? ''}|${filter ?? ''}`;
-        const baseline = full ? null : getSnapshotBaseline(key, attrs);
+        const baseline = full ? null : getSnapshotBaseline(key, attrs, currentUrl);
         const rendered = formatSnapshotResult(baseline?.text ?? null, text);
-        setSnapshotBaseline(key, attrs, text);
+        setSnapshotBaseline(key, attrs, text, currentUrl);
 
         return {
           content: [{ type: 'text' as const, text: rendered.text }],

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -343,6 +343,7 @@ export type RpcMethod =
   | 'browser.screenshot'
   | 'browser.evaluate'
   | 'browser.console.get'
+  | 'browser.lifecycle.get'
   | 'browser.network.get'
   | 'browser.responseBody.get'
   | 'browser.type.cdp'
@@ -520,6 +521,7 @@ export const ALL_RPC_METHODS = [
   'browser.screenshot',
   'browser.evaluate',
   'browser.console.get',
+  'browser.lifecycle.get',
   'browser.network.get',
   'browser.responseBody.get',
   'browser.type.cdp',


### PR DESCRIPTION
## What

Compresses the agent's act→verify loop in the MCP browser toolset — three techniques measured to dominate real agent-browser workloads (diff-sized verify reads, interactive-only trees, no polling for page state):

- **Snapshot auto-diff** — `browser_snapshot` returns a line-LCS diff against the previous snapshot of the same surface when that is smaller. First line always declares `[snapshot: full]` or `[snapshot: diff …]`; `full:true` forces the complete tree. Baselines are per-connection, keyed by workspace+surface+attrs, carry the page URL (a diff is never produced across different URLs), and are invalidated on navigation.
- **Scoping** — new `selector` param scopes the snapshot to a subtree via the shared DOM expression on both transports (Playwright and packaged RPC); new `filter:"interactive"` strips non-interactive nodes up front instead of only on overflow.
- **Inline lifecycle events** — `BrowserCaptureManager` enables the Page domain and records main-frame navigations (including SPA `navigatedWithinDocument`), load events, and guest closure; a new `browser.lifecycle.get` RPC drains them destructively and `withAutomationLease` prepends them to every `browser_*` tool result, so page changes surface inline instead of requiring a polling round-trip.

## Hardening (multi-model panel review)

URL guard on baselines, `filter` with zero interactive nodes reports instead of returning the full tree, `Page.enable` failure can no longer take down console/network capture, selector misses are errors and never become baselines, `lastLifecycleTarget` is bounded, and the diff DP bound is 800 lines to keep the synchronous LCS off the hot path.

## Tests

19 new tests: diff generation/fallback/bounds, URL guard, interactive filter, selector scoping + stale-ref wipe, lifecycle capture/cap/destructive drain/close synthesis, RPC handler cases, lease injection + baseline invalidation. Existing fallback suites updated to the new drain contract. `tsc` clean; targeted suites 380/380; full `npm test` green except the two known symlinked-node_modules false failures (notices, atlasCoherence).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `browser_snapshot` now supports compact automatic diffs, full snapshots, selector-scoped views, and interactive-only filtering.
  * Browser tool results now include recent navigation, load, and tab-closure events inline.
  * Added lifecycle retrieval through `browser.lifecycle.get`.
* **Documentation**
  * Updated the changelog and API reference to document the new snapshot and lifecycle capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->