### PR TITLE
fix(browser): strip the skip-navigation run browser_extract_text promised to remove

### DIFF
--- a/changelog.d/pr-h-extract-text-skip-nav.md
+++ b/changelog.d/pr-h-extract-text-skip-nav.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`browser_extract_text` now strips the skip-navigation links it promised to
+  remove.** Pages open with hidden-until-focused "skip to content" anchors for
+  keyboard users, and they came through as the first thing in the extracted
+  markdown — on naver.com eight of them pushed the first headline past
+  character 440, so a caller that previews the opening few hundred characters
+  read the page as empty. The leading run of in-page anchors is now dropped,
+  while a table of contents and links inside the text are kept. (#1077)

--- a/src/mcp/playwright/__tests__/markdown-extractor.skiplinks.test.ts
+++ b/src/mcp/playwright/__tests__/markdown-extractor.skiplinks.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+//
+// Skip-link filtering for browser_extract_text (issue #1077).
+//
+// Like the hidden-content tests, the evaluator here runs the real in-page
+// serialisation script against a jsdom document, because that is where the
+// filter lives.
+//
+// Dogfooding naver.com (2026-08-29) opened the extracted markdown with eight
+// "바로가기" skip links and pushed the first headline past character 440, so a
+// caller previewing the first few hundred characters saw an empty page. The
+// risk in filtering them is over-removal: a table of contents and a footnote
+// reference are the same `a[href^="#"]` shape, so these tests pin both sides.
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { extractMarkdown } from '../markdown-extractor';
+
+// jsdom has no layout engine: getClientRects() is unconditionally empty, which
+// would make the script judge EVERY element hidden. Model layout instead —
+// an element renders a box unless it opts out with data-zero-rect.
+beforeAll(() => {
+  Object.defineProperty(Element.prototype, 'getClientRects', {
+    configurable: true,
+    value(this: Element) {
+      return this.hasAttribute('data-zero-rect') ? [] : [{ width: 100, height: 20 }];
+    },
+  });
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+/** Evaluator that runs the in-page script string the way a browser would. */
+const evaluateInJsdom = (expression: string): Promise<unknown> =>
+  // Parenthesised on purpose: the script starts with a newline, and `return`
+  // followed by a line break is an automatic-semicolon return of undefined.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  Promise.resolve(new Function(`return (${expression});`)());
+
+describe('extractMarkdown — leading skip links (browser_extract_text)', () => {
+  it('drops the naver-shaped block of skip links, dangling target included', async () => {
+    // One <div> of bare anchors ahead of everything, exactly as naver.com
+    // ships it. #viewSetting matches no element on the real page either.
+    document.body.innerHTML = `
+      <div>
+        <a href="#topAsideButton">상단영역 바로가기</a>
+        <a href="#shortcutArea">서비스 메뉴 바로가기</a>
+        <a href="#viewSetting">보기 설정 바로가기</a>
+      </div>
+      <div id="topAsideButton"></div>
+      <div id="shortcutArea"></div>
+      <main><p>정부, 오늘 합동신속대응팀 9명 추가 파견</p></main>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).not.toContain('바로가기');
+    expect(md.startsWith('정부, 오늘')).toBe(true);
+  });
+
+  it('drops skip links wrapped in a list, the way MDN ships them', async () => {
+    document.body.innerHTML = `
+      <ul>
+        <li><a href="#content">Skip to main content</a></li>
+        <li><a href="#search">Skip to search</a></li>
+      </ul>
+      <main id="content"><h1>Element: getClientRects() method</h1></main>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).not.toContain('Skip to');
+    expect(md.startsWith('# Element: getClientRects() method')).toBe(true);
+  });
+
+  it('keeps a table of contents that follows the page heading', async () => {
+    document.body.innerHTML = `
+      <a href="#main">Skip to content</a>
+      <main id="main">
+        <h1>Built-in Functions</h1>
+        <ul>
+          <li><a href="#abs">abs()</a></li>
+          <li><a href="#all">all()</a></li>
+        </ul>
+        <dl id="abs"><dt>abs(x)</dt></dl>
+      </main>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).not.toContain('Skip to content');
+    expect(md).toContain('[abs()](#abs)');
+    expect(md).toContain('[all()](#all)');
+  });
+
+  it('keeps a table of contents that leads the page — its entries name headings', async () => {
+    document.body.innerHTML = `
+      <ul>
+        <li><a href="#install">Installation</a></li>
+        <li><a href="#usage">Usage</a></li>
+      </ul>
+      <h2 id="install">Installation</h2>
+      <p>Run the installer.</p>
+      <h2 id="usage">Usage</h2>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).toContain('[Installation](#install)');
+    expect(md).toContain('[Usage](#usage)');
+  });
+
+  it('keeps an in-page anchor that opens the first paragraph', async () => {
+    document.body.innerHTML = `
+      <main>
+        <p><a href="#note1">See note 1</a> before reading the rest of this.</p>
+      </main>
+      <p id="note1">Note 1</p>`;
+
+    expect(await extractMarkdown(evaluateInJsdom)).toContain('[See note 1](#note1)');
+  });
+
+  it('leaves a run longer than the skip-link cap alone', async () => {
+    const entries = Array.from(
+      { length: 13 },
+      (_, i) => `<a href="#s${i}">Section ${i}</a>`,
+    ).join('');
+    document.body.innerHTML = `<div>${entries}</div><div id="s0">Body</div>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).toContain('[Section 0](#s0)');
+    expect(md).toContain('[Section 12](#s12)');
+  });
+
+  it('sees past a hidden banner sitting above the skip links', async () => {
+    document.body.innerHTML = `
+      <div style="display:none"><p>Whale banner promo</p></div>
+      <a href="#main">Skip to content</a>
+      <main id="main"><p>Real body text</p></main>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).not.toContain('Skip to content');
+    expect(md).toContain('Real body text');
+  });
+
+  it('leaves a page without skip links untouched', async () => {
+    document.body.innerHTML = `
+      <main>
+        <h1>Plain article</h1>
+        <p>First paragraph.</p>
+        <p><a href="https://example.test/next">Next page</a></p>
+      </main>`;
+
+    const md = await extractMarkdown(evaluateInJsdom);
+
+    expect(md).toContain('# Plain article');
+    expect(md).toContain('First paragraph.');
+    expect(md).toContain('[Next page](https://example.test/next)');
+  });
+});

--- a/src/mcp/playwright/markdown-extractor.ts
+++ b/src/mcp/playwright/markdown-extractor.ts
@@ -318,11 +318,136 @@ const HIDDEN_ELEMENT_PREDICATE = `
       }`;
 
 /**
+ * In-page pass that removes the leading run of "skip to content" links.
+ *
+ * Skip links are in-page anchors a site puts at the very top of the document
+ * so keyboard and screen-reader users can jump past the chrome. They render,
+ * so the visibility filter keeps them, and they sit outside <nav>/<header>, so
+ * NOISE_SELECTORS misses them — yet they are pure navigation. On naver.com
+ * they were the first eight links of the extracted markdown and pushed the
+ * first headline past character 440, which reads as an empty page to a caller
+ * that previews the opening few hundred characters (issue #1077).
+ *
+ * A table of contents and a footnote reference have the same shape — an
+ * `a[href^="#"]` with a short label — so only position tells them apart. The
+ * scan is therefore confined to the LEADING run of the document: it walks in
+ * document order, drops anchors (and wrappers holding nothing but anchors)
+ * until the first node that produces real content, and stops there for good.
+ * It descends only through block wrappers that carry no text of their own, so
+ * an anchor opening the first paragraph is content, not chrome. Anything past
+ * that first content node — every real table of contents measured, which
+ * always follows a heading — is untouched.
+ *
+ * One more guard bounds the blast radius: a run longer than MAX_SKIP_LINKS is
+ * left alone entirely — a real skip-link block is a handful of links, so a
+ * longer one is more likely a table of contents that happens to lead the page.
+ *
+ * Where the target does resolve, it is read one way only: an anchor pointing
+ * at a heading is a table-of-contents entry and is kept, because a skip link
+ * targets the landmark it jumps over, never the heading that names a section.
+ * An anchor whose target is missing stays eligible — naver.com's eighth skip
+ * link points at #viewSetting, which no element on the page carries, and
+ * requiring a live target left exactly that link, the noise the issue
+ * reported, sitting at the top of the output.
+ */
+const SKIP_LINK_STRIPPER = `
+      function stripLeadingSkipLinks(root) {
+        const MAX_SKIP_LINKS = 12;
+        const MAX_DEPTH = 6;
+        // Block wrappers only. Descending into a <p> or a heading would let the
+        // scan eat a footnote link that merely opens the first paragraph.
+        const DESCENDABLE = { DIV: 1, SECTION: 1, MAIN: 1, ARTICLE: 1, BODY: 1 };
+
+        function resolveTarget(raw) {
+          const byId = document.getElementById(raw);
+          if (byId) return byId;
+          try {
+            return document.getElementById(decodeURIComponent(raw));
+          } catch (e) {
+            return null;
+          }
+        }
+
+        function isSkipLink(el) {
+          if (el.tagName !== 'A') return false;
+          const href = el.getAttribute('href') || '';
+          if (href.charAt(0) !== '#' || href.length < 2) return false;
+          if (!(el.textContent || '').trim()) return false;
+          // Its own label and nothing else — a link wrapping a figure, a table
+          // or a heading is carrying content, whatever its href says.
+          if (el.querySelector('img, svg, video, canvas, table, ul, ol, p, h1, h2, h3, h4, h5, h6')) return false;
+          // A table of contents that leads the page has the same shape, and its
+          // entries name headings. A skip link targets the landmark it jumps
+          // over, so a heading target rules it out.
+          const target = resolveTarget(href.slice(1));
+          return !(target && /^H[1-6]$/.test(target.tagName));
+        }
+
+        // 0 = renders nothing, 1 = skip links only, 2 = real content.
+        function classify(node, found) {
+          if (node.nodeType === 3) return (node.textContent || '').trim() ? 2 : 0;
+          if (node.nodeType !== 1) return 0;
+          if (isHidden(node)) return 0;
+          if (isSkipLink(node)) {
+            found.push(node);
+            return 1;
+          }
+          if (node.tagName === 'A') return 2;
+          // A wrapper whose whole subtree is skip links (ul > li > a) travels
+          // with them; one mixed child makes the wrapper content.
+          const nested = [];
+          let sawSkipLink = false;
+          for (const child of node.childNodes) {
+            const kind = classify(child, nested);
+            if (kind === 2) return 2;
+            if (kind === 1) sawSkipLink = true;
+          }
+          for (const link of nested) found.push(link);
+          return sawSkipLink ? 1 : 0;
+        }
+
+        function hasOwnText(el) {
+          for (const child of el.childNodes) {
+            if (child.nodeType === 3 && (child.textContent || '').trim()) return true;
+          }
+          return false;
+        }
+
+        const links = [];
+        const removals = [];
+
+        function walk(container, depth) {
+          for (const child of Array.from(container.childNodes)) {
+            const kind = classify(child, links);
+            if (kind === 0) continue;
+            if (kind === 1) {
+              removals.push(child);
+              continue;
+            }
+            if (
+              child.nodeType === 1 &&
+              depth < MAX_DEPTH &&
+              DESCENDABLE[child.tagName] === 1 &&
+              !hasOwnText(child)
+            ) {
+              walk(child, depth + 1);
+            }
+            return;
+          }
+        }
+
+        walk(root, 0);
+        if (links.length === 0 || links.length > MAX_SKIP_LINKS) return;
+        for (const node of removals) node.remove();
+      }`;
+
+/**
  * Returns a string that, when evaluated inside the browser, serialises the
  * DOM rooted at `rootSelector` into a JSON-safe tree structure.
  *
- * Noise elements are stripped before serialisation, and elements the browser
- * does not render are skipped along with their subtrees.
+ * Noise elements and the leading skip-link block are stripped before
+ * serialisation, and elements the browser does not render are skipped along
+ * with their subtrees.
  */
 function buildSerialiseScript(
   rootSelector: string | null,
@@ -343,6 +468,9 @@ function buildSerialiseScript(
       }
 
       ${HIDDEN_ELEMENT_PREDICATE}
+      ${SKIP_LINK_STRIPPER}
+
+      stripLeadingSkipLinks(root);
 
       function serialise(node, isRoot) {
         if (node.nodeType === 3) {


### PR DESCRIPTION
Closes #1077.

## Why

`browser_extract_text` advertises *"stripping navigation and noise"*, but on naver.com its eight skip links owned the **first 440 characters** — long enough that a caller previewing 200–300 characters to decide whether a page has content concludes it is empty.

These are not the hidden elements #1076 removed. Skip links render, and they belong in the accessibility tree (they exist for screen-reader users). They are structural navigation that `NOISE_SELECTORS` only catches when wrapped in `<nav>`/`<header>`.

## How

Walk the document from the start, removing skip links (and wrappers holding nothing else) until the first node producing real content — then stop for good. No tuned "first N nodes" threshold was needed: every table of contents measured sits *after* a heading, so "first content node" is both more accurate and self-adjusting.

Guards against over-removal:
- descends only through block wrappers with no text of their own, so an anchor opening the first paragraph survives;
- an anchor resolving to a **heading** counts as content, not a skip link — this protects a TOC even when one leads the page;
- bails entirely past twelve links rather than partially strip an unfamiliar shape (measured: naver 8, MDN 2, Wikipedia 1);
- hidden nodes do not end the run, since the promo banner #1076 removes sits ahead of naver's skip links.

Deliberately **not** a condition: whether the anchor target id exists. naver's eighth link points at an id the document does not contain, so requiring resolution left exactly that link behind. Target resolution now only ever argues for *keeping* a link.

## Measured

| Page | Result |
| --- | --- |
| naver.com | first article moves from char 440 → **~200** |
| MDN | skip links gone, `# Element: getClientRects()` leads |
| Wikipedia | `Jump to content` gone, article text leads |

Over-removal control (byte-identical before/after): Python docs page whose TOC is pure in-page anchors, an RFC, a GitHub repo page. MDN's mid-body `#browser-compatibility` anchor survives.

## Verification

tsc clean, `src/mcp/playwright` 308 tests pass (8 new), golden probe passes with **unchanged** baseline (no tool description was touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extracted markdown by removing leading “Skip to content” navigation links.
  - Preserved tables of contents, regular in-page links, and meaningful page content during extraction.
  - Handles pages with multiple skip links and nested navigation structures more reliably.

- **Documentation**
  - Added a changelog entry describing the improved text extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->