### PR TITLE
fix(hooks): stop projecting 'complete' for a turn still holding on background agents (#1096)

### DIFF
--- a/changelog.d/1121.md
+++ b/changelog.d/1121.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **A pane waiting on background agents no longer shows Completed.** When an
+  agent's turn ended with background agents still running (`Waiting for N
+  background agent(s) to finish`), the roster marked the pane Completed for the
+  whole hold — genuinely in-progress work read as done. The daemon already knew
+  the turn had not really ended (that knowledge is what kept the completion
+  alarm quiet); now the pane's status says the same thing: it stays running
+  until the real turn end, and the outbound turn-finished webhook waits with it.

--- a/src/daemon/hooks/HookIngest.ts
+++ b/src/daemon/hooks/HookIngest.ts
@@ -872,6 +872,30 @@ export class HookIngest {
       });
     }
 
+    // #1096 — a lead stop with background work still running is not a turn
+    // end, and the STATUS must say so, not just the alarm. The #907 verdict
+    // gate already judges this cue correctly ("treat as working evidence"),
+    // but the projection below would still broadcast eventShapeFor's
+    // 'complete', and 'internal' leaves the status dot live — so the roster
+    // wore Completed for the whole `Waiting for N background agent(s)` hold.
+    // Same shape as the subagent branch above: the pane's own turn keeps
+    // going, so the broadcast says RUNNING. observe() still feeds the cue so
+    // `seenWorking` lets the eventual real stop (leftoverWork 0) pass the
+    // gate; no resume closure — this candidate must never write the ledger or
+    // expire approvals, exactly like today's drop path.
+    if (signal.kind === 'agent.stop' && cue.class === 'stop' && cue.leftoverWork > 0) {
+      this.alarm.observe(sessionId, signal.agent, cue);
+      return this.broadcast(sessionId, {
+        agent: agentSlugToDisplay(signal.agent),
+        status: 'running',
+        message: 'Waiting on background agents',
+        source: 'hook',
+        hookKind: signal.kind,
+        decision: 'internal',
+        signal,
+      });
+    }
+
     // Awaiting input keeps its phone card IMMEDIATELY (R5): a remote device
     // must see the question while the provisional window runs, not 1.5s later.
     if (signal.kind === 'agent.awaiting_input') {

--- a/src/daemon/hooks/__tests__/HookIngest.test.ts
+++ b/src/daemon/hooks/__tests__/HookIngest.test.ts
@@ -457,15 +457,24 @@ describe('HookIngest', () => {
       }));
       // Not held — the bridge is answered and the candidate is rejected NOW.
       expect(res).toEqual({ ok: true });
+      // #1096 — the projection must agree with the verdict: the turn has NOT
+      // ended, so the status says running, not eventShapeFor's 'complete'
+      // (which sat on the roster for the whole background-agent hold).
       expect(fixture.emitted.at(-1)?.data).toMatchObject({
         hookKind: 'agent.stop',
         decision: 'internal',
+        status: 'running',
+        message: 'Waiting on background agents',
       });
       // The leftover stop counts as WORKING evidence (the turn is still going),
-      // so a subsequent clean stop in the same turn may still announce.
+      // so a subsequent clean stop in the same turn may still announce — and
+      // that real stop projects 'complete' exactly as before.
       ingest.handle(makeSignal({ ptyId: 'pty-a' }));
       vi.advanceTimersByTime(DEFAULT_ALARM_WINDOW_MS);
-      expect(fixture.emitted.at(-1)?.data.decision).toBe('emit');
+      expect(fixture.emitted.at(-1)?.data).toMatchObject({
+        decision: 'emit',
+        status: 'complete',
+      });
     });
 
     it('an answered cue cancels a pending attention window before its broadcast', () => {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2939,8 +2939,11 @@ function registerRpcHandlers(
         // Outbound notification sinks: the END of a turn, and only the real one.
         // `agent.subagent_stop` also reports `status:'complete'`, and a run with
         // a dozen subagents would fire a dozen pings for one turn — so this keys
-        // on the signal kind, not the projected status.
-        if (data.signal.kind === 'agent.stop') {
+        // on the signal kind, not the projected status alone. The status guard
+        // covers the one stop that is NOT a turn end: a lead stop with leftover
+        // background work projects 'running' (#1096), and pinging "finished"
+        // there would contradict the roster it just corrected.
+        if (data.signal.kind === 'agent.stop' && data.status !== 'running') {
           webhookSink?.notify(
             buildAttentionNotifyPayload(
               { sessionId, ...(data.agent ? { agent: data.agent } : {}) },

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.emit.test.ts
@@ -199,6 +199,31 @@ describe('hooks.signal — agent.lifecycle event tee', () => {
     );
   });
 
+  it('a stop with leftover background work clears activity but does NOT mark the pane complete (#1096)', async () => {
+    const stub = stubHookRouter();
+    stub.setDecision('emit');
+    const router = new RpcRouter();
+    registerHooksRpc(router, () => fakeWindow(), stub.router);
+
+    // The turn is still holding on `Waiting for N background agent(s)`, so the
+    // hook-authoritative completion stamp must wait for the real stop — the
+    // one that arrives with leftoverWork 0 after the hold.
+    await router.dispatch({
+      id: 'lw1',
+      method: 'hooks.signal',
+      params: signal({
+        kind: 'agent.stop',
+        agent: 'opencode',
+        payload: { wmux_leftover_work: 2 },
+      }) as unknown as Record<string, unknown>,
+    });
+
+    expect(broadcastMetadataUpdateMock).toHaveBeenCalledTimes(1);
+    const call = broadcastMetadataUpdateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(call).toMatchObject({ ptyId: 'pty-1', activity: '' });
+    expect(call).not.toHaveProperty('agentStatus');
+  });
+
   it('agent.session_start clears activity but does NOT mark the pane complete (a turn beginning is not an end)', async () => {
     const stub = stubHookRouter();
     const router = new RpcRouter();

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -169,12 +169,19 @@ export function activityFromSignalPayload(payload: Record<string, unknown> | und
 export function buildTurnBoundaryMetadata(
   kind: AgentSignal['kind'],
   stopMessage: AgentLastMessage | null,
+  leftoverWork = 0,
 ): { activity: string; pendingQuestion: string; agentStatus?: 'complete' } | null {
   if (kind !== 'agent.stop' && kind !== 'agent.session_start') return null;
   return {
     activity: '',
     pendingQuestion: stopMessage?.endsWithQuestion ? stopMessage.text : '',
-    ...(kind === 'agent.stop' ? { agentStatus: 'complete' as const } : {}),
+    // #1096 — a lead stop with background agents still running is not a turn
+    // end, so it must not stamp the hook-authoritative completion status: the
+    // pane sat on Completed for the whole `Waiting for N background agent(s)`
+    // hold. Activity clear + pendingQuestion still apply (the tool label IS
+    // stale); the real stop after the hold arrives with leftoverWork 0 and
+    // stamps 'complete' as before.
+    ...(kind === 'agent.stop' && leftoverWork === 0 ? { agentStatus: 'complete' as const } : {}),
   };
 }
 
@@ -651,7 +658,12 @@ export function registerHooksRpc(
     // The transcript tail is read ONCE here and reused for the EventBus tee
     // below — it is real file I/O inside the hook's 2s budget.
     const stopMessage = readStopMessage(signal);
-    const boundary = buildTurnBoundaryMetadata(signal.kind, stopMessage);
+    const boundaryCue = normalizeHookCue(signal);
+    const boundary = buildTurnBoundaryMetadata(
+      signal.kind,
+      stopMessage,
+      boundaryCue.class === 'stop' && !boundaryCue.child ? boundaryCue.leftoverWork : 0,
+    );
     if (boundary) {
       const win = getWindow();
       if (win) {


### PR DESCRIPTION
Fixes #1096.

## Mechanism

The daemon already knew the truth and ignored it at the last step:

1. The Claude bridge stamps a lead `agent.stop` with `wmux_leftover_work` when background agents are still running (`integrations/claude/bin/wmux-bridge.mjs`).
2. The #907 verdict gate (`CompletionAlarm`) already judges that cue correctly — "The turn has not actually ended: background work is running" — and drops the completion alarm.
3. But the status projection didn't follow the verdict: `HookIngest` broadcast `eventShapeFor`'s `'complete'` with `decision:'internal'`, and `'internal'` deliberately leaves the status dot live. So the roster wore **Completed** for the entire `Waiting for N background agent(s) to finish` hold — exactly the report.

## Change

- **`HookIngest`** — a leftover-work stop now broadcasts `status:'running'` (`decision:'internal'`), mirroring the adjacent `subagent_stop` branch's precedent ("the pane's own turn keeps going, so the broadcast says RUNNING"). The cue still feeds the alarm so `seenWorking` lets the eventual real stop (leftoverWork 0) pass the gate; no ledger write, no approval expiry — identical to today's drop path in everything but the projected status. As a side effect the daemon bridge settle now calls `noteAgentStatus('running')`, which re-arms `beginTurnIfInactive` — so the sparse spinner output during the hold (well under the 2 KB/3 s threshold) keeps the pane honest too.
- **`daemon/index.ts` webhook sink** — the outbound turn-end ping is now guarded on the projected status: the one stop that is NOT a turn end must not ping "finished" while the roster it just corrected says running.
- **`hooks.rpc.ts` (local-mode parity)** — the pre-gate boundary broadcast stamped `agentStatus:'complete'` on every `agent.stop` unconditionally. `buildTurnBoundaryMetadata` now skips the completion stamp for a leftover-work stop; activity clear and `pendingQuestion` behavior are unchanged, and the real stop after the hold stamps `'complete'` as before.

Daemon-mode main needs no change: `DaemonNotificationRouter` applies the status dot before its `'internal'` early-return and never replays boundary metadata for it, and the `running`+`internal` shape is already exercised in production by the `subagent_stop` branch — so old-main/new-daemon and new-main/old-daemon pairings both behave.

## Deliberately untouched

The `ActivityMonitor`/`onActive` once-per-cycle dedup (#1013's regression area). This change is projection-only.

## Tests

- `HookIngest.test.ts` — the existing leftover-work test now pins the projection: the drop broadcasts `status:'running'` / `'Waiting on background agents'`, and the subsequent clean stop still confirms with `status:'complete'`.
- `hooks.rpc.emit.test.ts` — new: a stop with `wmux_leftover_work: 2` clears activity but does NOT carry `agentStatus`, alongside the existing session_start twin.

Gates: `tsc --noEmit` clean, `npm run build:daemon` clean, `npm test` 13057 + 160 passed / 0 failed (fresh `npm ci`).