### PR TITLE
fix(updater): force-kill a hung own-tree process instead of refusing the install (#1084)

### DIFF
--- a/changelog.d/1085.md
+++ b/changelog.d/1085.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **An update could refuse itself over a hung process that had already been
+  asked to quit.** The in-app update waiter watches every process under the
+  install root and refuses to launch the installer if one of them does not
+  exit within its budget — necessary for the daemon, which needs time to
+  flush scrollback before it goes down, but the main window, renderer and
+  GPU/utility helpers were held to the same patient wait even though they
+  carry nothing to flush and had already been told to quit. If one of them
+  hung — a real machine showed a bare `wmux` process idling at 0% CPU well
+  past when it should have exited — the update refused entirely, and
+  recovering meant noticing the stray process in Task Manager and killing it
+  by hand before a retry would succeed. The waiter now gives that kind of
+  process a short grace period and force-kills it if it is still there,
+  instead of waiting out the full budget and giving up. The daemon's own
+  wait is unchanged.

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -91,6 +91,17 @@ const INSTALL_QUIT_WATCHDOG_MS = 30_000;
 // takes time — a live process writes one file in well under a second, so a
 // few seconds of silence already means it is gone, not just busy.
 const WAITER_HEARTBEAT_BUDGET_MS = 3_000;
+// #1084 — how long the waiter gives an own-tree, non-daemon process (main
+// window, renderer, GPU/utility helpers) to exit on its own before force-
+// killing it, instead of sitting in the full INSTALL_LOCK_BUDGET_MS wait and
+// refusing. Unlike the daemon, these have no flush to protect — the session
+// save this function triggers up front is the only state that matters for
+// them, and it already happened before performInstall got this far. Short,
+// like WAITER_HEARTBEAT_BUDGET_MS: a cooperating process that already got
+// app.quit() exits in milliseconds, so a few seconds of silence means it is
+// hung, not still working. Kept well under INSTALL_LOCK_BUDGET_MS so the
+// daemon (never in this set) still gets the long, patient wait it needs.
+const OWN_TREE_FORCE_KILL_GRACE_MS = 5_000;
 // Squirrel downloading and unpacking a ~120 MB bundle before it reports
 // 'update-downloaded'. Generous on purpose: a slow disk or an antivirus scan
 // makes this minutes, and aborting a healthy update is worse than waiting.
@@ -994,6 +1005,16 @@ export class AutoUpdater {
     const pids = survey.pids;
     const daemonPid = this.hooks.getDaemonPid();
     const forceKillPids = pids.filter((p) => p !== daemonPid && !survey.ownTree.has(p));
+    // #1084 — the OTHER half of survey.ownTree: pids we spare from the
+    // immediate force-kill above because app.quit() is about to ask them to
+    // exit on their own, but that is not the same as the daemon's exemption.
+    // The daemon is spared because it flushes scrollback; these have nothing
+    // left to flush (the session save above already ran) and are only
+    // waiting on ordinary window/process teardown. If one hangs anyway — a
+    // real machine showed a bare "wmux" process stuck at 0% CPU well past
+    // when app.quit() was called — the waiter should not sit out the full
+    // INSTALL_LOCK_BUDGET_MS and refuse over it; it can just finish the job.
+    const forceKillEligiblePids = pids.filter((p) => p !== daemonPid && survey.ownTree.has(p));
 
     // ORDER MATTERS, and it is the reverse of the obvious one.
     //
@@ -1014,6 +1035,8 @@ export class AutoUpdater {
       abortMarkerPath,
       readyMarkerPath,
       lockBudgetMs: INSTALL_LOCK_BUDGET_MS,
+      forceKillEligiblePids,
+      forceKillGraceMs: OWN_TREE_FORCE_KILL_GRACE_MS,
     });
     if (!waiterPath) {
       // No waiter means no safe way to start the installer. Falling back to

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -90,9 +90,14 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     fs.writeFileSync(scriptPath, script as string, 'utf-8');
   }
 
-  const plan = (pids: number[], lockBudgetMs: number): WaiterPlan => ({
+  const plan = (
+    pids: number[],
+    lockBudgetMs: number,
+    forceKillEligiblePids: number[] = [],
+    forceKillGraceMs = 5_000,
+  ): WaiterPlan => ({
     pids, setupExePath: fakeSetup, installRoot: root, abortMarkerPath: abortMarker,
-    readyMarkerPath: readyMarker, lockBudgetMs,
+    readyMarkerPath: readyMarker, lockBudgetMs, forceKillEligiblePids, forceKillGraceMs,
   });
 
   function runWaiter(timeoutMs: number): { status: number | null; timedOut: boolean } {
@@ -123,6 +128,42 @@ describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () =>
     // taskkill is best-effort. Before the wait was bounded, a survivor left the
     // waiter blocked forever — and wmux had already quit, so the update stalled
     // with nothing to show for it on the next boot.
+    const holder = holdRoot();
+    writeWaiter(plan([holder.pid as number], 3_000));
+
+    expect(runWaiter(60_000).status).toBe(3);
+    expect(fs.readFileSync(abortMarker, 'utf-8')).toContain('would not exit');
+    expect(fs.existsSync(setupStamp)).toBe(false);
+  }, 120_000);
+
+  it('#1084 — force-kills a hung force-kill-eligible pid instead of refusing over it', () => {
+    // The incident this closes: a process app.quit() already asked to exit
+    // sits at 0% CPU past the lock budget, and the waiter refused rather
+    // than ending it. Same holder as the "gives up" test above, but this
+    // pid is marked force-kill-eligible with a short grace window — the
+    // waiter must end it and go on to launch Setup.exe, not abort.
+    // Shape of a SUCCESSFUL install, same as the "launches the installer"
+    // test below — otherwise the real #1046 post-exit verification (Update.exe
+    // + icudtl.dat) fails after Start-Process, falls through to exit 6, and a
+    // MessageBox blocks a headless runner forever.
+    fs.writeFileSync(path.join(root, 'Update.exe'), 'x');
+    fs.writeFileSync(path.join(root, 'app-1.0.0', 'icudtl.dat'), 'x');
+
+    const holder = holdRoot();
+    writeWaiter(plan([holder.pid as number], 60_000, [holder.pid as number], 3_000));
+
+    expect(runWaiter(60_000).status).toBe(0);
+    expect(fs.existsSync(setupStamp)).toBe(true);
+    expect(fs.existsSync(abortMarker)).toBe(false);
+    // The waiter's own taskkill did the killing, not our afterEach cleanup —
+    // confirm the holder is actually gone rather than merely unobserved.
+    expect(() => process.kill(holder.pid as number, 0)).toThrow();
+  }, 120_000);
+
+  it('#1084 — still refuses a hung pid that is NOT force-kill-eligible (the daemon path)', () => {
+    // Same shape as the eligible case above, but forceKillEligiblePids stays
+    // empty — this is the daemon's own contract, unchanged: nothing but the
+    // graceful daemon.shutdown RPC may end it, so a hang still refuses.
     const holder = holdRoot();
     writeWaiter(plan([holder.pid as number], 3_000));
 
@@ -309,6 +350,8 @@ describe.skipIf(!onWindows)('concurrent waiters (#980)', () => {
       abortMarkerPath: marker,
       readyMarkerPath: marker.replace(/\.txt$/, '-ready.tmp'),
       lockBudgetMs: 90_000,
+      forceKillEligiblePids: [],
+      forceKillGraceMs: 5_000,
     });
 
     // Waiter A: async, long budget — parked in WaitForExit holding the mutex.
@@ -411,7 +454,7 @@ describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWa
   const mkPlan = (): WaiterPlan => ({
     pids: [], setupExePath: fakeSetup, installRoot: root,
     abortMarkerPath: marker, readyMarkerPath: path.join(sandbox, 'ready-transport.tmp'),
-    lockBudgetMs: 2_000,
+    lockBudgetMs: 2_000, forceKillEligiblePids: [], forceKillGraceMs: 5_000,
   });
 
   function sleep200(): void {

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -33,6 +33,8 @@ const PLAN: WaiterPlan = {
   abortMarkerPath: 'C:\\Users\\u\\AppData\\Roaming\\wmux\\install-abort.txt',
   readyMarkerPath: 'C:\\Users\\u\\AppData\\Roaming\\wmux\\install-ready.tmp',
   lockBudgetMs: 30_000,
+  forceKillEligiblePids: [],
+  forceKillGraceMs: 5_000,
 };
 
 describe('isSafePsPathLiteral', () => {
@@ -484,6 +486,8 @@ describe('buildWaiterScript — the clock has to survive a long uptime (#980)', 
     abortMarkerPath: 'C:/Data/aborted.txt',
     readyMarkerPath: 'C:/Data/ready.tmp',
     lockBudgetMs: 60_000,
+    forceKillEligiblePids: [],
+    forceKillGraceMs: 5_000,
   };
 
   it('uses a monotonic Stopwatch, never [Environment]::TickCount', () => {
@@ -499,7 +503,12 @@ describe('buildWaiterScript — the clock has to survive a long uptime (#980)', 
 
   it('measures both the handle wait and the lock loop against that clock', () => {
     const script = buildWaiterScript(plan)!;
-    expect(script).toContain('$left = $budget - $clock.ElapsedMilliseconds');
+    // #1084 — the handle wait's deadline is per-handle now ($budget for the
+    // daemon/anything not force-kill-eligible, a shorter grace window for an
+    // eligible own-tree pid), but both variants are still measured off the
+    // same shared $clock, never a fresh timer per handle.
+    expect(script).toContain('$deadline = if ($eligible) { [Math]::Min($graceBudget, $budget) } else { $budget }');
+    expect(script).toContain('$left = $deadline - $clock.ElapsedMilliseconds');
     expect(script).toContain('$lockClock.ElapsedMilliseconds -lt $budget');
   });
 
@@ -519,6 +528,8 @@ describe('buildWaiterScript — one waiter per install root (#980, coderabbit)',
     abortMarkerPath: 'C:/Data/aborted.txt',
     readyMarkerPath: 'C:/Data/ready.tmp',
     lockBudgetMs: 60_000,
+    forceKillEligiblePids: [],
+    forceKillGraceMs: 5_000,
   };
   const script = () => buildWaiterScript(plan)!;
 
@@ -581,6 +592,8 @@ describe('buildWaiterScript — post-exit install verification (#1046)', () => {
     abortMarkerPath: 'C:/t/marker.txt',
     readyMarkerPath: 'C:/t/ready.tmp',
     lockBudgetMs: 60000,
+    forceKillEligiblePids: [],
+    forceKillGraceMs: 5_000,
   };
   const script = (): string => buildWaiterScript(PLAN46) ?? '';
 

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -102,6 +102,17 @@ export interface WaiterPlan {
   readyMarkerPath: string;
   /** How long to keep re-checking the root for locks before giving up. */
   lockBudgetMs: number;
+  /**
+   * #1084 — subset of `pids` (own-tree, never the daemon) that the waiter may
+   * force-kill after `forceKillGraceMs` instead of counting them toward the
+   * `lockBudgetMs` stuck-and-refuse verdict. These already got `app.quit()`
+   * and have no flush to protect (unlike the daemon, which is deliberately
+   * never in this list), so a hang here costs nothing to end forcibly.
+   */
+  forceKillEligiblePids: number[];
+  /** How long an eligible pid gets before the waiter kills it. Short: see
+   *  OWN_TREE_FORCE_KILL_GRACE_MS in AutoUpdater.ts for the reasoning. */
+  forceKillGraceMs: number;
 }
 
 /**
@@ -300,6 +311,11 @@ export function buildWaiterScript(plan: WaiterPlan, launchStampPath?: string): s
   // deadline in the past, so the lock loop would fall through on its first
   // pass — turning the gate that makes this whole change work into a no-op.
   if (!Number.isInteger(plan.lockBudgetMs) || plan.lockBudgetMs <= 0) return null;
+  // #1084 — same shape as the pid/budget checks above: a malformed value here
+  // must fail closed (build nothing) rather than silently force-kill nothing
+  // or run with a nonsensical grace window.
+  if (!plan.forceKillEligiblePids.every((p) => Number.isInteger(p) && p > 0)) return null;
+  if (!Number.isInteger(plan.forceKillGraceMs) || plan.forceKillGraceMs <= 0) return null;
   // #1056 — optional execution-proof stamp. Stricter than isSafePsPathLiteral
   // on purpose: this path also rides through a cmd.exe trampoline command
   // line, where a double quote is structural. Optional, so the suites'
@@ -319,6 +335,7 @@ export function buildWaiterScript(plan: WaiterPlan, launchStampPath?: string): s
   ];
 
   const pidList = plan.pids.join(',');
+  const eligibleList = plan.forceKillEligiblePids.join(',');
   return [
     `$ErrorActionPreference = 'SilentlyContinue'`,
     `$root = ${psQuote(plan.installRoot)}`,
@@ -453,6 +470,16 @@ export function buildWaiterScript(plan: WaiterPlan, launchStampPath?: string): s
     // process look like ours).
     `$handles = @()`,
     `foreach ($id in @(${pidList})) { try { $handles += [System.Diagnostics.Process]::GetProcessById($id) } catch { } }`,
+    // #1084 — pids app.quit() already told to exit, with no flush to protect
+    // (the daemon is never in this set — see AutoUpdater.ts). A hang here
+    // gets a short grace window, then a kill, instead of riding the full
+    // $budget below toward a refusal the user has to notice and clear by
+    // hand.
+    `$forceKillEligible = @(${eligibleList})`,
+    `$graceBudget = ${plan.forceKillGraceMs}`,
+    `function Stop-WaiterOwnedProcess($procId) {`,
+    `  try { & (Join-Path $env:SystemRoot 'System32\\taskkill.exe') /PID $procId /T /F 2>&1 | Out-Null } catch { }`,
+    `}`,
     // Bounded, and the bound is the point. taskkill is best-effort: a process
     // it could not terminate would make an unbounded WaitForExit block forever,
     // and by then wmux has already quit — so the update would silently stall
@@ -474,12 +501,31 @@ export function buildWaiterScript(plan: WaiterPlan, launchStampPath?: string): s
     // contract as before — only the granularity changed. A WaitForExit
     // exception still reads as "this handle is not the blocker" ($exited
     // stays true), matching the original catch-and-continue.
+    //
+    // #1084 — an eligible handle's deadline is $graceBudget, not $budget, but
+    // it is measured off the SAME shared clock as everything else (not a
+    // fresh timer per handle): a handle reached late, after the clock has
+    // already run past $graceBudget waiting on earlier ones, force-kills
+    // immediately rather than getting a full grace window it did not need to
+    // wait for. On expiry it force-kills and moves on WITHOUT setting
+    // $stuck — that verdict stays reserved for a pid this waiter cannot end
+    // itself.
     `$clock = [System.Diagnostics.Stopwatch]::StartNew()`,
     `$stuck = $false`,
     `foreach ($h in $handles) {`,
+    `  $eligible = $forceKillEligible -contains $h.Id`,
+    `  $deadline = if ($eligible) { [Math]::Min($graceBudget, $budget) } else { $budget }`,
     `  while ($true) {`,
-    `    $left = $budget - $clock.ElapsedMilliseconds`,
-    `    if ($left -le 0) { $stuck = $true; break }`,
+    `    $left = $deadline - $clock.ElapsedMilliseconds`,
+    `    if ($left -le 0) {`,
+    `      if ($eligible) {`,
+    `        Stop-WaiterOwnedProcess $h.Id`,
+    `        try { $h.WaitForExit(2000) } catch { }`,
+    `      } else {`,
+    `        $stuck = $true`,
+    `      }`,
+    `      break`,
+    `    }`,
     `    $slice = [Math]::Min(200, $left)`,
     `    $exited = $true`,
     `    try { $exited = $h.WaitForExit([int]$slice) } catch { }`,


### PR DESCRIPTION
Addresses #1084, from the [concrete fix proposal](https://github.com/openwong2kim/wmux/issues/1084#issuecomment-5461923271) posted there.

## The incident

On 3.48.1, an update refused with the #980-era message ("a process under the install root would not exit"), even though the daemon acked its own `daemon.shutdown` RPC in 634ms. Task Manager showed a bare `wmux` process idling at 0% CPU well past that — killed by hand before a retry succeeded.

## Why this happens

`terminatePids`'s own doc comment in `installTeardown.ts` says why the daemon is spared from the pre-quit force-kill: "it gets the graceful shutdown so it can flush scrollback." The rest of `survey.ownTree` — the main window, renderer, GPU/utility helpers — ended up in the same wait-only treatment as a side effect of #980's fix (which correctly stopped force-killing them so `app.quit()`'s renderer-side session save could complete), not because they had anything left to protect. That session save (the `beforeunload` dispatch `performInstall` triggers up front) already finished before any of this runs. If one of them hangs anyway, the waiter had no escalation — it just sits out the full `INSTALL_LOCK_BUDGET_MS` (60s) and refuses.

## What this changes

`AutoUpdater.ts` now computes `forceKillEligiblePids = survey.ownTree` minus the daemon pid, and hands it to the waiter along with a new `OWN_TREE_FORCE_KILL_GRACE_MS` (5s). In the generated script, a handle for an eligible pid gets `min(graceBudget, budget)` off the *same* shared clock as everything else — not a fresh timer — so one reached late (after the clock already ran past the grace window on earlier handles) force-kills immediately instead of getting an unearned extra window. On expiry it runs the identical `taskkill /PID /T /F` the JS side already uses on foreign processes, gives it a short `WaitForExit`, and moves on **without** setting `$stuck` — that verdict stays reserved for a pid this waiter genuinely cannot end itself (the daemon, or anything eligible-but-still-alive after the kill attempt somehow leaves a lock behind — the file-lock probe (`Test-RootLocked`) right after this loop is untouched and remains the real backstop either way).

## Scope: daemon is deliberately NOT touched here

The original idea in the #1084 comment was to also force-kill the daemon once its `daemon.shutdown` RPC ack is in hand, since that ack already proves the flush completed. Reading `AutoUpdater.ts` closely showed that doesn't hold today: `spawnInstallWaiter` is called and its heartbeat verified **before** `onInstallRequiresFullShutdown()` even runs, so the ack (which happens later, inside the app's normal quit sequence) has no channel to reach an already-spawned, already-detached PowerShell process — that would need a new cross-process signal (e.g. the app writing a marker file the waiter polls for), which felt like a bigger, separate change with its own timing edge cases. This PR stays scoped to the set that never needed such a signal in the first place: own-tree processes that already got `app.quit()` and were never carrying anything to flush. The daemon keeps exactly today's contract — full budget, refuse on timeout — unchanged.

## Test plan

- Two new real-process runtime tests in `installTeardown.runtime.test.ts` (`describe.skipIf(!onWindows)`, real handles, real file locks, real `taskkill`):
  - `#1084 — force-kills a hung force-kill-eligible pid instead of refusing over it`: holds a real file lock via a spawned process, marks that pid force-kill-eligible with a 3s grace, confirms the waiter kills it, launches the fake `Setup.exe`, and exits 0 with no abort marker.
  - `#1084 — still refuses a hung pid that is NOT force-kill-eligible (the daemon path)`: same shape, empty eligible set — pins that the daemon's contract is byte-for-byte what it was before this PR.
- Existing `WaiterPlan` fixtures across `installTeardown.test.ts` and `installTeardown.runtime.test.ts` updated for the two new required fields (`forceKillEligiblePids`, `forceKillGraceMs`), all defaulting to `[]` / unchanged behavior where the test isn't about this feature.
- `npm run test:parallel` (excludes `*.runtime.test.ts`): 158/158 in `src/main/updater`.
- Real runtime suite (`vitest.runtime.config.ts`, actual PowerShell/Windows processes): 13/13 in `installTeardown.runtime.test.ts`.
- `npx tsc --noEmit`: clean. `eslint` on changed files: 0 errors (pre-existing warnings only, unrelated to this diff).

No version bump. Changelog fragment to follow once the PR number is assigned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the in-app update process by force-closing eligible application processes that remain open briefly after being asked to quit.
  - Updates no longer fail unnecessarily because of a hung main window, renderer, or helper process.
  - The background service continues to receive its existing wait period to finish saving state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->