### PR TITLE
fix(browser): honor filter on browser_snapshot's DOM paths instead of silently dropping it

### DIFF
--- a/src/mcp/playwright/__tests__/dom-intelligence.selector.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.selector.test.ts
@@ -44,3 +44,38 @@ describe('buildDomSnapshotExpression(rootSelector)', () => {
     expect(out).toBe('No element matches selector: #nope');
   });
 });
+
+describe('buildDomSnapshotExpression filter:"interactive" (#1066)', () => {
+  it('drops the heading block but keeps interactives and the Page/URL header', () => {
+    document.body.innerHTML = '<h1>Title</h1><h2>Section</h2><button id="b1">Go</button>';
+
+    const out = run(buildDomSnapshotExpression(undefined, { filter: 'interactive' }));
+
+    expect(out).not.toContain('H1: Title');
+    expect(out).not.toContain('H2: Section');
+    expect(out).toContain('"Go"');
+    // The auto-diff URL guard parses the "URL: …" line — it must survive the filter.
+    expect(out).toMatch(/^URL: /m);
+    expect(document.getElementById('b1')?.getAttribute('data-wmux-ref')).toBe('0');
+  });
+
+  it('composes with a rootSelector: scoped AND heading-free', () => {
+    document.body.innerHTML =
+      '<main><h2>Inside</h2><button id="b1">In</button></main>' +
+      '<h2>Outside</h2><button id="b2">Out</button>';
+
+    const out = run(buildDomSnapshotExpression('main', { filter: 'interactive' }));
+
+    expect(out).toContain('Scope: main');
+    expect(out).not.toContain('H2: Inside');
+    expect(out).not.toContain('H2: Outside');
+    expect(out).toContain('"In"');
+    expect(out).not.toContain('"Out"');
+  });
+
+  it('without the filter, headings remain (control)', () => {
+    document.body.innerHTML = '<h1>Title</h1><button>Go</button>';
+    const out = run(buildDomSnapshotExpression());
+    expect(out).toContain('H1: Title');
+  });
+});

--- a/src/mcp/playwright/__tests__/snapshot.fallthrough.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.fallthrough.test.ts
@@ -72,11 +72,34 @@ describe('generateSnapshot — root-only fallthrough (#353)', () => {
     expect(out).toBe('DOM-FALLBACK');
   });
 
-  it('falls through for aria format too, not just ai', async () => {
+  it('falls through for aria format too, with a note instead of a silent drop (#1066)', async () => {
     const { page } = makePage({ nodes: ROOT_ONLY, evalResult: 'DOM-FALLBACK' });
     const out = await generateSnapshot(page as never, { format: 'aria' });
     expect(page.evaluate).toHaveBeenCalledTimes(1);
+    // aria has no DOM-listing equivalent — the caller must be told, not
+    // handed the ai-style listing as if it were the aria tree.
+    expect(out).toBe(
+      '(note: aria format unavailable — the a11y tree collapsed, returning the DOM interactive listing)\nDOM-FALLBACK',
+    );
+  });
+
+  it('forwards filter:"interactive" into the DOM expression on fallthrough (#1066)', async () => {
+    const { page } = makePage({ nodes: ROOT_ONLY, evalResult: 'DOM-FALLBACK' });
+    const out = await generateSnapshot(page as never, { format: 'ai', filter: 'interactive' });
+    // The param must reach the expression instead of dying on the early return.
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.stringContaining('const interactiveOnly = true'),
+    );
+    // ai + filter needs no note: the filtered listing IS what was asked for.
     expect(out).toBe('DOM-FALLBACK');
+  });
+
+  it('fallthrough without filter keeps the heading block enabled', async () => {
+    const { page } = makePage({ nodes: ROOT_ONLY, evalResult: 'DOM-FALLBACK' });
+    await generateSnapshot(page as never, { format: 'ai' });
+    expect(page.evaluate).toHaveBeenCalledWith(
+      expect.stringContaining('const interactiveOnly = false'),
+    );
   });
 
   it('serializes the a11y tree (no DOM fallback) when the tree has children', async () => {

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -42,11 +42,21 @@ export const INTERACTIVE_SELECTOR =
  * re-numbering from 0. Without this, a shrunk interactive set between two
  * snapshots would leave two elements sharing one ref, and resolveRef's
  * `.first()` data-attr fallback (snapshot.ts) could pick the wrong one.
+ *
+ * `filter: 'interactive'` drops the heading (h1–h3) listing so the output is
+ * the ref listing alone — the DOM-path equivalent of stripNonInteractive on
+ * the a11y path (issue #1066: the param used to be dropped silently here).
+ * The `Page:`/`URL:` header always stays: the auto-diff URL guard in
+ * inspection.ts parses the `URL: …` line out of this text.
  */
-export function buildDomSnapshotExpression(rootSelector?: string): string {
+export function buildDomSnapshotExpression(
+  rootSelector?: string,
+  opts?: { filter?: 'interactive' },
+): string {
   return `(() => {
     const sel = ${JSON.stringify(INTERACTIVE_SELECTOR)};
     const rootSel = ${JSON.stringify(rootSelector ?? null)};
+    const interactiveOnly = ${JSON.stringify(opts?.filter === 'interactive')};
     const root = rootSel ? document.querySelector(rootSel) : document;
     if (!root) return 'No element matches selector: ' + rootSel;
     document.querySelectorAll('[data-wmux-ref]').forEach(el => el.removeAttribute('data-wmux-ref'));
@@ -56,7 +66,7 @@ export function buildDomSnapshotExpression(rootSelector?: string): string {
     const url = location.href;
     const lines = ['Page: ' + title, 'URL: ' + url, ''];
     if (rootSel) lines.push('Scope: ' + rootSel, '');
-    root.querySelectorAll('h1,h2,h3').forEach(h => {
+    if (!interactiveOnly) root.querySelectorAll('h1,h2,h3').forEach(h => {
       lines.push(h.tagName + ': ' + (h.textContent || '').trim().substring(0, 80));
     });
     lines.push('', 'Interactive elements (use ref number for click/fill/type):');

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -342,7 +342,17 @@ export async function generateSnapshot(
   // useless, and the interactive listing beats an empty result (issue #353).
   if (!tree || isRootOnly(tree)) {
     try {
-      const domSnapshot = (await page.evaluate(buildDomSnapshotExpression())) as string;
+      // Honor filter on the DOM path too — the listing drops its heading block
+      // (#1066: the param used to be dropped silently on this early return).
+      let domSnapshot = (await page.evaluate(
+        buildDomSnapshotExpression(undefined, { filter: options?.filter }),
+      )) as string;
+      // aria has no DOM-listing equivalent — say so instead of silently
+      // returning the ai-style listing (same honesty rule as the selector
+      // path in inspection.ts). 'ai' needs no note: the listing IS ai-style.
+      if (format === 'aria') {
+        domSnapshot = `(note: aria format unavailable — the a11y tree collapsed, returning the DOM interactive listing)\n${domSnapshot}`;
+      }
       // Leave the refMap empty so resolveRef falls through to the data-wmux-ref
       // locator the DOM expression just tagged.
       pageRefMaps.set(page, []);

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -336,7 +336,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
           // resolve via the data-attr locator — mark any live Page's a11y
           // refMap stale so resolveRef cannot use it.
           const evaluate = page ? pageEvaluator(page) : rpcEvaluator(scope);
-          text = String(await evaluate(buildDomSnapshotExpression(selector)));
+          text = String(await evaluate(buildDomSnapshotExpression(selector, { filter })));
           if (text.startsWith('No element matches selector:')) {
             // A miss is an error, not a snapshot — and must never become the
             // diff baseline for the next call (review consensus).
@@ -346,10 +346,11 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
             };
           }
           if (page) markDomRefsActive(page);
-          // The DOM listing has no format/filter concept — be honest about it
-          // instead of silently ignoring the params (review consensus).
-          if (format || filter) {
-            text = `(note: format/filter are ignored when selector is given)\n${text}`;
+          // filter is honored by the DOM listing (#1066); aria is not — be
+          // honest about it instead of silently ignoring the param (review
+          // consensus). 'ai' needs no note: the listing IS ai-style.
+          if (format === 'aria') {
+            text = `(note: aria format is ignored when selector is given)\n${text}`;
           }
         } else if (page) {
           text = await generateSnapshot(page, {
@@ -360,11 +361,15 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
           // Fallback: extract page structure via RPC evaluation. Tags interactive
           // elements with data-wmux-ref so interaction tools can resolve them.
           // Same expression the page-mode root-only fallthrough runs (snapshot.ts),
-          // via the shared buildDomSnapshotExpression() helper.
+          // via the shared buildDomSnapshotExpression() helper — filter honored,
+          // aria noted, same as there (#1066).
           const result = await sendScopedBrowserRpc<{ value: string }>('browser.evaluate', scope, {
-            expression: buildDomSnapshotExpression(),
+            expression: buildDomSnapshotExpression(undefined, { filter }),
           });
           text = result.value;
+          if (format === 'aria') {
+            text = `(note: aria format unavailable — no live page, returning the DOM interactive listing)\n${text}`;
+          }
         }
 
         // Auto-diff: a repeat snapshot with the same attributes returns a diff


### PR DESCRIPTION
Fixes #1066.

## What was broken

`browser_snapshot`'s `filter:"interactive"` and `format:"aria"` were silent no-ops on every DOM-listing path:

- **`snapshot.ts:343` root-only fallthrough** — early `return domSnapshot` fired before the filter block (365) or `serializeTree(…, format, …)` (375) were reached, so both params were structurally unreachable whenever the a11y tree was null or root-only.
- **`inspection.ts` RPC fallback** (no Playwright page) — same drop: `buildDomSnapshotExpression()` was called with neither param.
- The `selector` path was honest (`(note: format/filter are ignored…)`) but didn't honor `filter` either.

Live repro on v3.48.1, backend=chrome: wikipedia.org snapshot with and without `filter:"interactive"` was **byte-identical**; `format:"aria"` returned the ai listing unlabeled.

## The fix

1. `buildDomSnapshotExpression(rootSelector?, opts?)` grows `opts.filter:"interactive"` — drops the h1–h3 heading block from the listing (the DOM-path equivalent of `stripNonInteractive`). The `Page:`/`URL:` header stays: the auto-diff URL guard parses the `URL: …` line out of this text.
2. All three DOM call sites forward `filter`: the fallthrough, the selector path, and the RPC fallback.
3. `format:"aria"` remains unfulfillable on a DOM listing, so those paths now **say so** with a note instead of returning the ai listing unlabeled — the same honesty rule the selector path already applied. The selector-path note narrows to aria only, since `filter` is now honored and `ai` is the listing's native shape.

The #353 fallthrough design (root-only aria tree degrades to the interactive listing) is untouched — only the silent drop on top of it is fixed.

## Tests

The existing suites covered `filter` (`snapshot.filter.test.ts`) and the fallthrough (`snapshot.fallthrough.test.ts`) separately but never crossed them — which is exactly where this died. Added:

- fallthrough × `filter`: the param reaches the evaluated expression (`const interactiveOnly = true`), plus a no-filter control
- fallthrough × `aria`: note asserted verbatim (was `toBe('DOM-FALLBACK')`)
- builder-level: filter drops headings, keeps interactives + `URL:` line + ref tagging; composes with `rootSelector`; no-filter control

`vitest` 37/37 on the six touched/adjacent suites, `tsc --noEmit` clean, eslint 0 errors (7 pre-existing `no-explicit-any` warnings).

Not live-verified against a running build — the targeted fallthrough path is unit-covered above; happy to dogfood on the next canary if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012us6JCvefLbxqn4gGA5V9M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive filter for DOM snapshots, showing interactive elements while retaining page and URL details.
  * Interactive filtering now works with selector-scoped snapshots and fallback snapshot paths.
  * Added clear notices when aria-format snapshots are unavailable and a DOM listing is returned.

* **Bug Fixes**
  * Preserved heading content when no interactive filter is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->