### PR TITLE
feat(browser): show the workspace Chrome-profile submenu only on the chrome backend

### DIFF
--- a/src/renderer/components/Sidebar/WorkspaceChromeProfileMenu.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceChromeProfileMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { IconChevron } from '../icons';
 import { useT } from '../../hooks/useT';
+import { useStore } from '../../stores';
 
 /**
  * Workspace right-click → Chrome profile submenu (Phase 2.5, BIND ONLY).
@@ -11,6 +12,15 @@ import { useT } from '../../hooks/useT';
  * agents cannot pick a profile themselves. Already-connected agent sessions
  * keep their current browser; new page resolutions use the new binding.
  * Structure cloned from WorkspaceAccountMenu (same bind-only shape).
+ *
+ * Backend gate: a binding is only ever consulted on the 'chrome' path
+ * (requireChrome → chromeRegistry.forWorkspace in browser.rpc.ts), so under
+ * 'builtin' or 'external' the whole submenu is inert — it would offer a
+ * profile choice that changes nothing observable. Hide it there, the same way
+ * WorkspaceAccountMenu hides itself when no accounts are registered. The
+ * backend mirror is read synchronously at store-module load
+ * (readInitialBrowserBackend), so this is correct on first render and needs
+ * no hydration wait.
  */
 export default function WorkspaceChromeProfileMenu({
   workspaceId,
@@ -20,18 +30,22 @@ export default function WorkspaceChromeProfileMenu({
   flipLeft: boolean;
 }): React.ReactElement | null {
   const t = useT();
+  const browserBackend = useStore((s) => s.browserBackend);
+  const isChromeBackend = browserBackend === 'chrome';
   const [profiles, setProfiles] = useState<string[]>([]);
   const [bound, setBound] = useState<string | undefined>(undefined);
   const [open, setOpen] = useState(false);
 
   const reload = useCallback(() => {
     const api = window.electronAPI?.browser?.chromeProfiles;
-    if (!api) return;
+    // Skip the boot IPC entirely off the chrome backend: this effect runs once
+    // per rendered workspace row, and none of those rows will show the menu.
+    if (!api || !isChromeBackend) return;
     void api.list().then((res) => {
       setProfiles(res.profiles);
       setBound(res.bindings[workspaceId]);
     }).catch(() => { /* menu stays with stale rows */ });
-  }, [workspaceId]);
+  }, [workspaceId, isChromeBackend]);
 
   useEffect(() => { reload(); }, [reload]);
 
@@ -61,6 +75,8 @@ export default function WorkspaceChromeProfileMenu({
 
   // Hide on older builds without the preload surface.
   if (!window.electronAPI?.browser?.chromeProfiles) return null;
+  // Hide when the backend cannot act on a binding (see the gate note above).
+  if (!isChromeBackend) return null;
 
   const submenuPos = flipLeft ? 'right-full mr-0.5' : 'left-full ml-0.5';
 

--- a/src/renderer/components/Sidebar/__tests__/WorkspaceChromeProfileMenu.backendGate.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/WorkspaceChromeProfileMenu.backendGate.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+//
+// The Chrome-profile submenu is only actionable on the 'chrome' backend: a
+// binding is read exclusively by requireChrome/chromeRegistry.forWorkspace on
+// the chrome path, so under 'builtin' or 'external' the menu would offer a
+// choice that changes nothing observable. These tests pin the gate — both the
+// render and the boot IPC it would otherwise fire once per workspace row.
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import WorkspaceChromeProfileMenu from '../WorkspaceChromeProfileMenu';
+import { useStore } from '../../../stores';
+
+const list = vi.fn(async () => ({ profiles: ['default'], bindings: {} as Record<string, string> }));
+
+/** Install the preload surface the menu probes for. */
+function installApi(): void {
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    browser: {
+      chromeProfiles: {
+        list,
+        create: vi.fn(async () => ({ ok: true })),
+        bind: vi.fn(async () => ({ ok: true })),
+      },
+    },
+  };
+}
+
+const mounted: Array<() => void> = [];
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(ui));
+  mounted.push(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+  return container;
+}
+
+beforeEach(() => {
+  list.mockClear();
+  installApi();
+});
+
+afterEach(() => {
+  while (mounted.length) mounted.pop()?.();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+describe('WorkspaceChromeProfileMenu — browser-backend gate', () => {
+  it('renders on the chrome backend', () => {
+    act(() => { useStore.getState().setBrowserBackend('chrome'); });
+    const container = render(<WorkspaceChromeProfileMenu workspaceId="ws-1" flipLeft={false} />);
+    expect(container.querySelector('button')).not.toBeNull();
+  });
+
+  it('renders nothing on the builtin backend', () => {
+    act(() => { useStore.getState().setBrowserBackend('builtin'); });
+    const container = render(<WorkspaceChromeProfileMenu workspaceId="ws-1" flipLeft={false} />);
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('renders nothing on the external backend', () => {
+    act(() => { useStore.getState().setBrowserBackend('external'); });
+    const container = render(<WorkspaceChromeProfileMenu workspaceId="ws-1" flipLeft={false} />);
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('skips the boot profile-list IPC when the backend is not chrome', () => {
+    act(() => { useStore.getState().setBrowserBackend('builtin'); });
+    render(<WorkspaceChromeProfileMenu workspaceId="ws-1" flipLeft={false} />);
+    // This effect runs once per rendered workspace row — it must not fire at all.
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it('does fire the boot profile-list IPC on the chrome backend', () => {
+    act(() => { useStore.getState().setBrowserBackend('chrome'); });
+    render(<WorkspaceChromeProfileMenu workspaceId="ws-1" flipLeft={false} />);
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
+  it('still hides on an older preload with no chromeProfiles surface, even on chrome', () => {
+    act(() => { useStore.getState().setBrowserBackend('chrome'); });
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    const container = render(<WorkspaceChromeProfileMenu workspaceId="ws-1" flipLeft={false} />);
+    expect(container.querySelector('button')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The workspace right-click → **Chrome 프로필** submenu (Phase 2.5) rendered on every backend. But a binding is only ever consulted on the chrome path — `requireChrome` → `chromeRegistry.forWorkspace` in `browser.rpc.ts` — so under `builtin` or `external` the submenu offered a profile choice that changed nothing observable.

This gates it on `browserBackend === 'chrome'`.

## Why hide rather than disable

`WorkspaceAccountMenu`, the component this one was cloned from, already hides itself when there is nothing to bind ("Hides itself when no accounts are registered"). Following that idiom keeps the two bind-only submenus consistent instead of introducing a third state.

## Notes

- **No hydration wait needed.** `readInitialBrowserBackend` reads main's authoritative value synchronously at store-module load, so the mirror is correct before first render — no flash, no gate flipping after boot.
- **Also skips the boot IPC.** `reload()` fired `chromeProfiles.list()` on mount once per rendered workspace row. Off the chrome backend none of those rows would show the menu, so the call is now skipped rather than made and discarded.
- The older-preload guard (`if (!window.electronAPI?.browser?.chromeProfiles) return null`) is unchanged and still applies first.

## Tests

New `WorkspaceChromeProfileMenu.backendGate.test.tsx` — 6 cases: renders on chrome; renders nothing on builtin and on external; boot IPC skipped off chrome and fired on chrome; still hidden on an older preload even when the backend is chrome.

Verified the tests actually catch the regression: reverting the component alone fails exactly the 3 gate cases (builtin, external, skipped IPC) and passes the other 3.

`vitest` 136/136 across the Sidebar suites + `uiSlice`, `tsc --noEmit` clean, eslint clean on both touched files.

Not live-verified in a running build — the gate is pure renderer logic and unit-covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012us6JCvefLbxqn4gGA5V9M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the Chrome profile submenu and reload actions to supported Chrome backends.
  * Prevented unsupported browser backends from triggering unnecessary profile startup actions.
  * Hid the submenu when Chrome profile functionality is unavailable.

* **Tests**
  * Added coverage for Chrome, built-in, and external backends, including missing profile support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->