### PR TITLE
fix(browser): a cross-origin download no longer strands the page, and downloads report their filename

### DIFF
--- a/changelog.d/pr-q-download-page-state.md
+++ b/changelog.d/pr-q-download-page-state.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **A download that turns into a navigation no longer strands the agent on
+  another page.** Chrome ignores a link's `download` attribute across origins
+  and renders the target instead, so clicking a link to a video on someone
+  else's host navigates rather than downloading. `browser_download` timed out —
+  correctly — but left the tab sitting on the media URL, and the next snapshot
+  described a completely different page with nothing to say the original had
+  gone. The tab is now put back where it was, and the error names the cause, the
+  URL the browser ended up at, whether the page was recovered, and what to do
+  instead. Restoring goes through history rather than a fresh load: measured on
+  Chrome 141, reloading by URL leaves the stray entry in place, so a later
+  `browser_navigate_back` walks straight back into the failure.
+
+### Added
+
+- **`browser_download` now says what it downloaded.** It returned only the saved
+  path — an extension-less temp name when no `filename` was given — so the
+  browser's own filename and the source URL were reachable only by driving
+  `browser_click` and `browser_wait_for_download` instead. Both now come back
+  from the one call, which is what a follow-up step (handing the file to
+  `ffmpeg`, naming an output) actually needs.
+- **`browser_download` takes a `timeout`.** It bounds the wait for the download
+  to START, which is the property that lets large files work at all: a transfer
+  that begins in time then runs for minutes still completes — measured, a 60s
+  download succeeds under the 30s default. The default is unchanged; the
+  parameter exists for pages that are slow to begin, and the description now
+  says which half of the operation it covers.

--- a/changelog.d/pr-q-download-page-state.md
+++ b/changelog.d/pr-q-download-page-state.md
@@ -26,3 +26,7 @@
   download succeeds under the 30s default. The default is unchanged; the
   parameter exists for pages that are slow to begin, and the description now
   says which half of the operation it covers.
+- **`timeout: 0` disabled the download waits.** Playwright reads zero as "wait
+  forever", so on `browser_download` it removed the very start-bound the value
+  exists to impose, and on `browser_wait_for_download` it hung a call whose
+  entire job is to give up. Both now require a positive whole number.

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 80000,
-      "wireResultSha256": "0430f8c4bba1c94cdfc50034d7d1b7bdc675c346e04d73a421cd4440544ae0b7",
+      "wireResultSha256": "eac684085364f0a4851d3d21b4488526f6cf5e591c1fbaaed74fb9e5f3dc89f5",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/mcp/playwright/__tests__/file.download.test.ts
+++ b/src/mcp/playwright/__tests__/file.download.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 const { mockSendRpc, getPage, resolveRef } = vi.hoisted(() => ({
   mockSendRpc: vi.fn(),
@@ -19,7 +20,11 @@ vi.mock('../PlaywrightEngine', () => ({
 
 vi.mock('../snapshot', () => ({ resolveRef }));
 
-import { registerFileTools } from '../tools/file';
+import {
+  BROWSER_DOWNLOAD_SHAPE,
+  BROWSER_WAIT_FOR_DOWNLOAD_SHAPE,
+  registerFileTools,
+} from '../tools/file';
 
 type ToolResult = { content: { type: 'text'; text: string }[]; isError?: boolean };
 type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
@@ -253,4 +258,30 @@ describe('browser_download restore judges by URL, not by goBack resolving', () =
     // Returned on the poll, not after the 10s restore budget.
     expect(Date.now() - started).toBeLessThan(3_000);
   });
+});
+
+// Schema-level, because zod rejects before the handler runs. Playwright reads
+// timeout 0 as "wait forever": on browser_download that hangs the call the
+// start-timeout exists to bound, and on browser_wait_for_download it hangs a
+// call whose whole purpose is to give up.
+describe('download timeout bounds', () => {
+  for (const [name, shape] of [
+    ['browser_download', BROWSER_DOWNLOAD_SHAPE],
+    ['browser_wait_for_download', BROWSER_WAIT_FOR_DOWNLOAD_SHAPE],
+  ] as const) {
+    const schema = z.object(shape);
+    const base = name === 'browser_download' ? { ref: '0' } : {};
+
+    it(`${name} refuses 0, negatives and fractions`, () => {
+      expect(schema.safeParse({ ...base, timeout: 0 }).success).toBe(false);
+      expect(schema.safeParse({ ...base, timeout: -1 }).success).toBe(false);
+      expect(schema.safeParse({ ...base, timeout: 2.5 }).success).toBe(false);
+    });
+
+    it(`${name} accepts a positive whole number, and omitting it`, () => {
+      expect(schema.safeParse({ ...base, timeout: 1 }).success).toBe(true);
+      expect(schema.safeParse({ ...base, timeout: 90_000 }).success).toBe(true);
+      expect(schema.safeParse(base).success).toBe(true);
+    });
+  }
 });

--- a/src/mcp/playwright/__tests__/file.download.test.ts
+++ b/src/mcp/playwright/__tests__/file.download.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage, resolveRef } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+  resolveRef: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: { getInstance: () => ({ getPageForScope: getPage }) },
+}));
+
+vi.mock('../snapshot', () => ({ resolveRef }));
+
+import { registerFileTools } from '../tools/file';
+
+type ToolResult = { content: { type: 'text'; text: string }[]; isError?: boolean };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function collectTools(): Map<string, ToolHandler> {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  };
+  registerFileTools(server as never, { resolveWorkspaceId: vi.fn(async () => 'ws-test') });
+  return tools;
+}
+
+const download = collectTools().get('browser_download');
+if (!download) throw new Error('browser_download failed to register');
+
+const text = (r: ToolResult) => r.content.map((c) => c.text).join('\n');
+
+interface PageOpts {
+  /** Where the tab ends up once the click has run. */
+  navigatesTo?: string;
+  /** Reject waitForEvent, i.e. no download ever started. */
+  noDownload?: boolean;
+  /** Whether goBack restores the original URL. */
+  backWorks?: boolean;
+  /** Whether goto can reach the original URL. */
+  gotoWorks?: boolean;
+}
+
+const START_URL = 'https://app.test/project/42';
+
+function makePage(opts: PageOpts = {}) {
+  let url = START_URL;
+  const calls: string[] = [];
+  const waitArgs: Record<string, unknown>[] = [];
+
+  const page = {
+    url: () => url,
+    waitForEvent: vi.fn(async (_event: string, args?: Record<string, unknown>) => {
+      waitArgs.push(args ?? {});
+      if (opts.navigatesTo) url = opts.navigatesTo;
+      if (opts.noDownload) throw new Error('Timeout 30000ms exceeded while waiting for event "download"');
+      return {
+        path: async () => 'C:\\Temp\\playwright-artifacts-x\\abc-123',
+        suggestedFilename: () => 'render_final.mp4',
+        url: () => 'https://cdn.test/render_final.mp4',
+        saveAs: async () => undefined,
+      };
+    }),
+    goBack: vi.fn(async () => {
+      calls.push('goBack');
+      if (!opts.backWorks) throw new Error('no history entry');
+      url = START_URL;
+      return null;
+    }),
+    goto: vi.fn(async (to: string) => {
+      calls.push('goto');
+      if (opts.gotoWorks === false) throw new Error('net::ERR_ABORTED');
+      url = to;
+      return null;
+    }),
+  };
+  return { page, calls, waitArgs };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resolveRef.mockResolvedValue({ click: vi.fn(async () => undefined) });
+});
+
+// ---------------------------------------------------------------------------
+// What came back. The saved path is a temp name; the browser's own name and the
+// source URL used to be reachable only through a second, different tool.
+// ---------------------------------------------------------------------------
+
+describe('browser_download result', () => {
+  it('reports the browser filename and source URL alongside the saved path', async () => {
+    const { page } = makePage();
+    getPage.mockResolvedValue(page);
+
+    const res = await download({ ref: '0' });
+
+    expect(res.isError).toBeUndefined();
+    expect(text(res)).toContain('Downloaded: C:\\Temp\\playwright-artifacts-x\\abc-123');
+    expect(text(res)).toContain('suggestedFilename: render_final.mp4');
+    expect(text(res)).toContain('url: https://cdn.test/render_final.mp4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The timeout bounds the START of the download. Exposing it must not turn it
+// into a bound on the transfer, which is the property that lets big files work.
+// ---------------------------------------------------------------------------
+
+describe('browser_download timeout', () => {
+  it('defaults to 30s and applies it to the download event only', async () => {
+    const { page, waitArgs } = makePage();
+    getPage.mockResolvedValue(page);
+
+    await download({ ref: '0' });
+
+    expect(page.waitForEvent).toHaveBeenCalledWith('download', { timeout: 30_000 });
+    expect(waitArgs[0]).toEqual({ timeout: 30_000 });
+  });
+
+  it('passes a caller-supplied timeout through', async () => {
+    const { page } = makePage();
+    getPage.mockResolvedValue(page);
+
+    await download({ ref: '0', timeout: 90_000 });
+
+    expect(page.waitForEvent).toHaveBeenCalledWith('download', { timeout: 90_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The measured failure: a cross-origin "download" link navigates instead, and
+// the agent is left on a page it never asked for.
+// ---------------------------------------------------------------------------
+
+describe('browser_download stray navigation', () => {
+  const MEDIA = 'https://cdn.other/BigBuckBunny.mp4';
+
+  it('sends the tab back and says what happened', async () => {
+    const { page, calls } = makePage({ navigatesTo: MEDIA, noDownload: true, backWorks: true });
+    getPage.mockResolvedValue(page);
+
+    const res = await download({ ref: '0' });
+
+    expect(res.isError).toBe(true);
+    expect(calls).toEqual(['goBack']);
+    expect(page.url()).toBe(START_URL);
+    // The diagnosis survives alongside the cause.
+    expect(text(res)).toContain('Timeout 30000ms exceeded');
+    expect(text(res)).toContain('navigated instead of downloading');
+    expect(text(res)).toContain(MEDIA);
+    expect(text(res)).toContain(`The tab was sent back to ${START_URL}`);
+  });
+
+  it('reloads when there is no history entry, and admits the page was reloaded', async () => {
+    const { page, calls } = makePage({ navigatesTo: MEDIA, noDownload: true, backWorks: false });
+    getPage.mockResolvedValue(page);
+
+    const res = await download({ ref: '0' });
+
+    expect(calls).toEqual(['goBack', 'goto']);
+    expect(page.url()).toBe(START_URL);
+    expect(text(res)).toContain('reopened');
+    expect(text(res)).toContain('browser_navigate_back would land back here');
+  });
+
+  it('says where the tab is stranded when neither route works', async () => {
+    const { page } = makePage({
+      navigatesTo: MEDIA, noDownload: true, backWorks: false, gotoWorks: false,
+    });
+    getPage.mockResolvedValue(page);
+
+    const res = await download({ ref: '0' });
+
+    expect(page.url()).toBe(MEDIA);
+    expect(text(res)).toContain('could NOT be recovered');
+    expect(text(res)).toContain(`still on ${MEDIA}`);
+  });
+
+  it('leaves the page alone when a failure did not navigate', async () => {
+    // An ordinary miss — a ref that resolves but whose click downloads nothing.
+    const { page, calls } = makePage({ noDownload: true });
+    getPage.mockResolvedValue(page);
+
+    const res = await download({ ref: '0' });
+
+    expect(res.isError).toBe(true);
+    expect(calls).toEqual([]);
+    expect(text(res)).not.toContain('navigated instead of downloading');
+  });
+
+  it('does not undo a navigation the site made on a SUCCESSFUL download', async () => {
+    // A site that downloads and then moves to a "thanks" page meant to do that.
+    const { page, calls } = makePage({ navigatesTo: 'https://app.test/thanks' });
+    getPage.mockResolvedValue(page);
+
+    const res = await download({ ref: '0' });
+
+    expect(res.isError).toBeUndefined();
+    expect(calls).toEqual([]);
+    expect(page.url()).toBe('https://app.test/thanks');
+  });
+
+  it('still reports cleanly when there is no page at all', async () => {
+    getPage.mockResolvedValue(null);
+
+    const res = await download({ ref: '0' });
+
+    expect(res.isError).toBe(true);
+    expect(text(res)).toContain('No browser page available');
+    expect(text(res)).not.toContain('navigated instead of downloading');
+  });
+});
+
+// The measured wrinkle: in a wmux-opened tab the back navigation lands but
+// goBack's promise does not resolve until its own timeout. Judging by URL is
+// what keeps that case on the history-preserving route.
+describe('browser_download restore judges by URL, not by goBack resolving', () => {
+  const MEDIA = 'https://cdn.other/BigBuckBunny.mp4';
+
+  it('counts a back navigation that lands while its promise still hangs', async () => {
+    let url = START_URL;
+    const calls: string[] = [];
+    const page = {
+      url: () => url,
+      waitForEvent: vi.fn(async () => {
+        url = MEDIA;
+        throw new Error('Timeout 30000ms exceeded while waiting for event "download"');
+      }),
+      goBack: vi.fn(() => {
+        calls.push('goBack');
+        url = START_URL;                       // the navigation lands at once...
+        return new Promise(() => { /* ...and the promise never settles */ });
+      }),
+      goto: vi.fn(async () => { calls.push('goto'); return null; }),
+    };
+    getPage.mockResolvedValue(page);
+
+    const started = Date.now();
+    const res = await download({ ref: '0' });
+
+    expect(calls).toEqual(['goBack']);
+    expect(text(res)).toContain('The tab was sent back to');
+    // Returned on the poll, not after the 10s restore budget.
+    expect(Date.now() - started).toBeLessThan(3_000);
+  });
+});

--- a/src/mcp/playwright/tools/file.ts
+++ b/src/mcp/playwright/tools/file.ts
@@ -40,7 +40,7 @@ export const BROWSER_FILE_UPLOAD_SHAPE = {
   surfaceId: optionalSurfaceId,
 };
 
-const BROWSER_DOWNLOAD_SHAPE = {
+export const BROWSER_DOWNLOAD_SHAPE = {
   ref: z
     .string()
     .describe('Element that triggers the download.'),
@@ -50,18 +50,22 @@ const BROWSER_DOWNLOAD_SHAPE = {
     .describe('Save the download as this name.'),
   timeout: z
     .number()
+    .int()
+    .min(1)
     .optional()
     .describe('Milliseconds to wait for the download to START; default 30000.'),
   surfaceId: optionalSurfaceId,
 };
 
-const BROWSER_WAIT_FOR_DOWNLOAD_SHAPE = {
+export const BROWSER_WAIT_FOR_DOWNLOAD_SHAPE = {
   filename: z
     .string()
     .optional()
     .describe('Expected filename.'),
   timeout: z
     .number()
+    .int()
+    .min(1)
     .optional()
     .describe('Milliseconds; default 30000.'),
   surfaceId: optionalSurfaceId,

--- a/src/mcp/playwright/tools/file.ts
+++ b/src/mcp/playwright/tools/file.ts
@@ -48,6 +48,10 @@ const BROWSER_DOWNLOAD_SHAPE = {
     .string()
     .optional()
     .describe('Save the download as this name.'),
+  timeout: z
+    .number()
+    .optional()
+    .describe('Milliseconds to wait for the download to START; default 30000.'),
   surfaceId: optionalSurfaceId,
 };
 
@@ -255,6 +259,102 @@ async function uploadViaCdp(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Download: keeping the page the agent was on
+// ---------------------------------------------------------------------------
+
+/** Default wait for the download to START. See BROWSER_DOWNLOAD_SHAPE. */
+const DOWNLOAD_START_TIMEOUT_MS = 30_000;
+
+/** Budget for each half of the restore. Bounded so a failed download does not
+ *  also become a hang; the error is already on its way out. */
+const RESTORE_TIMEOUT_MS = 10_000;
+
+/**
+ * Put the tab back where it was after a click navigated instead of downloading.
+ *
+ * Chrome ignores the `download` attribute on a CROSS-ORIGIN link (spec
+ * behaviour) and renders the target instead, so a click on a link to a video on
+ * someone else's host fires no download event and NAVIGATES. Measured: the tool
+ * timed out and the agent's tab was left on the media URL — a snapshot taken
+ * afterwards described a completely different page, with nothing saying the
+ * page the agent was working on had gone.
+ *
+ * `goBack` first, and the reason is history rather than speed: it POPS the
+ * stray entry, while `goto` pushes a new one on top of it. Measured on Chrome
+ * 141 with the same three-entry history — page A, page B, then the media URL
+ * the click navigated to — a later browser_navigate_back lands on A after a
+ * goBack restore, and lands back on THE MEDIA URL after a goto restore, i.e.
+ * straight into the failure this function exists to undo.
+ *
+ * Neither route brings the document back. Also measured: a marker set on
+ * `window` before the click is gone after goBack, so Chrome did not keep the
+ * page in its back/forward cache and the restore is a reload either way. The
+ * caller is told which route ran, because only one of them leaves the history
+ * usable.
+ */
+async function restoreAfterStrayNavigation(
+  page: Page,
+  originalUrl: string,
+): Promise<'restored' | 'reloaded' | 'failed'> {
+  // Success is judged by where the tab ENDED UP, not by whether goBack's
+  // promise resolved. Measured against a wmux-opened tab: the back navigation
+  // lands immediately (the lifecycle ring records it at once) while the promise
+  // sits unresolved until its own timeout — so awaiting it would spend the
+  // whole budget and then fall through to the goto that leaves the stray entry
+  // in history. Polling the URL turns that into the good outcome. The same loop
+  // exits at once when goBack fails outright, which is the no-history case.
+  let settled = false;
+  const back = page
+    .goBack({ timeout: RESTORE_TIMEOUT_MS, waitUntil: 'commit' })
+    .catch(() => undefined)
+    .finally(() => { settled = true; });
+  const deadline = Date.now() + RESTORE_TIMEOUT_MS;
+  for (;;) {
+    if (page.url() === originalUrl) return 'restored';
+    if (settled || Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  await back;
+  if (page.url() === originalUrl) return 'restored';
+
+  try {
+    await page.goto(originalUrl, { timeout: RESTORE_TIMEOUT_MS, waitUntil: 'domcontentloaded' });
+    return page.url() === originalUrl ? 'reloaded' : 'failed';
+  } catch {
+    return 'failed';
+  }
+}
+
+/**
+ * What to tell an agent whose download turned into a navigation.
+ *
+ * The bare Playwright timeout ("Timeout 30000ms exceeded while waiting for
+ * event \"download\"") is true and useless: it names neither the cause nor the
+ * fact that the page moved. Both belong here, and so does the one thing the
+ * agent can actually do next — the URL is in hand, and on this machine a
+ * terminal can fetch it whenever the asset does not need the page's session.
+ */
+function describeStrayNavigation(
+  strandedUrl: string,
+  originalUrl: string,
+  outcome: 'restored' | 'reloaded' | 'failed',
+): string {
+  const state =
+    outcome === 'restored'
+      ? `The tab was sent back to ${originalUrl}; the page was reloaded, so anything it held in memory is gone.`
+      : outcome === 'reloaded'
+        ? `The tab was reopened at ${originalUrl} — the page was reloaded, and the stray entry is still in history, so browser_navigate_back would land back here.`
+        : `The tab could NOT be recovered and is still on ${strandedUrl} — navigate before using it again.`;
+  return (
+    `The click navigated instead of downloading: the browser is now at ${strandedUrl}. ` +
+    `Chrome ignores a link's "download" attribute across origins and renders the target instead, ` +
+    `so no download ever started. ${state} ` +
+    `That URL is the file — fetch it from a terminal if it needs no session, ` +
+    `otherwise use a control that builds the download in the page itself.`
+  );
+}
+
 /**
  * Marks the one error that means "this may actually have worked".
  *
@@ -391,23 +491,32 @@ export function registerFileTools(server: McpServer, deps: BrowserToolDeps): voi
   // -----------------------------------------------------------------------
   server.tool(
     'browser_download',
-    'Click an element by ref and capture the resulting download. Returns the file path.',
+    'Click an element by ref and capture the resulting download. Returns the saved path plus the name and URL the browser had for it. timeout bounds the wait for the download to START, not to finish — a download that begins in time then runs for minutes still completes (measured: a 60s transfer succeeds under the 30s default). If the click navigates instead of downloading, which is what Chrome does with a cross-origin "download" link, the tab is put back where it was and the error says so.',
     BROWSER_DOWNLOAD_SHAPE,
-    async ({ ref, filename, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ ref, filename, timeout, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+      // Captured before the click so a stray navigation has somewhere to go
+      // back to. Read outside the try: the catch needs it too.
+      let originalUrl = '';
+      let page: Awaited<ReturnType<typeof engine.getPageForScope>> = null;
       try {
-        const page = await engine.getPageForScope(scope);
+        page = await engine.getPageForScope(scope);
         if (!page) {
           throw new Error('No browser page available. Call browser_open with a URL first to establish a CDP connection (required even if a browser panel is already visible).');
         }
+        originalUrl = page.url();
 
         const el = await resolveRef(page, ref);
         if (!el) {
           throw new Error(`Could not resolve ref="${ref}" to an element.`);
         }
 
-        // Start waiting for download before clicking
+        // Start waiting for download before clicking. The timeout covers the
+        // START of the download only — Playwright resolves this event when the
+        // transfer begins, and download.path() below then waits out the rest
+        // unbounded. That split is deliberate and worth keeping: a large file
+        // is slow to finish, not slow to begin.
         const [download] = await Promise.all([
-          page.waitForEvent('download'),
+          page.waitForEvent('download', { timeout: timeout ?? DOWNLOAD_START_TIMEOUT_MS }),
           el.click(),
         ]);
 
@@ -430,16 +539,37 @@ export function registerFileTools(server: McpServer, deps: BrowserToolDeps): voi
           filePath = downloadPath ?? download.suggestedFilename();
         }
 
+        // The saved path is a temp name — `render.mp4` when the caller picked
+        // one, an extension-less GUID when it did not — so on its own it says
+        // nothing about WHAT was downloaded. The browser's own name and the URL
+        // it came from were previously reachable only through
+        // browser_wait_for_download, which meant learning the filename cost a
+        // second, differently-shaped call.
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Downloaded: ${filePath}`,
+              text:
+                `Downloaded: ${filePath}\n` +
+                `suggestedFilename: ${download.suggestedFilename()}\n` +
+                `url: ${download.url()}`,
             },
           ],
         };
       } catch (error) {
-        const message = describeToolError(error);
+        let message = describeToolError(error);
+        // A click that navigated is not just a failed download: the page the
+        // agent was working on is gone, and every later tool call would run
+        // against whatever replaced it. Only on the failure path — a download
+        // that succeeded AND navigated did so because the site meant to, and
+        // undoing that would be the wrong kind of help.
+        if (page) {
+          const strandedUrl = page.url();
+          if (originalUrl && strandedUrl !== originalUrl) {
+            const outcome = await restoreAfterStrayNavigation(page, originalUrl);
+            message = `${message}\n\n${describeStrayNavigation(strandedUrl, originalUrl, outcome)}`;
+          }
+        }
         return {
           content: [{ type: 'text' as const, text: message }],
           isError: true,


### PR DESCRIPTION
Two download-side fixes found while measuring the video workflow end to end. Builds on the upload PR (#1114).

### A download that navigates instead of downloading no longer strands the page

A cross-origin media link is the common case: Chrome ignores the link's `download` attribute across origins and **navigates** to the file instead. No download event fires, the call times out, and — the real damage — the tab is now on the media URL, so the original page is gone. Anything it held is lost, and later steps run against the wrong page.

`browser_download` now detects the navigation, sends the tab **back** to where it was, and returns an error that says what happened and what to do:

> The click navigated instead of downloading… The tab was sent back to `<url>`; the page was reloaded, so anything it held in memory is gone. That URL is the file — fetch it from a terminal if it needs no session…

`goBack` is tried first, `goto` as fallback. That ordering was measured, not guessed: with a three-entry history, `goto` leaves a stray entry so a later `browser_navigate_back` re-enters the media URL, while `goBack` returns history to where it belongs. The error names that when it has to fall back.

(One wrinkle handled along the way: on a wmux-driven tab the `goBack` promise doesn't resolve even though the navigation lands, so success is judged by polling `page.url()`, not by awaiting the promise. The wedged-promise root cause is noted but not resolved — a URL check sidesteps it.)

### `browser_download` now reports the filename, and its timeout is bounded

- The result carries `suggestedFilename` (and `url`). Before, only a GUID path came back, so an agent couldn't tell what it had downloaded before handing it to ffmpeg.
- `timeout` is now a schema field, `.int().min(1)`, on `browser_download` and `browser_wait_for_download`. `0` meant "no timeout" in Playwright — a tool whose whole job is to give up would hang forever. The default is unchanged and still bounds the wait for the download to **start**, not to finish: a 60s transfer under the 30s default still completes (measured).
- Also fixed: `timeout` was being silently dropped before, the same way `selector` was on upload — an unknown key discarded by the schema.

Progress reporting during a blocking download is deliberately **not** here: it needs a non-blocking start + a pollable status tool, a tool-surface change out of this PR's scope. Left as a separate track.

Measured live: cross-origin failure now restores the original page in the snapshot; a slow 40 MB download still completes at 54s under the default.
