### PR TITLE
docs: write down what the browser backends cannot do

### DIFF
--- a/changelog.d/pr-j-browser-backend-limits.md
+++ b/changelog.d/pr-j-browser-backend-limits.md
@@ -1,0 +1,9 @@
+### Added
+
+- New guide: [Browser backends](docs/browser-backends.md) — which of the three
+  backends to pick, what binding a workspace to each kind of Chrome profile
+  actually exposes (including why your existing Chrome profiles cannot appear in
+  that menu), the four things driving a browser over CDP genuinely cannot do
+  (real passkeys, canvas-rendered UIs, coordinates during compositor animation,
+  and sites that detect automation), and how password values are redacted from
+  tool output.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ The exact contract. Look things up here; do not read top to bottom.
 Background and design rationale — why the substrate is shaped the way it is.
 
 - [`PROTOCOL.md`](./PROTOCOL.md) — the substrate contract: PaneMetadata semantics, the event-bus model, the named-pipe security model, the identity model, and daemon lifecycle.
+- [`browser-backends.md`](./browser-backends.md) — the three browser backends, the three levels of Chrome-profile exposure, what CDP cannot do (real passkeys, canvas UIs, mid-animation coordinates, automation detection), and how password values are redacted.
 - [`phone-client-contract.md`](./phone-client-contract.md) — everything a phone client implements against `wmux web`: pairing, per-device credentials, stream tickets, the attention cursor, the approvals API, and the sealed push envelope.
 - [`internal/m0-design.md`](./internal/m0-design.md) — the transaction-aware MetadataStore design (optimistic concurrency, snapshot envelope).
 - [`internal/path-D-inventory.md`](./internal/path-D-inventory.md) — the workspace-identity resolution paths and the non-deterministic fallback being removed.

--- a/docs/browser-backends.md
+++ b/docs/browser-backends.md
@@ -1,0 +1,112 @@
+# Browser backends: what agents can drive, and what they cannot
+
+wmux drives a browser over the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+(CDP). That choice buys a lot — no browser to install, no fork to maintain, and
+the same MCP tool surface across backends — and it costs a few things outright.
+This page is the honest list of both, so you can pick a backend knowing what it
+will refuse to do.
+
+## The three backends
+
+Settings → Browser picks one. It applies to every workspace.
+
+| Backend | What it is | When to use it |
+| --- | --- | --- |
+| `builtin` (default) | A webview inside the wmux window | Ordinary page work you want to *watch* in the same window as your panes |
+| `chrome` | A real Chrome instance wmux launches with its own profile directory | Sites that reject embedded browsers (Google sign-in), or when logins must persist |
+| `external` | Hand the URL to your normal browser and stop | Anything an agent should not be driving at all |
+
+`external` is not a degraded mode. It is the right answer when a site is hostile
+to automation, and it is always available as an escape hatch.
+
+## Choosing a Chrome profile: three levels of exposure
+
+On the `chrome` backend, each workspace binds to a profile
+(workspace card → right-click → **Chrome profile**). The choice is a security
+decision, not a convenience one.
+
+### 1. A wmux profile, not signed in — safest
+
+`default`, or any profile you create with **New profile…**. Its own
+`--user-data-dir`, empty on first launch. An agent that misbehaves here has no
+session to lose, because there is none.
+
+### 2. A wmux profile you signed into once — the intended way to use accounts
+
+Same mechanism. You open the agent's Chrome window and sign in yourself, once;
+the login persists in that profile directory. Workspace A can drive an
+account-A Chrome while workspace B drives account B.
+
+Blast radius is that one profile and that one account. This is the option to
+reach for when you want per-workspace accounts.
+
+### 3. Live Chrome — your real browser, and everything in it
+
+`Live Chrome (your browser)` attaches to the Chrome you are already running,
+with the tabs and logins you already have. There is no way to scope it to one
+tab or one profile: the agent gets the browser.
+
+Three separate consents gate it — you enable remote debugging once at
+`chrome://inspect/#remote-debugging` (Chrome 144+), you confirm the binding in
+wmux, and Chrome itself asks on every connection — because the grant is that
+large. Use it when you genuinely want an agent working inside your own session,
+and prefer option 2 when you do not.
+
+> **Why your existing Chrome profiles are not in the list.** Since Chrome 136,
+> Chrome refuses `--remote-debugging-port` when the profile is the default user
+> data directory ([announcement](https://developer.chrome.com/blog/remote-debugging-port)).
+> Pointing wmux at `Profile 3` would produce a browser no tool could drive.
+> Live Chrome exists precisely because it is the supported path to a real
+> profile.
+
+## What the tools will not do
+
+These are limits of driving a browser from outside, not bugs to be filed.
+
+### Real passkeys and hardware authenticators
+
+An agent cannot complete a passkey, FIDO2, or security-key login. CDP's
+`WebAuthn` domain exists to *test* WebAuthn: it configures **virtual**
+authenticators, and has no command that drives the platform authenticator
+holding your real credential ([spec](https://chromedevtools.github.io/devtools-protocol/tot/WebAuthn/)).
+Sign in yourself when a site requires one; the session persists afterwards.
+
+### Canvas-rendered interfaces
+
+Figma, Flutter web, and anything else painting its UI into a `<canvas>` exposes
+no DOM and no accessibility tree. `browser_snapshot` returns an empty canvas
+element because that is genuinely all there is. Screenshots still work; nothing
+else meaningfully does.
+
+### Coordinates during compositor-driven animation
+
+`transform`, `opacity`, `filter`, and `backdrop-filter` animate on the
+compositor thread, and the main thread — which is where the accessibility tree
+and `getBoundingClientRect` live — does not track them frame by frame. An
+element's reported position can lag what is on screen mid-animation. Wait for
+the animation to settle before acting on a coordinate.
+
+### Sites that detect automation
+
+Attaching CDP is observable from inside the page: `navigator.webdriver`, and
+the side effects of enabling the `Runtime` domain, are signals the browser emits
+about itself. Bot-detection vendors have used them for years. wmux does not try
+to suppress them — it is a tool for driving *your* browser and *your* sessions,
+not for evading a site that has decided it does not want automated traffic. When
+a site blocks you, `external` hands it to your normal browser.
+
+## Password values are redacted
+
+Every tool result masks password field values as `[redacted:password]`:
+accessibility and DOM snapshots, `browser_type` echoes, console output, network
+URLs and bodies. A field is treated as a password when it is
+`input[type=password]` or carries `autocomplete="current-password"` /
+`"new-password"` — an attribute rule, not a guess from the label.
+
+What survives on purpose: the field itself, its role, label, name, and `ref`.
+You can still find and fill a login form. And because an empty field has no
+value at all, a redacted value means the field **is** filled.
+
+One deliberate exception: **`browser_evaluate` is not filtered.** Running
+arbitrary JavaScript is the point of that tool, and a filter narrow enough to be
+correct there does not exist. Treat it as the escape hatch it is.


### PR DESCRIPTION
## Why

The `chrome` backend shipped with real limits nobody had written down. Each of them reads as a bug when it surprises someone, and each is a support question waiting to happen.

## What the new page says

**The three backends** (`builtin` / `chrome` / `external`) and when each is right — including that `external` is not a degraded mode but the correct answer for a site hostile to automation.

**The profile choice as a security decision**, in three levels of exposure:
1. a fresh wmux profile — nothing to lose;
2. a wmux profile you signed into once — the intended way to run per-workspace accounts, blast radius one account;
3. Live Chrome — the whole browser, which is why three separate consents gate it.

It also explains why the menu **cannot** list your existing Chrome profiles: since Chrome 136 the default user data directory refuses `--remote-debugging-port`, so such an entry would produce a browser no tool could drive. Live Chrome is the supported path to a real profile.

**Four things CDP genuinely cannot do**, with sources:
- real passkeys / FIDO2 — CDP's `WebAuthn` domain configures *virtual* authenticators and has no command for the platform one;
- canvas-rendered UIs (Figma, Flutter web) — no DOM, no a11y tree;
- coordinates during compositor-driven animation — the main thread does not track them frame by frame;
- automation detection — attaching CDP is observable from inside the page, and wmux does not try to suppress it.

**Password redaction** (shipped in #1079 without a word about it): the attribute rule behind it, what survives on purpose, that a redacted value means the field *is* filled, and the one deliberate exception — `browser_evaluate` is not filtered.

Filed under Explanation in `docs/README.md`, per the repo's Diátaxis layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide explaining available browser backends and their Chrome profile exposure levels.
  * Documented security considerations, CDP limitations, and scenarios involving passkeys, canvas interfaces, animations, and automation detection.
  * Clarified password redaction behavior, including exceptions for evaluated browser output.
  * Linked the new guide from the main documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->