### PR TITLE
feat(remote): bootstrap a new workspace on a paired remote host (#1001)

### DIFF
--- a/changelog.d/1067.md
+++ b/changelog.d/1067.md
@@ -1,0 +1,3 @@
+### Added
+
+- Remote workspace attach: "New workspace on this host" in the Attach Remote modal bootstraps the first pane of a brand-new workspace on a paired remote daemon — previously only a sibling pane on a workspace the desktop app had already created could be added.

--- a/src/daemon/web/WebTerminalServer.ts
+++ b/src/daemon/web/WebTerminalServer.ts
@@ -2336,7 +2336,7 @@ export class WebTerminalServer {
       const workspaceId = typeof b.workspaceId === 'string' ? b.workspaceId.trim() : '';
       const cwd = typeof b.cwd === 'string' ? b.cwd.trim() : '';
       if (workspaceId) {
-        const bad = this.rejectWorkspaceId(workspaceId);
+        const bad = this.rejectWorkspaceId(workspaceId, principal);
         if (bad) return this.json(res, 400, bad);
       }
       lifecycle
@@ -2392,14 +2392,32 @@ export class WebTerminalServer {
    * not resolve to "so I will accept it" for a value that becomes an identity.
    * The workspace-less spawn (omit the field) is always available and is what a
    * client should fall back to.
+   *
+   * THE ONE EXCEPTION (#1001): `principal.kind === 'operator'` skips EXISTENCE
+   * only — shape is still enforced for everyone. This is an identity operation,
+   * not an execution one: minting a workspace id decides how a pane is filed
+   * and scoped, not what it can run, so it sits outside the "credential form
+   * must not gate capability" argument `handleSessionCreate` makes just above —
+   * that argument is about `mayInput`, which a device already has. The operator
+   * is the thing that owns the workspace registry (the renderer mints and files
+   * these ids today), so it is the thing allowed to extend it; a paired device
+   * still cannot claim an id nothing is running under. Stated limitation so
+   * this is not mistaken for a hard boundary: it is an audit-and-revocability
+   * one — a shell on the daemon's own host can already read the operator
+   * token, and a phone-only headless bootstrap still needs that operator
+   * credential once, elsewhere, to get here at all.
    */
-  private rejectWorkspaceId(workspaceId: string): { error: string; detail: string } | null {
+  private rejectWorkspaceId(
+    workspaceId: string,
+    principal: WebPrincipal,
+  ): { error: string; detail: string } | null {
     if (!/^[A-Za-z0-9_-]{1,64}$/.test(workspaceId)) {
       return {
         error: 'invalid-workspace-id',
         detail: 'workspaceId must match ^[A-Za-z0-9_-]{1,64}$',
       };
     }
+    if (principal.kind === 'operator') return null;
     const known = this.deps.sessionManager
       .listLiveSessions()
       .some((s) => s.env?.[ENV_KEYS.WORKSPACE_ID] === workspaceId);

--- a/src/daemon/web/__tests__/WebTerminalServer.test.ts
+++ b/src/daemon/web/__tests__/WebTerminalServer.test.ts
@@ -3327,14 +3327,36 @@ describe('WebTerminalServer', () => {
     expect(lifecycleCalls).toEqual([]);
   });
 
-  it('★ 400s a well-shaped workspaceId that no live pane is running in', async () => {
+  it('★ 400s a well-shaped workspaceId that no live pane is running in — for a paired DEVICE', async () => {
     // The daemon owns no workspace registry, so "some live session already
     // carries this id" is the only evidence it has that the workspace exists.
-    // Accepting an unverifiable id would be workspace impersonation.
-    const info = await startRW();
-    const res = await postSession(info.token as string, { workspaceId: 'ws-invented' });
+    // Accepting an unverifiable id from a device would be workspace
+    // impersonation — this is #1001's regression guard: the operator
+    // exception below must not have widened this for anyone else.
+    await startRW();
+    const device = await pairDevice('Phone');
+    const res = await postSession(device.token, { workspaceId: 'ws-invented' });
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: 'unknown-workspace-id' });
+    expect(lifecycleCalls).toEqual([]);
+  });
+
+  it('★ #1001 — the OPERATOR may bootstrap a brand-new workspaceId no pane is running in', async () => {
+    // "New workspace on this host" on a headless remote daemon has no live
+    // pane to vouch for the id yet — that is the whole gap #1001 closes.
+    // Shape is still enforced (mirrors the 400 test above); only the
+    // liveness/existence check is skipped, and only for this credential.
+    const info = await startRW();
+    const res = await postSession(info.token as string, { workspaceId: 'ws-brand-new' });
+    expect(res.status).toBe(201);
+    expect(lifecycleCalls).toEqual([{ op: 'create', arg: { workspaceId: 'ws-brand-new' } }]);
+  });
+
+  it('★ #1001 — the operator exception still enforces SHAPE', async () => {
+    const info = await startRW();
+    const res = await postSession(info.token as string, { workspaceId: 'ws 1' });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({ error: 'invalid-workspace-id' });
     expect(lifecycleCalls).toEqual([]);
   });
 

--- a/src/main/ipc/handlers/__tests__/remote.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/remote.handler.test.ts
@@ -109,6 +109,7 @@ function fakeClient(host: RemoteHost) {
     detachAll: vi.fn(),
     write: vi.fn(async () => undefined),
     listWorkspaces: vi.fn(async (): Promise<RemoteWorkspacesResponse> => ({ workspaces: [] })),
+    createWorkspace: vi.fn(async (): Promise<{ sessionId: string }> => ({ sessionId: 'web-1' })),
     onMeta: vi.fn((cb: (e: RemoteMetaEvent) => void) => { metaCbs.push(cb); }),
     onResize: vi.fn((cb: (e: RemoteResizeEvent) => void) => { resizeCbs.push(cb); }),
     onData: vi.fn((cb: (e: RemoteDataEvent) => void) => { dataCbs.push(cb); }),
@@ -125,6 +126,7 @@ function fakeClient(host: RemoteHost) {
     detachAll: ReturnType<typeof vi.fn>;
     write: ReturnType<typeof vi.fn>;
     listWorkspaces: ReturnType<typeof vi.fn>;
+    createWorkspace: ReturnType<typeof vi.fn>;
     emitMeta: (e: RemoteMetaEvent) => void;
     emitResize: (e: RemoteResizeEvent) => void;
     emitData: (e: RemoteDataEvent) => void;
@@ -483,6 +485,53 @@ describe('remote.handler — workspacesList', () => {
 
     expect(res).toEqual({ ok: false, error: 'unknown host' });
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('remote.handler — workspaceCreate (#1001)', () => {
+  const host: RemoteHost = { id: 'h1', label: 'box', origin: 'https://box:9600', token: 't', addedAt: 0 };
+
+  it('bootstraps a new workspace and returns its sessionId', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    client.createWorkspace.mockResolvedValueOnce({ sessionId: 'web-9' });
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+
+    const res = await getHandler(IPC.REMOTE_WORKSPACE_CREATE)({}, 'h1', 'ws-brand-new') as { ok: true; sessionId: string };
+
+    expect(res).toEqual({ ok: true, sessionId: 'web-9' });
+    expect(client.createWorkspace).toHaveBeenCalledWith('ws-brand-new', undefined);
+  });
+
+  it('forwards cwd when given', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+
+    await getHandler(IPC.REMOTE_WORKSPACE_CREATE)({}, 'h1', 'ws-1', '/repo');
+
+    expect(client.createWorkspace).toHaveBeenCalledWith('ws-1', '/repo');
+  });
+
+  it('maps a client rejection to {ok:false} rather than throwing', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    client.createWorkspace.mockRejectedValueOnce(new Error('unknown-workspace-id: workspaceId must match ...'));
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+
+    const res = await getHandler(IPC.REMOTE_WORKSPACE_CREATE)({}, 'h1', 'bad id') as { ok: false; error: string };
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/workspaceId must match/);
+  });
+
+  it('reports unknown host without touching a client', async () => {
+    const store = fakeStore([]);
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never });
+
+    const res = await getHandler(IPC.REMOTE_WORKSPACE_CREATE)({}, 'missing', 'ws-1') as { ok: boolean; error?: string };
+
+    expect(res).toEqual({ ok: false, error: 'unknown host' });
   });
 });
 

--- a/src/main/ipc/handlers/remote.handler.ts
+++ b/src/main/ipc/handlers/remote.handler.ts
@@ -462,6 +462,27 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
       }
     }));
 
+  ipcMain.removeHandler(IPC.REMOTE_WORKSPACE_CREATE);
+  ipcMain.handle(IPC.REMOTE_WORKSPACE_CREATE, wrapHandler(IPC.REMOTE_WORKSPACE_CREATE,
+    async (
+      _e: IpcMainInvokeEvent,
+      hostId: unknown,
+      workspaceId: unknown,
+      cwd?: unknown,
+    ): Promise<{ ok: true; sessionId: string } | { ok: false; error: string }> => {
+      const id = assertString(hostId, 'hostId');
+      const wsId = assertString(workspaceId, 'workspaceId');
+      const safeCwd = cwd === undefined ? undefined : assertString(cwd, 'cwd');
+      const client = getOrCreateClient(id);
+      if (!client) return { ok: false, error: 'unknown host' };
+      try {
+        const { sessionId } = await client.createWorkspace(wsId, safeCwd);
+        return { ok: true, sessionId };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }));
+
   // Attach descriptors — the persistence half of "attachments survive a
   // reload". Deliberately independent of the SSE attach lifecycle below: the
   // reload teardown in installSenderCleanup still kills every live stream (a
@@ -577,6 +598,7 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
     ipcMain.removeHandler(IPC.REMOTE_HOSTS_PAIR);
     ipcMain.removeHandler(IPC.REMOTE_HOSTS_REMOVE);
     ipcMain.removeHandler(IPC.REMOTE_WORKSPACES_LIST);
+    ipcMain.removeHandler(IPC.REMOTE_WORKSPACE_CREATE);
     ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_LIST);
     ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_ADD);
     ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_REMOVE);

--- a/src/main/remote/RemoteHostClient.ts
+++ b/src/main/remote/RemoteHostClient.ts
@@ -197,6 +197,50 @@ export class RemoteHostClient implements RemotePaneEvents {
     this.errorCbs.push(cb);
   }
 
+  /**
+   * Bootstrap the first pane of a NEW workspace on this host (#1001). Mints
+   * no id itself — the caller (the renderer, which owns the workspace
+   * registry today) supplies `workspaceId`, and this is the operator-Bearer
+   * request `WebTerminalServer.rejectWorkspaceId` lets mint an unknown id
+   * for: `RemoteHost.token` is always the operator credential (parsed from
+   * the pasted wmux-web URL or the pair exchange — see remoteHosts.ts), never
+   * a paired device's, so every call through this client already qualifies.
+   *
+   * Returns the new pane's `sessionId` on success — the caller attaches to
+   * it the same way `REMOTE_PANE_ATTACH` attaches to any other remote pane.
+   */
+  async createWorkspace(workspaceId: string, cwd?: string): Promise<{ sessionId: string }> {
+    const res = await this.fetchImpl(`${this.host.origin}/api/sessions`, {
+      method: 'POST',
+      headers: { ...this.authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId, ...(cwd ? { cwd } : {}) }),
+      redirect: 'error',
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      let message = `createWorkspace failed: HTTP ${res.status}`;
+      try {
+        const parsed = (await res.json()) as { error?: string; detail?: string };
+        if (parsed?.detail) message = parsed.detail;
+        else if (parsed?.error) message = parsed.error;
+      } catch {
+        /* body wasn't JSON — fall back to the generic message */
+      }
+      throw new Error(message);
+    }
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      throw new Error('createWorkspace failed: response body was not JSON');
+    }
+    const sessionId = (body as { id?: unknown } | null)?.id;
+    if (typeof sessionId !== 'string' || !sessionId) {
+      throw new Error('createWorkspace failed: response carried no session id');
+    }
+    return { sessionId };
+  }
+
   async listWorkspaces(): Promise<RemoteWorkspacesResponse> {
     const res = await this.fetchImpl(`${this.host.origin}/api/workspaces`, {
       headers: this.authHeaders(),

--- a/src/main/remote/__tests__/RemoteHostClient.test.ts
+++ b/src/main/remote/__tests__/RemoteHostClient.test.ts
@@ -62,6 +62,72 @@ describe('RemoteHostClient', () => {
     vi.useRealTimers();
   });
 
+  describe('createWorkspace (#1001)', () => {
+    it('POSTs to /api/sessions with the operator Bearer token and the caller-supplied workspaceId', async () => {
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => ({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: 'web-1' }),
+      }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      const result = await client.createWorkspace('ws-brand-new');
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchImpl.mock.calls[0];
+      expect(url).toBe(`${host.origin}/api/sessions`);
+      expect(init?.method).toBe('POST');
+      expect((init?.headers as Record<string, string>)?.Authorization).toBe(`Bearer ${host.token}`);
+      expect(init?.redirect).toBe('error');
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      expect(JSON.parse(init?.body as string)).toEqual({ workspaceId: 'ws-brand-new' });
+      expect(result).toEqual({ sessionId: 'web-1' });
+    });
+
+    it('includes cwd in the body only when given', async () => {
+      const fetchImpl = vi.fn(async () => ({ ok: true, status: 201, json: async () => ({ id: 'web-1' }) }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await client.createWorkspace('ws-1', '/repo');
+
+      const [, init] = fetchImpl.mock.calls[0];
+      expect(JSON.parse(init?.body as string)).toEqual({ workspaceId: 'ws-1', cwd: '/repo' });
+    });
+
+    it('rejects with the daemon-supplied detail on a non-OK response', async () => {
+      const fetchImpl = vi.fn(async () => ({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: 'invalid-workspace-id', detail: 'workspaceId must match ^[A-Za-z0-9_-]{1,64}$' }),
+      }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.createWorkspace('bad id')).rejects.toThrow(
+        'workspaceId must match ^[A-Za-z0-9_-]{1,64}$',
+      );
+    });
+
+    it('rejects with a generic message when the error body is not JSON', async () => {
+      const fetchImpl = vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => { throw new Error('not json'); },
+      }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.createWorkspace('ws-1')).rejects.toThrow('createWorkspace failed: HTTP 500');
+    });
+
+    it('rejects when the response carries no session id', async () => {
+      const fetchImpl = vi.fn(async () => ({ ok: true, status: 201, json: async () => ({}) }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.createWorkspace('ws-1')).rejects.toThrow(
+        'createWorkspace failed: response carried no session id',
+      );
+    });
+  });
+
   describe('listWorkspaces', () => {
     it('sends Authorization: Bearer <token> and parses the body', async () => {
       const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => {

--- a/src/main/remote/__tests__/RemoteHostClient.test.ts
+++ b/src/main/remote/__tests__/RemoteHostClient.test.ts
@@ -85,7 +85,7 @@ describe('RemoteHostClient', () => {
     });
 
     it('includes cwd in the body only when given', async () => {
-      const fetchImpl = vi.fn(async () => ({ ok: true, status: 201, json: async () => ({ id: 'web-1' }) }) as unknown as Response);
+      const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => ({ ok: true, status: 201, json: async () => ({ id: 'web-1' }) }) as unknown as Response);
       const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
 
       await client.createWorkspace('ws-1', '/repo');

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1352,6 +1352,10 @@ document.addEventListener('DOMContentLoaded', () => {
     ipcRenderer.invoke(IPC.REMOTE_WORKSPACES_LIST, hostId) as Promise<
       { ok: true; workspaces: RemoteWorkspaceSummary[] } | { ok: false; error: string }
     >,
+  workspaceCreate: (hostId: string, workspaceId: string, cwd?: string) =>
+    ipcRenderer.invoke(IPC.REMOTE_WORKSPACE_CREATE, hostId, workspaceId, cwd) as Promise<
+      { ok: true; sessionId: string } | { ok: false; error: string }
+    >,
   attachmentsList: () =>
     ipcRenderer.invoke(IPC.REMOTE_ATTACHMENTS_LIST) as Promise<RemoteAttachmentDescriptor[]>,
   attachmentsAdd: (descriptor: RemoteAttachmentDescriptor) =>

--- a/src/renderer/components/Sidebar/AttachRemoteModal.tsx
+++ b/src/renderer/components/Sidebar/AttachRemoteModal.tsx
@@ -68,6 +68,9 @@ export default function AttachRemoteModal({ onClose }: AttachRemoteModalProps) {
   const [pairing, setPairing] = useState(false);
   const [pairError, setPairError] = useState<string | null>(null);
 
+  const [creatingWorkspace, setCreatingWorkspace] = useState(false);
+  const [createWorkspaceError, setCreateWorkspaceError] = useState<string | null>(null);
+
   const refreshHosts = useCallback(async () => {
     const remote = window.electronAPI?.remote;
     if (!remote) return [];
@@ -104,6 +107,7 @@ export default function AttachRemoteModal({ onClose }: AttachRemoteModalProps) {
     setSelectedHostId(hostId);
     setWorkspaces([]);
     setWorkspacesError(null);
+    setCreateWorkspaceError(null);
     setLoadingWorkspaces(true);
     const remote = window.electronAPI?.remote;
     if (!remote) { setLoadingWorkspaces(false); return; }
@@ -237,6 +241,41 @@ export default function AttachRemoteModal({ onClose }: AttachRemoteModalProps) {
     });
     onClose();
   }, [hosts, selectedHostId, attachRemoteWorkspace, onClose]);
+
+  /**
+   * Bootstraps the FIRST pane of a brand-new workspace on the selected host
+   * (#1001) — the desktop mints the id (the daemon has no registry of its
+   * own to mint one from), calls the operator-authenticated create route,
+   * then attaches exactly like picking an existing workspace does.
+   */
+  const handleCreateWorkspace = useCallback(async () => {
+    const remote = window.electronAPI?.remote;
+    const host = hosts.find((h) => h.id === selectedHostId);
+    if (!remote?.workspaceCreate || !host) return;
+    setCreatingWorkspace(true);
+    setCreateWorkspaceError(null);
+    try {
+      const workspaceId = crypto.randomUUID();
+      const res = await remote.workspaceCreate(host.id, workspaceId);
+      if (!res.ok) {
+        setCreateWorkspaceError(t('remote.createWorkspaceFailed', { error: res.error }));
+        return;
+      }
+      attachRemoteWorkspace({
+        key: remoteAttachmentKey(host.id, workspaceId),
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceId,
+        name: '',
+        panes: [{ sessionId: res.sessionId }],
+      });
+      onClose();
+    } catch {
+      setCreateWorkspaceError(t('remote.createWorkspaceFailed', { error: t('remote.workspacesFailed') }));
+    } finally {
+      setCreatingWorkspace(false);
+    }
+  }, [hosts, selectedHostId, attachRemoteWorkspace, onClose, t]);
 
   const selectedHost = hosts.find((h) => h.id === selectedHostId) ?? null;
 
@@ -427,6 +466,23 @@ export default function AttachRemoteModal({ onClose }: AttachRemoteModalProps) {
             {!selectedHostId && (
               <div className="text-[11px]" style={{ color: 'var(--text-subtle)' }}>
                 {hosts.length === 0 ? t('remote.noHostsHint') : t('remote.selectHostHint')}
+              </div>
+            )}
+            {selectedHostId && (
+              <div>
+                <Button
+                  variant="secondary"
+                  className="w-full text-[11px]"
+                  disabled={creatingWorkspace}
+                  onClick={handleCreateWorkspace}
+                >
+                  {creatingWorkspace ? t('remote.loading') : t('remote.createWorkspaceHere')}
+                </Button>
+                {createWorkspaceError && (
+                  <div className="text-[10px] mt-1" style={{ color: 'var(--accent-red)' }}>
+                    {createWorkspaceError}
+                  </div>
+                )}
               </div>
             )}
             {selectedHostId && loadingWorkspaces && (

--- a/src/renderer/components/Sidebar/__tests__/AttachRemoteModal.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/AttachRemoteModal.test.tsx
@@ -65,6 +65,7 @@ describe('AttachRemoteModal', () => {
   let hostsPair: ReturnType<typeof vi.fn>;
   let hostsRemove: ReturnType<typeof vi.fn>;
   let workspacesList: ReturnType<typeof vi.fn>;
+  let workspaceCreate: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     hostsList = vi.fn().mockResolvedValue([HOST]);
@@ -72,6 +73,7 @@ describe('AttachRemoteModal', () => {
     hostsPair = vi.fn();
     hostsRemove = vi.fn().mockResolvedValue(true);
     workspacesList = vi.fn().mockResolvedValue({ ok: true, workspaces: [WORKSPACE] });
+    workspaceCreate = vi.fn().mockResolvedValue({ ok: true, sessionId: 'web-1' });
 
     (window as unknown as { electronAPI: unknown }).electronAPI = {
       remote: {
@@ -80,6 +82,7 @@ describe('AttachRemoteModal', () => {
         hostsPair,
         hostsRemove,
         workspacesList,
+        workspaceCreate,
         paneAttach: vi.fn(),
         paneDetach: vi.fn(),
         paneWrite: vi.fn(),
@@ -181,6 +184,77 @@ describe('AttachRemoteModal', () => {
     });
 
     unmount();
+  });
+
+  // #1001 — bootstrapping the first pane of a NEW workspace on the selected
+  // host, from the exact dead end the VPS test hit (host paired, "no
+  // workspaces on that host", nothing further to click).
+  describe('create workspace on host (#1001)', () => {
+    it('mints an id, creates it on the host, and attaches it like an existing workspace would', async () => {
+      const uuidSpy = vi.spyOn(crypto, 'randomUUID').mockReturnValue('11111111-1111-1111-1111-111111111111');
+      const { container, unmount } = render(<AttachRemoteModal onClose={() => { /* noop */ }} />);
+      await flush();
+
+      const hostButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'office-mac')!;
+      act(() => { hostButton.click(); });
+      await flush();
+
+      const createButton = Array.from(container.querySelectorAll('button'))
+        .find((b) => b.textContent === 'New workspace on this host')!;
+      expect(createButton).toBeTruthy();
+      act(() => { createButton.click(); });
+      await flush();
+
+      expect(workspaceCreate).toHaveBeenCalledWith('host-1', '11111111-1111-1111-1111-111111111111');
+
+      const remoteWorkspaces = useStore.getState().remoteWorkspaces;
+      expect(remoteWorkspaces).toHaveLength(1);
+      expect(remoteWorkspaces[0]).toMatchObject({
+        key: 'host-1:11111111-1111-1111-1111-111111111111',
+        hostId: 'host-1',
+        hostLabel: 'office-mac',
+        workspaceId: '11111111-1111-1111-1111-111111111111',
+        panes: [{ sessionId: 'web-1' }],
+      });
+
+      uuidSpy.mockRestore();
+      unmount();
+    });
+
+    it('is offered even when the host has no live workspaces yet', async () => {
+      workspacesList.mockResolvedValue({ ok: true, workspaces: [] });
+      const { container, unmount } = render(<AttachRemoteModal onClose={() => { /* noop */ }} />);
+      await flush();
+
+      const hostButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'office-mac')!;
+      act(() => { hostButton.click(); });
+      await flush();
+
+      expect(container.textContent).toContain('No workspaces on that host');
+      expect(Array.from(container.querySelectorAll('button')).some((b) => b.textContent === 'New workspace on this host')).toBe(true);
+
+      unmount();
+    });
+
+    it('shows the error and does not attach on failure', async () => {
+      workspaceCreate.mockResolvedValue({ ok: false, error: 'unknown-workspace-id' });
+      const { container, unmount } = render(<AttachRemoteModal onClose={() => { /* noop */ }} />);
+      await flush();
+
+      const hostButton = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === 'office-mac')!;
+      act(() => { hostButton.click(); });
+      await flush();
+
+      const createButton = Array.from(container.querySelectorAll('button'))
+        .find((b) => b.textContent === 'New workspace on this host')!;
+      act(() => { createButton.click(); });
+      await flush();
+
+      expect(container.textContent).toContain('Could not create workspace');
+      expect(useStore.getState().remoteWorkspaces).toHaveLength(0);
+
+      unmount();
+    });
   });
 
   // I3(a) — hostsRemove existed on the handler/preload/types but nothing in

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1716,6 +1716,8 @@ export const en = {
   'remote.selectHostHint': 'Select a host to see its workspaces',
   'remote.noWorkspaces': 'No workspaces on that host — the list is built from panes that are open right now, so open a pane there and reselect',
   'remote.attach': 'Attach',
+  'remote.createWorkspaceHere': 'New workspace on this host',
+  'remote.createWorkspaceFailed': 'Could not create workspace — {error}',
   'remote.detach': 'Detach',
   'remote.loading': 'Loading…',
   'remote.readOnly': 'Read-only — start the remote server with --allow-input to type',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -1724,6 +1724,8 @@ export const pl = {
   'remote.selectHostHint': 'Wybierz hosta, aby zobaczyć jego obszary robocze',
   'remote.noWorkspaces': 'Brak obszarów roboczych na tym hoście — lista jest budowana z paneli otwartych właśnie teraz, więc otwórz tam panel i wybierz ponownie',
   'remote.attach': 'Dołącz',
+  'remote.createWorkspaceHere': 'Nowy obszar roboczy na tym hoście',
+  'remote.createWorkspaceFailed': 'Nie udało się utworzyć obszaru roboczego — {error}',
   'remote.detach': 'Odłącz',
   'remote.loading': 'Wczytywanie…',
   'remote.readOnly': 'Tylko do odczytu — uruchom zdalny serwer z --allow-input, aby pisać',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -554,6 +554,11 @@ export const IPC = {
   REMOTE_HOSTS_PAIR: 'remote:hosts:pair',
   REMOTE_HOSTS_REMOVE: 'remote:hosts:remove',
   REMOTE_WORKSPACES_LIST: 'remote:workspaces:list',
+  // Bootstrap the FIRST pane of a NEW workspace on a remote host (#1001):
+  // the desktop mints the workspace id and hands it to `POST /api/sessions`
+  // as an operator-authenticated caller (WebTerminalServer.rejectWorkspaceId's
+  // one exception). See RemoteHostClient.createWorkspace.
+  REMOTE_WORKSPACE_CREATE: 'remote:workspace:create',
   // Persisted attach descriptors (see RemoteAttachmentsStore). The renderer's
   // remote-workspace slice is memory-only, so these are what survive a reload
   // and an app restart; panes are never stored, only re-fetched.

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -214,6 +214,15 @@ declare global {
         workspacesList: (hostId: string) => Promise<
           { ok: true; workspaces: RemoteWorkspaceSummary[] } | { ok: false; error: string }
         >;
+        /** Bootstraps the FIRST pane of a NEW workspace on `hostId` (#1001).
+         *  The caller mints `workspaceId` — the daemon has no registry of its
+         *  own, so this is the one place a fresh id gets minted at all.
+         *  Resolves `{ ok: false }` (never rejects) on any failure — an
+         *  unreachable host, a rejected token, or the remote's own daemon
+         *  refusing the create. */
+        workspaceCreate: (hostId: string, workspaceId: string, cwd?: string) => Promise<
+          { ok: true; sessionId: string } | { ok: false; error: string }
+        >;
         /** Persisted attach descriptors — read on renderer boot to restore
          *  the attachments a reload/restart wiped out of the memory-only
          *  slice. Panes are never part of a descriptor: they are re-fetched


### PR DESCRIPTION
Closes the concrete gap flagged in #1001: pairing a headless remote daemon worked end-to-end, but there was no way to create the FIRST pane of a NEW workspace on it — only to add a sibling pane to a workspace the desktop app had already created. "New workspace on this host" in the Attach Remote modal closes it.

## Server contract (quoted, not guessed)

From the maintainer's decision in #1001:

> Server contract I'd take: keep the shape check for everyone; relax only the existence check when `principal.kind === 'operator'`. Mint the uuid on the desktop side — the renderer owns the registry today, so the server accepts an operator-supplied new id rather than generating one. No separate `POST /api/workspaces` mint endpoint: if it records anything it invents the registry the daemon deliberately doesn't have, and if it doesn't, it is the same relaxation with more API surface.
>
> Stated limitation, so nobody later mistakes A for more than it is: this is an audit-and-revocability boundary, not a hard one — a shell on the daemon's own host can read the operator token, and a phone-only headless bootstrap still needs the operator credential once. Both deserve a line in the `rejectWorkspaceId` comment when this lands.

Implemented exactly that — both halves in one PR, as offered.

## Server-side gate

`WebTerminalServer.rejectWorkspaceId` now takes the caller's `WebPrincipal`. Shape (`^[A-Za-z0-9_-]{1,64}$`) is still enforced unconditionally; the existence check (some live pane already carries the id) is skipped only when `principal.kind === 'operator'`. A paired device's behavior is byte-for-byte unchanged — see the regression test below. The rationale from #1001 (identity operation, not an execution one; the thing that owns the registry may extend it) plus the stated audit-and-revocability limitation are now in the comment.

Credential path, confirmed rather than assumed: `RemoteHost.token` (what `RemoteHostClient` sends as `Authorization: Bearer`) is always the operator token — parsed from the pasted `wmux web` URL or minted by the code-pairing exchange — never a paired device's credential. That was established in #1001's own discussion thread and is what makes every call through this client already qualify.

## Desktop half

- `RemoteHostClient.createWorkspace(workspaceId, cwd?)` — `POST /api/sessions` with the operator token and a desktop-minted id, returns the new pane's `sessionId`.
- `remote:workspace:create` IPC route (main) + `window.electronAPI.remote.workspaceCreate` (preload/types), wired the same way `remote:workspaces:list` already is.
- `AttachRemoteModal`: a "New workspace on this host" button, shown whenever a host is selected — including the empty-workspaces state the #1001 VPS test actually hit ("no workspaces on that host"). Success mints a UUID, creates it on the host, and calls `attachRemoteWorkspace` exactly like picking an existing workspace does.

## Test plan

- `WebTerminalServer.test.ts`:
  - operator bootstraps a brand-new `workspaceId` → 201, reaches `lifecycle.create`
  - operator's exception still enforces shape → 400 `invalid-workspace-id`
  - a **paired device** on the same unknown id → still 400 `unknown-workspace-id`, unchanged (regression guard — this is the test that used to run against the operator token; split so the device case keeps its original assertion)
- `RemoteHostClient.test.ts`: request method/URL/headers/redirect/timeout, cwd included only when given, daemon-supplied error detail surfaced, non-JSON error body falls back to a generic message, missing-session-id response rejects.
- `remote.handler.test.ts`: success + sessionId passthrough, cwd forwarding, client rejection mapped to `{ok:false}` (never throws across IPC), unknown host reported without touching a client.
- `AttachRemoteModal.test.tsx`: mint → create → attach end to end (checks the store gets the right `AttachedRemoteWorkspace`), button offered on an empty workspace list, failure path shows the error and attaches nothing.
- `plLocaleCoverage.test.ts`: the two new `remote.*` strings are translated (Polish is the only locale with enforced coverage; the other 20 are an accepted gap per #997).
- `npm run test:parallel`: 811 passed / 7 failed test files — every failure is in `worktree.handler.test.ts` (EBUSY / timeout, git-worktree fixture cleanup racing under load) and `channelsSlice.test.ts` (unrelated timeout), none touching a file this PR changes; confirmed by `git diff --name-only` against the failing files.
- `tsc --noEmit` and `eslint` on every changed file: clean (pre-existing warnings/errors elsewhere untouched).

House rules followed: English, no version bump, changelog fragment to follow once the PR number is known.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create a new workspace directly on a paired remote host.
  * “New workspace on this host” is available even when no workspaces exist.
  * Optionally select the workspace’s initial working directory.
  * Clear error messages are displayed when creation fails.

* **Bug Fixes**
  * Operators can now bootstrap new remote workspaces, while device access continues to require an active workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->