### PR TITLE
feat(remote): remote-terminal as an ordinary Surface, not a separate workspace (#1086/#1091)

### DIFF
--- a/changelog.d/1100.md
+++ b/changelog.d/1100.md
@@ -1,3 +1,3 @@
-### Changed
+### Added
 
-- Laid the type + store foundation (stage 1 of 2) for mirroring a session on a paired remote host as a surface inside an ordinary local workspace's own pane tree, instead of a separate remote-workspace entity — `Surface.surfaceType` gains a `'remote-terminal'` variant (`remoteHostId`/`remoteSessionId` fields, `ptyId: ''` like `browser`), plus a new `addRemoteSurface` store action mirroring `addBrowserSurface`. No renderer wiring yet (#1086/#1091 follow-up).
+- A workspace attached to a paired remote host can now hold a session as an ordinary pane tab, right alongside local terminal/browser/editor/diff tabs — pick "New remote pane" from a pane's ⋮ menu, choose a paired host, and it bootstraps a fresh remote session into the CURRENT local workspace instead of a separate "attached remote workspace" entity (#1086/#1091). Rename, color tags, and every other local-workspace affordance apply to it for free. The tab's name also follows the remote shell's own `rename`/window-title command, the same way a local pane's does.

--- a/changelog.d/1100.md
+++ b/changelog.d/1100.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Laid the type + store foundation (stage 1 of 2) for mirroring a session on a paired remote host as a surface inside an ordinary local workspace's own pane tree, instead of a separate remote-workspace entity — `Surface.surfaceType` gains a `'remote-terminal'` variant (`remoteHostId`/`remoteSessionId` fields, `ptyId: ''` like `browser`), plus a new `addRemoteSurface` store action mirroring `addBrowserSurface`. No renderer wiring yet (#1086/#1091 follow-up).

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -886,7 +886,7 @@ export default function AppLayout() {
 
       const activeSurface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
       // browser/editor/diff는 PTY가 없어 경로 붙여넣기 대상이 아님(J2 — diff 추가).
-      if (!activeSurface || activeSurface.surfaceType === 'browser' || activeSurface.surfaceType === 'editor' || activeSurface.surfaceType === 'diff') return;
+      if (!activeSurface || activeSurface.surfaceType === 'browser' || activeSurface.surfaceType === 'editor' || activeSurface.surfaceType === 'diff' || activeSurface.surfaceType === 'remote-terminal') return;
 
       const text = paths.map((p) => (p.includes(' ') ? `"${p}"` : p)).join(' ');
       // Route the joined path string through the paste chunker. Single-file
@@ -1036,7 +1036,7 @@ export default function AppLayout() {
           for (const surface of pane.surfaces) {
             if (signal?.aborted) return;
             // browser/editor/diff는 PTY를 갖지 않음 — 재조정·자가생성 대상에서 제외(J2).
-            if (surface.surfaceType === 'browser' || surface.surfaceType === 'editor' || surface.surfaceType === 'diff') continue;
+            if (surface.surfaceType === 'browser' || surface.surfaceType === 'editor' || surface.surfaceType === 'diff' || surface.surfaceType === 'remote-terminal') continue;
             if (!surface.ptyId) {
               console.log(`[AppLayout] Surface ${surface.id}: no ptyId, Terminal will self-create`);
               continue;

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -183,7 +183,7 @@ export function pickOverlaySurfaces<T extends { surfaceType?: string }>(
   surfaces: ReadonlyArray<T>,
 ): T[] {
   return surfaces.filter(
-    (s) => s.surfaceType === 'diff' || s.surfaceType === 'editor',
+    (s) => s.surfaceType === 'diff' || s.surfaceType === 'editor' || s.surfaceType === 'remote-terminal',
   );
 }
 
@@ -1175,6 +1175,21 @@ function SplitSurfaceView({
             isActive={surface.id === activeSurfaceId}
             surfaceId={surface.id}
             verifiedWorkspaceId={surface.diffOwnerWorkspaceId || workspaceId}
+          />
+        ) : surface.surfaceType === 'remote-terminal' ? (
+          // #1086/#1091, CodeRabbit round 1 — the hasBoth split previously
+          // routed remote-terminal into the editor ternary below (empty
+          // filePath, nothing rendered). Same overlay contract as Diff/Editor
+          // (absolute inset-0, isActive→display:none inside the component).
+          <RemotePaneSurface
+            key={surface.id}
+            hostId={surface.remoteHostId || ''}
+            sessionId={surface.remoteSessionId || ''}
+            surfaceId={surface.id}
+            shell={surface.shell}
+            cwd={surface.cwd}
+            isActive={surface.id === activeSurfaceId}
+            onTitleChange={updateRemoteSurfaceTitle}
           />
         ) : (
           <EditorPanel

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -10,6 +10,8 @@ import TerminalComponent from '../Terminal/Terminal';
 import BrowserPanel from '../Browser/BrowserPanel';
 import EditorPanel from '../Editor/EditorPanel';
 import DiffPanel from '../Diff/DiffPanel';
+import RemotePaneSurface from '../Remote/RemotePaneSurface';
+import AddRemotePaneModal from '../Remote/AddRemotePaneModal';
 import SurfaceTabs, { paneClusterWidth, paneActionsMode, type PaneActionsMode } from './SurfaceTabs';
 import { useElementWidth } from '../../hooks/useElementWidth';
 import { ErrorBoundary } from '../ErrorBoundary';
@@ -282,6 +284,8 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
   const setActivePane = useStore((s) => s.setActivePane);
   const setActiveSurface = useStore((s) => s.setActiveSurface);
   const addBrowserSurface = useStore((s) => s.addBrowserSurface);
+  const addRemoteSurface = useStore((s) => s.addRemoteSurface);
+  const [addRemoteModalOpen, setAddRemoteModalOpen] = useState(false);
   const splitPane = useStore((s) => s.splitPane);
   const closeSurface = useStore((s) => s.closeSurface);
   const updateSurfacePtyId = useStore((s) => s.updateSurfacePtyId);
@@ -409,6 +413,14 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     if (maybeDelegateExternalBrowser(undefined)) return;
     addBrowserSurface(pane.id, undefined, undefined, workspace.id);
   }, [addBrowserSurface, pane.id, workspace.id]);
+
+  const handleAddRemote = useCallback(() => {
+    setAddRemoteModalOpen(true);
+  }, []);
+
+  const handleRemoteCreated = useCallback((hostId: string, sessionId: string) => {
+    addRemoteSurface(pane.id, hostId, sessionId, undefined, undefined, workspace.id);
+  }, [addRemoteSurface, pane.id, workspace.id]);
 
   const closePane = useStore((s) => s.closePane);
 
@@ -944,7 +956,14 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         onSplitVertical={handleSplitVertical}
         onAddTerminal={handleAddTerminal}
         onAddBrowser={handleAddBrowser}
+        onAddRemote={handleAddRemote}
       />
+      {addRemoteModalOpen && (
+        <AddRemotePaneModal
+          onClose={() => setAddRemoteModalOpen(false)}
+          onCreated={handleRemoteCreated}
+        />
+      )}
 
       <SplitSurfaceView
         pane={pane}
@@ -1001,6 +1020,7 @@ function SplitSurfaceView({
   // 인 것만 split 위에 오버레이로 겹쳐 렌더한다(각 패널이 display:isActive로 자기
   // 가시성을 관리하므로 비active는 보이지 않음 — editor 기존 단독 경로는 무회귀).
   const others = useMemo(() => pickOverlaySurfaces(pane.surfaces), [pane.surfaces]);
+  const updateRemoteSurfaceTitle = useStore((s) => s.updateRemoteSurfaceTitle);
 
   const hasBoth = terminals.length > 0 && browsers.length > 0;
 
@@ -1051,6 +1071,22 @@ function SplitSurfaceView({
               isActive={surface.id === activeSurfaceId}
               surfaceId={surface.id}
               verifiedWorkspaceId={surface.diffOwnerWorkspaceId || workspaceId}
+            />
+          ) : surface.surfaceType === 'remote-terminal' ? (
+            // #1086/#1091 — a remote session mirrored as an ordinary tab in a
+            // LOCAL workspace's pane, not a whole separate "attached remote
+            // workspace". No local PTY, so it sits outside the `terminals`
+            // group above (which is keyed on ptyId-bearing surfaces) even
+            // though it visually shares the same tab strip.
+            <RemotePaneSurface
+              key={surface.id}
+              hostId={surface.remoteHostId || ''}
+              sessionId={surface.remoteSessionId || ''}
+              surfaceId={surface.id}
+              shell={surface.shell}
+              cwd={surface.cwd}
+              isActive={surface.id === activeSurfaceId}
+              onTitleChange={updateRemoteSurfaceTitle}
             />
           ) : (
             <TerminalComponent

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -12,7 +12,7 @@ import { computePaneAutoName, paneDisplayName } from '../../utils/paneNaming';
 import { findPane } from '../../../shared/paneUtils';
 import PaneDragGrip from './PaneDragGrip';
 import { FOCUS_RING } from '../focusRing';
-import { IconSplitRight, IconSplitDown, IconBrowser, IconEyeOff, IconPencil } from '../icons';
+import { IconSplitRight, IconSplitDown, IconBrowser, IconExternalLink, IconEyeOff, IconPencil } from '../icons';
 import { displayPath } from '../../utils/displayPath';
 import { workspaceColorHex } from '../../../shared/workspaceColors';
 import PaneActionsMenu, { PANE_ACTIONS_MENU_WIDTH, type PaneActionItem } from './PaneActionsMenu';
@@ -189,6 +189,11 @@ interface SurfaceTabsProps {
   onAddTerminal: () => void;
   /** New browser surface (tab) in this pane. */
   onAddBrowser: () => void;
+  /** #1086/#1091 — new remote-terminal surface (tab) in this pane, mirroring
+   *  a session on one of the user's paired hosts. Optional so existing
+   *  callers/tests that mount this component standalone keep working
+   *  unchanged — omitted just drops the menu item. */
+  onAddRemote?: () => void;
   /**
    * How the pane-action cluster renders. Pane.tsx owns this because it is the
    * Settings toggle AND the width check — the cluster is fixed-width and
@@ -211,6 +216,7 @@ export default function SurfaceTabs({
   onSplitVertical,
   onAddTerminal,
   onAddBrowser,
+  onAddRemote,
   actionsMode,
 }: SurfaceTabsProps) {
   const t = useT();
@@ -399,6 +405,12 @@ export default function SurfaceTabs({
       icon: <IconBrowser size={14} />,
       onSelect: onAddBrowser,
     },
+    ...(onAddRemote ? [{
+      key: 'new-remote',
+      label: t('pane.newRemote'),
+      icon: <IconExternalLink size={14} />,
+      onSelect: onAddRemote,
+    }] : []),
     {
       key: 'rename-pane',
       label: t('pane.rename'),
@@ -427,7 +439,7 @@ export default function SurfaceTabs({
       onSelect: toggleZoom,
     },
   ], [
-    t, onSplitHorizontal, onSplitVertical, onAddBrowser, startPaneRename,
+    t, onSplitHorizontal, onSplitVertical, onAddBrowser, onAddRemote, startPaneRename,
     stashChord, stashDisabled, stashTooltip, stashThisPane, isZoomed, toggleZoom,
   ]);
 

--- a/src/renderer/components/Pane/__tests__/Pane.splitVisibility.test.tsx
+++ b/src/renderer/components/Pane/__tests__/Pane.splitVisibility.test.tsx
@@ -116,4 +116,13 @@ describe('pickOverlaySurfaces — F6 mixed-split diff/editor routing', () => {
     ];
     expect(pickOverlaySurfaces(surfaces)).toEqual([]);
   });
+
+  it('#1100 CodeRabbit round 1 — remote-terminal도 오버레이 집합에 포함 (terminal+browser+remote 혼재에서 사라지지 않아야 함)', () => {
+    const surfaces = [
+      { id: 't', surfaceType: 'terminal' },
+      { id: 'b', surfaceType: 'browser' },
+      { id: 'r', surfaceType: 'remote-terminal' },
+    ];
+    expect(pickOverlaySurfaces(surfaces).map((s) => s.id)).toEqual(['r']);
+  });
 });

--- a/src/renderer/components/Pane/__tests__/paneClusterWidth.test.ts
+++ b/src/renderer/components/Pane/__tests__/paneClusterWidth.test.ts
@@ -222,8 +222,11 @@ describe('the ⋮ menu offers exactly what the cluster does', () => {
     // decision here rather than silent drift. rename-pane is menu-only by
     // design (#1021): the label fold removed the double-click target on
     // unnamed single-tab panes, and the menu replaces that affordance; the
-    // cluster keeps to icon-sized layout actions.
+    // cluster keeps to icon-sized layout actions. new-remote (#1086/#1091) is
+    // the same kind of deliberate menu-only addition, conditionally rendered
+    // (only when a caller passes onAddRemote) rather than promoted to the
+    // icon cluster.
     for (const key of cluster) expect(menu).toContain(key);
-    expect(menu.filter((k) => !cluster.includes(k))).toEqual(['rename-pane']);
+    expect(menu.filter((k) => !cluster.includes(k))).toEqual(['new-remote', 'rename-pane']);
   });
 });

--- a/src/renderer/components/Remote/AddRemotePaneModal.tsx
+++ b/src/renderer/components/Remote/AddRemotePaneModal.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { useT } from '../../hooks/useT';
+import type { RemoteHostPublic } from '../../../shared/remoteHosts';
+
+export interface AddRemotePaneModalProps {
+  onClose: () => void;
+  /** Resolves once a session exists on the chosen host — the caller adds the
+   *  surface to its own pane; this component only picks the host and mints
+   *  the remote session. */
+  onCreated: (hostId: string, sessionId: string) => void;
+}
+
+/**
+ * #1086/#1091 — "Add remote pane": pick one of the already-paired hosts
+ * (same list `AttachRemoteModal` shows) and bootstrap a fresh session on it
+ * via `remote.workspaceCreate` (#1001's operator-mint path). The `workspaceId`
+ * that call requires is opaque here — this feature does not create a remote
+ * "workspace" at all, so a fresh id is minted purely to satisfy the
+ * bootstrap contract and is never referenced again afterward.
+ */
+export default function AddRemotePaneModal({ onClose, onCreated }: AddRemotePaneModalProps) {
+  const t = useT();
+  const [hosts, setHosts] = useState<RemoteHostPublic[] | null>(null);
+  const [creatingHostId, setCreatingHostId] = useState<string | null>(null);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electronAPI?.remote?.hostsList().then((list) => {
+      if (!cancelled) setHosts(list);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const pick = async (hostId: string): Promise<void> => {
+    setError(undefined);
+    setCreatingHostId(hostId);
+    const remote = window.electronAPI?.remote;
+    if (!remote) return;
+    const freshId = `remote-pane-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    const res = await remote.workspaceCreate(hostId, freshId);
+    setCreatingHostId(null);
+    if (res.ok) {
+      onCreated(hostId, res.sessionId);
+      onClose();
+    } else {
+      setError(res.error);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[var(--z-modal)] flex items-center justify-center"
+      style={{ background: 'rgba(0,0,0,0.4)' }}
+      onMouseDown={onClose}
+    >
+      <div
+        className="w-[360px] max-h-[70vh] overflow-y-auto rounded-lg p-3"
+        style={{ background: 'var(--bg-surface)', border: '1px solid var(--border-soft)' }}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="text-sm font-medium mb-2" style={{ color: 'var(--text-main)' }}>
+          {t('pane.newRemote')}
+        </div>
+        {error && (
+          <div className="text-xs mb-2" style={{ color: 'var(--accent-red, #e5484d)' }}>{error}</div>
+        )}
+        {hosts === null ? (
+          <div className="text-xs" style={{ color: 'var(--text-muted)' }}>…</div>
+        ) : hosts.length === 0 ? (
+          <div className="text-xs" style={{ color: 'var(--text-muted)' }}>{t('remote.noHostsHint')}</div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {hosts.map((h) => (
+              <button
+                key={h.id}
+                type="button"
+                disabled={creatingHostId !== null}
+                className="text-left px-2 py-1.5 rounded text-xs font-mono truncate hover:bg-[rgba(var(--bg-surface-rgb),0.6)] disabled:opacity-50"
+                style={{ color: 'var(--text-main)' }}
+                onClick={() => void pick(h.id)}
+              >
+                {h.label || h.origin} {creatingHostId === h.id ? '…' : ''}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/Remote/AddRemotePaneModal.tsx
+++ b/src/renderer/components/Remote/AddRemotePaneModal.tsx
@@ -34,17 +34,31 @@ export default function AddRemotePaneModal({ onClose, onCreated }: AddRemotePane
 
   const pick = async (hostId: string): Promise<void> => {
     setError(undefined);
-    setCreatingHostId(hostId);
     const remote = window.electronAPI?.remote;
+    // #1100, CodeRabbit round 1 — the guard must run BEFORE the spinner
+    // latches: a missing bridge with no reset would leave every host button
+    // disabled forever (setCreatingHostId(null) was only reachable after
+    // this line). The `await` below gets the same protection via try/catch —
+    // a rejected IPC call (as opposed to an { ok: false } response, already
+    // handled) is the second way to strand the same spinner, and the caller
+    // (`onClick={() => void pick(h.id)}`) attaches no handler of its own, so
+    // an uncaught rejection here would surface as a genuine unhandled
+    // promise rejection, not just leave the spinner stuck.
     if (!remote) return;
+    setCreatingHostId(hostId);
     const freshId = `remote-pane-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-    const res = await remote.workspaceCreate(hostId, freshId);
-    setCreatingHostId(null);
-    if (res.ok) {
-      onCreated(hostId, res.sessionId);
-      onClose();
-    } else {
-      setError(res.error);
+    try {
+      const res = await remote.workspaceCreate(hostId, freshId);
+      if (res.ok) {
+        onCreated(hostId, res.sessionId);
+        onClose();
+      } else {
+        setError(res.error);
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreatingHostId(null);
     }
   };
 

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { useT } from '../../hooks/useT';
+import { sanitizeTitle } from '../../../main/pty/titleDetect';
 import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
 import { computeMirrorFontSize, mirrorFitKey, MAX_FIT_PASSES } from './mirrorFit';
 import { decideMirrorKeyWithRepeat } from './mirrorInput';
@@ -21,6 +22,13 @@ export interface RemoteMirrorTerminalProps {
   /** True when the remote host was started without --allow-input — writes
    *  must be swallowed locally rather than silently dropped server-side. */
   readOnly?: boolean;
+  /** #1086/#1091 — fired, already run through {@link sanitizeTitle}, whenever
+   *  the remote shell sets its window title via OSC 0/2 (e.g. a `rename`
+   *  command) — xterm's own parser extracts the OSC payload; this component
+   *  sanitizes it the same way PTYBridge does for a local pane before handing
+   *  it up. Optional: RemoteWorkspaceView's mirror-grid cells have no
+   *  per-surface title to update and pass nothing. */
+  onTitleChange?: (title: string) => void;
 }
 
 /** Decode a base64 payload into raw bytes and hand it to xterm as-is — the
@@ -86,8 +94,13 @@ const FIT_DEBOUNCE_MS = 150;
  * container/remote aspect mismatch is letterboxed by the parent's CSS, not by
  * resizing the terminal.
  */
-export default function RemoteMirrorTerminal({ attachId, error, readOnly }: RemoteMirrorTerminalProps) {
+export default function RemoteMirrorTerminal({ attachId, error, readOnly, onTitleChange }: RemoteMirrorTerminalProps) {
   const t = useT();
+  // Ref, same reason as readOnlyRef below: the title subscription is wired
+  // once inside the mount-only effect, and a parent re-render passing a new
+  // closure must not tear down and re-attach the whole terminal.
+  const onTitleChangeRef = useRef(onTitleChange);
+  onTitleChangeRef.current = onTitleChange;
   /** The clipping box. Its content size is what the remote grid must fit in. */
   const boxRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -409,6 +422,14 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
       autoCopy.onSelection(term.getSelection());
     });
 
+    // #1086/#1091 — xterm's own parser already extracts the OSC 0/2 payload
+    // (icon title / window title); sanitize it exactly like PTYBridge does
+    // for a local pane before handing it to the surface-title callback.
+    const titleDisposable = term.onTitleChange((raw) => {
+      const title = sanitizeTitle(raw);
+      if (title) onTitleChangeRef.current?.(title);
+    });
+
     term.attachCustomKeyEventHandler((ev) => {
       const decision = decideMirrorKeyWithRepeat(ev, {
         isMac,
@@ -468,6 +489,7 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly }: Remo
     return () => {
       if (isMac) container.removeEventListener('paste', blockNativePaste, true);
       selectionDisposable.dispose();
+      titleDisposable.dispose();
       // Cancels a debounced write that would otherwise fire against a disposed
       // terminal's last selection.
       autoCopy.dispose();

--- a/src/renderer/components/Remote/RemotePaneSurface.tsx
+++ b/src/renderer/components/Remote/RemotePaneSurface.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import RemoteMirrorTerminal from './RemoteMirrorTerminal';
+
+export interface RemotePaneSurfaceProps {
+  hostId: string;
+  sessionId: string;
+  surfaceId: string;
+  shell?: string;
+  cwd?: string;
+  /** Stacked/tab case (one surface visible at a time in the pane) — same
+   *  isActive→display:none pattern TerminalComponent/BrowserPanel use, so an
+   *  inactive remote tab stays mounted (no SSE re-attach on tab switch) but
+   *  invisible instead of overlapping the active one. */
+  isActive?: boolean;
+  onTitleChange: (surfaceId: string, title: string) => void;
+}
+
+/**
+ * #1086/#1091 — one remote-terminal surface living as an ordinary tab inside
+ * a LOCAL workspace's own pane tree, instead of a whole separate
+ * "attached remote workspace" (RemoteWorkspaceView's fixed mirror grid).
+ *
+ * Attach/detach lifecycle is the same shape as RemoteWorkspaceView's
+ * `PaneCell` (teardown-then-attach ordering, chained onto the previous
+ * detach so a fast remount can't race main's idempotency key) — that
+ * component is left untouched (still used by the older mirror-grid view for
+ * an ATTACHED remote workspace); this is its single-surface twin for a pane
+ * that lives in a normal workspace.
+ */
+export default function RemotePaneSurface({ hostId, sessionId, surfaceId, shell, cwd, isActive = true, onTitleChange }: RemotePaneSurfaceProps) {
+  const [attachId, setAttachId] = useState<string | null>(null);
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [allowInput, setAllowInput] = useState<boolean | undefined>(undefined);
+  const teardown = useRef<Promise<void>>(Promise.resolve());
+
+  useEffect(() => {
+    let cancelled = false;
+    const remote = window.electronAPI?.remote;
+    if (!remote) return;
+    remote.hostsList().then((hosts) => {
+      if (cancelled) return;
+      const host = hosts.find((h) => h.id === hostId);
+      setAllowInput(host?.allowInput);
+    });
+    return () => { cancelled = true; };
+  }, [hostId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const remote = window.electronAPI?.remote;
+    if (!remote) return;
+    setAttachId(null);
+    setError(undefined);
+    let openedId: string | null = null;
+
+    const attaching = teardown.current
+      .then(() => remote.paneAttach(hostId, sessionId))
+      .then((res) => {
+        if (res.ok) {
+          openedId = res.attachId;
+          if (!cancelled) setAttachId(res.attachId);
+        } else if (!cancelled) {
+          setError(res.error);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+
+    return () => {
+      cancelled = true;
+      teardown.current = attaching
+        .then(() => (openedId ? remote.paneDetach(openedId) : undefined))
+        .catch(() => { /* teardown is best effort — main drops it on reload anyway */ });
+    };
+  }, [hostId, sessionId]);
+
+  return (
+    <div className="flex flex-col h-full w-full" style={{ background: 'var(--bg-base)', display: isActive ? 'flex' : 'none' }}>
+      {(shell || cwd) && (
+        <div
+          className="h-6 flex items-center px-2 text-[10px] font-mono truncate flex-shrink-0"
+          style={{ color: 'var(--text-subtle)', borderBottom: '1px solid var(--bg-overlay)' }}
+        >
+          {shell ?? sessionId.slice(0, 8)}
+          {cwd ? ` — ${cwd}` : ''}
+        </div>
+      )}
+      <div className="flex-1 min-h-0">
+        <RemoteMirrorTerminal
+          attachId={attachId}
+          error={error}
+          readOnly={allowInput === false}
+          onTitleChange={(title) => onTitleChange(surfaceId, title)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/Remote/RemotePaneSurface.tsx
+++ b/src/renderer/components/Remote/RemotePaneSurface.tsx
@@ -76,7 +76,7 @@ export default function RemotePaneSurface({ hostId, sessionId, surfaceId, shell,
   }, [hostId, sessionId]);
 
   return (
-    <div className="flex flex-col h-full w-full" style={{ background: 'var(--bg-base)', display: isActive ? 'flex' : 'none' }}>
+    <div className="absolute inset-0 flex flex-col" style={{ background: 'var(--bg-base)', display: isActive ? 'flex' : 'none' }}>
       {(shell || cwd) && (
         <div
           className="h-6 flex items-center px-2 text-[10px] font-mono truncate flex-shrink-0"

--- a/src/renderer/components/Remote/__tests__/AddRemotePaneModal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/AddRemotePaneModal.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+//
+// #1100, CodeRabbit round 1 — AddRemotePaneModal.pick had two ways to strand
+// its "creating…" spinner permanently disabling every host button:
+// (1) setCreatingHostId(hostId) ran before the `!remote` guard, so a missing
+//     bridge left the spinner latched with nothing to ever clear it;
+// (2) a rejected remote.workspaceCreate() call (as opposed to an { ok: false }
+//     response, already handled) had no catch/finally to reset it.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import AddRemotePaneModal from '../AddRemotePaneModal';
+import type { RemoteHostPublic } from '../../../../shared/remoteHosts';
+
+function render(ui: React.ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(ui));
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function flush(ticks = 8) {
+  await act(async () => {
+    for (let i = 0; i < ticks; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+const HOST: RemoteHostPublic = {
+  id: 'host-1',
+  label: 'office-mac',
+  origin: 'https://office-mac.example:9600',
+  addedAt: 1,
+  allowInput: true,
+};
+
+describe('AddRemotePaneModal', () => {
+  afterEach(() => {
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it('does not strand the host button disabled when window.electronAPI.remote is missing', async () => {
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+    const { container, unmount } = render(
+      <AddRemotePaneModal onClose={() => { /* noop */ }} onCreated={() => { /* noop */ }} />,
+    );
+    // Manually seed the host list — hostsList() itself is unreachable with no
+    // bridge, but pick()'s guard is what's under test here, not the loader.
+    await flush();
+
+    const btn = container.querySelector('button');
+    if (btn) {
+      act(() => { btn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      await flush();
+      // The guard returns before setCreatingHostId ever latches — button
+      // must not be left permanently disabled.
+      expect(btn.disabled).toBe(false);
+    }
+    unmount();
+  });
+
+  it('re-enables every host button after a rejected workspaceCreate call (not just an { ok: false } response)', async () => {
+    // mockImplementation, not mockRejectedValue — the latter constructs the
+    // rejected Promise eagerly at mock-setup time, which Node's unhandled-
+    // rejection detector can flag before the test's own await ever attaches
+    // a handler. A factory defers construction until the call the test awaits.
+    const workspaceCreate = vi.fn().mockImplementation(() => Promise.reject(new Error('IPC channel closed')));
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      remote: {
+        hostsList: vi.fn().mockResolvedValue([HOST]),
+        workspaceCreate,
+      },
+    };
+
+    const { container } = render(
+      <AddRemotePaneModal onClose={() => { /* noop */ }} onCreated={() => { /* noop */ }} />,
+    );
+    await flush();
+
+    const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('office-mac'));
+    expect(btn).toBeTruthy();
+    if (!btn) return;
+
+    // pick() throws past the `await` — the component must not propagate it
+    // uncaught, and must still clear creatingHostId in a finally.
+    await act(async () => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve().catch(() => { /* swallow: assertion is on DOM state below */ });
+    });
+    await flush();
+
+    expect(workspaceCreate).toHaveBeenCalled();
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('succeeds normally when workspaceCreate resolves ok (sanity check, unchanged behavior)', async () => {
+    const onCreated = vi.fn();
+    const onClose = vi.fn();
+    const workspaceCreate = vi.fn().mockResolvedValue({ ok: true, sessionId: 'sess-1' });
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      remote: {
+        hostsList: vi.fn().mockResolvedValue([HOST]),
+        workspaceCreate,
+      },
+    };
+
+    const { container } = render(<AddRemotePaneModal onClose={onClose} onCreated={onCreated} />);
+    await flush();
+
+    const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('office-mac'));
+    expect(btn).toBeTruthy();
+    if (!btn) return;
+    await act(async () => {
+      btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    expect(onCreated).toHaveBeenCalledWith('host-1', 'sess-1');
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -78,6 +78,13 @@ class FakeTerminal {
     this.selectionHandler = cb;
     return { dispose: vi.fn() };
   }
+  /** #1086/#1091 — RemoteMirrorTerminal always wires this in its mount
+   *  effect now, whether or not a test passes onTitleChange. */
+  titleHandler: ((title: string) => void) | null = null;
+  onTitleChange(cb: (title: string) => void): { dispose: () => void } {
+    this.titleHandler = cb;
+    return { dispose: vi.fn() };
+  }
   getSelection(): string { return this.selection; }
   hasSelection(): boolean { return this.selection.length > 0; }
   clearSelection(): void { this.clearSelectionCalls++; this.selection = ''; }
@@ -219,6 +226,44 @@ describe('RemoteMirrorTerminal', () => {
 
     expect(term.written).toHaveLength(1);
 
+    unmount();
+  });
+
+  it('#1086/#1091 — fires onTitleChange with the sanitized OSC title', () => {
+    const onTitleChange = vi.fn();
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" onTitleChange={onTitleChange} />);
+    const term = termInstances[0];
+
+    act(() => {
+      term.titleHandler?.('claude: feature-x\x07');
+    });
+
+    expect(onTitleChange).toHaveBeenCalledWith('claude: feature-x');
+    unmount();
+  });
+
+  it('#1086/#1091 — drops an all-control-character title (nothing printable to show)', () => {
+    const onTitleChange = vi.fn();
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" onTitleChange={onTitleChange} />);
+    const term = termInstances[0];
+
+    act(() => {
+      term.titleHandler?.('\x07');
+    });
+
+    expect(onTitleChange).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('#1086/#1091 — works without an onTitleChange prop (mirror-grid callers pass none)', () => {
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    const term = termInstances[0];
+
+    expect(() => {
+      act(() => {
+        term.titleHandler?.('claude: feature-x');
+      });
+    }).not.toThrow();
     unmount();
   });
 

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -289,6 +289,7 @@ export const en = {
   'pane.splitDown': 'Split down',
   'pane.newTerminal': 'New terminal',
   'pane.newBrowser': 'New browser',
+  'pane.newRemote': 'New remote pane',
   // Label for the ⋮ that replaces the five-button cluster on a pane too
   // narrow to hold it, and for the header's right-click menu. Names the SET of
   // actions, not the glyph — it is the accessible name a screen reader reads.

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -295,6 +295,7 @@ export const pl = {
   'pane.splitDown': 'Podziel w dół',
   'pane.newTerminal': 'Nowy terminal',
   'pane.newBrowser': 'Nowa przeglądarka',
+  'pane.newRemote': 'Nowy panel zdalny',
   // Label for the ⋮ that replaces the five-button cluster on a pane too
   // narrow to hold it, and for the header's right-click menu. Names the SET of
   // actions, not the glyph — it is the accessible name a screen reader reads.

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -752,6 +752,7 @@ export const zh = {
   'pane.dragGrip': '拖动以移动此面板',
   'pane.newTerminal': '新建终端',
   'pane.newBrowser': '新建浏览器',
+  'pane.newRemote': '新建远程面板',
   'pane.addSurface': '新建标签页',
   'pane.maxLeavesReached': '已达到面板数量上限（{count}）。请先关闭一个面板再分割。',
   'pane.maxLeavesReachedWithStash': '已达到面板数量上限（{count}，其中已收起 {stashed}）。请取回一个并关闭，或关闭一个可见面板。',

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -28,7 +28,7 @@ export interface FleetPane {
   paneLabel?: string;
   cwd?: string;
   title: string;
-  surfaceType: 'terminal' | 'browser' | 'editor' | 'diff' | 'git' | 'review';
+  surfaceType: 'terminal' | 'browser' | 'editor' | 'diff' | 'git' | 'review' | 'remote-terminal';
   /** True when this leaf is its workspace's active pane (badge fidelity hint). */
   isActivePane: boolean;
   /**

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -730,3 +730,60 @@ describe('surfaceSlice.addRemoteSurface (#1086/#1091)', () => {
     expect(pane.surfaces).toHaveLength(0);
   });
 });
+
+describe('surfaceSlice.updateRemoteSurfaceTitle (#1086/#1091)', () => {
+  it('sets the title of the remote-terminal surface identified by surfaceId', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addRemoteSurface(paneId, 'host-abc', 'session-xyz');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId = pane.surfaces[0].id;
+
+    slice.updateRemoteSurfaceTitle(surfaceId, 'my-remote-shell');
+
+    expect(pane.surfaces[0].title).toBe('my-remote-shell');
+  });
+
+  it('is a no-op for an unknown surfaceId', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addRemoteSurface(paneId, 'host-abc', 'session-xyz');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const before = pane.surfaces[0].title;
+
+    slice.updateRemoteSurfaceTitle('ghost', 'nope');
+
+    expect(pane.surfaces[0].title).toBe(before);
+  });
+
+  it('never touches a terminal surface, even by a matching surfaceId collision', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addSurface(paneId, 'pty-1', 'pwsh', 'C:\\a');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId = pane.surfaces[0].id;
+    const before = pane.surfaces[0].title;
+
+    slice.updateRemoteSurfaceTitle(surfaceId, 'should-not-apply');
+
+    expect(pane.surfaces[0].title).toBe(before);
+  });
+
+  it('is ignored once the surface title is locked by a manual rename', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+    slice.addRemoteSurface(paneId, 'host-abc', 'session-xyz');
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    const surfaceId = pane.surfaces[0].id;
+
+    slice.updateSurfaceTitle(surfaceId, 'my-name'); // manual rename → locks
+    slice.updateRemoteSurfaceTitle(surfaceId, 'osc-set'); // must be ignored
+
+    expect(pane.surfaces[0].title).toBe('my-name');
+    expect(pane.surfaces[0].titleLocked).toBe(true);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -673,3 +673,60 @@ describe('surfaceSlice.closeSurface — stashed panes', () => {
     expect(ws.stashedPanes).toBeUndefined();
   });
 });
+
+describe('surfaceSlice.addRemoteSurface (#1086/#1091)', () => {
+  it('pushes a remote-terminal surface into an ordinary local workspace pane, with an empty ptyId', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+
+    slice.addRemoteSurface(paneId, 'host-abc', 'session-xyz', 'bash', '/root');
+
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    expect(pane.surfaces).toHaveLength(1);
+    const surface = pane.surfaces[0];
+    expect(surface.surfaceType).toBe('remote-terminal');
+    expect(surface.ptyId).toBe('');
+    expect(surface.remoteHostId).toBe('host-abc');
+    expect(surface.remoteSessionId).toBe('session-xyz');
+    expect(surface.shell).toBe('bash');
+    expect(surface.cwd).toBe('/root');
+    expect(pane.activeSurfaceId).toBe(surface.id);
+  });
+
+  it('lands in a background workspace when workspaceId is given, mirroring addBrowserSurface/#236', () => {
+    const { state, slice } = createHarness();
+    const ws2 = createWorkspace('Background');
+    state.workspaces.push(ws2);
+
+    slice.addRemoteSurface(ws2.rootPane.id, 'host-1', 'session-1', 'pwsh', 'D:\\bg', ws2.id);
+
+    const ws2Pane = state.workspaces.find((w) => w.id === ws2.id)!.rootPane;
+    if (ws2Pane.type !== 'leaf') throw new Error('expected leaf');
+    expect(ws2Pane.surfaces).toHaveLength(1);
+    expect(ws2Pane.surfaces[0].remoteSessionId).toBe('session-1');
+  });
+
+  it('defaults shell/cwd to empty strings when omitted', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+
+    slice.addRemoteSurface(paneId, 'host-abc', 'session-xyz');
+
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    expect(pane.surfaces[0].shell).toBe('');
+    expect(pane.surfaces[0].cwd).toBe('');
+    expect(pane.surfaces[0].title).toBe('Remote');
+  });
+
+  it('is a no-op when the target pane does not exist', () => {
+    const { state, slice } = createHarness();
+
+    slice.addRemoteSurface('no-such-pane', 'host-abc', 'session-xyz');
+
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    expect(pane.surfaces).toHaveLength(0);
+  });
+});

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -46,6 +46,12 @@ export interface SurfaceSlice {
   updateSurfacePtyId: (paneId: string, surfaceId: string, ptyId: string) => void;
   updateSurfaceTitle: (surfaceId: string, title: string) => void;
   updateSurfaceTitleByPty: (ptyId: string, title: string) => void;
+  /** #1086/#1091 — the remote-terminal twin of updateSurfaceTitleByPty. A
+   *  remote-terminal surface's ptyId is always '' (see createRemoteSurface),
+   *  so it can never be found by that lookup — this one is keyed by surfaceId
+   *  directly instead, the same identity RemotePaneSurface already has to
+   *  hand. Same manual-rename guard: never overrides a titleLocked surface. */
+  updateRemoteSurfaceTitle: (surfaceId: string, title: string) => void;
   /**
    * Update the live working directory of the surface bound to `ptyId`. Driven
    * by the OSC 7 shell-integration channel (onCwdChanged), so each terminal
@@ -435,6 +441,19 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
         if (!surface) continue;
         // Terminal surfaces only, and never override a user's manual rename.
         if ((surface.surfaceType ?? 'terminal') === 'terminal' && !surface.titleLocked) {
+          surface.title = title;
+        }
+        return;
+      }
+    }
+  }),
+
+  updateRemoteSurfaceTitle: (surfaceId, title) => set((state: StoreState) => {
+    for (const ws of state.workspaces) {
+      for (const pane of getWorkspaceLeafPanes(ws)) {
+        const surface = pane.surfaces.find((s) => s.id === surfaceId);
+        if (!surface) continue;
+        if (surface.surfaceType === 'remote-terminal' && !surface.titleLocked) {
           surface.title = title;
         }
         return;

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -1,7 +1,7 @@
 import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
 import type { Pane, PaneLeaf, Surface, Workspace } from '../../../shared/types';
-import { createSurface, generateId } from '../../../shared/types';
+import { createRemoteSurface, createSurface, generateId } from '../../../shared/types';
 import { isPlausibleCwd } from '../../../shared/cwdShape';
 import { getWorkspaceLeafPanes } from '../../../shared/paneUtils';
 import { isSafeBrowserUrl } from '../../utils/browserPane';
@@ -18,6 +18,14 @@ export interface SurfaceSlice {
    * callers are unchanged. */
   addSurface: (paneId: string, ptyId: string, shell: string, cwd: string, workspaceId?: string) => void;
   addBrowserSurface: (paneId: string, url?: string, partition?: string, workspaceId?: string) => void;
+  /** #1086/#1091 — mirror a session on a paired remote host as a surface in
+   * an ordinary LOCAL workspace's own pane tree (stage 1: store only, no
+   * SSE attach yet — that's the renderer wiring in Pane.tsx, a follow-up).
+   * Same shape as addBrowserSurface: caller splits an empty leaf first via
+   * splitPane, then calls this to populate it. ptyId stays '' (see
+   * createRemoteSurface), so every ptyId-gated check already treats this
+   * surface as non-local without further changes. */
+  addRemoteSurface: (paneId: string, hostId: string, sessionId: string, shell?: string, cwd?: string, workspaceId?: string) => void;
   addEditorSurface: (paneId: string, filePath: string) => void;
   /** J2 — diff 리뷰 서피스 추가. taskId만 영속(diff 내용은 파생 데이터).
    * 같은 taskId가 이미 열려 있으면 그 탭으로 전환. editor/browser처럼 ptyId 없음. */
@@ -141,6 +149,17 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
       browserUrl: url || 'https://google.com',
       browserPartition: partition || 'persist:wmux-default',
     };
+    pane.surfaces.push(surface);
+    pane.activeSurfaceId = surface.id;
+  }),
+
+  addRemoteSurface: (paneId, hostId, sessionId, shell, cwd, workspaceId) => set((state: StoreState) => {
+    const targetWsId = workspaceId || state.activeWorkspaceId;
+    const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
+    if (!ws) return;
+    const pane = findLeafPane(ws.rootPane, paneId);
+    if (!pane) return;
+    const surface = createRemoteSurface(hostId, sessionId, shell || '', cwd || '');
     pane.surfaces.push(surface);
     pane.activeSurfaceId = surface.id;
   }),

--- a/src/shared/__tests__/clonePaneTreeFresh.test.ts
+++ b/src/shared/__tests__/clonePaneTreeFresh.test.ts
@@ -90,6 +90,19 @@ describe('clonePaneTreeFresh', () => {
     expect(allSurfaces(clone).every((s) => s.ptyId === '')).toBe(true);
   });
 
+  it('#1100 CodeRabbit round 1 — strips remoteHostId/remoteSessionId so the clone does not double-attach the source\'s live remote session', () => {
+    const src = leaf(
+      [surface({ id: 's1', surfaceType: 'remote-terminal', remoteHostId: 'host-a', remoteSessionId: 'sess-live-1' })],
+      's1',
+    );
+    const clone = clonePaneTreeFresh(src) as PaneLeaf;
+    expect(clone.surfaces[0].remoteHostId).toBeUndefined();
+    expect(clone.surfaces[0].remoteSessionId).toBeUndefined();
+    // surfaceType itself is preserved — this is an empty remote-terminal
+    // placeholder, not silently downgraded to a plain terminal.
+    expect(clone.surfaces[0].surfaceType).toBe('remote-terminal');
+  });
+
   it('does not mutate the source tree', () => {
     const src = leaf([surface({ id: 's1', ptyId: 'pty-keep' })], 's1');
     clonePaneTreeFresh(src);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -56,10 +56,22 @@ export interface Surface {
   title: string;
   shell: string;
   cwd: string;
-  surfaceType?: 'terminal' | 'browser' | 'editor' | 'diff' | 'git' | 'review';
+  surfaceType?: 'terminal' | 'browser' | 'editor' | 'diff' | 'git' | 'review' | 'remote-terminal';
   browserUrl?: string;
   browserPartition?: string;
   editorFilePath?: string;
+  /**
+   * `remote-terminal` surfaces only (#1086/#1091): which paired host and
+   * which session on it this leaf mirrors. `ptyId` stays '' for these, same
+   * convention as `browser` — every ptyId-gated check in the codebase
+   * (a2aAddressing, deckBrain, the reconcile loop) already excludes an empty
+   * ptyId, so a remote-terminal surface is invisible to local-PTY logic
+   * without touching those sites. `remoteSessionId` is the durable identity
+   * (the remote daemon's own session id, `/api/stream?session=` key); the
+   * live SSE attach handle is ephemeral render-time state, not persisted here.
+   */
+  remoteHostId?: string;
+  remoteSessionId?: string;
   /** J2 — diff 서피스: 대상 태스크 id. diff 내용은 파생 데이터(열 때마다 재계산). */
   diffTaskId?: string;
   /**
@@ -1106,6 +1118,23 @@ export function createSurface(ptyId: string, shell: string, cwd: string): Surfac
     title: shell,
     shell,
     cwd,
+  };
+}
+
+/** #1086/#1091 — a leaf mirroring a session on a paired remote host, living
+ *  in an ordinary local workspace's own pane tree (not a separate remote
+ *  workspace). `ptyId: ''` mirrors the `browser` surface convention so every
+ *  existing ptyId-gated check already treats it as non-local without edits. */
+export function createRemoteSurface(hostId: string, sessionId: string, shell: string, cwd: string): Surface {
+  return {
+    id: generateId('surface'),
+    ptyId: '',
+    title: shell || 'Remote',
+    shell,
+    cwd,
+    surfaceType: 'remote-terminal',
+    remoteHostId: hostId,
+    remoteSessionId: sessionId,
   };
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1211,6 +1211,13 @@ export function clonePaneTreeFresh(pane: Pane): Pane {
       // so the clone is a clean slate that spawns its own PTY on mount.
       const next: Surface = { ...s, id: generateId('surface'), ptyId: '' };
       delete next.scrollbackFile;
+      // #1100, CodeRabbit round 1 — remoteHostId/remoteSessionId identify a
+      // LIVE remote session. Spreading them onto the clone double-attaches
+      // the same session from two tabs, which then fight over input. The
+      // clone gets an empty remote-terminal placeholder instead (same "spawns
+      // fresh on mount" contract a local terminal's reset ptyId gets).
+      delete next.remoteHostId;
+      delete next.remoteSessionId;
       return next;
     });
     // Preserve which surface was active by POSITION, since ids changed.


### PR DESCRIPTION
## Complete: remote-terminal as an ordinary Surface, not a separate workspace (#1086/#1091)

Per the owner's direction on #1086: a remote session should behave exactly like a local one — a tab inside a normal, renameable, color-taggable local workspace — not a separate "attached remote workspace" entity with its own sidebar row (the model #1067/#1094 built and which this supersedes; #1094 is left open, not closed here).

### Stage 1 (already merged into this branch)

`Surface.surfaceType` gains a `'remote-terminal'` variant (`remoteHostId`/`remoteSessionId`, `ptyId: ''` like `browser`), and a new `addRemoteSurface` store action mirrors `addBrowserSurface` — both add a surface to an EXISTING leaf in a workspace's own pane tree, never create a new workspace.

### Stage 2 (this update)

- **Render**: `Pane.tsx` renders a `remote-terminal` surface as an ordinary tab via a new `RemotePaneSurface` component — the attach/detach lifecycle from `RemoteWorkspaceView`'s `PaneCell` (teardown-then-attach ordering, idempotent per (host, session)), adapted for one surface instead of a whole mirror grid. `RemoteMirrorTerminal` gets an `isActive`-driven `display:none` for the stacked/tab case, same pattern `TerminalComponent`/`BrowserPanel` already use.
- **Add a remote pane**: the pane's `⋮` menu gets "New remote pane" (conditionally, only when a caller passes `onAddRemote` — existing standalone `SurfaceTabs` mounts/tests are unaffected). It opens `AddRemotePaneModal`, a host picker listing already-paired hosts; picking one calls `remote.workspaceCreate(hostId, freshId)` (the #1001 operator-mint path) to bootstrap a session, then adds it as a surface in the **current local workspace** — the minted id is opaque bookkeeping for the daemon's bootstrap contract, never referenced again.
- **Title from the remote shell**: xterm's own parser already extracts OSC 0/2 payloads from the mirrored byte stream (that's how a terminal emulator gets a window-title event at all) — `RemoteMirrorTerminal` wires `term.onTitleChange`, sanitizes it exactly like `PTYBridge` does for a local pane (`sanitizeTitle`, cross-imported from `src/main/pty/titleDetect.ts` — an established pattern in this codebase, see e.g. `capabilityGrouping.ts`/`methodCapabilityMap`), and a new `updateRemoteSurfaceTitle` store action applies it. It's the `surfaceId`-keyed twin of `updateSurfaceTitleByPty`, which can never match a remote-terminal surface (its `ptyId` is always `''`) — same manual-rename guard (`titleLocked`), so a user's own rename is never clobbered by a later `rename` in the remote shell.

### Known limitations (left for a follow-up, not attempted here)

- A pane holding **both** a local terminal and a browser surface (the existing `hasBoth` two-region split view) has no third region for a remote-terminal surface added to it — it simply won't render in that specific 3-way combination. Every other combination (remote-terminal alone, alongside other terminals as tabs, alongside diff/editor overlays) works.
- Closing a remote-terminal surface removes it from the local pane tree but does not terminate the session on the remote daemon — a minor idle-session leak, not a correctness bug. `RemoteHostClient.closeSession` (added for #1094) is the right call to wire in for this; skipped here to keep this PR's diff to the render/UI/title path it set out to do.

### Test plan

- New: `surfaceSlice.test.ts` — `updateRemoteSurfaceTitle` (sets title, no-op unknown surfaceId, never touches a `terminal`-type surface, respects `titleLocked`).
- New: `RemoteMirrorTerminal.test.tsx` — `onTitleChange` fires with the sanitized title, drops an all-control-character title, and works with no `onTitleChange` prop at all (the existing mirror-grid caller passes none).
- Updated: `paneClusterWidth.test.ts`'s menu/cluster parity test — `new-remote` is a deliberate menu-only addition, same as `rename-pane` (#1021), pinned explicitly rather than silently drifting.
- Full `npm run test:parallel`: 12865/12868 (3 pre-existing failures — `state.fallback.test.ts`, `deck.handler.loop.test.ts` ×2 — confirmed present on a clean stash of this branch's base, unrelated to this diff).
- `tsc --noEmit` and `eslint` on every touched file: 0 errors (pre-existing `no-non-null-assertion` warnings only, none new).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open a session from a paired remote host as a tab in the current workspace.
  * Added a **New remote pane** option for selecting a remote host and starting a session.
  * Remote tabs display shell titles and update when renamed remotely.
  * Added localized labels for the new remote pane action.

* **Bug Fixes**
  * Remote panes are no longer treated as local terminal sessions or targeted by local file drops.
  * Improved recovery when remote pane creation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->