### PR TITLE
fix(setup): wait out a held file instead of failing the rename

### DIFF
--- a/changelog.d/1108.md
+++ b/changelog.d/1108.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Installing the hooks or the usage statusline no longer fails because something had the file open.** Both write by renaming a temp file into place, which Windows refuses when another process is holding the destination — and both destinations are held open by design: Claude Code reads `settings.json`, and the statusline script runs every time the input box redraws. A sharing violation or an antivirus scan landing in that instant surfaced as a bare install failure. The rename now waits out a transient hold, up to a fifth of a second, before reporting a problem that is real. (#1108)

--- a/changelog.d/1108.md
+++ b/changelog.d/1108.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- **Installing the hooks or the usage statusline no longer fails because something had the file open.** Both write by renaming a temp file into place, which Windows refuses when another process is holding the destination — and both destinations are held open by design: Claude Code reads `settings.json`, and the statusline script runs every time the input box redraws. A sharing violation or an antivirus scan landing in that instant surfaced as a bare install failure. The rename now waits out a transient hold, up to a fifth of a second, before reporting a problem that is real. (#1108)

--- a/changelog.d/1112.md
+++ b/changelog.d/1112.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Installing the hooks or the usage statusline no longer fails because something had the file open.** Both write by renaming a temp file into place, which Windows refuses when another process is holding the destination — and both destinations are held open by design: Claude Code reads `settings.json`, and the statusline script runs every time the input box redraws. A sharing violation or an antivirus scan landing in that instant surfaced as a bare install failure. The rename now waits out a transient hold, up to a fifth of a second, before reporting a problem that is real. (#1112)

--- a/src/shared/__tests__/settingsFile.test.ts
+++ b/src/shared/__tests__/settingsFile.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { writeJsonAtomic, copyFileAtomic, resolveWriteTarget } from '../settingsFile';
+import { writeJsonAtomic, copyFileAtomic, resolveWriteTarget, renameWithRetry } from '../settingsFile';
 
 let tmpDir: string;
 
@@ -119,5 +119,55 @@ describe('resolveWriteTarget', () => {
   it('returns the path unchanged when nothing is there yet', () => {
     const missing = path.join(tmpDir, 'not-yet.json');
     expect(resolveWriteTarget(missing)).toBe(missing);
+  });
+});
+
+// Windows refuses to rename over a file another process holds open, and both
+// destinations here are held open by design: Claude Code reads settings.json,
+// and the statusline script runs at input-box frequency. POSIX allows it, so
+// no amount of macOS testing reaches this — the injected rename is the only
+// way to exercise it off-platform.
+describe('renameWithRetry', () => {
+  const err = (code: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(code), { code });
+
+  it('rides out a transient sharing violation', () => {
+    let calls = 0;
+    const slept: number[] = [];
+    renameWithRetry('a', 'b', {
+      rename: () => { calls += 1; if (calls < 3) throw err('EPERM'); },
+      sleep: (ms) => slept.push(ms),
+    });
+    expect(calls).toBe(3);
+    expect(slept).toEqual([10, 20]);
+  });
+
+  it('gives up rather than spinning, and surfaces the last error', () => {
+    let calls = 0;
+    expect(() =>
+      renameWithRetry('a', 'b', {
+        rename: () => { calls += 1; throw err('EBUSY'); },
+        sleep: () => { /* no real waiting in tests */ },
+        attempts: 4,
+      }),
+    ).toThrow('EBUSY');
+    expect(calls).toBe(4);
+  });
+
+  it('does not retry an error that will not clear on its own', () => {
+    let calls = 0;
+    expect(() =>
+      renameWithRetry('a', 'b', {
+        rename: () => { calls += 1; throw err('ENOENT'); },
+        sleep: () => { throw new Error('should not sleep'); },
+      }),
+    ).toThrow('ENOENT');
+    expect(calls).toBe(1);
+  });
+
+  it('is transparent when the rename just works', () => {
+    let calls = 0;
+    renameWithRetry('a', 'b', { rename: () => { calls += 1; }, sleep: () => { throw new Error('no'); } });
+    expect(calls).toBe(1);
   });
 });

--- a/src/shared/settingsFile.ts
+++ b/src/shared/settingsFile.ts
@@ -24,8 +24,54 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 
+/** Sharing violations and antivirus scans surface as these. They say "someone
+ *  is holding the file right now", not "you may not do this", so a bounded
+ *  wait is the correct response to all three. */
+const RENAME_RETRY_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+const RENAME_ATTEMPTS = 5;
+
+/** Block the thread. These call sites are synchronous by contract — the whole
+ *  installer is — and the total wait is capped at 150ms. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export interface RenameDeps {
+  rename?: (from: string, to: string) => void;
+  sleep?: (ms: number) => void;
+  attempts?: number;
+}
+
+/**
+ * `fs.renameSync` with a bounded backoff over the transient codes.
+ *
+ * Retried by error code rather than by platform: the same codes mean the same
+ * thing wherever they appear, and a genuine permission failure still surfaces
+ * — 150ms later, on a path a human just clicked.
+ */
+export function renameWithRetry(from: string, to: string, deps: RenameDeps = {}): void {
+  const rename = deps.rename ?? ((a: string, b: string) => fs.renameSync(a, b));
+  const sleep = deps.sleep ?? sleepSync;
+  const attempts = deps.attempts ?? RENAME_ATTEMPTS;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      rename(from, to);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code ?? '';
+      if (attempt >= attempts || !RENAME_RETRY_CODES.has(code)) throw err;
+      sleep(10 * 2 ** (attempt - 1));
+    }
+  }
+}
+
 /** Mode for a config file we are creating from scratch. Claude's settings.json
- *  can hold credentials in `env`; owner-only is the safe thing to author. */
+ *  can hold credentials in `env`; owner-only is the safe thing to author.
+ *
+ *  POSIX only, and worth being plain about: on Windows `chmod` moves the
+ *  read-only bit and nothing else, so neither this nor the mode carried over
+ *  from an existing file changes who can read it. There the file inherits the
+ *  profile directory's ACL, which is already user-scoped. */
 const NEW_FILE_MODE = 0o600;
 
 /** Follow a symlinked config to the file it points at, so the write lands on
@@ -73,7 +119,7 @@ export function writeJsonAtomic(filePath: string, data: unknown): void {
     // openSync's mode argument is masked by umask; set it outright so a
     // 0600 config does not come back 0644.
     fs.chmodSync(tmp, mode);
-    fs.renameSync(tmp, target);
+    renameWithRetry(tmp, target);
   } catch (err) {
     try {
       fs.unlinkSync(tmp);
@@ -119,7 +165,7 @@ export function copyFileAtomic(source: string, dest: string): void {
   const tmp = `${dest}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
   try {
     fs.copyFileSync(source, tmp);
-    fs.renameSync(tmp, dest);
+    renameWithRetry(tmp, dest);
   } catch (err) {
     try {
       fs.unlinkSync(tmp);


### PR DESCRIPTION
## Why

#1104 shipped a shared write path for `~/.claude/settings.json` and the statusline script. It was dogfooded end to end — but on macOS, and wmux ships Windows-only. The one difference that matters was therefore never exercised.

POSIX lets a rename replace a file another process holds open. Windows does not: a reader without `FILE_SHARE_DELETE` turns the rename into a sharing violation (`EPERM` / `EACCES` / `EBUSY`), and antivirus touching the temp file produces the same codes. Both destinations here are held open as a matter of course:

- `~/.claude/settings.json` — Claude Code reads it
- `~/.wmux/hooks/wmux-statusline.mjs` — executed every time the input box redraws

So on the shipping platform, an install could fail for a reason the operator can neither see nor act on, and a retry a second later would have worked.

## What

`renameWithRetry` — five attempts, 10/20/40/80ms, 150ms worst case — for those three codes only. Anything else rethrows on the first try, so a genuine permission error still surfaces immediately. Retried by error code rather than by platform: the codes mean the same thing wherever they appear, and a transient `EBUSY` on POSIX benefits equally.

Tests inject the rename, since POSIX cannot produce the failure being guarded against.

Also corrects an overclaim rather than leaving it to be discovered: `chmod` on Windows moves the read-only bit and nothing else, so neither the `0600` default for a new file nor the mode carried from an existing one changes who can read it there — the file inherits the profile directory's ACL. The tests already scoped those assertions to POSIX; the docblock now says so too.

## What a Windows agent should verify

CI covers the unit level on `windows-latest` already. What follows needs a real Windows box, because it is about file handles and ACLs that no injected dependency reproduces. Items 1-3 are this PR; 4-8 are #1104, which reached `main` verified on macOS only.

**1. Rename over a genuinely held file.** Open `%USERPROFILE%\.claude\settings.json` in an application that holds an exclusive handle (Notepad works; a running Claude Code session is the real case), then run `wmux setup-statusline --force`. Expect: it succeeds, or fails with a real error — never a bare unexplained failure. Confirm no `.tmp` file is left in `.claude\`.

**2. Statusline script replaced while it is running.** With a Claude Code session actively rendering the wmux statusline, run `wmux setup-statusline` again. The script is being executed at input-box frequency, so this is the live-handle case. Expect the copy to land and the statusline to keep rendering — not a truncated script or a failed install.

**3. Antivirus in the path.** With Defender real-time protection on (default), repeat 1 and 2 several times. The temp file is created and renamed immediately, which is exactly the window a scanner occupies.

**4. Backup and restore round trip.** Set a non-wmux `statusLine` in `settings.json`, install from Settings → Accounts, click **Replace**, confirm `%USERPROFILE%\.wmux\hooks\statusline-replaced\` gains a file, then `wmux setup-statusline --remove`. Expect the original entry back byte-for-byte, including any extra keys such as `padding`.

**5. Fail-closed when the backup cannot be written.** Deny write on `%USERPROFILE%\.wmux\hooks\statusline-replaced` (ACL, not read-only attribute), then Replace. Expect the install to refuse and the foreign `statusLine` to be untouched. This is the property that keeps Replace from destroying something it cannot give back, and Windows ACLs are a different enforcement path from the POSIX permissions it was proven against.

**6. Path identity.** `normalizedTargetKey` folds case and resolves symlinks. On Windows confirm that a `CLAUDE_CONFIG_DIR` written as `C:\Users\me\.claude` and as `c:\users\me\.claude` is treated as one target — not installed twice, not two backup files. If you have a directory junction or a `subst` drive pointing at a config dir, include it.

**7. New-file mode.** Delete `settings.json` entirely and install. Expect it recreated and readable by the owner. This is the assertion the unit tests skip on Windows; the point is to confirm nothing is broken by the attempt, not that `0600` took.

**8. Multi-account UI.** Register two Claude accounts, leave one with a foreign statusline, install. Expect the Settings row to say `installed` and still name the remaining profile with its command, with **Replace** available.

Report back on 1, 2, 5, and 6 in particular — the rest are likely to behave as they did on macOS, while those four are where the platform genuinely differs.