### PR TITLE
chore(release): 3.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## [3.49.0] — 2026-08-29
+
+### Added
+
+- `browser_snapshot` now returns a compact diff against the previous snapshot of the same page when that is smaller (`full:true` forces the complete tree), and accepts `selector` to scope the snapshot to a subtree and `filter:"interactive"` to strip non-interactive nodes.
+
+- Browser tool results now report page lifecycle changes inline — navigations (including SPA route changes), page loads, and tab closure — including changes the call itself caused, so a navigation is reported on the very result that triggered it and agents no longer need to poll for page state.
+
+- New `chrome` browser backend (Settings → Browser): wmux launches a dedicated real-Chrome instance with its own persistent profile — sign in once and logins stick, fully separate from your daily browser — and agents get the full automation toolset against it. Sites that block embedded browsers (e.g. Google sign-in) work normally there.
+
+- Each workspace can bind its own Chrome profile (workspace card → right-click → Chrome profile): separate logins per workspace, so one workspace can automate account A while another uses account B.
+
+- Bind a workspace to "Live Chrome" to let its agent work inside your own running browser — your real tabs and logins — using Chrome 144+'s official remote-debugging consent flow (enable once at chrome://inspect, Chrome asks permission on every connection).
+
+- Remote workspace attach: "New workspace on this host" in the Attach Remote modal bootstraps the first pane of a brand-new workspace on a paired remote daemon — previously only a sibling pane on a workspace the desktop app had already created could be added.
+
+### Changed
+
+- The workspace right-click → Chrome profile submenu now appears only when the browser backend is `chrome`. On `builtin` or `external` a profile binding changes nothing, so the menu no longer offers a choice without an effect — and the per-workspace profile-list lookup at boot is skipped there too.
+
+- Inline browser lifecycle events are now attributed to the tool call that caused them: the lifecycle ring is drained again after each tool body, so a click that navigates (or `browser_navigate` itself, which now reports events like every other browser tool) shows the navigation on its own result instead of one call late. A lone `navigated` that merely repeats the URL the result already states is suppressed; redirect hops stay visible.
+
+### Fixed
+
+- **Replayed terminal history no longer relies on a timing window.** wmux now
+  labels replayed daemon PTY data at its source, authenticates its in-band
+  boundaries, and keeps replay-only control sequences muted across pane
+  adoption without suppressing live terminal behavior. (#1062)
+
+- Chrome backend: a Chrome left running by a crashed wmux session is now adopted on the next use instead of bricking the backend on its profile lock — instances launch with an ephemeral debugging port recorded in the profile, which is what makes the recovery path actually able to find them.
+
+- Live Chrome: agents can now actually drive pages in your attached live Chrome — both tabs wmux opened and your pre-existing tabs picked from the tab list. Previously only opening and listing tabs worked.
+
+- The browser-backend setting description now covers the Chrome option (and points at the per-workspace profile menu) in Korean, Chinese, and Polish, not just English.
+
+- `browser_snapshot` no longer silently ignores `filter:"interactive"` and `format:"aria"` on its DOM-listing paths. The filter now actually strips the heading block wherever the DOM listing is used — the background-surface fallthrough, the `selector` path, and the RPC fallback — and `aria`, which has no DOM-listing equivalent, now says so with a note instead of returning the default listing unlabeled. (#1066)
+
 ## [3.48.1] — 2026-08-28
 
 ### Fixed

--- a/changelog.d/1062.md
+++ b/changelog.d/1062.md
@@ -1,6 +1,0 @@
-### Fixed
-
-- **Replayed terminal history no longer relies on a timing window.** wmux now
-  labels replayed daemon PTY data at its source, authenticates its in-band
-  boundaries, and keeps replay-only control sequences muted across pane
-  adoption without suppressing live terminal behavior. (#1062)

--- a/changelog.d/1063.md
+++ b/changelog.d/1063.md
@@ -1,4 +1,0 @@
-### Added
-
-- `browser_snapshot` now returns a compact diff against the previous snapshot of the same page when that is smaller (`full:true` forces the complete tree), and accepts `selector` to scope the snapshot to a subtree and `filter:"interactive"` to strip non-interactive nodes.
-- Browser tool results now report page lifecycle changes inline — navigations (including SPA route changes), page loads, and tab closure — including changes the call itself caused, so a navigation is reported on the very result that triggered it and agents no longer need to poll for page state.

--- a/changelog.d/1064.md
+++ b/changelog.d/1064.md
@@ -1,5 +1,0 @@
-### Added
-
-- New `chrome` browser backend (Settings → Browser): wmux launches a dedicated real-Chrome instance with its own persistent profile — sign in once and logins stick, fully separate from your daily browser — and agents get the full automation toolset against it. Sites that block embedded browsers (e.g. Google sign-in) work normally there.
-- Each workspace can bind its own Chrome profile (workspace card → right-click → Chrome profile): separate logins per workspace, so one workspace can automate account A while another uses account B.
-- Bind a workspace to "Live Chrome" to let its agent work inside your own running browser — your real tabs and logins — using Chrome 144+'s official remote-debugging consent flow (enable once at chrome://inspect, Chrome asks permission on every connection).

--- a/changelog.d/1065.md
+++ b/changelog.d/1065.md
@@ -1,5 +1,0 @@
-### Fixed
-
-- Chrome backend: a Chrome left running by a crashed wmux session is now adopted on the next use instead of bricking the backend on its profile lock — instances launch with an ephemeral debugging port recorded in the profile, which is what makes the recovery path actually able to find them.
-- Live Chrome: agents can now actually drive pages in your attached live Chrome — both tabs wmux opened and your pre-existing tabs picked from the tab list. Previously only opening and listing tabs worked.
-- The browser-backend setting description now covers the Chrome option (and points at the per-workspace profile menu) in Korean, Chinese, and Polish, not just English.

--- a/changelog.d/1067.md
+++ b/changelog.d/1067.md
@@ -1,3 +1,0 @@
-### Added
-
-- Remote workspace attach: "New workspace on this host" in the Attach Remote modal bootstraps the first pane of a brand-new workspace on a paired remote daemon — previously only a sibling pane on a workspace the desktop app had already created could be added.

--- a/changelog.d/1070.md
+++ b/changelog.d/1070.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Inline browser lifecycle events are now attributed to the tool call that caused them: the lifecycle ring is drained again after each tool body, so a click that navigates (or `browser_navigate` itself, which now reports events like every other browser tool) shows the navigation on its own result instead of one call late. A lone `navigated` that merely repeats the URL the result already states is suppressed; redirect hops stay visible.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -7,7 +7,7 @@
 
 # wmux API Reference (generated)
 
-> **Generated from wmux v3.48.1 sources.** This file is produced by
+> **Generated from wmux v3.49.0 sources.** This file is produced by
 > `scripts/gen-api-reference.mjs` directly from the code — it lists every
 > RPC method, event type, required capability, and the key event-bus
 > constants exactly as the running daemon sees them. For the hand-curated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wmux",
-  "version": "3.48.1",
+  "version": "3.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wmux",
-      "version": "3.48.1",
+      "version": "3.49.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wmux",
   "productName": "wmux",
-  "version": "3.48.1",
+  "version": "3.49.0",
   "description": "Workspace multiplexer for AI agents — run fleets of Claude Code, Codex & Gemini in parallel on Windows & macOS, with MCP browser automation built in",
   "private": true,
   "main": ".vite/build/index.js",


### PR DESCRIPTION
Release cut for **v3.49.0** — the 8 unreleased commits on main since v3.48.1.

## What ships

**Added**
- `chrome` browser backend: dedicated real-Chrome instance with persistent agent profile (#1064), DevToolsActivePort port discovery + live-tab driving (#1065)
- Per-workspace Chrome profile bindings (#1065, gated to the chrome backend by #1069)
- `browser_snapshot` auto-diff, `selector` scoping, inline lifecycle events (#1063)
- Remote workspace bootstrap on a paired host (#1067)

**Fixed**
- `browser_snapshot` `filter`/`format` silent no-op on DOM paths (#1066 → #1068)
- Inline lifecycle events attributed to the causing call — the #1063 contract corrected before first ship (#1070)
- Replayed PTY data labeled at the source (#1062)

## Mechanics

- 8 `changelog.d/` fragments folded via `scripts/collect-changelog.mjs`; missing fragments for #1068/#1069 written in this PR before folding
- `npm version 3.49.0 --no-git-tag-version` (package.json + lock)
- `docs/api/reference.md` regenerated via `scripts/gen-api-reference.mjs`
- Follows the v3.48.1 precedent (#1061): merge this PR, then push the `v3.49.0` tag to trigger `.github/workflows/release.yml` (build, sign, GitHub release, Chocolatey/WinGet)

## Pre-release verification (this session)

- #1070 live-dogfooded on the dog1066 rig: the headline #1063 symptom (events one call late) verified gone end-to-end; snapshot diff intact
- #1068 filter verified against real Chrome DOM (headings 7→0, refs preserved, URL guard intact)
- #1069 gate verified live on all three backends via CDP-driven renderer
- CI green on every constituent PR; the one validate failure on #1070 was an unrelated flake (both suites pass locally 13/13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012us6JCvefLbxqn4gGA5V9M