### PR TITLE
fix(daemon): identify the daemon by its argv entry script — the #1027 redo (#1025)

### DIFF
--- a/changelog.d/1132.md
+++ b/changelog.d/1132.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- wmux could SIGKILL an unrelated program that happened to be running a
+  script at `.../daemon/index.js` if the operating system had recycled the
+  daemon's process id onto it. The daemon is now identified by the exact
+  entry script wmux itself launches (compared at the argv entry position),
+  and when that identity cannot be proven, wmux asks before cleaning up and
+  spawning — it no longer risks starting a second daemon over a live one.
+  (#1025, #1132; redo of the reverted #1027 per #1028)

--- a/changelog.d/1132.md
+++ b/changelog.d/1132.md
@@ -7,3 +7,10 @@
   and when that identity cannot be proven, wmux asks before cleaning up and
   spawning — it no longer risks starting a second daemon over a live one.
   (#1025, #1132; redo of the reverted #1027 per #1028)
+- On macOS, wmux failed to recognize its own daemon when the app was
+  installed under a path containing a space (for example `wmux 2.app`, the
+  name macOS gives a second copy): the process listing joins arguments with
+  spaces, so the executable path itself arrived shattered and the daemon's
+  identity could never be proven — leaving that user with a confirmation
+  dialog on every launch. The executable is now read separately and kept
+  whole, so the daemon identifies correctly. (#1132)

--- a/src/main/daemon/launcher.ts
+++ b/src/main/daemon/launcher.ts
@@ -15,8 +15,8 @@ import {
   pollDaemonReady,
   isDaemonPipeGone,
   ensureDaemon as ensureDaemonCore,
-  killDaemonByPidFile,
-  killVerifiedDaemonPid,
+  killDaemonByPidFile as killDaemonByPidFileCore,
+  killVerifiedDaemonPid as killVerifiedDaemonPidCore,
   type DaemonInfo,
   type DaemonLauncherDeps,
   type ProcessLiveness,
@@ -48,8 +48,6 @@ export {
   DAEMON_READY_HARD_CEILING_MS,
   pollDaemonReady,
   isDaemonPipeGone,
-  killDaemonByPidFile,
-  killVerifiedDaemonPid,
 };
 export type {
   DaemonInfo,
@@ -143,6 +141,29 @@ function resolveDaemonScriptCandidates(): string[] {
     path.join(projectRoot, 'dist', 'daemon', 'daemon', 'index.js'),
     path.join(projectRoot, 'dist', 'daemon', 'index.js'),
   ];
+}
+
+/**
+ * #1025/#1028 — the kill gate identifies a PID by comparing its argv entry
+ * script against the exact daemon scripts this host would spawn, so both
+ * kill entry points hand the resolver's answer down. #1027 called the
+ * resolver OUTSIDE the core's try/catch, so a throwing app.getAppPath()
+ * would have crashed a path documented as "never throws"; here a resolver
+ * failure degrades to the exact-shape fallback (no candidates) instead.
+ */
+function safeScriptCandidates(): string[] {
+  try { return resolveDaemonScriptCandidates(); } catch { return []; }
+}
+
+export function killDaemonByPidFile(): boolean {
+  return killDaemonByPidFileCore(safeScriptCandidates());
+}
+
+export function killVerifiedDaemonPid(
+  pid: number,
+  opts: { definitiveOnly: boolean },
+): boolean {
+  return killVerifiedDaemonPidCore(pid, { ...opts, scriptCandidates: safeScriptCandidates() });
 }
 
 const electronDeps: DaemonLauncherDeps = {

--- a/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
+++ b/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { spawn, type ChildProcess } from 'child_process';
 import {
   argvIdentifiesDaemonScript,
+  psArgvFromCommand,
   killVerifiedDaemonPid,
   ensureDaemon,
   type DaemonLauncherDeps,
@@ -95,6 +96,44 @@ describe('argvIdentifiesDaemonScript — unit (#1025/#1028)', () => {
       ['/usr/bin/node', '/opt/wmux/daemon-bundle/other.js'],
       [],
     )).toBe(false);
+  });
+
+  it('#1132: a macOS install whose EXECUTABLE and script both fragment still matches', () => {
+    // Real dogfood argv from `/Applications/wmux 2.app` — the name macOS
+    // gives a second copy. `ps -o comm=` anchors argv[0] whole, so only the
+    // script fragments and the progressive re-join reaches the candidate.
+    const exe = '/Applications/wmux 2.app/Contents/MacOS/wmux';
+    const script = '/Applications/wmux 2.app/Contents/Resources/daemon-bundle/index.js';
+    const argv = psArgvFromCommand(`${exe} ${script}`, exe);
+    expect(argv).toEqual([exe, '/Applications/wmux', '2.app/Contents/Resources/daemon-bundle/index.js']);
+    expect(argvIdentifiesDaemonScript(argv!, [script])).toBe(true);
+  });
+
+  it('#1132: the trailing-argument case stays false through the same probe path', () => {
+    // Requirement 1 re-checked against comm-anchored argv: our script as a
+    // mere argument must still not verify the process.
+    const argv = psArgvFromCommand(
+      '/usr/bin/node /srv/other-tool/main.js /opt/wmux/dist/daemon-bundle/index.js',
+      '/usr/bin/node',
+    );
+    expect(argvIdentifiesDaemonScript(argv!, ['/opt/wmux/dist/daemon-bundle/index.js'])).toBe(false);
+    // ...and with a fragmented executable in front of it too.
+    const spacedExe = '/Applications/evil 2.app/Contents/MacOS/node';
+    const argv2 = psArgvFromCommand(
+      `${spacedExe} /srv/other-tool/main.js /opt/wmux/dist/daemon-bundle/index.js`,
+      spacedExe,
+    );
+    expect(argvIdentifiesDaemonScript(argv2!, ['/opt/wmux/dist/daemon-bundle/index.js'])).toBe(false);
+  });
+
+  it('#1132: psArgvFromCommand falls back to whitespace tokens without a usable comm', () => {
+    expect(psArgvFromCommand('/usr/bin/node /x/index.js', '')).toEqual(['/usr/bin/node', '/x/index.js']);
+    // comm that is not the line's prefix (argv[0] rewritten) must not be forced on.
+    expect(psArgvFromCommand('/usr/bin/node /x/index.js', '/other/bin/node'))
+      .toEqual(['/usr/bin/node', '/x/index.js']);
+    expect(psArgvFromCommand('   ', '/usr/bin/node')).toBe(null);
+    expect(psArgvFromCommand('/Applications/wmux 2.app/Contents/MacOS/wmux', '/Applications/wmux 2.app/Contents/MacOS/wmux'))
+      .toEqual(['/Applications/wmux 2.app/Contents/MacOS/wmux']);
   });
 
   it('no entry script (flags only, or bare executable) never matches', () => {

--- a/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
+++ b/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn, type ChildProcess } from 'child_process';
+import {
+  argvIdentifiesDaemonScript,
+  killVerifiedDaemonPid,
+  ensureDaemon,
+  type DaemonLauncherDeps,
+} from '../daemonLauncherCore';
+
+/**
+ * #1025 redo (#1028) — the four requirements, each pinned here:
+ *
+ *  1. Entry-script POSITION comparison, not any-token: our script path as a
+ *     mere argument must not verify the process as the daemon.
+ *  2. argv preserved as an array (NUL-split /proc cmdline on Linux; the
+ *     progressive re-join covers space-joined `ps` output elsewhere).
+ *  3. The cross-host fallback is an exclusive branch with an EXACT shape
+ *     (`daemon-bundle/index.js`), so `daemon-bundler` / `daemon-bundle-backup`
+ *     no longer match via startsWith.
+ *  4. ensureDaemon's cmdline-mismatch branch REFUSES (or asks) instead of
+ *     cleaning + spawning over a possibly-live daemon (#537/#543 shape).
+ *
+ * #1027's test flaw ("injected candidates by hand, leaving the actual new
+ * wiring unexercised") is answered by the ensureDaemon tests below, which
+ * reach the matcher through `deps.resolveDaemonScriptCandidates` — the real
+ * wiring — and by the execution tests, which assert on real OS probes.
+ */
+describe('argvIdentifiesDaemonScript — unit (#1025/#1028)', () => {
+  it('matches a candidate at the entry position', () => {
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/opt/wmux/dist/daemon/index.js'],
+      ['/opt/wmux/dist/daemon/index.js'],
+    )).toBe(true);
+  });
+
+  it('skips runtime flags when locating the entry script', () => {
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '--max-old-space-size=4096', '/opt/wmux/dist/daemon/index.js'],
+      ['/opt/wmux/dist/daemon/index.js'],
+    )).toBe(true);
+  });
+
+  it('requirement 1: a candidate path in a NON-entry argument does not match (the vim case)', () => {
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/srv/other-tool/main.js', '/opt/wmux/dist/daemon-bundle/index.js'],
+      ['/opt/wmux/dist/daemon-bundle/index.js'],
+    )).toBe(false);
+  });
+
+  it('requirement 2 corollary: a space-shattered POSIX line re-joins against a known candidate', () => {
+    // macOS `ps` output for an install under "/Applications/wmux 2.app/...":
+    // the path arrives as two whitespace tokens. The exact candidate is
+    // known, so the progressive re-join recovers the identity.
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/Applications/wmux', '2.app/daemon-bundle/index.js'],
+      ['/Applications/wmux 2.app/daemon-bundle/index.js'],
+    )).toBe(true);
+  });
+
+  it('the #1025 bug stays dead: a generic daemon/index.js layout never matches', () => {
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/srv/someones-app/daemon/index.js'],
+      [],
+    )).toBe(false);
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/srv/someones-app/daemon/index.js'],
+      ['/opt/wmux/dist/daemon/index.js'],
+    )).toBe(false);
+  });
+
+  it('cross-host fallback: exact daemon-bundle/index.js shape matches with no candidates', () => {
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/other-host-node', '/opt/wmux/resources/daemon-bundle/index.js'],
+      [],
+    )).toBe(true);
+  });
+
+  it('requirement 3: suffixed directory names no longer match (startsWith is gone)', () => {
+    for (const dir of ['daemon-bundler', 'daemon-bundle-backup', 'my-daemon-bundle']) {
+      expect(argvIdentifiesDaemonScript(
+        ['/usr/bin/node', `/srv/${dir}/index.js`],
+        [],
+      )).toBe(false);
+    }
+    // A single segment merely CONTAINING the marker is not the shape either.
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/tmp/daemon-bundle-fake-index.js'],
+      [],
+    )).toBe(false);
+    // Right directory, wrong entry file.
+    expect(argvIdentifiesDaemonScript(
+      ['/usr/bin/node', '/opt/wmux/daemon-bundle/other.js'],
+      [],
+    )).toBe(false);
+  });
+
+  it('no entry script (flags only, or bare executable) never matches', () => {
+    expect(argvIdentifiesDaemonScript(['/usr/bin/node', '--version'], ['/x/index.js'])).toBe(false);
+    expect(argvIdentifiesDaemonScript(['/usr/bin/node'], ['/x/index.js'])).toBe(false);
+    expect(argvIdentifiesDaemonScript([], ['/x/index.js'])).toBe(false);
+  });
+
+  it.runIf(process.platform === 'win32')('win32: backslashes and case fold for comparison', () => {
+    expect(argvIdentifiesDaemonScript(
+      ['C:\\wmux\\wmux.exe', 'C:\\Wmux\\Resources\\Daemon-Bundle\\Index.js'],
+      ['c:/wmux/resources/daemon-bundle/index.js'],
+    )).toBe(true);
+  });
+});
+
+describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
+  let tmpDir = '';
+  let child: ChildProcess | null = null;
+
+  afterEach(async () => {
+    if (child && child.pid && child.exitCode === null) {
+      try { process.kill(child.pid, 'SIGKILL'); } catch { /* already gone */ }
+      await new Promise<void>((resolve) => {
+        if (!child) return resolve();
+        child.once('exit', () => resolve());
+        setTimeout(resolve, 2000);
+      });
+    }
+    child = null;
+    if (tmpDir) {
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        try { fs.rmSync(tmpDir, { recursive: true, force: true }); break; }
+        catch { await new Promise((resolve) => setTimeout(resolve, 200)); }
+      }
+      tmpDir = '';
+    }
+  });
+
+  async function spawnSleeper(scriptPath: string, extraArgs: string[] = []): Promise<number> {
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, 'setTimeout(() => {}, 30000);\n');
+    child = spawn(process.execPath, [scriptPath, ...extraArgs], { stdio: 'ignore' });
+    expect(child.pid).toBeTruthy();
+    // Let the OS register the PID before tasklist/ps is asked about it.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return child.pid as number;
+  }
+
+  function isAlive(pid: number): boolean {
+    try { process.kill(pid, 0); return true; } catch { return false; }
+  }
+
+  it('refuses an unrelated process whose argv merely ends in daemon/index.js (the #1025 repro)', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-innocent-'));
+    // Somebody else's program, using the same everyday layout. The image
+    // matches too (both plain node), so the argv gate is the ONLY thing
+    // standing between this process and a SIGKILL.
+    const pid = await spawnSleeper(path.join(tmpDir, 'someone-elses-app', 'daemon', 'index.js'));
+
+    expect(killVerifiedDaemonPid(pid, { definitiveOnly: false })).toBe(false);
+    expect(killVerifiedDaemonPid(pid, {
+      definitiveOnly: false,
+      scriptCandidates: [path.join(tmpDir, 'unrelated', 'daemon-bundle', 'index.js')],
+    })).toBe(false);
+    expect(isAlive(pid)).toBe(true);
+  }, 15_000);
+
+  it('requirement 1, executed: our script path as a trailing ARGUMENT does not verify the process', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-arg-'));
+    const bundlePath = path.join(tmpDir, 'daemon-bundle', 'index.js');
+    // The running entry script is unrelated; the daemon-bundle path rides
+    // along as a plain argument (an editor, a build tool, a log grepper).
+    const pid = await spawnSleeper(path.join(tmpDir, 'unrelated-entry.js'), [bundlePath]);
+
+    expect(killVerifiedDaemonPid(pid, {
+      definitiveOnly: false,
+      scriptCandidates: [bundlePath],
+    })).toBe(false);
+    expect(isAlive(pid)).toBe(true);
+  }, 15_000);
+
+  it('kills a process running exactly one of the supplied candidate scripts', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-ours-'));
+    // An everyday layout that the fallback shape does NOT accept — only the
+    // candidate identity can clear it, which is the point.
+    const scriptPath = path.join(tmpDir, 'dist', 'daemon', 'index.js');
+    const pid = await spawnSleeper(scriptPath);
+
+    expect(killVerifiedDaemonPid(pid, {
+      definitiveOnly: false,
+      scriptCandidates: [path.join(tmpDir, 'dist', 'daemon-bundle', 'index.js'), scriptPath],
+    })).toBe(true);
+  }, 15_000);
+
+  it('requirement 3, executed: daemon-bundler/index.js is refused, daemon-bundle/index.js is killed', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-shape-'));
+    const bundlerPid = await spawnSleeper(path.join(tmpDir, 'daemon-bundler', 'index.js'));
+    expect(killVerifiedDaemonPid(bundlerPid, { definitiveOnly: false })).toBe(false);
+    expect(isAlive(bundlerPid)).toBe(true);
+    try { process.kill(bundlerPid, 'SIGKILL'); } catch { /* cleanup */ }
+
+    const exactPid = await spawnSleeper(path.join(tmpDir, 'daemon-bundle', 'index.js'));
+    expect(killVerifiedDaemonPid(exactPid, { definitiveOnly: false })).toBe(true);
+  }, 20_000);
+});
+
+describe('ensureDaemon — cmdline-mismatch branch refuses instead of cleaning (#1028 requirement 4)', () => {
+  let wmuxDir: string;
+  let prevSuffix: string | undefined;
+  let suffix: string;
+  let tmpDir = '';
+  let child: ChildProcess | null = null;
+
+  beforeEach(() => {
+    // Same isolation as daemonLauncherCore.deps.test.ts: a per-run
+    // WMUX_DATA_SUFFIX keeps this away from the real ~/.wmux and any live
+    // daemon on the test box.
+    suffix = `-identity-redo-test-${process.pid}-${Math.floor(Math.random() * 1e6)}`;
+    prevSuffix = process.env.WMUX_DATA_SUFFIX;
+    process.env.WMUX_DATA_SUFFIX = suffix;
+    wmuxDir = path.join(os.homedir(), `.wmux${suffix}`);
+    fs.mkdirSync(wmuxDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (prevSuffix === undefined) delete process.env.WMUX_DATA_SUFFIX;
+    else process.env.WMUX_DATA_SUFFIX = prevSuffix;
+    if (child && child.pid && child.exitCode === null) {
+      try { process.kill(child.pid, 'SIGKILL'); } catch { /* already gone */ }
+      await new Promise<void>((resolve) => {
+        if (!child) return resolve();
+        child.once('exit', () => resolve());
+        setTimeout(resolve, 2000);
+      });
+    }
+    child = null;
+    fs.rmSync(wmuxDir, { recursive: true, force: true });
+    if (tmpDir) { fs.rmSync(tmpDir, { recursive: true, force: true }); tmpDir = ''; }
+  });
+
+  /** A live process whose image matches this test runner (plain node) but
+   *  whose argv does not identify the daemon script — the exact ambiguity
+   *  the (b) branch must no longer resolve by cleaning + spawning. */
+  async function occupyPidFile(): Promise<number> {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-ensure-'));
+    const scriptPath = path.join(tmpDir, 'innocent-app', 'daemon', 'index.js');
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
+    fs.writeFileSync(scriptPath, 'setTimeout(() => {}, 30000);\n');
+    child = spawn(process.execPath, [scriptPath], { stdio: 'ignore' });
+    expect(child.pid).toBeTruthy();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    fs.writeFileSync(path.join(wmuxDir, 'daemon.pid'), String(child.pid));
+    return child.pid as number;
+  }
+
+  function deps(overrides: Partial<DaemonLauncherDeps>): DaemonLauncherDeps {
+    return {
+      // REAL wiring under test (#1027's test flaw): the matcher receives
+      // these through deps inside ensureDaemon, not through hand-injected
+      // opts on the kill helper.
+      resolveDaemonScriptCandidates: () => [path.join(wmuxDir, 'nonexistent', 'daemon-bundle', 'index.js')],
+      resolveSpawnedByVersion: () => '9.9.9-test',
+      askUserToRecoverFromStalePid: async () => false,
+      isElectronHost: () => false,
+      ...overrides,
+    };
+  }
+
+  it('refuses by default: throws, kills nothing, deletes no state files', async () => {
+    const pid = await occupyPidFile();
+    const asked: string[] = [];
+
+    await expect(ensureDaemon(deps({
+      askUserToRecoverFromStalePid: async (opts) => { asked.push(opts.reason); return false; },
+    }))).rejects.toThrow(/does not identify the wmux daemon script/);
+
+    // The user was consulted (with the mismatch reason), the innocent
+    // process survived, and daemon.pid was NOT cleaned — nothing was
+    // spawned over a possibly-live daemon.
+    expect(asked.length).toBe(1);
+    expect(asked[0]).toContain('does not identify the wmux daemon script');
+    let alive = true;
+    try { process.kill(pid, 0); } catch { alive = false; }
+    expect(alive).toBe(true);
+    expect(fs.existsSync(path.join(wmuxDir, 'daemon.pid'))).toBe(true);
+  }, 15_000);
+
+  it('proceeds to cleanup + spawn ONLY on explicit user approval', async () => {
+    const pid = await occupyPidFile();
+
+    // Approval falls through to the stale-file cleanup + spawn; the spawn
+    // then fails on the nonexistent candidate list, which is exactly the
+    // proof that the flow moved PAST the refusal into the (approved)
+    // clean-and-spawn path — without ever killing the occupant.
+    await expect(ensureDaemon(deps({
+      askUserToRecoverFromStalePid: async () => true,
+    }))).rejects.toThrow(/Daemon script not found/);
+
+    let alive = true;
+    try { process.kill(pid, 0); } catch { alive = false; }
+    expect(alive).toBe(true);
+  }, 15_000);
+});

--- a/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
+++ b/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
@@ -132,6 +132,22 @@ describe('argvIdentifiesDaemonScript — unit (#1025/#1028)', () => {
     expect(psArgvFromCommand('/usr/bin/node /x/index.js', '/other/bin/node'))
       .toEqual(['/usr/bin/node', '/x/index.js']);
     expect(psArgvFromCommand('   ', '/usr/bin/node')).toBe(null);
+    // A TRUNCATED comm that happens to be a prefix must not cut mid-path:
+    // the remainder would not start with '/' or '-', so the strip is refused.
+    expect(psArgvFromCommand(
+      '/Applications/wmux 2.app/Contents/MacOS/wmux /Applications/wmux 2.app/x/daemon-bundle/index.js',
+      '/Applications/wmux',
+    )).toEqual([
+      '/Applications/wmux', '2.app/Contents/MacOS/wmux',
+      '/Applications/wmux', '2.app/x/daemon-bundle/index.js',
+    ]);
+    // Runtime flags after the executable are a legitimate remainder.
+    expect(psArgvFromCommand(
+      '/Applications/wmux 2.app/Contents/MacOS/wmux --max-old-space-size=4096 /a/b.js',
+      '/Applications/wmux 2.app/Contents/MacOS/wmux',
+    )).toEqual([
+      '/Applications/wmux 2.app/Contents/MacOS/wmux', '--max-old-space-size=4096', '/a/b.js',
+    ]);
     expect(psArgvFromCommand('/Applications/wmux 2.app/Contents/MacOS/wmux', '/Applications/wmux 2.app/Contents/MacOS/wmux'))
       .toEqual(['/Applications/wmux 2.app/Contents/MacOS/wmux']);
   });

--- a/src/shared/daemon/__tests__/killVerifiedDaemonPid.crossHost.test.ts
+++ b/src/shared/daemon/__tests__/killVerifiedDaemonPid.crossHost.test.ts
@@ -56,10 +56,12 @@ describe('killVerifiedDaemonPid — cross-host image mismatch (#1019)', () => {
     fs.copyFileSync(process.execPath, renamedNodePath);
     if (process.platform !== 'win32') fs.chmodSync(renamedNodePath, 0o755);
 
-    // The command line must carry a daemon-script marker for the cmdline
-    // check to accept it — 'daemon-bundle' is one of the markers this
-    // module looks for verbatim.
-    const scriptPath = path.join(tmpDir, 'daemon-bundle-fake-index.js');
+    // The command line must carry the daemon entry-script shape for the
+    // argv check to accept it — since #1025's redo that is EXACTLY
+    // `daemon-bundle/index.js` at the entry position (a suffixed variant
+    // like `daemon-bundle-fake-index.js` is somebody else's name now).
+    const scriptPath = path.join(tmpDir, 'daemon-bundle', 'index.js');
+    fs.mkdirSync(path.dirname(scriptPath), { recursive: true });
     fs.writeFileSync(scriptPath, 'setTimeout(() => {}, 30000);\n');
 
     child = spawn(renamedNodePath, [scriptPath], { stdio: 'ignore' });

--- a/src/shared/daemon/daemonLauncherCore.ts
+++ b/src/shared/daemon/daemonLauncherCore.ts
@@ -230,18 +230,55 @@ function getProcessArgv(pid: number): string[] | null {
   }
   // macOS / other POSIX without /proc: shell out to `ps`. (Codex
   // review #5 — Darwin builds need this path so the daemon verifier
-  // can confirm cmdline carries the daemon-script path.) `ps` joins argv
-  // with spaces and the boundaries are genuinely gone — tokenize on
-  // whitespace; the matcher compensates with a progressive re-join against
-  // known candidate paths, and an unprovable identity now refuses instead
-  // of cleaning (#1028).
+  // can confirm cmdline carries the daemon-script path.) `ps -o command=`
+  // joins argv with spaces and the boundaries are genuinely gone — tokenize
+  // on whitespace; the matcher compensates with a progressive re-join
+  // against known candidate paths, and an unprovable identity refuses
+  // instead of cleaning (#1028).
+  //
+  // `ps -o comm=` is asked for in the same breath because it returns the
+  // executable path on ONE line, spaces intact. Without that anchor a
+  // packaged install whose path contains a space (`/Applications/wmux
+  // 2.app/...`, the name macOS gives a second copy) shatters the EXECUTABLE
+  // too, and the re-join then starts inside the executable's tail fragment
+  // and can never reach the script — wmux stopped recognizing its own
+  // daemon (#1132). Stripping the comm prefix restores `[exe, ...rest]`.
   try {
-    const result = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'command='], {
+    const command = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'command='], {
       encoding: 'utf-8', timeout: 3000,
-    });
-    const trimmed = result.trim();
-    return trimmed.length > 0 ? tokenizeCommandLine(trimmed) : null;
+    }).trim();
+    if (command.length === 0) return null;
+    let comm = '';
+    try {
+      comm = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'comm='], {
+        encoding: 'utf-8', timeout: 3000,
+      }).trim();
+    } catch { comm = ''; }
+    return psArgvFromCommand(command, comm);
   } catch { return null; }
+}
+
+/**
+ * Rebuild argv-shaped tokens from macOS `ps` output (#1132).
+ *
+ * `command=` is argv space-joined; `comm=` is argv[0] alone, whole. When the
+ * line starts with that executable path, emit it as a SINGLE token and
+ * tokenize only what follows, so the matcher's progressive re-join begins at
+ * the real entry position instead of inside a fragment of the executable.
+ * When comm is missing or is not the line's prefix (empty output, a process
+ * that rewrote argv[0]), fall back to plain whitespace tokenization — the
+ * historical behavior, which is refuse-safe.
+ *
+ * Exported for tests only.
+ */
+export function psArgvFromCommand(command: string, comm: string): string[] | null {
+  const trimmed = command.trim();
+  if (trimmed.length === 0) return null;
+  if (comm.length > 0 && (trimmed === comm || trimmed.startsWith(`${comm} `))) {
+    const rest = trimmed.slice(comm.length).trim();
+    return rest.length > 0 ? [comm, ...tokenizeCommandLine(rest)] : [comm];
+  }
+  return tokenizeCommandLine(trimmed);
 }
 
 /** Quote-aware split of a raw command line into argv-shaped tokens, so a
@@ -291,6 +328,15 @@ function tokenizeCommandLine(cmdline: string): string[] {
  *
  * Callers that cannot supply candidates get the fallback alone — refusing
  * to kill degrades safely, a false-positive kill does not.
+ *
+ * Known limitation (#1132): the fallback inspects the entry token alone, so
+ * a CROSS-HOST daemon installed under a path containing a space still fails
+ * to prove its identity on macOS — the script fragments and no candidate is
+ * available to re-join it against. Widening the fallback to re-joined spans
+ * would re-admit #1027's third defect (`node innocent.js <our path>`), and
+ * an unproven identity refuses rather than kills, so the limitation is
+ * accepted. The identity branch — the common case, same host — is fixed by
+ * the comm anchor in `psArgvFromCommand`.
  */
 export function argvIdentifiesDaemonScript(argv: string[], scriptCandidates: string[]): boolean {
   // Windows path comparison is case-insensitive; POSIX is not, and folding

--- a/src/shared/daemon/daemonLauncherCore.ts
+++ b/src/shared/daemon/daemonLauncherCore.ts
@@ -193,7 +193,7 @@ function getProcessImageName(pid: number): string | null {
  * deprecated and this path runs at most once per ensureDaemon() call.
  * Returns null on any failure; callers must treat null as "can't verify".
  */
-function getProcessCommandLine(pid: number): string | null {
+function getProcessArgv(pid: number): string[] | null {
   if (process.platform === 'win32') {
     try {
       const systemRoot = process.env.SystemRoot || 'C:\\Windows';
@@ -211,25 +211,36 @@ function getProcessCommandLine(pid: number): string | null {
         { encoding: 'utf-8', timeout: 5000, windowsHide: true },
       );
       const trimmed = result.trim();
-      return trimmed.length > 0 ? trimmed : null;
+      // The CIM string quotes arguments that carry spaces; the quote-aware
+      // tokenizer reconstructs the exact argv.
+      return trimmed.length > 0 ? tokenizeCommandLine(trimmed) : null;
     } catch { return null; }
   }
-  // Linux: /proc/<pid>/cmdline carries the argv joined by NUL.
+  // Linux: /proc/<pid>/cmdline is argv NUL-separated — the one platform
+  // where the exact array is recoverable. #1028: joining it with spaces and
+  // re-tokenizing shattered any install path containing a space, which is
+  // what could turn wmux's OWN daemon into a "mismatch" downstream. Keep
+  // the array; never round-trip it through a space-joined string.
   if (process.platform === 'linux') {
     try {
       const raw = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
-      return raw.replace(/\0/g, ' ').trim() || null;
+      const argv = raw.split('\0').filter((part) => part.length > 0);
+      return argv.length > 0 ? argv : null;
     } catch { return null; }
   }
   // macOS / other POSIX without /proc: shell out to `ps`. (Codex
   // review #5 — Darwin builds need this path so the daemon verifier
-  // can confirm cmdline carries the daemon-script path.)
+  // can confirm cmdline carries the daemon-script path.) `ps` joins argv
+  // with spaces and the boundaries are genuinely gone — tokenize on
+  // whitespace; the matcher compensates with a progressive re-join against
+  // known candidate paths, and an unprovable identity now refuses instead
+  // of cleaning (#1028).
   try {
     const result = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'command='], {
       encoding: 'utf-8', timeout: 3000,
     });
     const trimmed = result.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    return trimmed.length > 0 ? tokenizeCommandLine(trimmed) : null;
   } catch { return null; }
 }
 
@@ -247,44 +258,69 @@ function tokenizeCommandLine(cmdline: string): string[] {
 }
 
 /**
- * Does this command line invoke one of wmux's daemon entry-script paths?
+ * Does this argv invoke one of wmux's daemon entry scripts? (#1025/#1028 redo)
  *
- * #1019 review: `.includes()` on the whole raw string has no path-boundary
- * awareness, so the bare `'daemon-bundle'` marker matches an unrelated
- * `/srv/my-daemon-bundle-backup/index.js` (that string genuinely contains
- * `daemon-bundle` as a substring) on a recycled PID. Segment-based matching
- * fixes exactly that: tokenize the cmdline (quote-aware, so a Windows path
- * with spaces in one argument isn't split apart), split each token on `/`
- * or `\`, and require the KNOWN marker to occupy its own path segment(s) —
- * `my-daemon-bundle-backup` is one segment, not two, so it can never equal
- * the segment `'daemon-bundle'` no matter what substring it contains.
+ * Decided from the ENTRY-SCRIPT POSITION, never from every token. The daemon
+ * is spawned `<node|electron> <script>` (see spawnDaemon), so the entry
+ * script is the first non-flag token after the executable. #1027's third
+ * defect was any-token comparison: `vim /path/daemon-bundle/index.js`
+ * carries our script path in argv and "verified" as the daemon.
  *
- * This does not (and cannot) resolve the adjacent, fuzzier case of a
- * genuinely unrelated program that happens to be installed at a path whose
- * LAST TWO segments are literally `daemon/index.js` — that is a real path
- * shape collision, not a substring artifact, and is accepted as a residual
- * false-positive risk the way it always has been (this marker was never the
- * only signal; image-name checks and `definitiveOnly` gate what a match is
- * allowed to authorize).
+ * Two signals, strongest first:
+ *
+ * **Identity.** `scriptCandidates` are the exact paths THIS host would spawn
+ * (`deps.resolveDaemonScriptCandidates()`). A match at the entry position is
+ * proof, not a pattern. On platforms whose probe returns a space-joined line
+ * (macOS `ps`), a path with spaces arrives shattered across tokens — so the
+ * comparison progressively re-joins tokens from the entry position, letting
+ * a known candidate still match exactly. (On Linux the probe preserves the
+ * NUL-split argv and no re-join is ever needed; on Windows the CIM command
+ * line is quoted and the tokenizer keeps spaced paths whole.)
+ *
+ * **Exclusive cross-host fallback (#1001).** A daemon spawned by the OTHER
+ * host kind (Electron vs the headless CLI) runs a script this host's
+ * candidate list cannot name. Every packaged install's entry script is
+ * `.../daemon-bundle/index.js` (package.json `build:daemon` esbuild
+ * outfile), so accept EXACTLY that shape — at the entry position only, with
+ * exact segment equality. #1027's second defect was `startsWith`: it
+ * accepted `daemon-bundler/…` and `daemon-bundle-backup/…`, which are other
+ * programs' names, not a renamed wmux directory. A cross-host DEV daemon
+ * (tsc layout, no bundle) is deliberately not covered: refusing degrades to
+ * the respawn budget, while a generic `daemon/index.js` marker is the exact
+ * false positive #1025 reproduced by execution.
+ *
+ * Callers that cannot supply candidates get the fallback alone — refusing
+ * to kill degrades safely, a false-positive kill does not.
  */
-function cmdlineMatchesDaemonScript(cmdline: string): boolean {
-  for (const token of tokenizeCommandLine(cmdline)) {
-    const segments = token.replace(/\\/g, '/').split('/').filter(Boolean);
-    for (let i = 0; i < segments.length; i++) {
-      // 'daemon-bundle' needs to START this segment, not equal it exactly —
-      // a build/test variant may suffix it (`daemon-bundle-fake-index.js`,
-      // a hashed hot-reload dir, etc), and `startsWith` still accepts that.
-      // It still rejects the false positive this fix exists for: a `my-`
-      // PREFIX before the marker (`my-daemon-bundle-backup`) fails
-      // `startsWith('daemon-bundle')`, because the marker isn't at the
-      // segment's start there — that's the actual boundary that matters,
-      // not "is this the ENTIRE segment".
-      if (segments[i].startsWith('daemon-bundle')) return true;
-      if (segments[i] === 'daemon' && segments[i + 1] === 'daemon' && segments[i + 2] === 'index.js') return true;
-      if (segments[i] === 'daemon' && segments[i + 1] === 'index.js') return true;
+export function argvIdentifiesDaemonScript(argv: string[], scriptCandidates: string[]): boolean {
+  // Windows path comparison is case-insensitive; POSIX is not, and folding
+  // case there would accept a genuinely different file.
+  const normalize = (raw: string): string => {
+    const slashed = raw.replace(/\\/g, '/');
+    return process.platform === 'win32' ? slashed.toLowerCase() : slashed;
+  };
+
+  let entryIdx = -1;
+  for (let i = 1; i < argv.length; i++) {
+    if (!argv[i].startsWith('-')) { entryIdx = i; break; }
+  }
+  if (entryIdx === -1) return false;
+
+  if (scriptCandidates.length > 0) {
+    const wanted = new Set(scriptCandidates.map(normalize));
+    let joined = '';
+    for (let k = entryIdx; k < argv.length; k++) {
+      joined = joined.length === 0 ? argv[k] : `${joined} ${argv[k]}`;
+      if (wanted.has(normalize(joined))) return true;
     }
   }
-  return false;
+
+  const segments = normalize(argv[entryIdx]).split('/').filter(Boolean);
+  return (
+    segments.length >= 2 &&
+    segments[segments.length - 2] === 'daemon-bundle' &&
+    segments[segments.length - 1] === 'index.js'
+  );
 }
 
 export interface DaemonPingResult {
@@ -966,11 +1002,12 @@ export async function ensureDaemon(deps: DaemonLauncherDeps): Promise<DaemonInfo
     //
     //   (a) Verified-daemon → kill, then spawn. Safe because we know
     //       what we're killing.
-    //   (b) Verified-stale-reuse (we are sure the PID is NOT our daemon
-    //       anymore — it's ourselves, an unrelated program, or another
-    //       Electron app whose cmdline doesn't carry the daemon script
-    //       path) → don't kill, but the stale-files cleanup + spawn
-    //       path below is safe because the actual daemon is gone.
+    //   (b) Verified-stale-reuse (the PID is provably NOT our daemon —
+    //       it's ourselves) → don't kill; the stale-files cleanup + spawn
+    //       path below is safe because the actual daemon is gone. A mere
+    //       cmdline mismatch is NOT proof since #1025's redo (#1028): an
+    //       unprovable path can be our own daemon, so that case refuses /
+    //       asks instead of cleaning.
     //   (c) Unverified-live (process is alive but we couldn't read its
     //       image or command line at all) → refuse to act. Spawning over
     //       an unverified live daemon would orphan its PTYs and produce
@@ -1037,8 +1074,8 @@ export async function ensureDaemon(deps: DaemonLauncherDeps): Promise<DaemonInfo
               `could be a daemon spawned by a different host (Electron vs headless CLI); checking cmdline before deciding`,
           );
         }
-        const cmdline = getProcessCommandLine(existingPid);
-        if (cmdline === null) {
+        const argv = getProcessArgv(existingPid);
+        if (argv === null) {
           // (c) Lookup failed — same recovery dance as the image path, and the
           // same escalated re-ping FIRST. The image already matches wmux here,
           // so a daemon that answers a ping is almost certainly the real one:
@@ -1071,12 +1108,48 @@ export async function ensureDaemon(deps: DaemonLauncherDeps): Promise<DaemonInfo
             `[launcher] user approved cleanup of unverified PID ${existingPid} (cmdline lookup failed)`,
           );
         } else {
-          const cmdlineMatches = cmdlineMatchesDaemonScript(cmdline);
+          // #1028: a resolver throw must degrade to "no candidates" (the
+          // exact-shape fallback alone), never crash the launcher — #1027
+          // called it outside every try/catch.
+          let scriptCandidates: string[] = [];
+          try { scriptCandidates = deps.resolveDaemonScriptCandidates(); } catch { /* shape-only */ }
+          const cmdlineMatches = argvIdentifiesDaemonScript(argv, scriptCandidates);
           if (!cmdlineMatches) {
-            // (b) Same image but different app (e.g. another Electron
-            // tool). Don't kill, but the cleanup path below is safe.
+            // (b) Same image, argv does not identify the daemon script.
+            // #1027's disqualifying defect lived here: under identity
+            // matching, a mismatch no longer proves "someone else's app on
+            // a recycled PID" — it can also be wmux's OWN daemon whose path
+            // this host failed to prove (a space-joined `ps` line on macOS,
+            // a throwing resolver). Cleaning + spawning on that ambiguity
+            // IS the #537/#543 split-brain. So this branch now refuses by
+            // default (#1028): escalated re-ping first — a process that
+            // answers on the authed pipe is our daemon regardless of path
+            // proof — then the user decides; cleanup happens only on
+            // explicit approval, exactly like the blocked-probe paths.
+            const outcome = await recoverFromBlockedProbe({
+              token,
+              reping: (timeoutMs) => pingDaemon(pipeName, token, timeoutMs),
+              sleep: (ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
+              askUser: () =>
+                deps.askUserToRecoverFromStalePid({
+                  reason: `PID ${existingPid} (image "${imageName}") is alive but its command line does not identify the wmux daemon script — an unrelated process on a recycled PID, or a wmux daemon whose script path could not be proven`,
+                  pid: existingPid,
+                  pidFile,
+                }),
+            });
+            if (outcome === 'reuse') {
+              (deps.log ?? console.log)(
+                `[launcher] Daemon (PID ${existingPid}) answered escalated re-ping despite an unproven cmdline — reusing, no kill`,
+              );
+              return { pid: existingPid, authToken: token, pipeName, spawned: false };
+            }
+            if (outcome === 'refuse') {
+              throw new Error(
+                `[launcher] daemon.pid=${existingPid} alive but its command line does not identify the wmux daemon script; refusing to spawn over a possibly-live daemon. Manually delete ${pidFile} if you have verified the daemon is gone (or in elevated PowerShell: taskkill /F /PID ${existingPid}).`,
+              );
+            }
             (deps.warn ?? console.warn)(
-              `[launcher] PID ${existingPid} image matches but cmdline does not reference daemon script — stale-PID reuse by sibling Electron app, cleaning + spawning fresh`,
+              `[launcher] user approved cleanup of unproven PID ${existingPid} (cmdline mismatch)`,
             );
           } else {
             // (a) Verified wmux daemon (image+cmdline match) that missed the
@@ -1285,7 +1358,7 @@ export async function ensureDaemon(deps: DaemonLauncherDeps): Promise<DaemonInfo
  * Best-effort: never throws. Returns true only when a verified daemon was
  * signalled.
  */
-export function killDaemonByPidFile(): boolean {
+export function killDaemonByPidFile(scriptCandidates: string[] = []): boolean {
   try {
     const wmuxDir = getWmuxDir();
     const pidStr = fs.readFileSync(path.join(wmuxDir, 'daemon.pid'), 'utf8').trim();
@@ -1293,7 +1366,7 @@ export function killDaemonByPidFile(): boolean {
     // Before-quit mode: indeterminate verification still proceeds — this
     // path runs seconds after we were actively talking to that PID, so
     // reuse is near-impossible and an orphan is the worse outcome.
-    return killVerifiedDaemonPid(pid, { definitiveOnly: false });
+    return killVerifiedDaemonPid(pid, { definitiveOnly: false, scriptCandidates });
   } catch {
     return false;
   }
@@ -1320,7 +1393,7 @@ export function killDaemonByPidFile(): boolean {
  */
 export function killVerifiedDaemonPid(
   pid: number,
-  opts: { definitiveOnly: boolean },
+  opts: { definitiveOnly: boolean; scriptCandidates?: string[] },
 ): boolean {
   try {
     if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return false;
@@ -1344,8 +1417,8 @@ export function killVerifiedDaemonPid(
     if (image === null) {
       if (opts.definitiveOnly) return false; // indeterminate — refuse
     }
-    const cmdline = getProcessCommandLine(pid);
-    if (cmdline === null) {
+    const argv = getProcessArgv(pid);
+    if (argv === null) {
       // `definitiveOnly` already refuses on any indeterminate cmdline. Below
       // that threshold, a null cmdline COMBINED with an already-confirmed
       // image mismatch is refused too: neither signal alone proves the PID
@@ -1354,7 +1427,7 @@ export function killVerifiedDaemonPid(
       // mismatch blocks the kill — it just needs the second, cmdline signal
       // to also fail to clear it, rather than mismatch alone.
       if (opts.definitiveOnly || imageDefinitivelyMismatched) return false;
-    } else if (!cmdlineMatchesDaemonScript(cmdline)) {
+    } else if (!argvIdentifiesDaemonScript(argv, opts.scriptCandidates ?? [])) {
       return false; // definitive: same image but not our daemon script
     }
 

--- a/src/shared/daemon/daemonLauncherCore.ts
+++ b/src/shared/daemon/daemonLauncherCore.ts
@@ -250,8 +250,11 @@ function getProcessArgv(pid: number): string[] | null {
     if (command.length === 0) return null;
     let comm = '';
     try {
+      // Shorter budget than the command= probe on purpose: this call is an
+      // optional refinement, and two 3s probes back to back would double the
+      // worst-case synchronous block on the launch path.
       comm = execFileSync('/bin/ps', ['-p', String(pid), '-o', 'comm='], {
-        encoding: 'utf-8', timeout: 3000,
+        encoding: 'utf-8', timeout: 1000,
       }).trim();
     } catch { comm = ''; }
     return psArgvFromCommand(command, comm);
@@ -269,6 +272,13 @@ function getProcessArgv(pid: number): string[] | null {
  * that rewrote argv[0]), fall back to plain whitespace tokenization — the
  * historical behavior, which is refuse-safe.
  *
+ * The strip is also rejected when what follows is neither an absolute path
+ * nor a flag: a platform whose `comm` is TRUNCATED can end mid-path and still
+ * pass the prefix test (`/Applications/wmux` against `/Applications/wmux
+ * 2.app/...`), which would cut at the wrong boundary. macOS returns comm
+ * whole, so the real spawn shape — an absolute script path, optionally behind
+ * runtime flags — always survives this check.
+ *
  * Exported for tests only.
  */
 export function psArgvFromCommand(command: string, comm: string): string[] | null {
@@ -276,7 +286,10 @@ export function psArgvFromCommand(command: string, comm: string): string[] | nul
   if (trimmed.length === 0) return null;
   if (comm.length > 0 && (trimmed === comm || trimmed.startsWith(`${comm} `))) {
     const rest = trimmed.slice(comm.length).trim();
-    return rest.length > 0 ? [comm, ...tokenizeCommandLine(rest)] : [comm];
+    if (rest.length === 0) return [comm];
+    if (rest.startsWith('/') || rest.startsWith('-')) {
+      return [comm, ...tokenizeCommandLine(rest)];
+    }
   }
   return tokenizeCommandLine(trimmed);
 }


### PR DESCRIPTION
Redo of #1027 (reverted by #1028), implementing all four requirements #1028's post-merge panel set. Reopens nothing; closes the class #1025 reproduced by execution: an unrelated `node <anything>/daemon/index.js` on a recycled PID was verified as wmux's daemon and SIGKILLed.

## The four requirements, and where each landed

1. **Entry-script position, not any-token.** `argvIdentifiesDaemonScript` locates the first non-flag token after the executable and compares only that. A process merely *holding* our script path as an argument (`vim .../daemon-bundle/index.js`-class, #1027's third defect) no longer verifies. Pinned by a unit case and a real-process execution test.
2. **argv preserved as an array.** `getProcessArgv` replaces the string-returning probe: Linux NUL-splits `/proc/<pid>/cmdline` and never round-trips it through spaces — the exact mechanism (#1028) by which a spaced install path shattered and turned wmux's *own* daemon into a "mismatch". Windows keeps the quote-aware CIM tokenization; macOS `ps` output is inherently space-joined, so the matcher compensates with a progressive re-join against known candidate paths (unit-tested with a `/Applications/wmux 2.app/...` shape).
3. **Fallback exclusive + exact shape.** The cross-host branch accepts exactly `daemon-bundle/index.js` at the entry position — segment equality, no `startsWith` — so `daemon-bundler/…` and `daemon-bundle-backup/…` (#1027's second defect) are out. A cross-host **dev** daemon (tsc layout, no bundle) is deliberately not covered: refusing degrades to the respawn budget, while the generic `daemon/index.js` marker is the very false positive #1025 executed. The crossHost test's marker path moves to the exact shape accordingly.
4. **`ensureDaemon` mismatch branch refuses instead of cleaning + spawning.** This is the split-brain-sensitive piece #1028 asked to have reviewed separately — please look at it in isolation. Under identity matching, a mismatch can mean "our own daemon we failed to prove", so branch (b) now runs the same recovery dance as the blocked-probe paths: **escalated re-ping first** (a process that answers on the authed pipe is our daemon regardless of path proof) → **user approval** → only then the cleanup + spawn. Default (headless, or declined) is a refusal that names the pid file and the manual command. Behavior change accepted with this: the genuine sibling-app-on-recycled-PID case, which used to self-heal silently, now asks — one dialog, and the #537/#543 spawn-over-live-daemon path is unreachable without explicit consent.

Also fixed from the #1028 findings list: the Electron seam calls the resolver **inside** a try/catch (a throwing `app.getAppPath()` degrades to the shape-only fallback instead of crashing a "never throws" path), and the tests reach the matcher **through `deps.resolveDaemonScriptCandidates`** — the real wiring #1027's tests bypassed — plus real-process execution tests asserting on the real OS probes.

## Tests

- 10 new unit cases on the matcher (position, flags, re-join, exact shape, #1025 layout, win32 normalization)
- 4 real-process execution tests (innocent refused, trailing-argument refused, candidate killed, `daemon-bundler` vs `daemon-bundle` split)
- 2 `ensureDaemon` branch tests through injected deps (refuse-by-default: nothing killed, nothing cleaned; approval: falls through to clean+spawn without killing the occupant)
- Full `src/shared/daemon` + `src/main/daemon` suites: 158 passed; `tsc --noEmit` clean; eslint at main's baseline

## Follow-up: spaced install paths on macOS (dogfood finding)

Live dogfooding on macOS found the identity branch still failing whenever the
app path contains a space (`/Applications/wmux 2.app/...`, the name macOS gives
a second copy). `ps -o command=` joins argv with spaces, so the **executable**
fragments too, not just the script; the entry position then landed inside a tail
fragment of the executable (`2.app/Contents/MacOS/wmux`) and the progressive
re-join could never reach a candidate. Requirement 4 kept it safe — it refused
rather than killed — but such an install could never prove its daemon's
identity, so every launch raised the approval dialog.

Fix: read `ps -o comm=` alongside the command line. It returns argv[0] on one
line with spaces intact, so stripping that prefix reconstructs `[exe, ...rest]`
and the entry position is correct again. A missing or non-prefix `comm` falls
back to the historical whitespace tokenization (refuse-safe). The alternative —
generalizing the re-join start position — was rejected because allowing a match
at an arbitrary offset re-admits #1027's third defect (`node innocent.js <our
path>`), and no cheap check distinguishes a fragmented executable from a real
extra argument.

Known limitation, accepted: the cross-host fallback still inspects the entry
token alone, so a cross-host daemon under a spaced path remains unprovable on
macOS. Widening it to re-joined spans would re-admit that same trailing-argument
false positive, and an unproven identity refuses rather than kills. Documented
in the matcher's doc comment.

New regression tests (same file): the real dogfood argv — executable *and*
script both fragmented — matches its candidate; the trailing-argument case is
re-asserted false through the same probe path, including with a fragmented
executable in front; plus the probe normalizer's fallbacks. Verified live
against a real spaced-path process and the real `ps` probe: fragmented case
`true`, trailing-argument case `false`, old tokenization reproduces the `false`.

A two-model panel review of that follow-up added two hardening changes: the
optional `comm=` probe gets a 1s budget of its own (it is a refinement, not
the primary read, and two 3s probes back to back doubled the worst-case
synchronous block on the launch path), and the prefix strip is refused unless
what follows is an absolute path or a flag — a platform whose `comm` is
truncated can end mid-path and still pass the prefix test, cutting at the
wrong boundary. Anything else falls back to the historical tokenization.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon identification to prevent unrelated processes from being terminated.
  * Prevented duplicate daemon launches when an existing process cannot be verified.
  * Added a confirmation prompt before cleanup and restart when daemon identity is uncertain.
  * Improved recognition of executable paths containing spaces on macOS.
  * Ensured daemon matching requires the exact launched entry script, reducing false matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
