### PR TITLE
fix(mcp): say what full does, and that password values come back redacted

### DIFF
--- a/changelog.d/pr-g-snapshot-doc-regressions.md
+++ b/changelog.d/pr-g-snapshot-doc-regressions.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `browser_snapshot`'s `full` parameter documents itself again — the tool-description
+  slimming in the previous release left it with no description at all, so nothing said
+  what it was for.
+- The browser tools now say that password field values read as `[redacted:password]`.
+  The redaction shipped without a word about it, and an agent reading a snapshot could
+  reasonably conclude its input had failed, or guess the wrong rule for which fields are
+  masked. `browser_type` likewise notes that it replaces an existing value rather than
+  appending to it.

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 80000,
-      "wireResultSha256": "1a6af58be2480d8286e1e90f54ec08cb370bdb9931297772082510a7953388d5",
+      "wireResultSha256": "05cd41a6f3568348fc7acf6647cb01bd5acba53ba2caeb0164c469bc24ab78d2",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -52,7 +52,7 @@ const BROWSER_SNAPSHOT_SHAPE = {
     .enum(['interactive'])
     .optional()
     .describe('Strips non-interactive nodes — much smaller output.'),
-  full: z.boolean().optional(),
+  full: z.boolean().optional().describe('Force the complete tree instead of a diff.'),
   surfaceId: optionalSurfaceId,
 };
 
@@ -341,7 +341,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
   // -----------------------------------------------------------------------
   server.tool(
     'browser_snapshot',
-    'Accessibility-tree snapshot of the page, with interactive elements annotated with ref numbers. A repeat snapshot of the same page returns a diff against the previous one when that is smaller — pass full:true for the complete tree.',
+    'Accessibility-tree snapshot of the page, with interactive elements annotated with ref numbers. A repeat snapshot of the same page returns a diff against the previous one when that is smaller — pass full:true for the complete tree. Password field values read as "[redacted:password]" (the field is still listed and fillable); an empty field has no value at all, so a redacted one means it IS filled.',
     BROWSER_SNAPSHOT_SHAPE,
     async ({ format, selector, filter, full, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -284,7 +284,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
   // -----------------------------------------------------------------------
   server.tool(
     'browser_type',
-    'Type text into an element by ref.',
+    'Type text into an element by ref, replacing any existing value. Typing into a password field echoes "[redacted:password]" back — the text still went in.',
     BROWSER_TYPE_SHAPE,
     async ({ ref, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {


### PR DESCRIPTION
## Why

Live dogfood of #1078 and #1079 — a fresh agent driving the slimmed tool surface against a real login form. It completed the task with **zero failed calls**, so the compression did not cause misuse. But it surfaced two things the descriptions should have said, both introduced by those two PRs:

- It inferred the **wrong rule** for redaction (guessed a label/name heuristic; the predicate is `type=password` / `autocomplete` current-|new-password) — the behavior shipped undocumented.
- It burned a round-trip re-snapshotting to find out whether `browser_type` replaces or appends.

## What

- **`full` gets its description back.** The diet deduplicated it against the tool text and left the parameter with none at all, which is worse than a short one.
- **`browser_snapshot` states the redaction**: password values read as `[redacted:password]`, the field stays listed and fillable, and a redacted value means the field *is* filled — answering the "did my input fail?" question the dogfood raised.
- **`browser_type`** says it replaces rather than appends, and that a password echo comes back redacted.

Cost: ~88 tokens against the ~1300 the diet saved. Golden-wire baseline moves with the intended description change.

## Verification

tsc clean, probe PASS after re-baseline, `src/mcp` 507 tests pass, token measurement re-run.

Pre-existing gaps the same dogfood found (console/network collection start, `browser_tabs` selected-vs-active, aria+filter combination, evaluate's return contract) are filed separately — they are not regressions from these PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6