### PR TITLE
Reclaim idle REPL sessions from one process-wide sweep

### DIFF
--- a/changelog.d/1131.md
+++ b/changelog.d/1131.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- REPL sessions left idle for 15 minutes now have their Node child process reclaimed, instead of holding memory for the life of the MCP connection. The next `repl_run` on a reclaimed session says why its state is gone rather than handing back a silently empty runtime.
+- A REPL session running a long eval is no longer killed by its own idle deadline. A session that had been quiet for nearly 15 minutes and then started a multi-minute run could be terminated mid-flight, losing state that was actively in use.
+- `repl_sessions` now shows how long each session has left before it is reclaimed.

--- a/src/mcp/repl/ReplSession.ts
+++ b/src/mcp/repl/ReplSession.ts
@@ -18,7 +18,7 @@
  *                   │                 │
  *                   └────────┬────────┴──── hard deadline (SIGKILL)
  *                            │         ├──── child exited on its own
- *                            │         ├──── idle timer
+ *                            │         ├──── the registry's idle sweep
  *                            ▼         └──── reset() / dispose()
  *                          dead  ── state is gone; the registry respawns clean
  *
@@ -130,8 +130,6 @@ function delay(ms: number): Promise<void> {
 export interface ReplSessionOptions {
   readonly name: string;
   readonly cwd: string;
-  /** Idle lifetime before the child is reaped. */
-  readonly idleMs: number;
 }
 
 export class ReplSession {
@@ -153,13 +151,10 @@ export class ReplSession {
   /** Id of the eval in flight; only a reply carrying it may settle. */
   private pendingId: number | null = null;
   private readonly ready: Promise<void>;
-  private idleTimer: NodeJS.Timeout | null = null;
-  private readonly idleMs: number;
 
   constructor(options: ReplSessionOptions) {
     this.name = options.name;
     this.cwd = options.cwd;
-    this.idleMs = options.idleMs;
 
     // Validated before spawn so a bad cwd reads as a bad cwd, not as an opaque
     // ENOENT from a process that never started.
@@ -244,8 +239,6 @@ export class ReplSession {
       this.pending = null;
       settle?.(message);
     });
-
-    this.armIdleTimer();
   }
 
   get status(): ReplSessionState {
@@ -277,23 +270,10 @@ export class ReplSession {
     return this.deathReason;
   }
 
-  private armIdleTimer(): void {
-    if (this.idleTimer) clearTimeout(this.idleTimer);
-    this.idleTimer = setTimeout(() => {
-      this.destroy(`idle for ${Math.round(this.idleMs / 60000)} minutes`);
-    }, this.idleMs);
-    // Never hold the MCP server open just to wait out an idle REPL.
-    this.idleTimer.unref?.();
-  }
-
   private markDead(reason: string): void {
     if (this.state === 'dead') return;
     this.state = 'dead';
     this.deathReason = reason;
-    if (this.idleTimer) {
-      clearTimeout(this.idleTimer);
-      this.idleTimer = null;
-    }
     const settle = this.pending;
     this.pending = null;
     this.pendingId = null;
@@ -413,7 +393,6 @@ export class ReplSession {
 
     this.state = 'idle';
     this.lastUsedAt = Date.now();
-    this.armIdleTimer();
 
     if (message.ok) {
       return {

--- a/src/mcp/repl/__tests__/replIdleReclaim.test.ts
+++ b/src/mcp/repl/__tests__/replIdleReclaim.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Idle reclaim: the axis that bounds how many REPL children a long-lived MCP
+ * connection can leave resident. Every case here runs a real child, because the
+ * thing being asserted is that an OS process actually went away.
+ */
+import * as os from 'os';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createConnectionScope, runInConnectionScope } from '../../connectionScope';
+import {
+  IDLE_SWEEP_INTERVAL_MS,
+  IDLE_TIMEOUT_MS,
+  ReplRegistry,
+  getReplRegistry,
+  idleSweepTimerForTest,
+  reclaimIdleSessions,
+} from '../replRegistry';
+import { createReplToolCatalog } from '../tools';
+
+const registries: ReplRegistry[] = [];
+
+function makeRegistry(): ReplRegistry {
+  const registry = new ReplRegistry();
+  registries.push(registry);
+  return registry;
+}
+
+function alive(pid: number | undefined): boolean {
+  try {
+    process.kill(pid as number, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  while (registries.length > 0) registries.pop()?.disposeAll();
+});
+
+describe('idle reclaim', () => {
+  it('kills the child of a session that has gone quiet past the threshold', async () => {
+    const registry = makeRegistry();
+    const { session } = registry.acquire('default', os.tmpdir());
+    await session.run('let held = 1;', 5000);
+    const pid = session.pid;
+    expect(alive(pid)).toBe(true);
+
+    // One millisecond short of the threshold is still a live session.
+    expect(reclaimIdleSessions(session.lastUsed + IDLE_TIMEOUT_MS - 1)).toBe(0);
+    expect(session.dead).toBe(false);
+
+    expect(reclaimIdleSessions(session.lastUsed + IDLE_TIMEOUT_MS)).toBe(1);
+    expect(session.dead).toBe(true);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(alive(pid)).toBe(false);
+  }, 20_000);
+
+  it('tells the next repl_run why its state is gone instead of quietly respawning', async () => {
+    const registry = makeRegistry();
+    const first = registry.acquire('default', os.tmpdir());
+    await first.session.run('let survivor = "old";', 5000);
+    reclaimIdleSessions(Date.now() + IDLE_TIMEOUT_MS);
+
+    const second = registry.acquire('default', os.tmpdir());
+    expect(second.created).toBe(true);
+    // The same field the hard-kill and crash paths use: a reclaimed session
+    // must never look like one the caller simply never started.
+    expect(second.previousDeath).toBe('idle for 15 minutes');
+    const outcome = await second.session.run('typeof survivor', 5000);
+    expect(outcome.result?.text).toContain('undefined');
+  }, 20_000);
+
+  it('spares a session that is still running code', async () => {
+    const registry = makeRegistry();
+    const { session } = registry.acquire('default', os.tmpdir());
+    await session.run('1', 5000);
+
+    // A single eval may legitimately run for minutes, and `lastUsed` is stamped
+    // when it STARTS; reclaiming one mid-flight would destroy state the caller
+    // is actively using.
+    const inFlight = session.run('await new Promise((r) => setTimeout(r, 1500)); "done"', 10_000);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(session.busy).toBe(true);
+    expect(reclaimIdleSessions(Date.now() + 10 * IDLE_TIMEOUT_MS)).toBe(0);
+    expect(session.dead).toBe(false);
+
+    const outcome = await inFlight;
+    expect(outcome.ok).toBe(true);
+    expect(outcome.result?.text).toContain('done');
+  }, 20_000);
+
+  it('reclaims on its own interval once enough time passes', async () => {
+    // The clock goes fake BEFORE the registry exists, so the sweep interval is
+    // the fake one; an interval scheduled on the real clock would never see
+    // advanceTimersByTime. shouldAdvanceTime keeps real I/O progressing
+    // meanwhile — the child under test is a real process and still needs it.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const registry = makeRegistry();
+    const { session } = registry.acquire('default', os.tmpdir());
+    await session.run('let stale = 1;', 5000);
+    const pid = session.pid;
+    expect(session.dead).toBe(false);
+
+    vi.advanceTimersByTime(IDLE_TIMEOUT_MS + IDLE_SWEEP_INTERVAL_MS);
+    vi.useRealTimers();
+
+    expect(session.dead).toBe(true);
+    expect(session.diedBecause).toBe('idle for 15 minutes');
+    await new Promise((r) => setTimeout(r, 300));
+    expect(alive(pid)).toBe(false);
+  }, 20_000);
+});
+
+describe('the sweep timer', () => {
+  it("is one per process, unref'd, and released with the last registry", () => {
+    const a = new ReplRegistry();
+    const timer = idleSweepTimerForTest();
+    expect(timer).not.toBeNull();
+    // Waiting out an idle REPL is not work worth keeping the MCP server alive
+    // for: a ref'd interval would stop the process ever exiting on its own.
+    expect(timer?.hasRef()).toBe(false);
+
+    const b = new ReplRegistry();
+    // One interval for the process, not one per registry — and emphatically
+    // not one per session.
+    expect(idleSweepTimerForTest()).toBe(timer);
+
+    a.disposeAll();
+    expect(idleSweepTimerForTest()).toBe(timer);
+    b.disposeAll();
+    expect(idleSweepTimerForTest()).toBeNull();
+  });
+});
+
+describe('repl_sessions idle reporting', () => {
+  const sessionsTool = createReplToolCatalog().find((spec) => spec.name === 'repl_sessions');
+
+  function listSessions(scope: ReturnType<typeof createConnectionScope>): string {
+    const result = runInConnectionScope(
+      scope,
+      () => sessionsTool?.invoke({}, {} as never),
+    ) as CallToolResult;
+    return String(result.content[0]?.type === 'text' ? result.content[0].text : '');
+  }
+
+  it('reports time since the last run and time left before reclaim', async () => {
+    const scope = createConnectionScope();
+    const registry = runInConnectionScope(scope, () => getReplRegistry());
+    registries.push(registry);
+    const { session } = registry.acquire('default', os.tmpdir());
+    await session.run('1', 5000);
+
+    const idleView = listSessions(scope);
+    expect(idleView).toMatch(/idle \d+s/);
+    expect(idleView).toMatch(/reclaim in 1[45]m\d+s/);
+
+    // A busy session has no countdown to report — the sweep does not touch it.
+    const inFlight = session.run('await new Promise((r) => setTimeout(r, 1200)); 1', 10_000);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(listSessions(scope)).toContain('reclaim held while busy');
+    await inFlight;
+  }, 20_000);
+});

--- a/src/mcp/repl/__tests__/replIdleReclaim.test.ts
+++ b/src/mcp/repl/__tests__/replIdleReclaim.test.ts
@@ -34,6 +34,18 @@ function alive(pid: number | undefined): boolean {
   }
 }
 
+/**
+ * Wait for a SIGKILLed child to actually leave the process table. A killed
+ * child is a zombie until its parent reaps it, and `kill(pid, 0)` succeeds on a
+ * zombie — so a fixed sleep is a flake on a loaded CI runner, not a check.
+ */
+async function waitForExit(pid: number | undefined, deadlineMs = 5000): Promise<void> {
+  const until = Date.now() + deadlineMs;
+  while (alive(pid) && Date.now() < until) {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
 afterEach(() => {
   vi.useRealTimers();
   while (registries.length > 0) registries.pop()?.disposeAll();
@@ -47,13 +59,15 @@ describe('idle reclaim', () => {
     const pid = session.pid;
     expect(alive(pid)).toBe(true);
 
-    // One millisecond short of the threshold is still a live session.
-    expect(reclaimIdleSessions(session.lastUsed + IDLE_TIMEOUT_MS - 1)).toBe(0);
+    // One millisecond short of the threshold is still a live session. Counted
+    // through the registry, not the process-wide entry point, so a registry
+    // another test forgot to dispose cannot skew the number.
+    expect(registry.reclaimIdle(session.lastUsed + IDLE_TIMEOUT_MS - 1)).toBe(0);
     expect(session.dead).toBe(false);
 
-    expect(reclaimIdleSessions(session.lastUsed + IDLE_TIMEOUT_MS)).toBe(1);
+    expect(registry.reclaimIdle(session.lastUsed + IDLE_TIMEOUT_MS)).toBe(1);
     expect(session.dead).toBe(true);
-    await new Promise((r) => setTimeout(r, 300));
+    await waitForExit(pid);
     expect(alive(pid)).toBe(false);
   }, 20_000);
 
@@ -72,6 +86,37 @@ describe('idle reclaim', () => {
     expect(outcome.result?.text).toContain('undefined');
   }, 20_000);
 
+  it('still explains itself after repl_sessions has listed the connection', async () => {
+    // Regression: `list()` used to DELETE dead sessions, so a repl_sessions
+    // call landing between the reclaim and the next repl_run threw away the
+    // reason and the agent got a silently empty runtime instead of a warning.
+    const registry = makeRegistry();
+    const first = registry.acquire('default', os.tmpdir());
+    await first.session.run('let doomed = 1;', 5000);
+    registry.reclaimIdle(Date.now() + IDLE_TIMEOUT_MS);
+
+    expect(registry.list().map((s) => s.name)).toEqual([]);
+    expect(registry.get('default')).toBeUndefined();
+
+    const second = registry.acquire('default', os.tmpdir());
+    expect(second.created).toBe(true);
+    expect(second.previousDeath).toBe('idle for 15 minutes');
+  }, 20_000);
+
+  it('does not let corpses occupy the per-connection session cap', async () => {
+    const registry = makeRegistry();
+    const { session } = registry.acquire('default', os.tmpdir());
+    await session.run('1', 5000);
+    registry.reclaimIdle(Date.now() + IDLE_TIMEOUT_MS);
+
+    // Four fresh sessions must still fit beside the corpse.
+    for (let i = 0; i < 4; i++) registry.acquire(`live${i}`, os.tmpdir());
+    expect(registry.liveCount).toBe(4);
+    expect(() => registry.acquire('one-too-many', os.tmpdir())).toThrow(
+      /already holds 4 REPL sessions/,
+    );
+  }, 30_000);
+
   it('spares a session that is still running code', async () => {
     const registry = makeRegistry();
     const { session } = registry.acquire('default', os.tmpdir());
@@ -83,7 +128,7 @@ describe('idle reclaim', () => {
     const inFlight = session.run('await new Promise((r) => setTimeout(r, 1500)); "done"', 10_000);
     await new Promise((r) => setTimeout(r, 200));
     expect(session.busy).toBe(true);
-    expect(reclaimIdleSessions(Date.now() + 10 * IDLE_TIMEOUT_MS)).toBe(0);
+    expect(registry.reclaimIdle(Date.now() + 10 * IDLE_TIMEOUT_MS)).toBe(0);
     expect(session.dead).toBe(false);
 
     const outcome = await inFlight;
@@ -99,7 +144,10 @@ describe('idle reclaim', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const registry = makeRegistry();
     const { session } = registry.acquire('default', os.tmpdir());
-    await session.run('let stale = 1;', 5000);
+    // A generous per-run timeout: under shouldAdvanceTime the hard deadline
+    // burns real seconds, and a slow runner must not turn this into a hard-kill
+    // death that masquerades as the reclaim being asserted.
+    await session.run('let stale = 1;', 60_000);
     const pid = session.pid;
     expect(session.dead).toBe(false);
 
@@ -108,21 +156,27 @@ describe('idle reclaim', () => {
 
     expect(session.dead).toBe(true);
     expect(session.diedBecause).toBe('idle for 15 minutes');
-    await new Promise((r) => setTimeout(r, 300));
+    await waitForExit(pid);
     expect(alive(pid)).toBe(false);
   }, 20_000);
 });
 
 describe('the sweep timer', () => {
   it("is one per process, unref'd, and released with the last registry", () => {
-    const a = new ReplRegistry();
+    // A registry alone arms nothing: a connection that only ever ran
+    // repl_sessions should not carry a sixty-second wakeup for its lifetime.
+    expect(idleSweepTimerForTest()).toBeNull();
+    const a = makeRegistry();
+    a.acquire('default', os.tmpdir());
     const timer = idleSweepTimerForTest();
     expect(timer).not.toBeNull();
     // Waiting out an idle REPL is not work worth keeping the MCP server alive
     // for: a ref'd interval would stop the process ever exiting on its own.
     expect(timer?.hasRef()).toBe(false);
 
-    const b = new ReplRegistry();
+    const b = makeRegistry();
+    b.acquire('default', os.tmpdir());
+    b.acquire('second', os.tmpdir());
     // One interval for the process, not one per registry — and emphatically
     // not one per session.
     expect(idleSweepTimerForTest()).toBe(timer);
@@ -131,7 +185,7 @@ describe('the sweep timer', () => {
     expect(idleSweepTimerForTest()).toBe(timer);
     b.disposeAll();
     expect(idleSweepTimerForTest()).toBeNull();
-  });
+  }, 20_000);
 });
 
 describe('repl_sessions idle reporting', () => {

--- a/src/mcp/repl/__tests__/replSession.runtime.test.ts
+++ b/src/mcp/repl/__tests__/replSession.runtime.test.ts
@@ -15,8 +15,8 @@ import { ReplSession, buildReplChildEnv } from '../ReplSession';
 
 const live: ReplSession[] = [];
 
-function makeSession(cwd = os.tmpdir(), idleMs = 60_000): ReplSession {
-  const session = new ReplSession({ name: 'test', cwd, idleMs });
+function makeSession(cwd = os.tmpdir()): ReplSession {
+  const session = new ReplSession({ name: 'test', cwd });
   live.push(session);
   return session;
 }

--- a/src/mcp/repl/replRegistry.ts
+++ b/src/mcp/repl/replRegistry.ts
@@ -22,6 +22,22 @@ export const MAX_SESSIONS_PER_CONNECTION = 4;
  */
 export const IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 /**
+ * How often the process looks for sessions to reclaim.
+ *
+ * ONE interval for the whole process, not one timer per session: the broker
+ * hosts N connections holding up to four sessions each, and a timer per session
+ * is N x 4 handles on the event loop to enforce a single coarse deadline. The
+ * cost of the coarse tick is that a session can outlive its idle deadline by up
+ * to one interval, which is noise against a fifteen-minute threshold.
+ */
+export const IDLE_SWEEP_INTERVAL_MS = 60 * 1000;
+/**
+ * Why a reclaimed session's state is gone. Written once here because the next
+ * `repl_run` reads it back out through `previousDeath` and tells the caller —
+ * a reclaimed session must never look like a silently fresh one.
+ */
+const IDLE_DEATH_REASON = `idle for ${Math.round(IDLE_TIMEOUT_MS / 60000)} minutes`;
+/**
  * Ceiling on live children across the WHOLE process.
  *
  * The per-connection cap alone is not a limit in the broker: it hosts N agents
@@ -54,11 +70,47 @@ function processLiveSessions(): number {
   return total;
 }
 
+/** The one sweep for this process, started with the first registry. */
+let sweepTimer: NodeJS.Timeout | null = null;
+
+function startSweepTimer(): void {
+  if (sweepTimer) return;
+  sweepTimer = setInterval(() => reclaimIdleSessions(), IDLE_SWEEP_INTERVAL_MS);
+  // An idle REPL waiting to be reaped is not work worth keeping the MCP server
+  // alive for. Without this the sweep would hold the event loop open forever
+  // and the process would never exit on its own.
+  sweepTimer.unref?.();
+}
+
+function stopSweepTimerWhenUnused(): void {
+  if (sweepTimer && liveRegistries.size === 0) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
+
+/**
+ * Kill every child whose session has gone quiet for longer than the threshold.
+ * Returns how many were reclaimed. `now` is injectable so a test can age
+ * sessions without aging the child processes it is testing against.
+ */
+export function reclaimIdleSessions(now: number = Date.now()): number {
+  let reclaimed = 0;
+  for (const registry of liveRegistries) reclaimed += registry.reclaimIdle(now);
+  return reclaimed;
+}
+
+/** The sweep handle, for the test that asserts it does not hold the loop open. */
+export function idleSweepTimerForTest(): NodeJS.Timeout | null {
+  return sweepTimer;
+}
+
 export class ReplRegistry {
   private readonly sessions = new Map<string, ReplSession>();
 
   constructor() {
     liveRegistries.add(this);
+    startSweepTimer();
   }
 
   /** Sessions this registry currently holds whose child is still alive. */
@@ -108,7 +160,7 @@ export class ReplRegistry {
       );
     }
 
-    const session = new ReplSession({ name, cwd, idleMs: IDLE_TIMEOUT_MS });
+    const session = new ReplSession({ name, cwd });
     this.sessions.set(name, session);
     return { session, created: true, previousDeath };
   }
@@ -129,6 +181,32 @@ export class ReplRegistry {
     }
     this.sessions.clear();
     liveRegistries.delete(this);
+    stopSweepTimerWhenUnused();
+  }
+
+  /**
+   * Kill the children of sessions that have gone quiet, and leave the corpses
+   * in the map.
+   *
+   * Deleting the entry here would be the obvious tidier move and is exactly
+   * wrong: `acquire` reads the dead session's `diedBecause` to tell the next
+   * caller WHY its variables are gone, and an entry deleted by the sweep would
+   * make a reclaimed session indistinguishable from one that never existed. The
+   * corpse is a few hundred bytes and the next `acquire`/`list` drops it; the
+   * forty megabytes this is actually about died with the child.
+   *
+   * A busy session is spared no matter how stale `lastUsed` looks: it is mid-
+   * eval, and an eval may legitimately run for the full five-minute ceiling.
+   */
+  reclaimIdle(now: number): number {
+    let reclaimed = 0;
+    for (const session of this.sessions.values()) {
+      if (session.dead || session.busy) continue;
+      if (now - session.lastUsed < IDLE_TIMEOUT_MS) continue;
+      session.destroy(IDLE_DEATH_REASON);
+      reclaimed++;
+    }
+    return reclaimed;
   }
 
   /** Forget sessions whose child is already gone (idle reap, crash, kill). */

--- a/src/mcp/repl/replRegistry.ts
+++ b/src/mcp/repl/replRegistry.ts
@@ -96,7 +96,17 @@ function stopSweepTimerWhenUnused(): void {
  */
 export function reclaimIdleSessions(now: number = Date.now()): number {
   let reclaimed = 0;
-  for (const registry of liveRegistries) reclaimed += registry.reclaimIdle(now);
+  for (const registry of liveRegistries) {
+    // Per registry, because this runs on an interval callback in the broker:
+    // an exception escaping here is an uncaughtException that takes down every
+    // agent's connection, and it would also skip the registries after it in
+    // the iteration. One connection's bad session is not the others' problem.
+    try {
+      reclaimed += registry.reclaimIdle(now);
+    } catch {
+      /* a session that will not die is not worth the whole process */
+    }
+  }
   return reclaimed;
 }
 
@@ -110,7 +120,6 @@ export class ReplRegistry {
 
   constructor() {
     liveRegistries.add(this);
-    startSweepTimer();
   }
 
   /** Sessions this registry currently holds whose child is still alive. */
@@ -120,15 +129,25 @@ export class ReplRegistry {
     return count;
   }
 
-  /** Live sessions, oldest first. Dead ones are swept as they are noticed. */
+  /**
+   * Live sessions, oldest first.
+   *
+   * Dead ones are FILTERED, not deleted. Deleting here is what a tidier reading
+   * suggests and it silently breaks the contract next door: `acquire` reads a
+   * dead session's `diedBecause` to tell the caller why its variables are gone,
+   * so a `repl_sessions` call between the reclaim and the next `repl_run` would
+   * swallow the explanation and hand back a fresh runtime as if nothing had
+   * happened.
+   */
   list(): ReplSession[] {
     this.sweep();
-    return [...this.sessions.values()];
+    return [...this.sessions.values()].filter((session) => !session.dead);
   }
 
   get(name: string): ReplSession | undefined {
     this.sweep();
-    return this.sessions.get(name);
+    const session = this.sessions.get(name);
+    return session && !session.dead ? session : undefined;
   }
 
   /**
@@ -147,10 +166,14 @@ export class ReplRegistry {
     if (existing) this.sessions.delete(name);
     this.sweep();
 
-    if (this.sessions.size >= MAX_SESSIONS_PER_CONNECTION) {
+    // Live sessions, not map entries: the map also holds reclaimed corpses,
+    // and letting those occupy the cap would refuse a caller a runtime on
+    // behalf of sessions that no longer exist.
+    const live = [...this.sessions.values()].filter((session) => !session.dead);
+    if (live.length >= MAX_SESSIONS_PER_CONNECTION) {
       throw new Error(
         `this connection already holds ${MAX_SESSIONS_PER_CONNECTION} REPL sessions ` +
-          `(${[...this.sessions.keys()].join(', ')}). Call repl_reset on one before starting another.`,
+          `(${live.map((session) => session.name).join(', ')}). Call repl_reset on one before starting another.`,
       );
     }
     if (processLiveSessions() >= MAX_SESSIONS_PER_PROCESS) {
@@ -162,6 +185,13 @@ export class ReplRegistry {
 
     const session = new ReplSession({ name, cwd });
     this.sessions.set(name, session);
+    // Re-assert membership rather than relying on the constructor's: a registry
+    // that was disposed and then used again would otherwise hold a child no
+    // sweep can see and no host-wide count knows about. Arming the sweep here
+    // and not in the constructor also keeps a connection that only ever called
+    // repl_sessions from carrying a sixty-second wakeup for nothing.
+    liveRegistries.add(this);
+    startSweepTimer();
     return { session, created: true, previousDeath };
   }
 
@@ -209,11 +239,19 @@ export class ReplRegistry {
     return reclaimed;
   }
 
-  /** Forget sessions whose child is already gone (idle reap, crash, kill). */
+  /**
+   * Drop corpses the caller can no longer plausibly be told about.
+   *
+   * A dead session is kept ON PURPOSE — `acquire` reads its `diedBecause`. But
+   * session names are the caller's to invent, so an agent that never reuses one
+   * would grow this map without bound. Keep as many corpses as there are live
+   * slots and drop the rest, oldest first (the Map iterates in insertion
+   * order).
+   */
   private sweep(): void {
-    for (const [name, session] of this.sessions) {
-      if (session.dead) this.sessions.delete(name);
-    }
+    const dead = [...this.sessions.entries()].filter(([, session]) => session.dead);
+    const excess = dead.length - MAX_SESSIONS_PER_CONNECTION;
+    for (let i = 0; i < excess; i++) this.sessions.delete(dead[i][0]);
   }
 }
 

--- a/src/mcp/repl/tools.ts
+++ b/src/mcp/repl/tools.ts
@@ -232,6 +232,12 @@ export function createReplToolCatalog(): readonly WmuxToolSpec[] {
           `${s.evals} run(s)`,
           `up ${formatDuration(now - s.createdAt)}`,
           `idle ${formatDuration(now - s.lastUsed)}`,
+          // Runtime output, not schema: the countdown an agent needs to decide
+          // whether its runtime will still be there costs nothing in tools/list.
+          // Busy sessions are spared by the sweep, so no countdown applies.
+          s.busy
+            ? 'reclaim held while busy'
+            : `reclaim in ${formatDuration(Math.max(0, IDLE_TIMEOUT_MS - (now - s.lastUsed)))}`,
           s.cwd,
         ].join(' · '),
       );

--- a/src/mcp/repl/tools.ts
+++ b/src/mcp/repl/tools.ts
@@ -20,6 +20,7 @@ import {
 } from '../toolCatalog';
 import {
   DEFAULT_SESSION_NAME,
+  IDLE_SWEEP_INTERVAL_MS,
   IDLE_TIMEOUT_MS,
   MAX_SESSIONS_PER_CONNECTION,
   getReplRegistry,
@@ -217,7 +218,11 @@ export function createReplToolCatalog(): readonly WmuxToolSpec[] {
       const sessions = getReplRegistry().list();
       const header =
         `REPL sessions are scoped to this MCP connection, capped at ${MAX_SESSIONS_PER_CONNECTION}, ` +
-        `and reaped after ${Math.round(IDLE_TIMEOUT_MS / 60000)} minutes idle.`;
+        `and reaped after ${Math.round(IDLE_TIMEOUT_MS / 60000)} minutes idle ` +
+        // Say the granularity rather than let the per-row countdown imply a
+        // precision it does not have: the sweep is coarse, so a row reading
+        // "reclaim in 0s" still has up to one interval left to live.
+        `(checked every ${Math.round(IDLE_SWEEP_INTERVAL_MS / 1000)}s).`;
       if (sessions.length === 0) {
         return text(`No REPL sessions running.\n${header}`);
       }


### PR DESCRIPTION
## Why

`repl_run` spawns a Node child per session and holds it for the life of the MCP connection. This repo has a measurement of what that costs at scale — eleven resident stdio MCP children at 433 MB of private memory (`docs/design/mcp-vnext-2026-07-28.md:74-76`) — so process count is an axis that actually hurts. Agents are about to start using the REPL as a primary tool.

Idle enforcement already existed, as a per-session `setTimeout`. This replaces it with one sweep and fixes a real bug in the old shape.

## What changed

**One sweep, not N timers.** The broker hosts N connections holding up to four sessions each, so the old design put N×4 handles on the event loop to enforce a single coarse deadline. There is now one `setInterval` for the whole process, `unref()`'d so it never keeps the server alive, armed with the first session and released with the last registry.

**A busy session is no longer killed by its own idle deadline.** The old per-session timer was armed when an eval *finished* and kept ticking while the session was `busy`. A session idle for fourteen minutes that then started a five-minute eval (the documented ceiling) was SIGKILLed mid-flight by a deadline it was no longer idle for, losing state the caller was actively using. The sweep skips busy sessions.

**A reclaimed session still explains itself.** The sweep kills the child but leaves the dead session in the map, so the next `repl_run` reads `diedBecause` and reports `the previous "default" runtime is gone (idle for 15 minutes); this is a fresh one with no state` — the same field and phrasing the hard-kill and crash paths already use. No new vocabulary. `list()`/`get()` filter dead sessions instead of deleting them, because deleting is what swallowed the explanation when a `repl_sessions` call landed between the reclaim and the next run; the per-connection cap counts live sessions so a corpse cannot refuse a caller a runtime, and `sweep()` bounds corpses at the number of live slots since session names are the caller's to invent.

**`repl_sessions` shows the countdown.** Each row gains `reclaim in 12m4s` (or `reclaim held while busy`), and the header names the sweep granularity so the countdown does not imply a precision it lacks.

Threshold is 15 minutes, unchanged from what shipped, and there is no configuration — one constant.

## tools/list budget

**Zero bytes.** The countdown is runtime output, not schema, so no description or input schema changed. `full` stays at 74,119 / 75,000 B with an identical `wireResultSha256`, so no baseline profile needed updating. `npm run build:mcp && npm run probe:mcp` both green.

## Tests

New `src/mcp/repl/__tests__/replIdleReclaim.test.ts`, all against real spawned children:

- an idle session's child is actually killed, and one millisecond short of the threshold it is not
- the next `repl_run` names the reason instead of quietly respawning
- the explanation survives an intervening `repl_sessions` call (regression)
- corpses do not occupy the per-connection cap
- a session still running code is spared
- the sweep fires on its own interval under `vi.useFakeTimers`, and the reason is the idle one
- the interval is one per process, `unref()`'d, and released with the last registry
- `repl_sessions` renders both the countdown and the busy case

`npx tsc --noEmit`, `npx eslint src/mcp/repl`, and `npx vitest run src/mcp` (729 tests) are green.

## Dogfood

A standalone script against the compiled bundle, spawning real children:

```
child pid 63256 -> 63256  46672 /Users/.../node        # ~45 MB resident

=== 2. repl_sessions ===
default · pid 63256 · idle · 1 run(s) · up 0s · idle 0s · reclaim in 15m0s · /var/.../T
REPL sessions are ... reaped after 15 minutes idle (checked every 60s).

=== 3. sweep ===
reclaimIdleSessions() reclaimed 1 session(s)
child pid 63256 still alive? false  -> (no such process)

=== 3b. an intervening repl_sessions must not eat the explanation ===
No REPL sessions running.

=== 4. the next repl_run ===
note: the previous "default" runtime is gone (idle for 15 minutes); this is a fresh one with no state
--- result ---
'undefined'

=== 5. sweep timer ===
sweep interval present: true, hasRef(): false
```

The script exits on its own with the sweep still armed, which is the point of the `unref()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Idle REPL sessions are automatically reclaimed after 15 minutes to reduce resource usage.
  * `repl_sessions` now shows each session’s remaining time before reclamation.
  * Busy sessions display that reclamation is temporarily paused.
* **Bug Fixes**
  * Long-running evaluations are no longer terminated by idle-session cleanup.
  * When reclaimed state is accessed again, `repl_run` explains that the session was idle for 15 minutes instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->