### PR TITLE
fix(sidebar): clear activeRemoteKey on a pane-row jump within the already-active workspace

### DIFF
--- a/changelog.d/1089.md
+++ b/changelog.d/1089.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Clicking a pane or agent row nested inside the currently-active workspace no longer leaves an attached remote workspace's mirror on screen — the jump now correctly switches back to the local view in one click, matching the workspace's own sidebar row (#1086).

--- a/src/renderer/hooks/__tests__/useNotificationListener.test.ts
+++ b/src/renderer/hooks/__tests__/useNotificationListener.test.ts
@@ -699,7 +699,7 @@ describe('focusNotificationTarget', () => {
 // ─── S-C1 — focusPaneByPtyId (Fleet card click → pane jump) ─────────────────
 
 describe('focusPaneByPtyId (Fleet View jump)', () => {
-  function makeState(opts: { workspaces: Workspace[]; activeWorkspaceId: string }) {
+  function makeState(opts: { workspaces: Workspace[]; activeWorkspaceId: string; activeRemoteKey?: string | null }) {
     const spies = {
       setActiveWorkspace: vi.fn(),
       setActivePane: vi.fn(),
@@ -711,11 +711,19 @@ describe('focusPaneByPtyId (Fleet View jump)', () => {
     const state: FocusTargetState = {
       workspaces: opts.workspaces,
       activeWorkspaceId: opts.activeWorkspaceId,
+      activeRemoteKey: opts.activeRemoteKey ?? null,
       zoomedPaneId: null,
       notifications: [],
       ...spies,
     };
-    spies.setActiveWorkspace.mockImplementation((id: string) => { state.activeWorkspaceId = id; });
+    spies.setActiveWorkspace.mockImplementation((id: string) => {
+      state.activeWorkspaceId = id;
+      // Mirrors the real setActiveWorkspace (workspaceSlice.ts), which always
+      // calls clearRemoteSelection once past its own existence guard — the
+      // fixture needs this so AT4 below can tell "did the guard even let us
+      // in" apart from "did the real clear-on-select behavior run".
+      state.activeRemoteKey = null;
+    });
     return { state, spies, getState: () => state };
   }
 
@@ -773,5 +781,21 @@ describe('focusPaneByPtyId (Fleet View jump)', () => {
     h.state.zoomedPaneId = 'pane-zoomed-sibling';
     activatePaneTarget(h.getState, { workspaceId: 'ws-a', paneId: 'pane-a', surfaceId: 'sf-a' });
     expect(h.spies.togglePaneZoom).toHaveBeenCalledWith('pane-zoomed-sibling');
+  });
+
+  // #1086: a remote mirror can be the visible pane while activeWorkspaceId
+  // never moved (WorkspaceCenter checks activeRemoteKey first, ahead of the
+  // local tree) — so a pane-row jump within the already-active workspace
+  // must still call setActiveWorkspace to drop the mirror, even though AT2
+  // (no remote mirror showing) is right that it should stay a no-op there.
+  it('AT4: #1086 — still calls setActiveWorkspace when a remote mirror is showing, even though the workspace already matches', () => {
+    const h = makeState({
+      workspaces: [ws('ws-a', 'pane-a', 'sf-a', 'pty-a')],
+      activeWorkspaceId: 'ws-a',
+      activeRemoteKey: 'remote-host-1',
+    });
+    activatePaneTarget(h.getState, { workspaceId: 'ws-a', paneId: 'pane-a', surfaceId: 'sf-a' });
+    expect(h.spies.setActiveWorkspace).toHaveBeenCalledWith('ws-a');
+    expect(h.state.activeRemoteKey).toBeNull();
   });
 });

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -107,6 +107,14 @@ export interface FocusTargetState {
    * existing minimal test fixtures stay terse; the live store always has it.
    */
   unstashPane?: (paneId: string, workspaceId?: string) => boolean;
+  /**
+   * #1086 — a remote mirror can be the visible pane while `activeWorkspaceId`
+   * itself never moved (WorkspaceCenter checks this first, ahead of the local
+   * tree). Optional for the same reason as `unstashPane`: minimal test
+   * fixtures without the remoteWorkspacesSlice mounted stay terse, and a
+   * missing field reads as "no remote mirror is showing", the correct default.
+   */
+  activeRemoteKey?: string | null;
 }
 
 /**
@@ -122,7 +130,15 @@ export function activatePaneTarget(
   target: { workspaceId: string; paneId: string; surfaceId: string },
 ): FocusTargetState {
   const state = getState();
-  if (target.workspaceId !== state.activeWorkspaceId) {
+  // #1086: `activeWorkspaceId` can already equal the target while a remote
+  // mirror is what's actually on screen (activeRemoteKey is a separate flag
+  // WorkspaceCenter checks first) — in that case the plain !== guard below
+  // would skip setActiveWorkspace, and with it the only call in this function
+  // that drops the remote selection (setActiveWorkspace always calls
+  // clearRemoteSelection, unconditionally, once past its own existence
+  // guard). A pane-row jump within the already-active workspace must still
+  // surface the local tree, so fire setActiveWorkspace on either condition.
+  if (target.workspaceId !== state.activeWorkspaceId || state.activeRemoteKey) {
     state.setActiveWorkspace(target.workspaceId);
   }
   const fresh = getState();


### PR DESCRIPTION
Addresses #1086 (the click-through bug half — Bug 2 there, rename/color/marker/startup parity, is a separate follow-up per the issue thread).

## Root cause

`activatePaneTarget` (`src/renderer/hooks/useNotificationListener.ts`) guards the only call to `setActiveWorkspace` in the function on a workspace-id inequality:

```ts
if (target.workspaceId !== state.activeWorkspaceId) {
  state.setActiveWorkspace(target.workspaceId);
}
```

`setActiveWorkspace` is also the only place that calls `clearRemoteSelection` — unconditionally, once past its own existence guard (`workspaceSlice.ts`). `activeWorkspaceId` never changes when a remote mirror becomes the visible pane: `WorkspaceCenter` checks `activeRemoteKey` first, ahead of the local tree, and `activeRemoteKey` is a wholly separate piece of state.

So: click a workspace's own top-level sidebar row (`WorkspaceItem`'s `onSelect={setActiveWorkspace}`, no guard) — works, always calls `setActiveWorkspace`. Click a *nested* pane/agent row inside that same, already-active workspace (`WorkspaceAgentRoster` → `focusPaneByPtyId` → `focusNotificationTarget` → `activatePaneTarget`) while a remote mirror is showing — the guard above sees `target.workspaceId === state.activeWorkspaceId` (true — the workspace never stopped being "active" in the local-only sense), skips `setActiveWorkspace`, and the remote mirror stays on screen with no way back except clicking a *different* workspace first.

Traced live against the reporter's running app via CDP (MutationObserver on the pane-grid wrapper's `display` style + a click listener), not from static reading alone — the original issue thread has the full trace, including two wrong turns before landing on this.

## Fix

Widen the guard to also fire `setActiveWorkspace` when a remote mirror is currently showing:

```ts
if (target.workspaceId !== state.activeWorkspaceId || state.activeRemoteKey) {
  state.setActiveWorkspace(target.workspaceId);
}
```

`activeRemoteKey` is added to `FocusTargetState` as optional (same convention as `unstashPane` — minimal test fixtures without the remote slice mounted stay terse, and `undefined` correctly reads as "no mirror showing").

## Test plan

- New test `AT4` (`useNotificationListener.test.ts`): `activeWorkspaceId` already equals the jump target, `activeRemoteKey` set — asserts `setActiveWorkspace` is now called and the mirror selection clears. Existing `AT2` (no mirror showing → still a no-op) is untouched and still passes, confirming the widened guard doesn't regress the plain case.
- `npm run test:parallel` on the touched files: 41/41 (`useNotificationListener.test.ts`) plus 145/145 across `Notification`, `FleetView`, `Sidebar`, `Toast` component suites (both call sites of `activatePaneTarget`/`focusNotificationTarget`) — all pass.
- `npx tsc --noEmit` and `eslint` on both changed files: clean.

Bug 2 from #1086 (rename/color/remote-marker/startup-config parity for remote workspace rows) is left untouched, per the prior diagnostic comment recommending it as a separate follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking nested panes or agent rows now switches from a remote workspace mirror back to the local view in one click.
  * Selecting an item in the currently active workspace correctly clears the remote mirror and displays the local workspace tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->