### PR TITLE
feat(rpc): record which workspace a wire caller claimed (#922 PR-A)

### DIFF
--- a/src/main/ipc/handlers/workspaceMirror.handler.ts
+++ b/src/main/ipc/handlers/workspaceMirror.handler.ts
@@ -13,6 +13,7 @@
 import { ipcMain } from 'electron';
 import { IPC } from '../../../shared/constants';
 import { getWorkspaceMirror } from '../../workspace/WorkspaceMirror';
+import { reconcileWorkspaceClaims } from '../../workspace/workspaceClaimTrust';
 import type {
   WorkspaceListEntry,
   FleetSnapshot,
@@ -159,6 +160,18 @@ export function registerWorkspaceMirrorHandler(): () => void {
     // Drop a structurally-unusable push — never overwrite last-good with junk.
     if (!payload) return;
     getWorkspaceMirror().setSnapshot(payload);
+    // #922 — retire workspace claim tokens whose workspace is gone. This push
+    // is the only authoritative workspace-lifecycle signal main receives: the
+    // sidebar's X, the close keybinding and the settings reset all remove a
+    // workspace through the renderer store without touching a main handler, so
+    // the `workspace.close` RPC alone would leave those claims bound forever.
+    // Best-effort and last — a bookkeeping failure must never cost the mirror
+    // the snapshot it just accepted.
+    try {
+      reconcileWorkspaceClaims(payload.entries.map((e) => e.id));
+    } catch {
+      /* claim bookkeeping must never affect the mirror */
+    }
   };
   ipcMain.removeAllListeners(IPC.WORKSPACE_MIRROR_PUSH);
   ipcMain.on(IPC.WORKSPACE_MIRROR_PUSH, onPush);

--- a/src/main/pipe/handlers/__tests__/workspace.rpc.claimToken.test.ts
+++ b/src/main/pipe/handlers/__tests__/workspace.rpc.claimToken.test.ts
@@ -163,3 +163,79 @@ describe('workspace.close — token retirement', () => {
     expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-claimed' });
   });
 });
+
+describe('workspace.close — a REFUSED close must not retire the claim', () => {
+  // The renderer reports a refusal as a resolved `{ error }` envelope, not a
+  // rejection (#799), so awaiting the call proves nothing on its own. Revoking
+  // unconditionally would kill the claim of a workspace that is STILL OPEN and
+  // still the holder's — and under the lane that refuses a stale claim, that
+  // holder is then locked out of its own live workspace, because re-claiming
+  // mints a new workspace rather than re-binding the old one.
+  //
+  // It is reachable by someone else, too: ids come from `workspace.list`, so a
+  // second caller can aim a close it knows will be refused at a claimant's
+  // workspace and destroy only that claim.
+  const claim = async (router: RpcRouter): Promise<string | undefined> => {
+    sendToRendererMock.mockResolvedValue(CLAIM_RESULT);
+    const res = await router.dispatch(
+      { id: 'rc', method: 'mcp.claimWorkspace', params: {} },
+      { externalWire: true },
+    );
+    return tokenFrom(res);
+  };
+
+  it.each([
+    ['an unknown id', { error: 'workspace.close: no workspace with id "ws-claimed"' }],
+    [
+      'the last-workspace guard',
+      { error: 'workspace.close: refusing to close "ws-claimed" — it is the only workspace' },
+    ],
+    [
+      'a removal the store refused',
+      { error: 'workspace.close: "ws-claimed" is still open — the removal was refused' },
+    ],
+  ])('keeps the claim alive when the close is refused by %s', async (_label, refusal) => {
+    const router = setup();
+    const token = await claim(router);
+
+    sendToRendererMock.mockResolvedValue(refusal);
+    const res = await router.dispatch({
+      id: 'rc-close',
+      method: 'workspace.close',
+      params: { id: 'ws-claimed' },
+    });
+
+    // The refusal is passed through unchanged...
+    expect((res as { result?: unknown }).result).toEqual(refusal);
+    // ...and the workspace is still open, so the claim must still resolve.
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-claimed' });
+  });
+
+  it.each([
+    ['a shape it does not recognise', { closed: true }],
+    ['a bare string', 'closed'],
+    ['null', null],
+  ])('leaves the claim alone for %s — being wrong safely', async (_label, weird) => {
+    // A positive `ok === true` check rather than "no error": an unrecognised
+    // response should cost a stale binding at worst, never a live claimant's
+    // access to its own workspace.
+    const router = setup();
+    const token = await claim(router);
+
+    sendToRendererMock.mockResolvedValue(weird);
+    await router.dispatch({ id: 'rc-weird', method: 'workspace.close', params: { id: 'ws-claimed' } });
+
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-claimed' });
+  });
+
+  it('still retires the claim when the close actually succeeds', async () => {
+    // The positive control: the fix must not turn revocation off altogether.
+    const router = setup();
+    const token = await claim(router);
+
+    sendToRendererMock.mockResolvedValue({ ok: true });
+    await router.dispatch({ id: 'rc-ok', method: 'workspace.close', params: { id: 'ws-claimed' } });
+
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
+  });
+});

--- a/src/main/pipe/handlers/__tests__/workspace.rpc.claimToken.test.ts
+++ b/src/main/pipe/handlers/__tests__/workspace.rpc.claimToken.test.ts
@@ -1,0 +1,165 @@
+// #922 PR-A — issuing and retiring the workspace claim token, through the real
+// router and the real handler.
+//
+// `mcp.claimWorkspace` is the one call where main CREATES a workspace for a
+// specific caller, so the association it records is a fact main holds rather
+// than one the caller asserts. What is pinned here:
+//
+//   - the token is minted and returned only for the external wire;
+//   - it is bound to the workspace the claim actually produced;
+//   - it rides ALONGSIDE the existing response fields, so no caller that
+//     ignores it can notice this change;
+//   - closing the workspace retires it.
+//
+// Nothing reads the token for an authorisation decision in PR-A. These tests
+// therefore assert issuance and lifecycle only — the lane that consumes it is
+// PR-B, and adding a consumer here would defeat the point of the split.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import { registerWorkspaceRpc } from '../workspace.rpc';
+import {
+  __resetWorkspaceClaimTrustForTesting,
+  lookupWorkspaceClaim,
+} from '../../../workspace/workspaceClaimTrust';
+
+const { sendToRendererMock } = vi.hoisted(() => ({ sendToRendererMock: vi.fn() }));
+vi.mock('../_bridge', () => ({ sendToRenderer: sendToRendererMock }));
+
+const fakeWindow = {} as BrowserWindow;
+
+function setup(): RpcRouter {
+  const router = new RpcRouter();
+  registerWorkspaceRpc(router, () => fakeWindow);
+  return router;
+}
+
+/** The claim response the renderer really returns (paneResolver reads both ids). */
+const CLAIM_RESULT = { ptyId: 'daemon-mcp', workspaceId: 'ws-claimed', workspaceName: 'MCP' };
+
+function tokenFrom(response: unknown): string | undefined {
+  const result = (response as { result?: Record<string, unknown> } | null)?.result;
+  const token = result?.['workspaceToken'];
+  return typeof token === 'string' ? token : undefined;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetWorkspaceClaimTrustForTesting();
+  sendToRendererMock.mockResolvedValue(CLAIM_RESULT);
+});
+
+describe('mcp.claimWorkspace — token issuance', () => {
+  it('mints a token bound to the workspace the claim created', async () => {
+    const res = await setup().dispatch(
+      { id: 'c1', method: 'mcp.claimWorkspace', params: { name: 'MCP' }, clientName: 'claude-code' },
+      { externalWire: true },
+    );
+
+    const token = tokenFrom(res);
+    expect(token).toBeTruthy();
+    expect(lookupWorkspaceClaim(token)).toEqual({
+      kind: 'bound',
+      workspaceId: 'ws-claimed',
+    });
+  });
+
+  it('leaves every existing response field untouched', async () => {
+    // Additive by construction: a caller that never looks at the new key must
+    // not be able to tell this shipped.
+    const res = await setup().dispatch(
+      { id: 'c2', method: 'mcp.claimWorkspace', params: {} },
+      { externalWire: true },
+    );
+
+    const result = (res as { result?: Record<string, unknown> }).result!;
+    expect(result).toMatchObject(CLAIM_RESULT);
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'mcp.claimWorkspace',
+      {},
+    );
+  });
+
+  it('issues nothing to the in-process surfaces', async () => {
+    // The renderer is the operator and the plugin host carries a
+    // host-derived binding already (#941/#1097); neither needs a bearer
+    // secret, and issuing one would only add a place for it to leak from.
+    for (const opts of [
+      { operator: true as const },
+      { firstParty: true as const, hostedWorkspace: 'ws-host' },
+    ]) {
+      sendToRendererMock.mockResolvedValue(CLAIM_RESULT);
+      const res = await setup().dispatch(
+        { id: 'c3', method: 'mcp.claimWorkspace', params: {}, clientName: 'hello-panel' },
+        opts,
+      );
+      expect(tokenFrom(res)).toBeUndefined();
+      expect((res as { result?: Record<string, unknown> }).result).toMatchObject(CLAIM_RESULT);
+    }
+  });
+
+  it.each([
+    ['a renderer error envelope', { error: 'workspace limit reached' }],
+    ['a response with no workspaceId', { ptyId: 'daemon-mcp' }],
+    ['a blank workspaceId', { ptyId: 'daemon-mcp', workspaceId: '   ' }],
+    ['a non-object result', 'nope'],
+    ['null', null],
+  ])('returns %s unchanged rather than failing the claim', async (_label, rendererResult) => {
+    sendToRendererMock.mockResolvedValue(rendererResult);
+    const res = await setup().dispatch(
+      { id: 'c4', method: 'mcp.claimWorkspace', params: {} },
+      { externalWire: true },
+    );
+
+    expect(res.ok).toBe(true);
+    expect((res as { result?: unknown }).result).toEqual(rendererResult);
+    expect(tokenFrom(res)).toBeUndefined();
+  });
+});
+
+describe('workspace.close — token retirement', () => {
+  it('turns the claim stale so a re-minted id cannot inherit it', async () => {
+    const router = setup();
+    const claim = await router.dispatch(
+      { id: 'c5', method: 'mcp.claimWorkspace', params: {} },
+      { externalWire: true },
+    );
+    const token = tokenFrom(claim);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-claimed' });
+
+    sendToRendererMock.mockResolvedValue({ ok: true });
+    const closed = await router.dispatch({
+      id: 'c6',
+      method: 'workspace.close',
+      params: { id: 'ws-claimed' },
+    });
+
+    expect(closed.ok).toBe(true);
+    expect((closed as { result?: unknown }).result).toEqual({ ok: true });
+    // Stale, NOT unclaimed: the holder presented something that no longer
+    // resolves, and PR-B must be able to tell that from never having claimed.
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
+  });
+
+  it('still rejects a close with no id, before touching the registry', async () => {
+    const res = await setup().dispatch({ id: 'c7', method: 'workspace.close', params: {} });
+    expect(res.ok).toBe(false);
+    expect(sendToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unrelated workspace\'s claim alone', async () => {
+    const router = setup();
+    const claim = await router.dispatch(
+      { id: 'c8', method: 'mcp.claimWorkspace', params: {} },
+      { externalWire: true },
+    );
+    const token = tokenFrom(claim);
+
+    sendToRendererMock.mockResolvedValue({ ok: true });
+    await router.dispatch({ id: 'c9', method: 'workspace.close', params: { id: 'ws-other' } });
+
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-claimed' });
+  });
+});

--- a/src/main/pipe/handlers/workspace.rpc.ts
+++ b/src/main/pipe/handlers/workspace.rpc.ts
@@ -8,6 +8,10 @@ import {
 
 type GetWindow = () => BrowserWindow | null;
 
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
 export function registerWorkspaceRpc(router: RpcRouter, getWindow: GetWindow): void {
   /**
    * workspace.list — returns all workspaces as {id, name}[]
@@ -45,11 +49,28 @@ export function registerWorkspaceRpc(router: RpcRouter, getWindow: GetWindow): v
       throw new Error('workspace.close: missing required param "id"');
     }
     const result = await sendToRenderer(getWindow, 'workspace.close', { id: params['id'] });
-    // #922 PR-A — retire any claim bound to this workspace. Revoking AFTER the
-    // close keeps the token alive for the duration of a close that fails, and
-    // a workspace id can be re-minted later: a surviving binding would then
-    // point a stale token at a workspace its holder never claimed.
-    revokeWorkspaceClaimTokensFor(params['id']);
+    // #922 PR-A — retire any claim bound to this workspace, but ONLY once the
+    // close actually happened.
+    //
+    // The renderer reports a REFUSAL as a resolved `{ error }` envelope, not a
+    // rejection: an unknown id, the last-workspace guard, and the post-removal
+    // "still open" assertion all return one (`useRpcBridge.ts`, #799). So
+    // awaiting the call proves nothing on its own — revoking unconditionally
+    // would kill the claim of a workspace that is still open and still the
+    // holder's. Under the lane that refuses a stale claim, that holder would be
+    // locked out of its own live workspace with no way back: re-claiming mints
+    // a NEW workspace, it does not re-bind the old one.
+    //
+    // It is also reachable by anyone else: workspace ids come from
+    // `workspace.list`, so a second caller could aim a close it knows will be
+    // refused at a claimant's workspace and destroy only that claim.
+    //
+    // Hence a POSITIVE success check rather than "no error" — a shape this
+    // handler does not recognise leaves the claim alone, which is the safe way
+    // to be wrong.
+    if (isRecord(result) && result['ok'] === true) {
+      revokeWorkspaceClaimTokensFor(params['id']);
+    }
     return result;
   });
 

--- a/src/main/pipe/handlers/workspace.rpc.ts
+++ b/src/main/pipe/handlers/workspace.rpc.ts
@@ -1,6 +1,10 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { sendToRenderer } from './_bridge';
+import {
+  mintWorkspaceClaimToken,
+  revokeWorkspaceClaimTokensFor,
+} from '../../workspace/workspaceClaimTrust';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -36,11 +40,17 @@ export function registerWorkspaceRpc(router: RpcRouter, getWindow: GetWindow): v
    * workspace.close — removes a workspace
    * params: { id: string }
    */
-  router.register('workspace.close', (params) => {
+  router.register('workspace.close', async (params) => {
     if (typeof params['id'] !== 'string') {
-      return Promise.reject(new Error('workspace.close: missing required param "id"'));
+      throw new Error('workspace.close: missing required param "id"');
     }
-    return sendToRenderer(getWindow, 'workspace.close', { id: params['id'] });
+    const result = await sendToRenderer(getWindow, 'workspace.close', { id: params['id'] });
+    // #922 PR-A — retire any claim bound to this workspace. Revoking AFTER the
+    // close keeps the token alive for the duration of a close that fails, and
+    // a workspace id can be re-minted later: a surviving binding would then
+    // point a stale token at a workspace its holder never claimed.
+    revokeWorkspaceClaimTokensFor(params['id']);
+    return result;
   });
 
   /**
@@ -65,8 +75,37 @@ export function registerWorkspaceRpc(router: RpcRouter, getWindow: GetWindow): v
    * params: { name?: string }
    * returns: { ptyId, workspaceId, workspaceName }
    */
-  router.register('mcp.claimWorkspace', (params) => {
+  router.register('mcp.claimWorkspace', async (params, ctx) => {
     const name = typeof params['name'] === 'string' ? params['name'] : undefined;
-    return sendToRenderer(getWindow, 'mcp.claimWorkspace', name !== undefined ? { name } : {});
+    const result = await sendToRenderer(
+      getWindow,
+      'mcp.claimWorkspace',
+      name !== undefined ? { name } : {},
+    );
+
+    // ── #922 PR-A — issue the claim token ────────────────────────────────
+    //
+    // This is the one call where main CREATES a workspace for a specific
+    // caller, so "this caller owns that workspace" is a fact main already
+    // holds rather than something the caller asserts. Minting here records it
+    // (workspaceClaimTrust.ts) and hands the holder its half.
+    //
+    // Issued ONLY to the external wire. The in-process surfaces have stronger
+    // bindings already — the renderer is the operator, and the plugin host
+    // carries `hostedWorkspace` derived by the host itself (#941/#1097) — so
+    // handing them a bearer secret would add a credential neither needs and
+    // widen where one can leak from.
+    //
+    // Additive and non-fatal by construction: the token rides ALONGSIDE the
+    // existing fields, never replacing one, and a response that carries no
+    // workspaceId (a renderer error envelope, an older renderer) is returned
+    // untouched. Nothing reads the token for an authorisation decision yet —
+    // PR-B adds that — so a caller that ignores it behaves exactly as before.
+    if (ctx?.externalWire !== true) return result;
+    if (result === null || typeof result !== 'object' || Array.isArray(result)) return result;
+    const workspaceId = (result as Record<string, unknown>)['workspaceId'];
+    const token = mintWorkspaceClaimToken(workspaceId);
+    if (!token) return result;
+    return { ...(result as Record<string, unknown>), workspaceToken: token };
   });
 }

--- a/src/main/workspace/__tests__/workspaceClaimTrust.test.ts
+++ b/src/main/workspace/__tests__/workspaceClaimTrust.test.ts
@@ -1,0 +1,119 @@
+// #922 PR-A — the workspace claim registry.
+//
+// The behaviour worth pinning here is not "a map stores things"; it is the
+// SHAPE of the lookup result. A nullable binding would let a consumer write
+// `if (!binding) { /* carry on */ }` and silently demote a caller whose token
+// was revoked into one free to name its own workspace — the fail-open the BYOB
+// commander gate already had to close by hand. These tests fix the three-state
+// contract that makes that unwritable.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetWorkspaceClaimTrustForTesting,
+  lookupWorkspaceClaim,
+  mintWorkspaceClaimToken,
+  revokeWorkspaceClaimToken,
+  revokeWorkspaceClaimTokensFor,
+} from '../workspaceClaimTrust';
+
+beforeEach(() => {
+  __resetWorkspaceClaimTrustForTesting();
+});
+
+describe('workspaceClaimTrust — minting', () => {
+  it('binds a minted token to the workspace it was minted for', () => {
+    const token = mintWorkspaceClaimToken('ws-claimed');
+    expect(token).toBeTruthy();
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-claimed' });
+  });
+
+  it('mints a distinct token per claim', () => {
+    const a = mintWorkspaceClaimToken('ws-a');
+    const b = mintWorkspaceClaimToken('ws-a');
+    expect(a).not.toEqual(b);
+    expect(lookupWorkspaceClaim(a)).toEqual({ kind: 'bound', workspaceId: 'ws-a' });
+    expect(lookupWorkspaceClaim(b)).toEqual({ kind: 'bound', workspaceId: 'ws-a' });
+  });
+
+  it.each([undefined, null, '', '   ', 42, {}])(
+    'issues nothing for a workspace it cannot bind to (%p)',
+    (workspaceId) => {
+      // An unbound token would be a secret that proves nothing, and its mere
+      // presence would invite a consumer to read meaning into it.
+      expect(mintWorkspaceClaimToken(workspaceId)).toBeNull();
+    },
+  );
+
+  it('trims the binding so a padded id cannot mint a second, unmatchable one', () => {
+    const token = mintWorkspaceClaimToken('  ws-padded  ');
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-padded' });
+  });
+});
+
+describe('workspaceClaimTrust — lookup states', () => {
+  it('reports an absent token as unclaimed, not as stale', () => {
+    // The distinction is the whole point: `unclaimed` is every caller that
+    // never claimed and must keep working unchanged; `stale` must be refused.
+    expect(lookupWorkspaceClaim(undefined)).toEqual({ kind: 'unclaimed' });
+    expect(lookupWorkspaceClaim(null)).toEqual({ kind: 'unclaimed' });
+  });
+
+  it.each(['not-a-real-token', '', 0, false, {}, []])(
+    'reports a presented-but-unresolvable token as stale (%p)',
+    (token) => {
+      expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
+    },
+  );
+
+  it('never answers with a bare string or null, so demotion cannot be written', () => {
+    // A consumer must switch on `kind`; there is no falsy value to shortcut on.
+    const live = lookupWorkspaceClaim(mintWorkspaceClaimToken('ws-x'));
+    const dead = lookupWorkspaceClaim('nope');
+    const none = lookupWorkspaceClaim(undefined);
+    for (const result of [live, dead, none]) {
+      expect(typeof result).toBe('object');
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty('kind');
+    }
+    expect(new Set([live.kind, dead.kind, none.kind])).toEqual(
+      new Set(['bound', 'stale', 'unclaimed']),
+    );
+  });
+});
+
+describe('workspaceClaimTrust — revocation', () => {
+  it('turns a revoked token stale rather than unclaimed', () => {
+    const token = mintWorkspaceClaimToken('ws-gone');
+    revokeWorkspaceClaimToken(token);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
+  });
+
+  it('is idempotent and ignores junk', () => {
+    const token = mintWorkspaceClaimToken('ws-gone');
+    revokeWorkspaceClaimToken(token);
+    revokeWorkspaceClaimToken(token);
+    revokeWorkspaceClaimToken(undefined);
+    revokeWorkspaceClaimToken('');
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
+  });
+
+  it('revokes every token bound to a closed workspace, leaving others alone', () => {
+    // A workspace id can be re-minted later, so a surviving binding would
+    // point an old token at a workspace its holder never claimed.
+    const a1 = mintWorkspaceClaimToken('ws-closing');
+    const a2 = mintWorkspaceClaimToken('ws-closing');
+    const other = mintWorkspaceClaimToken('ws-staying');
+
+    expect(revokeWorkspaceClaimTokensFor('ws-closing')).toBe(2);
+
+    expect(lookupWorkspaceClaim(a1)).toEqual({ kind: 'stale' });
+    expect(lookupWorkspaceClaim(a2)).toEqual({ kind: 'stale' });
+    expect(lookupWorkspaceClaim(other)).toEqual({ kind: 'bound', workspaceId: 'ws-staying' });
+  });
+
+  it.each([undefined, '', '   ', 7])('revokes nothing for a junk workspace id (%p)', (ws) => {
+    const token = mintWorkspaceClaimToken('ws-safe');
+    expect(revokeWorkspaceClaimTokensFor(ws)).toBe(0);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-safe' });
+  });
+});

--- a/src/main/workspace/__tests__/workspaceClaimTrust.test.ts
+++ b/src/main/workspace/__tests__/workspaceClaimTrust.test.ts
@@ -12,6 +12,7 @@ import {
   __resetWorkspaceClaimTrustForTesting,
   lookupWorkspaceClaim,
   mintWorkspaceClaimToken,
+  reconcileWorkspaceClaims,
   revokeWorkspaceClaimToken,
   revokeWorkspaceClaimTokensFor,
 } from '../workspaceClaimTrust';
@@ -51,14 +52,26 @@ describe('workspaceClaimTrust — minting', () => {
 });
 
 describe('workspaceClaimTrust — lookup states', () => {
-  it('reports an absent token as unclaimed, not as stale', () => {
+  it('reports an ABSENT token as unclaimed', () => {
     // The distinction is the whole point: `unclaimed` is every caller that
     // never claimed and must keep working unchanged; `stale` must be refused.
+    // Only absence qualifies — see the null case below.
     expect(lookupWorkspaceClaim(undefined)).toEqual({ kind: 'unclaimed' });
-    expect(lookupWorkspaceClaim(null)).toEqual({ kind: 'unclaimed' });
   });
 
-  it.each(['not-a-real-token', '', 0, false, {}, []])(
+  it('reports an explicit null as STALE, not unclaimed', () => {
+    // The demotion this whole type exists to prevent, reached through data
+    // rather than through code. A consumer gates on "the field is present and
+    // not undefined", which `null` satisfies; if the lookup then answered
+    // `unclaimed`, nothing would be stamped on the context and the caller would
+    // fall through to the lane that lets it name any workspace. So a caller
+    // whose token was revoked could send `workspaceToken: null` and be restored
+    // to the freedom it just lost. JSON carries null freely, so this is a
+    // one-word change away for anyone who tries it.
+    expect(lookupWorkspaceClaim(null)).toEqual({ kind: 'stale' });
+  });
+
+  it.each(['not-a-real-token', '', 0, false, {}, [], NaN])(
     'reports a presented-but-unresolvable token as stale (%p)',
     (token) => {
       expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
@@ -70,6 +83,8 @@ describe('workspaceClaimTrust — lookup states', () => {
     const live = lookupWorkspaceClaim(mintWorkspaceClaimToken('ws-x'));
     const dead = lookupWorkspaceClaim('nope');
     const none = lookupWorkspaceClaim(undefined);
+    // `null` must land with `dead`, not with `none`.
+    expect(lookupWorkspaceClaim(null)).toEqual(dead);
     for (const result of [live, dead, none]) {
       expect(typeof result).toBe('object');
       expect(result).not.toBeNull();
@@ -115,5 +130,96 @@ describe('workspaceClaimTrust — revocation', () => {
     const token = mintWorkspaceClaimToken('ws-safe');
     expect(revokeWorkspaceClaimTokensFor(ws)).toBe(0);
     expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-safe' });
+  });
+});
+
+describe('workspaceClaimTrust — reconcile against the live workspace set', () => {
+  // The `workspace.close` RPC is not how most workspaces die: the sidebar X,
+  // the close keybinding and the settings reset all remove one through the
+  // renderer store without reaching a main handler. The renderer's workspace
+  // mirror push is the signal that does see those, and `bound` must not stay
+  // true for a workspace that is gone — a scoping lane trusts `bound` to mean
+  // "alive and owned by this holder".
+  let clock = 1_000_000;
+
+  beforeEach(() => {
+    clock = 1_000_000;
+    __resetWorkspaceClaimTrustForTesting(() => clock);
+  });
+
+  /** Push a token past the grace window so reconcile may act on it. */
+  const age = (ms = 120_000) => { clock += ms; };
+
+  it('retires a claim whose workspace is no longer live', () => {
+    const token = mintWorkspaceClaimToken('ws-closed-in-ui');
+    age();
+
+    expect(reconcileWorkspaceClaims(['ws-still-here'])).toBe(1);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'stale' });
+  });
+
+  it('leaves a claim whose workspace is still live', () => {
+    const token = mintWorkspaceClaimToken('ws-alive');
+    age();
+
+    expect(reconcileWorkspaceClaims(['ws-alive', 'ws-other'])).toBe(0);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-alive' });
+  });
+
+  it('never retires a claim younger than the grace window', () => {
+    // The race this guards: a mirror push already in flight when the claim
+    // created its workspace describes the tree BEFORE that workspace existed,
+    // and would arrive just after the mint. Retiring on it would kill a claim
+    // that is perfectly live, one call after it was issued.
+    const token = mintWorkspaceClaimToken('ws-brand-new');
+
+    expect(reconcileWorkspaceClaims(['ws-something-else'])).toBe(0);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-brand-new' });
+  });
+
+  it('ignores an empty live set rather than retiring everything', () => {
+    // The renderer store always keeps one workspace, so an empty set is far
+    // more likely to be a bad frame than a real observation.
+    const token = mintWorkspaceClaimToken('ws-alive');
+    age();
+
+    expect(reconcileWorkspaceClaims([])).toBe(0);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-alive' });
+  });
+
+  it('ignores junk ids in the live set without retiring good claims', () => {
+    const token = mintWorkspaceClaimToken('ws-alive');
+    age();
+
+    expect(reconcileWorkspaceClaims(['ws-alive', '', '   '])).toBe(0);
+    expect(lookupWorkspaceClaim(token)).toEqual({ kind: 'bound', workspaceId: 'ws-alive' });
+  });
+
+  it('retires several claims for one dead workspace in a single pass', () => {
+    const a = mintWorkspaceClaimToken('ws-dead');
+    const b = mintWorkspaceClaimToken('ws-dead');
+    const keep = mintWorkspaceClaimToken('ws-alive');
+    age();
+
+    expect(reconcileWorkspaceClaims(['ws-alive'])).toBe(2);
+    expect(lookupWorkspaceClaim(a)).toEqual({ kind: 'stale' });
+    expect(lookupWorkspaceClaim(b)).toEqual({ kind: 'stale' });
+    expect(lookupWorkspaceClaim(keep)).toEqual({ kind: 'bound', workspaceId: 'ws-alive' });
+  });
+});
+
+describe('workspaceClaimTrust — bounded growth', () => {
+  beforeEach(() => {
+    __resetWorkspaceClaimTrustForTesting();
+  });
+
+  it('evicts the oldest claim past the cap so secrets cannot accumulate', () => {
+    // Backstop for a main that never receives a mirror push. Claims need the
+    // renderer to mint, so this should be unreachable — it exists so a
+    // long-lived process cannot hold an unbounded set of live secrets.
+    const first = mintWorkspaceClaimToken('ws-first');
+    for (let i = 0; i < 512; i++) mintWorkspaceClaimToken(`ws-${i}`);
+
+    expect(lookupWorkspaceClaim(first)).toEqual({ kind: 'stale' });
   });
 });

--- a/src/main/workspace/workspaceClaimTrust.ts
+++ b/src/main/workspace/workspaceClaimTrust.ts
@@ -43,11 +43,50 @@
 // PR-A (this) mints, stores, and revokes. NOTHING reads a token to make an
 // authorisation decision yet, so a caller that ignores the token behaves
 // exactly as before. PR-B adds the lane that consults `lookupWorkspaceClaim`.
+//
+// ── Known residual: a claim minted onto a workspace that just died ─────────
+//
+// `mcp.claimWorkspace` mints AFTER the renderer answers, so a close that lands
+// in that window is revoked before the token exists and the token is then
+// issued bound to a dead id. Checking liveness at mint time does not fix it:
+// the workspace was created microseconds earlier and has not reached the mirror
+// yet, so a freshly claimed workspace would look absent and every honest claim
+// would be refused instead.
+//
+// `reconcileWorkspaceClaims` clears it instead — one grace window plus the next
+// structural or periodic mirror push, so bounded, not permanent. Until then the
+// holder's calls resolve to a workspace that no longer exists, which fails as a
+// missing target rather than as access to anyone else's workspace. Recorded
+// rather than papered over: a lane that trusts `bound` should know the one case
+// where it is briefly wrong.
 
 import { randomUUID } from 'node:crypto';
 
-/** token -> the workspace the claim created for its holder. */
-const live = new Map<string, string>();
+/** token -> the workspace the claim created for its holder, and when it was issued. */
+const live = new Map<string, { workspaceId: string; mintedAt: number }>();
+
+/**
+ * Grace window before `reconcileWorkspaceClaims` may retire a young token.
+ *
+ * The reconcile source is the renderer's workspace mirror, which is pushed
+ * asynchronously. A push that was already in flight when a claim created its
+ * workspace describes the tree BEFORE that workspace existed, so without a
+ * grace window it would arrive just after the mint and retire a claim that is
+ * perfectly live. The window only has to outlast an in-flight IPC push.
+ */
+const RECONCILE_GRACE_MS = 60_000;
+
+/**
+ * Hard cap on live claims, as a backstop for the case where reconcile never
+ * runs (no renderer pushing a mirror). Claims are only minted through
+ * `mcp.claimWorkspace`, which needs the renderer, so this should be
+ * unreachable; it exists so a long-lived main can never accumulate secrets
+ * without bound. Oldest first — a claim's usefulness ends with its workspace.
+ */
+const MAX_LIVE_CLAIMS = 512;
+
+/** Injectable for deterministic tests. */
+let now: () => number = Date.now;
 
 /**
  * The result of presenting (or not presenting) a claim token.
@@ -62,7 +101,18 @@ const live = new Map<string, string>();
  * only correct handling is to refuse.
  */
 export type WorkspaceClaimLookup =
-  /** No token was presented. The caller never claimed; nothing changes for it. */
+  /**
+   * No token was presented AT ALL — the field was absent (`undefined`). The
+   * caller never claimed; nothing changes for it.
+   *
+   * `null` is deliberately NOT this. A `null` arrives over the wire as a value
+   * the caller CHOSE to send, so it is a presented token that does not resolve,
+   * not an absent one. Treating it as absent would let a caller whose claim was
+   * revoked send `workspaceToken: null` and be read as "never claimed" — back to
+   * naming any workspace it likes, which is the exact demotion this type exists
+   * to make unwritable. The three states only close that hole if the mapping
+   * from wire values onto them is airtight too.
+   */
   | { kind: 'unclaimed' }
   /** A live token. Its holder owns this workspace by construction. */
   | { kind: 'bound'; workspaceId: string }
@@ -80,7 +130,12 @@ export function mintWorkspaceClaimToken(workspaceId: unknown): string | null {
   const trimmed = workspaceId.trim();
   if (trimmed.length === 0) return null;
   const token = `${randomUUID()}${randomUUID()}`;
-  live.set(token, trimmed);
+  live.set(token, { workspaceId: trimmed, mintedAt: now() });
+  if (live.size > MAX_LIVE_CLAIMS) {
+    // Map preserves insertion order, so the first key is the oldest claim.
+    const oldest = live.keys().next();
+    if (!oldest.done) live.delete(oldest.value);
+  }
   return token;
 }
 
@@ -99,8 +154,8 @@ export function revokeWorkspaceClaimTokensFor(workspaceId: unknown): number {
   if (typeof workspaceId !== 'string' || workspaceId.trim().length === 0) return 0;
   const target = workspaceId.trim();
   let revoked = 0;
-  for (const [token, ws] of live) {
-    if (ws === target) {
+  for (const [token, entry] of live) {
+    if (entry.workspaceId === target) {
       live.delete(token);
       revoked++;
     }
@@ -109,19 +164,69 @@ export function revokeWorkspaceClaimTokensFor(workspaceId: unknown): number {
 }
 
 /**
+ * Retire every claim whose workspace is no longer in the live set.
+ *
+ * `revokeWorkspaceClaimTokensFor` above only fires on the `workspace.close`
+ * RPC, and that is not how most workspaces die: the sidebar's X, the
+ * close-workspace keybinding, and the settings reset all call the renderer's
+ * own `removeWorkspace` and never reach a main handler. Without this, a claim
+ * for a workspace closed from the UI would stay `bound` forever — and `bound`
+ * is exactly the fact a scoping lane trusts ("the workspace is alive and this
+ * holder owns it"), so leaving it true after the workspace is gone means the
+ * lane trusts something false.
+ *
+ * The live set comes from the renderer's workspace mirror, which is pushed on
+ * every STRUCTURAL change (immediately, never debounced) plus a slow periodic
+ * refresh — the authoritative lifecycle signal main already receives.
+ *
+ * Two guards, both deliberate:
+ *   - a claim younger than `RECONCILE_GRACE_MS` is never retired here, because
+ *     a push already in flight when its workspace was created describes a tree
+ *     without it;
+ *   - an EMPTY live set is ignored. The mirror's own contract says an empty
+ *     push is legitimate ("every workspace was closed"), but the renderer store
+ *     always keeps one workspace, so in practice an empty set means a caller
+ *     handed us nothing rather than a real observation. Refusing to act on it
+ *     costs one reconcile cycle and avoids retiring every claim on a bad frame.
+ *
+ * Returns how many were retired (for logging/tests).
+ */
+export function reconcileWorkspaceClaims(liveWorkspaceIds: Iterable<string>): number {
+  const alive = new Set<string>();
+  for (const id of liveWorkspaceIds) {
+    if (typeof id === 'string' && id.trim().length > 0) alive.add(id.trim());
+  }
+  if (alive.size === 0) return 0;
+
+  const cutoff = now() - RECONCILE_GRACE_MS;
+  let retired = 0;
+  for (const [token, entry] of live) {
+    if (alive.has(entry.workspaceId)) continue;
+    if (entry.mintedAt > cutoff) continue;
+    live.delete(token);
+    retired++;
+  }
+  return retired;
+}
+
+/**
  * Classify a presented token. See `WorkspaceClaimLookup` for why the absent
  * and stale cases are distinct — collapsing them is the fail-open this type
  * exists to prevent.
  */
 export function lookupWorkspaceClaim(token: unknown): WorkspaceClaimLookup {
-  if (token === undefined || token === null) return { kind: 'unclaimed' };
+  // ONLY an absent field is "unclaimed". Every other value the wire can carry —
+  // `null`, a number, an object, an empty string — is something the caller sent
+  // and that does not resolve, i.e. `stale`. See `WorkspaceClaimLookup`.
+  if (token === undefined) return { kind: 'unclaimed' };
   if (typeof token !== 'string' || token.length === 0) return { kind: 'stale' };
-  const workspaceId = live.get(token);
-  if (workspaceId === undefined) return { kind: 'stale' };
-  return { kind: 'bound', workspaceId };
+  const entry = live.get(token);
+  if (entry === undefined) return { kind: 'stale' };
+  return { kind: 'bound', workspaceId: entry.workspaceId };
 }
 
-/** Test-only: clear every registered token. */
-export function __resetWorkspaceClaimTrustForTesting(): void {
+/** Test-only: clear every registered token and restore the real clock. */
+export function __resetWorkspaceClaimTrustForTesting(clock?: () => number): void {
   live.clear();
+  now = clock ?? Date.now;
 }

--- a/src/main/workspace/workspaceClaimTrust.ts
+++ b/src/main/workspace/workspaceClaimTrust.ts
@@ -1,0 +1,127 @@
+// ─── #922 PR-A — workspace claim token registry (wire caller track) ─────────
+//
+// The `declared` lane in `browser.rpc.ts` checks that a caller sent SOME
+// workspaceId, not that it sent its own, because nothing in the main process
+// records which workspace a wire caller belongs to. Workspace ids are not
+// secret either — `workspace.list` hands them out under an ordinary declarable
+// capability — so naming a foreign workspace has been enough.
+//
+// `mcp.claimWorkspace` is where that record can be made honestly: it is the
+// one point where main CREATES a workspace *for* a specific caller, so the
+// association is a fact main already knows rather than something the caller
+// asserts. This registry stores it, keyed on a secret main mints and hands
+// back in the claim response.
+//
+// Why a minted secret rather than the caller's name: `clientName` is
+// self-asserted (spec §2.3), so keying on it would bind a claim to a string
+// anyone can send — two callers claiming the same name would share one
+// binding. The token is issued by main and never guessable, so possession is
+// the whole check.
+//
+// Why not the pipe connection: `sendRpc` opens a fresh socket per call
+// (`src/mcp/wmux-client.ts`), so there is no connection to bind to and a
+// per-request credential is the only shape that works. Peer credentials
+// (`GetNamedPipeClientProcessId`) would be the unforgeable version, but the OS
+// handle behind a Node pipe socket is not reachable from JS — measured: the
+// accepted socket reports `_handle.fd === -1` and the `Pipe` prototype exposes
+// no accessor — so it needs a compiled native addon, which buys nothing here
+// (see the ceiling below).
+//
+// ── Ceiling, so this is never read as more than it is ──────────────────────
+//
+// The token lives in the caller's process memory, exactly like the daemon auth
+// token and the commander token before it. Same-user code can read another
+// same-user process's memory, so this does NOT contain hostile code already
+// running as the user — `firstParty.ts` states that ceiling and it still
+// holds. What it changes is the bar for an APPROVED tool: from "name any
+// workspace id" (and the ids are handed out on request) to "hold a secret
+// wmux issued to you". That is confinement of an approved caller to the scope
+// its approval implied, and nothing more.
+//
+// ── PR split ───────────────────────────────────────────────────────────────
+//
+// PR-A (this) mints, stores, and revokes. NOTHING reads a token to make an
+// authorisation decision yet, so a caller that ignores the token behaves
+// exactly as before. PR-B adds the lane that consults `lookupWorkspaceClaim`.
+
+import { randomUUID } from 'node:crypto';
+
+/** token -> the workspace the claim created for its holder. */
+const live = new Map<string, string>();
+
+/**
+ * The result of presenting (or not presenting) a claim token.
+ *
+ * Deliberately NOT `string | null`. A nullable binding invites a plain
+ * `if (!binding)` early-return, which silently DEMOTES a caller whose token
+ * was revoked or has gone stale into an ordinary caller free to name its own
+ * workspace — the exact fail-open the BYOB commander gate had to
+ * write a paragraph about (`RpcRouter.dispatch`: "an invalid/stale token
+ * rejects the whole request instead of demoting"). Three named states make the
+ * demotion unrepresentable: a consumer must handle `stale` explicitly, and the
+ * only correct handling is to refuse.
+ */
+export type WorkspaceClaimLookup =
+  /** No token was presented. The caller never claimed; nothing changes for it. */
+  | { kind: 'unclaimed' }
+  /** A live token. Its holder owns this workspace by construction. */
+  | { kind: 'bound'; workspaceId: string }
+  /** A token was presented but is unknown, revoked, or its workspace is gone. */
+  | { kind: 'stale' };
+
+/**
+ * Mint a token bound to `workspaceId`, or `null` when there is no workspace to
+ * bind to. `null` means "issue nothing" — an unbound token would be a secret
+ * that proves nothing, and handing one out invites a consumer to treat its
+ * presence as meaningful.
+ */
+export function mintWorkspaceClaimToken(workspaceId: unknown): string | null {
+  if (typeof workspaceId !== 'string') return null;
+  const trimmed = workspaceId.trim();
+  if (trimmed.length === 0) return null;
+  const token = `${randomUUID()}${randomUUID()}`;
+  live.set(token, trimmed);
+  return token;
+}
+
+/** Revoke one token. Idempotent. */
+export function revokeWorkspaceClaimToken(token: unknown): void {
+  if (typeof token !== 'string' || token.length === 0) return;
+  live.delete(token);
+}
+
+/**
+ * Revoke every token bound to `workspaceId` — called when the workspace goes
+ * away, so a re-minted id can never inherit a dead claim's binding. Returns
+ * how many were revoked (for logging/tests).
+ */
+export function revokeWorkspaceClaimTokensFor(workspaceId: unknown): number {
+  if (typeof workspaceId !== 'string' || workspaceId.trim().length === 0) return 0;
+  const target = workspaceId.trim();
+  let revoked = 0;
+  for (const [token, ws] of live) {
+    if (ws === target) {
+      live.delete(token);
+      revoked++;
+    }
+  }
+  return revoked;
+}
+
+/**
+ * Classify a presented token. See `WorkspaceClaimLookup` for why the absent
+ * and stale cases are distinct — collapsing them is the fail-open this type
+ * exists to prevent.
+ */
+export function lookupWorkspaceClaim(token: unknown): WorkspaceClaimLookup {
+  if (token === undefined || token === null) return { kind: 'unclaimed' };
+  if (typeof token !== 'string' || token.length === 0) return { kind: 'stale' };
+  const workspaceId = live.get(token);
+  if (workspaceId === undefined) return { kind: 'stale' };
+  return { kind: 'bound', workspaceId };
+}
+
+/** Test-only: clear every registered token. */
+export function __resetWorkspaceClaimTrustForTesting(): void {
+  live.clear();
+}

--- a/src/mcp/__tests__/wmux-client.workspaceToken.test.ts
+++ b/src/mcp/__tests__/wmux-client.workspaceToken.test.ts
@@ -52,10 +52,17 @@ describe('wmux-client workspace claim token', () => {
     expect(getWorkspaceToken()).toBe('tok-padded');
   });
 
-  it('is dropped with the rest of the identity when the transport closes', () => {
-    // A trailing RPC after the transport tears down must not keep presenting a
-    // claim on behalf of a caller that has already disconnected — the same
-    // reasoning clearClientIdentity documents for the plugin name.
+  it('is dropped with the rest of the identity by clearClientIdentity', () => {
+    // Single-child mode calls this on transport close (`entry.ts`), so a
+    // trailing RPC after teardown cannot keep presenting a claim on behalf of a
+    // caller that has gone — the same reasoning clearClientIdentity documents
+    // for the plugin name.
+    //
+    // The broker does NOT call it (`broker.ts` teardown), so this is not the
+    // mechanism that protects broker connections. There the token is safe for a
+    // different reason, pinned by the isolation tests below: each connection
+    // owns its scope object and the scope is discarded with the connection, so
+    // there is nothing left to leak into the next one.
     setClientIdentity('claude-code', '1.0.0');
     setWorkspaceToken('tok-abc');
     clearClientIdentity();

--- a/src/mcp/__tests__/wmux-client.workspaceToken.test.ts
+++ b/src/mcp/__tests__/wmux-client.workspaceToken.test.ts
@@ -1,0 +1,155 @@
+// #922 PR-A — the caller's half of the claim token: hold it, scope it to the
+// connection that claimed it, and drop it when that connection goes.
+//
+// The isolation test is the one that matters. Under the broker, ONE process
+// hosts N server instances, so a process-global token would let connection B
+// stamp connection A's claim onto its own envelopes — B acting as A's
+// workspace, which is precisely the confusion this whole track exists to end.
+// `pinnedRoute` already lives per connection for the same reason; the token
+// rides in the same scope object.
+//
+// Like `wmux-client.identity.test.ts`, these assert through the in-process
+// getter rather than the wire: `attemptRpc` opens a real socket, and the
+// getter reads the exact state it builds the envelope from. The end-to-end
+// envelope round-trip is covered separately against a live pipe.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearClientIdentity,
+  getWorkspaceToken,
+  setClientIdentity,
+  setWorkspaceToken,
+} from '../wmux-client';
+import { createConnectionScope, runInConnectionScope } from '../connectionScope';
+import { claimPinnedRoute, __resetPaneResolverForTesting } from '../paneResolver';
+
+beforeEach(() => {
+  setWorkspaceToken(undefined);
+  clearClientIdentity();
+  __resetPaneResolverForTesting();
+});
+
+describe('wmux-client workspace claim token', () => {
+  it('round-trips a token through the setter', () => {
+    setWorkspaceToken('tok-abc');
+    expect(getWorkspaceToken()).toBe('tok-abc');
+  });
+
+  it('treats blank and whitespace-only tokens as absent', () => {
+    // An empty string would reach the substrate as a PRESENTED token that does
+    // not resolve, which PR-B must refuse. Absent and stale are different
+    // answers and the client must not manufacture the wrong one.
+    setWorkspaceToken('tok-abc');
+    setWorkspaceToken('   ');
+    expect(getWorkspaceToken()).toBeUndefined();
+    setWorkspaceToken('tok-abc');
+    setWorkspaceToken(undefined);
+    expect(getWorkspaceToken()).toBeUndefined();
+  });
+
+  it('trims padding so the stamped token matches the minted one', () => {
+    setWorkspaceToken('  tok-padded  ');
+    expect(getWorkspaceToken()).toBe('tok-padded');
+  });
+
+  it('is dropped with the rest of the identity when the transport closes', () => {
+    // A trailing RPC after the transport tears down must not keep presenting a
+    // claim on behalf of a caller that has already disconnected — the same
+    // reasoning clearClientIdentity documents for the plugin name.
+    setClientIdentity('claude-code', '1.0.0');
+    setWorkspaceToken('tok-abc');
+    clearClientIdentity();
+    expect(getWorkspaceToken()).toBeUndefined();
+  });
+});
+
+describe('wmux-client workspace claim token — broker isolation', () => {
+  it('keeps one connection\'s claim out of another\'s envelopes', () => {
+    const a = createConnectionScope();
+    const b = createConnectionScope();
+
+    runInConnectionScope(a, () => setWorkspaceToken('tok-a'));
+    runInConnectionScope(b, () => setWorkspaceToken('tok-b'));
+
+    expect(runInConnectionScope(a, () => getWorkspaceToken())).toBe('tok-a');
+    expect(runInConnectionScope(b, () => getWorkspaceToken())).toBe('tok-b');
+  });
+
+  it('never writes a connection\'s token into the process globals', () => {
+    // If the scope check were missed, the last connection to claim would leak
+    // its token to the single-child path — and to every other connection.
+    const scope = createConnectionScope();
+    runInConnectionScope(scope, () => setWorkspaceToken('tok-scoped'));
+    expect(getWorkspaceToken()).toBeUndefined();
+  });
+
+  it('does not let the process-global token leak into a connection', () => {
+    setWorkspaceToken('tok-global');
+    const scope = createConnectionScope();
+    expect(runInConnectionScope(scope, () => getWorkspaceToken())).toBeUndefined();
+  });
+
+  it('clears only the connection that closed', () => {
+    const a = createConnectionScope();
+    const b = createConnectionScope();
+    runInConnectionScope(a, () => setWorkspaceToken('tok-a'));
+    runInConnectionScope(b, () => setWorkspaceToken('tok-b'));
+
+    runInConnectionScope(a, () => clearClientIdentity());
+
+    expect(runInConnectionScope(a, () => getWorkspaceToken())).toBeUndefined();
+    expect(runInConnectionScope(b, () => getWorkspaceToken())).toBe('tok-b');
+  });
+});
+
+describe('paneResolver — handing the minted token over', () => {
+  const CLAIM = { ptyId: 'daemon-mcp', workspaceId: 'ws-claimed' };
+
+  it('publishes the token before the route, so no call is routed without it', async () => {
+    const order: string[] = [];
+    await claimPinnedRoute({
+      sendRpc: async () => ({ ...CLAIM, workspaceToken: 'tok-minted' }),
+      onWorkspaceToken: (token) => {
+        order.push(`token:${token}`);
+        setWorkspaceToken(token);
+      },
+    });
+    order.push('claim-returned');
+
+    expect(order).toEqual(['token:tok-minted', 'claim-returned']);
+    expect(getWorkspaceToken()).toBe('tok-minted');
+  });
+
+  it('claims fine when main mints nothing', async () => {
+    // An older main process, or an in-process caller, is issued no token. The
+    // claim must succeed exactly as before — nothing in PR-A depends on it.
+    const seen: string[] = [];
+    const route = await claimPinnedRoute({
+      sendRpc: async () => CLAIM,
+      onWorkspaceToken: (t) => seen.push(t),
+    });
+
+    expect(route).toEqual(CLAIM);
+    expect(seen).toEqual([]);
+    expect(getWorkspaceToken()).toBeUndefined();
+  });
+
+  it('ignores a blank or non-string token from the wire', async () => {
+    for (const workspaceToken of ['', '   ', 42, null, {}]) {
+      __resetPaneResolverForTesting();
+      const seen: string[] = [];
+      await claimPinnedRoute({
+        sendRpc: async () => ({ ...CLAIM, workspaceToken }),
+        onWorkspaceToken: (t) => seen.push(t),
+      });
+      expect(seen, String(workspaceToken)).toEqual([]);
+    }
+  });
+
+  it('works without the callback at all', async () => {
+    const route = await claimPinnedRoute({
+      sendRpc: async () => ({ ...CLAIM, workspaceToken: 'tok-minted' }),
+    });
+    expect(route).toEqual(CLAIM);
+  });
+});

--- a/src/mcp/connectionScope.ts
+++ b/src/mcp/connectionScope.ts
@@ -26,6 +26,17 @@ export interface RpcIdentityState {
   clientVersion?: string;
   /** Commander role claim (BYOB P4). Presence of the field IS the claim. */
   commanderToken?: string;
+  /**
+   * #922 PR-A — the workspace claim token returned by `mcp.claimWorkspace`.
+   *
+   * It lives HERE, beside the rest of the envelope identity, for the same
+   * reason `pinnedRoute` does: the broker hosts N server instances in one
+   * process, and a process-global token would let two hosted callers stamp
+   * each other's claim onto outbound envelopes — one connection acting as
+   * another's workspace. Scoping it with the pin it belongs to makes that
+   * unrepresentable rather than merely avoided.
+   */
+  workspaceToken?: string;
 }
 
 export interface ConnectionScope {

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -505,6 +505,14 @@ async function callRpc(
 function invalidateStaleRoute(pinnedRouteAtDispatch: PinnedRoute | null): void {
   invalidateWorkspaceId();
   clearPinnedRoute(pinnedRouteAtDispatch);
+  // #922 — drop the claim token with the pin it belongs to. The registry lives
+  // in main's memory while workspaces survive a restart, so a main restart
+  // leaves this process holding a token that no longer resolves. Every call
+  // opens its own socket, so nothing here notices the restart; without this the
+  // memoised pin would never be rebuilt and the token would be presented
+  // forever. Clearing both together makes the next call re-claim, which mints a
+  // fresh token — the same recovery path a closed workspace already takes.
+  setWorkspaceToken(undefined);
 }
 
 /**

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { sendRpc, setClientIdentity, setCommanderRole } from './wmux-client';
+import { sendRpc, setClientIdentity, setCommanderRole, setWorkspaceToken } from './wmux-client';
 import { COMMANDER_TOOL_SURFACE } from '../shared/commanderSurface';
 import type { RpcMethod } from '../shared/rpc';
 import {
@@ -856,7 +856,7 @@ async function resolveTerminalRouteBound(explicitPtyId?: string) {
         workspaceResolved = true;
       },
       getPinnedRoute,
-      claimPinnedRoute: () => claimPinnedRoute({ sendRpc }),
+      claimPinnedRoute: () => claimPinnedRoute({ sendRpc, onWorkspaceToken: setWorkspaceToken }),
     },
     explicitPtyId,
   );

--- a/src/mcp/paneResolver.ts
+++ b/src/mcp/paneResolver.ts
@@ -35,6 +35,17 @@ export interface PinnedRoute {
 export interface ClaimDeps {
   /** JSON-RPC sender (wmux-client.sendRpc, usually). */
   sendRpc: (method: RpcMethod, params?: Record<string, unknown>) => Promise<unknown>;
+  /**
+   * #922 PR-A — hand the minted workspace claim token to whatever stamps
+   * outbound envelopes (wmux-client.setWorkspaceToken, usually). Injected
+   * rather than imported so this module keeps its one-way dependency on the
+   * sender and stays testable without the socket layer.
+   *
+   * Optional: a main process that mints no token (an older build, or an
+   * in-process caller, which is not issued one) simply never calls it, and the
+   * claim succeeds exactly as before.
+   */
+  onWorkspaceToken?: (token: string) => void;
 }
 
 let pinned: PinnedRoute | null = null;
@@ -119,6 +130,25 @@ export async function claimPinnedRoute(deps: ClaimDeps): Promise<PinnedRoute> {
         // Pinning the ptyId without its owner would leave terminal RPCs with
         // no trustworthy workspaceId to assert against — fail closed instead.
         throw new Error('mcp.claimWorkspace returned no workspaceId');
+      }
+      // #922 PR-A — the claim token, when main issued one. Deliberately NOT
+      // part of `PinnedRoute`: the route is the terminal target, the token is
+      // envelope identity, and the two are read by different layers. It is
+      // handed over BEFORE the route is published so no RPC can be routed by
+      // this claim while the envelope still lacks its token.
+      //
+      // Its absence is never fatal. Unlike ptyId/workspaceId above — which
+      // fail closed because a pin without them reopens the #163 bypass —
+      // nothing in PR-A depends on the token, so a main process that does not
+      // mint one leaves the caller exactly where it was.
+      // Trimmed at the source, not just downstream: a blank token would be
+      // handed over as if it were a real one, and presenting a blank reads to
+      // the substrate as a token that does not resolve — "stale", which PR-B
+      // must refuse — rather than as the "never claimed" it actually is.
+      const rawToken = (result as { workspaceToken?: unknown } | null)?.workspaceToken;
+      const workspaceToken = typeof rawToken === 'string' ? rawToken.trim() : '';
+      if (workspaceToken.length > 0) {
+        deps.onWorkspaceToken?.(workspaceToken);
       }
       const route = { ptyId, workspaceId };
       s.set(route);

--- a/src/mcp/wmux-client.ts
+++ b/src/mcp/wmux-client.ts
@@ -57,10 +57,12 @@ export function clearClientIdentity(): void {
   if (scope) {
     scope.rpcIdentity.clientName = undefined;
     scope.rpcIdentity.clientVersion = undefined;
+    scope.rpcIdentity.workspaceToken = undefined;
     return;
   }
   CLIENT_NAME = undefined;
   CLIENT_VERSION = undefined;
+  WORKSPACE_TOKEN = undefined;
 }
 
 export function getClientIdentity(): { name?: string; version?: string } {
@@ -69,6 +71,35 @@ export function getClientIdentity(): { name?: string; version?: string } {
     return { name: scope.rpcIdentity.clientName, version: scope.rpcIdentity.clientVersion };
   }
   return { name: CLIENT_NAME, version: CLIENT_VERSION };
+}
+
+// #922 PR-A: the workspace claim token minted by `mcp.claimWorkspace`. Set by
+// paneResolver the moment a claim succeeds, and stamped on every later
+// envelope so main can tell WHICH workspace this caller claimed — a fact main
+// itself recorded at claim time, not one the caller asserts.
+//
+// Scope-aware for the same reason as the identity above: under the broker one
+// process hosts N connections, and a shared token would let one hosted caller
+// send another's claim. `clearClientIdentity` drops it with the rest of the
+// identity, so trailing RPCs after a transport closes cannot keep presenting a
+// claim on behalf of a caller that has gone.
+let WORKSPACE_TOKEN: string | undefined;
+
+export function setWorkspaceToken(token: string | undefined): void {
+  const trimmed = typeof token === 'string' ? token.trim() : '';
+  const value = trimmed.length > 0 ? trimmed : undefined;
+  const scope = getConnectionScope();
+  if (scope) {
+    scope.rpcIdentity.workspaceToken = value;
+    return;
+  }
+  WORKSPACE_TOKEN = value;
+}
+
+export function getWorkspaceToken(): string | undefined {
+  const scope = getConnectionScope();
+  if (scope) return scope.rpcIdentity.workspaceToken;
+  return WORKSPACE_TOKEN;
 }
 
 // BYOB P4: commander role claim. Set once at startup by index.ts when the
@@ -93,10 +124,16 @@ function currentEnvelopeIdentity(): {
   clientName?: string;
   clientVersion?: string;
   commanderToken?: string;
+  workspaceToken?: string;
 } {
   const scope = getConnectionScope();
   if (scope) return scope.rpcIdentity;
-  return { clientName: CLIENT_NAME, clientVersion: CLIENT_VERSION, commanderToken: COMMANDER_TOKEN };
+  return {
+    clientName: CLIENT_NAME,
+    clientVersion: CLIENT_VERSION,
+    commanderToken: COMMANDER_TOKEN,
+    workspaceToken: WORKSPACE_TOKEN,
+  };
 }
 
 function readAuthToken(): string | undefined {
@@ -132,6 +169,10 @@ function attemptRpc(
     if (identity.clientName) envelope.clientName = identity.clientName;
     if (identity.clientVersion) envelope.clientVersion = identity.clientVersion;
     if (identity.commanderToken !== undefined) envelope.commanderToken = identity.commanderToken;
+    // #922 PR-A. Absent until a claim succeeds, and omitted entirely when
+    // there is none — an empty string would read as a presented-but-stale
+    // token to the lane PR-B adds, which must refuse rather than demote.
+    if (identity.workspaceToken !== undefined) envelope.workspaceToken = identity.workspaceToken;
     const request = JSON.stringify(envelope) + '\n';
 
     const socket = typeof target === 'string' ? net.connect(target) : net.connect(target);

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -32,6 +32,24 @@ export interface RpcRequest {
    * close). A validated token puts `commanderWorkspace` on RpcContext.
    */
   commanderToken?: string;
+  /**
+   * #922 PR-A — workspace claim token. Minted by main in the
+   * `mcp.claimWorkspace` response and bound there to the workspace that call
+   * created for this caller (`workspaceClaimTrust.ts`); the MCP server holds
+   * it for the life of its claim and stamps it on every later envelope.
+   *
+   * Unlike `clientName` this is not self-asserted — a caller cannot invent one
+   * that resolves, because main issued it. Unlike `commanderToken` it grants
+   * no role: it only says WHICH workspace the holder claimed.
+   *
+   * PR-A carries it and nothing more. NO handler reads it for an
+   * authorisation decision yet, so a caller that omits or ignores it behaves
+   * exactly as before. PR-B adds the lane that consults it, where a presented
+   * token that does not resolve must REFUSE the request rather than demote the
+   * caller (the same rule `commanderToken` documents above, and the reason
+   * `lookupWorkspaceClaim` returns three states instead of a nullable).
+   */
+  workspaceToken?: string;
 }
 
 /**


### PR DESCRIPTION
Part 1 of the wire-caller half of #922. **This PR refuses nothing.** It issues a token, carries it, and records what it means — no handler reads it to make a decision. A caller that ignores the token behaves identically.

That split is deliberate: it lets us confirm the token actually round-trips on real traffic before any request depends on it.

### Why a token and not peer credentials

#922 suggested `GetNamedPipeClientProcessId` as the identity primitive. Measured, it does not work on the transport that matters. Node's named-pipe socket exposes no HANDLE (`_handle.fd === -1`), so the call needs a native addon — and this repo has deliberately avoided a compile step.

Loopback TCP *can* be measured today. But the pipe is the primary path and TCP is only the Windows EPERM fallback (`wmux-client.ts`), so gating TCP alone would be theatre: a caller that wants to skip the check just uses the pipe.

So this follows a mechanism already in the tree and already proven — the per-spawn token behind `commanderTrust`. `mcp.claimWorkspace` is where wmux *creates* the workspace, so it is also where it can hand out a secret bound to it. The binding is to the issued secret, not to `clientName` — which is what #922 warned against.

### Broker scope

The token lives in `ConnectionScope.rpcIdentity`, the same scope object as `pinnedRoute`. Under a broker, pins are per-connection, so a process-global token would let two callers behind one broker share a binding. Tests pin all four directions: A/B isolation, no scope-to-global leak, no global-to-scope leak, clearing one connection only.

### Demotion is unrepresentable

`lookupWorkspaceClaim` returns `{unclaimed} | {bound} | {stale}`, not `string | null`. There is no falsy value to fall through on, so `if (!binding) { carry on }` cannot be written. A consumer must handle `stale` explicitly, and the only correct answer is to refuse — BYOB hit the demotion trap already and the router comment records why.

### Strength

The same ceiling #922 set, and no more: the secret sits in the caller's process, and a same-user process can read it — exactly as the daemon auth token and commanderToken already do (`firstParty.ts:27-37`). This confines an **approved** tool to the workspace its approval implied. It is not a defence against malicious code already running as the user.

No changelog fragment: this PR has no user-visible behaviour change, and the collector rejects prose outside a section heading.
