### PR TITLE
fix(sidebar): clear the listening-port badge when the ports go away (#1135)

### DIFF
--- a/changelog.d/1137.md
+++ b/changelog.d/1137.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The sidebar's listening-port badge could stay lit long after the port
+  closed — even across a full app restart. The stale value was being saved
+  into the session file and restored verbatim, closing the pane that owned
+  the ports never recomputed the workspace badge, and a session whose
+  process died was dropped without a final "no ports" signal. All three
+  paths now clear the badge, an already-saved stale value is stripped on
+  load, and a server that was listening before an app restart is
+  re-announced to the new window instead of staying invisible. (#1135, #1137)

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -2868,7 +2868,12 @@ function registerRpcHandlers(
   pipeServer.onRpc('daemon.events.subscribe', async (_params, ctx) => {
     // A false result is an expected first step of the compatibility handshake,
     // so do not warn here. DaemonClient identifies and immediately retries.
-    return { ok: pipeServer.subscribeEvents(ctx.clientId) };
+    const ok = pipeServer.subscribeEvents(ctx.clientId);
+    // #1135: a subscribing app has an empty context mirror — re-emit the live
+    // port sets so an already-listening dev server shows up without waiting
+    // for it to change.
+    if (ok) { try { resyncContextWatchers?.(); } catch { /* best effort */ } }
+    return { ok };
   });
 
   pipeServer.onRpc('daemon.events.unsubscribe', async (_params, ctx) => {
@@ -4815,6 +4820,8 @@ function wireContextWatchers(
     gitWatcher.update(s.id, s.cwd);
   }
 
+  resyncContextWatchers = () => { portWatcher.resync(); };
+
   return () => {
     sessionManager.off('session:created', onCreated);
     sessionManager.off('session:cwd', onCwd);
@@ -4822,8 +4829,17 @@ function wireContextWatchers(
     sessionManager.off('session:destroyed', onGone);
     portWatcher.stop();
     gitWatcher.dispose();
+    resyncContextWatchers = null;
   };
 }
+
+/**
+ * #1135 — re-emit the current per-session port sets. Set by
+ * wireContextWatchers, called when an app subscribes to the event stream: the
+ * daemon survives app restarts, so a new app's empty port map has to be
+ * refilled from the watcher rather than from whatever the last app persisted.
+ */
+let resyncContextWatchers: (() => void) | null = null;
 
 /** Set in main(); consumed by shutdown(). */
 let disposeContextWatchers: (() => void) | null = null;

--- a/src/main/pty/__tests__/portWatch.test.ts
+++ b/src/main/pty/__tests__/portWatch.test.ts
@@ -91,11 +91,11 @@ describe('PortWatcher', () => {
     expect(events[1]).toEqual({ sessionId: 's1', ports: [] });
   });
 
-  it('drops diff state for sessions that disappeared', async () => {
+  it('clears and drops diff state for sessions that disappeared (#1135)', async () => {
     let sessions = [{ sessionId: 's1', pid: 100 }];
     const snapshot = async (): Promise<PortSnapshot> =>
       snap([[200, 100]], [{ port: 3000, pid: 200 }]);
-    const events: unknown[] = [];
+    const events: Array<{ sessionId: string; ports: unknown[] }> = [];
     const watcher = new PortWatcher(() => sessions, { snapshot });
     watcher.on('ports', (e) => events.push(e));
 
@@ -104,11 +104,34 @@ describe('PortWatcher', () => {
 
     sessions = []; // session destroyed
     await watcher.tick();
-    expect(events).toHaveLength(1);
+    // #1135: one final empty set so the sidebar chip of a dead session clears.
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ sessionId: 's1', ports: [] });
+
+    await watcher.tick(); // still gone — nothing more to say
+    expect(events).toHaveLength(2);
 
     sessions = [{ sessionId: 's1', pid: 100 }]; // same id recreated
     await watcher.tick();
-    expect(events).toHaveLength(2); // re-emits — diff state was reset
+    expect(events).toHaveLength(3); // re-emits — diff state was reset
+  });
+
+  it('does not emit a clear for a vanished session that never reported ports (#1135)', async () => {
+    let sessions = [{ sessionId: 's1', pid: 100 }];
+    let current: PortSnapshot = snap([[200, 100]], [{ port: 3000, pid: 200 }]);
+    const events: unknown[] = [];
+    const watcher = new PortWatcher(() => sessions, { snapshot: async () => current });
+    watcher.on('ports', (e) => events.push(e));
+
+    await watcher.tick();
+    expect(events).toHaveLength(1);
+    current = snap([[200, 100]], []);
+    await watcher.tick(); // already cleared
+    expect(events).toHaveLength(2);
+
+    sessions = [];
+    await watcher.tick(); // last value was already empty — no redundant clear
+    expect(events).toHaveLength(2);
   });
 
   it('swallows snapshot failures silently', async () => {

--- a/src/main/pty/__tests__/portWatch.test.ts
+++ b/src/main/pty/__tests__/portWatch.test.ts
@@ -134,6 +134,28 @@ describe('PortWatcher', () => {
     expect(events).toHaveLength(2);
   });
 
+  it('resync() re-emits the current port set for a fresh subscriber (#1135)', async () => {
+    const current = snap([[200, 100]], [{ port: 3000, pid: 200 }]);
+    const events: Array<{ sessionId: string; ports: unknown[] }> = [];
+    const watcher = new PortWatcher(
+      () => [{ sessionId: 's1', pid: 100 }],
+      { snapshot: async () => current },
+    );
+    watcher.on('ports', (e) => events.push(e));
+
+    await watcher.tick();
+    expect(events).toHaveLength(1);
+    await watcher.tick(); // unchanged — silent
+    expect(events).toHaveLength(1);
+
+    // A new app attached: it has no port state of its own, so the unchanged
+    // set has to be announced again.
+    watcher.resync();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(events).toHaveLength(2);
+    expect(events[1]).toEqual({ sessionId: 's1', ports: [{ port: 3000, pid: 200 }] });
+  });
+
   it('swallows snapshot failures silently', async () => {
     const watcher = new PortWatcher(
       () => [{ sessionId: 's1', pid: 100 }],

--- a/src/main/pty/portWatch.ts
+++ b/src/main/pty/portWatch.ts
@@ -50,6 +50,12 @@ const SNAPSHOT_TIMEOUT_MS = 8_000;
 /** After this many consecutive snapshot failures, pause polling briefly. */
 const FAILURE_BACKOFF_THRESHOLD = 3;
 const FAILURE_BACKOFF_MS = 60_000;
+/**
+ * The encoded form of "this session has no listening ports". Shared by the
+ * diff-state writer and the vanished-session clear below so the two can never
+ * drift apart from the JSON encoding they both depend on.
+ */
+const EMPTY_PORTS_ENCODED = JSON.stringify([] as SessionPort[]);
 
 /**
  * Windows: in-process FFI snapshot (see winSnapshotNative.ts — issue #1051).
@@ -230,7 +236,7 @@ export class PortWatcher extends EventEmitter {
         if (liveIds.has(id)) continue;
         const prev = this.lastBySession.get(id);
         this.lastBySession.delete(id);
-        if (prev && prev !== '[]') this.emit('ports', { sessionId: id, ports: [] });
+        if (prev && prev !== EMPTY_PORTS_ENCODED) this.emit('ports', { sessionId: id, ports: [] });
       }
       if (sessions.length === 0) return;
 

--- a/src/main/pty/portWatch.ts
+++ b/src/main/pty/portWatch.ts
@@ -212,6 +212,23 @@ export class PortWatcher extends EventEmitter {
     this.lastBySession.clear();
   }
 
+  /**
+   * Forget every session's diff state and poll again, so the NEXT tick re-emits
+   * the current port set for every session instead of staying silent because
+   * nothing changed.
+   *
+   * #1135 — the daemon outlives the app (tmux-style detach), so a freshly
+   * launched app starts with an empty per-surface port map while the watcher
+   * still holds the diff state of the previous app's lifetime. Without a
+   * resync, a dev server that was already listening before the restart is
+   * invisible until it happens to change. Called when a client subscribes to
+   * the event stream.
+   */
+  resync(): void {
+    this.lastBySession.clear();
+    void this.tick();
+  }
+
   /** One poll cycle. Public so tests (and the daemon on session-create) can drive it. */
   async tick(): Promise<void> {
     if (this.ticking) return; // a slow snapshot must not stack subprocesses

--- a/src/main/pty/portWatch.ts
+++ b/src/main/pty/portWatch.ts
@@ -216,11 +216,21 @@ export class PortWatcher extends EventEmitter {
         (s) => Number.isInteger(s.pid) && s.pid > 0,
       );
 
-      // Sessions that disappeared: drop diff state so a recreated session
-      // with the same id re-emits its first non-empty set.
+      // Sessions that disappeared: emit one final empty set, then drop the
+      // diff state so a recreated session with the same id re-emits its first
+      // non-empty set.
+      //
+      // #1135 — the final empty emit is the important half. A session whose
+      // process died stops being matched at all, so without it the LAST set of
+      // ports it ever reported was also the last thing the sidebar heard, and
+      // the chip stayed lit for a dead dev server until the surface itself was
+      // closed. Suppressed when the last emitted value was already empty.
       const liveIds = new Set(sessions.map((s) => s.sessionId));
-      for (const id of this.lastBySession.keys()) {
-        if (!liveIds.has(id)) this.lastBySession.delete(id);
+      for (const id of [...this.lastBySession.keys()]) {
+        if (liveIds.has(id)) continue;
+        const prev = this.lastBySession.get(id);
+        this.lastBySession.delete(id);
+        if (prev && prev !== '[]') this.emit('ports', { sessionId: id, ports: [] });
       }
       if (sessions.length === 0) return;
 

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -296,6 +296,11 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
   return {
     workspaces: state.workspaces.map((ws) => ({
       ...ws,
+      // #1135: never persist listeningPorts. It describes processes that are
+      // alive right now; a saved value outlives them and the daemon's
+      // PortWatcher cannot contradict it (its first empty observation for a
+      // session is a deliberate no-op), so the sidebar chip survived restarts.
+      ...(ws.metadata ? { metadata: { ...ws.metadata, listeningPorts: undefined } } : {}),
       rootPane: cloneWithScrollback(ws.rootPane, dumped),
       stashedPanes: cloneStashedPanes(ws, dumped),
     })),

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -289,6 +289,17 @@ function cloneStashedPanes(
   });
 }
 
+/**
+ * #1135 — a copy of workspace metadata with the live-only `listeningPorts`
+ * key genuinely absent (not present-but-undefined, which round-trips as a
+ * `listeningPorts: null`-shaped hole through some serializers).
+ */
+function stripLivePorts(metadata: NonNullable<Workspace['metadata']>): Workspace['metadata'] {
+  const copy = { ...metadata };
+  delete copy.listeningPorts;
+  return copy;
+}
+
 /** Build a consistent SessionData snapshot for save operations */
 function buildSessionData(dumped: Map<string, boolean>): SessionData {
   const state = useStore.getState();
@@ -300,7 +311,7 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
       // alive right now; a saved value outlives them and the daemon's
       // PortWatcher cannot contradict it (its first empty observation for a
       // session is a deliberate no-op), so the sidebar chip survived restarts.
-      ...(ws.metadata ? { metadata: { ...ws.metadata, listeningPorts: undefined } } : {}),
+      ...(ws.metadata ? { metadata: stripLivePorts(ws.metadata) } : {}),
       rootPane: cloneWithScrollback(ws.rootPane, dumped),
       stashedPanes: cloneStashedPanes(ws, dumped),
     })),

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -16,6 +16,7 @@ import {
   findWorkspaceSurfaceById,
 } from '../utils/paneTraversal';
 import { getWorkspacePtyIds } from '../../shared/paneUtils';
+import { unionSurfacePorts } from '../stores/slices/workspacePorts';
 import { FrameCoalescer } from '../utils/frameCoalescer';
 import { normalizeWorktreePath } from '../../shared/workTask';
 import { isBrainPtyId } from '../../shared/constants';
@@ -749,16 +750,16 @@ export function useNotificationListener() {
             // X1 — ports: store per-surface, publish the workspace union.
             if (Array.isArray(rest.listeningPorts)) {
               state.setSurfacePorts(ptyId, rest.listeningPorts);
-              const merged = new Set<number>();
-              // Workspace-wide (#977): this branch now runs for stashed panes
-              // too, so a visible-tree union would report the workspace's ports
-              // MINUS whatever the stashed pane is serving — including the
+              // Workspace-wide (#977): getWorkspacePtyIds covers stashed panes
+              // too — a visible-tree union would report the workspace's ports
+              // MINUS whatever the stashed pane is serving, including the
               // stashed pane's own ports on the very update that announced them.
-              const freshPorts = useStore.getState().surfacePorts;
-              for (const id of getWorkspacePtyIds(ws)) {
-                for (const p of freshPorts[id] ?? []) merged.add(p);
-              }
-              rest.listeningPorts = [...merged].sort((a, b) => a - b);
+              // #1135: shared with the teardown paths so the union is derived
+              // from surfacePorts in exactly one place.
+              rest.listeningPorts = unionSurfacePorts(
+                getWorkspacePtyIds(ws),
+                useStore.getState().surfacePorts,
+              );
             }
             // Only update exclusive context (cwd/git/PR) from the active
             // pane's active surface to prevent stale PTYs from overwriting it.

--- a/src/renderer/stores/__tests__/listeningPorts.stale.test.ts
+++ b/src/renderer/stores/__tests__/listeningPorts.stale.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+//
+// #1135 — the sidebar's listening-port chip must never outlive the ports.
+//
+// Two independent leaks are covered here:
+//   1. a saved session restoring `metadata.listeningPorts` verbatim (the chip
+//      survived a full app restart, because the daemon's PortWatcher treats
+//      its first empty observation for a session as "nothing to clear");
+//   2. a surface that owned the ports being closed, which deletes the
+//      per-surface entry but used to leave the workspace-level union frozen.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useStore } from '../index';
+import type { SessionData, Workspace } from '../../../shared/types';
+
+function makeWs(): Workspace {
+  return {
+    id: 'ws-1',
+    name: 'Alpha',
+    rootPane: {
+      id: 'leaf',
+      type: 'leaf',
+      activeSurfaceId: 's1',
+      surfaces: [
+        { id: 's1', ptyId: 'pty-1', title: 'a', shell: 'bash', cwd: '/tmp', surfaceType: 'terminal' },
+        { id: 's2', ptyId: 'pty-2', title: 'b', shell: 'bash', cwd: '/tmp', surfaceType: 'terminal' },
+      ],
+    },
+    activePaneId: 'leaf',
+    metadata: { listeningPorts: [18856, 63361] },
+  } as unknown as Workspace;
+}
+
+function load(): void {
+  const data: SessionData = {
+    workspaces: [makeWs()],
+    activeWorkspaceId: 'ws-1',
+    sidebarVisible: true,
+  };
+  useStore.getState().loadSession(data);
+}
+
+describe('#1135 stale listening-port badge', () => {
+  beforeEach(() => {
+    // The store is a module singleton — drop any per-surface ports a previous
+    // case left behind before restoring the fixture session.
+    const s = useStore.getState();
+    for (const id of Object.keys(s.surfacePorts)) s.setSurfacePorts(id, null);
+    load();
+  });
+
+  it('drops persisted listeningPorts on session load', () => {
+    const ws = useStore.getState().workspaces.find((w) => w.id === 'ws-1');
+    expect(ws?.metadata?.listeningPorts).toBeUndefined();
+  });
+
+  it('recomputes the workspace union when a port-owning surface closes', () => {
+    const s = useStore.getState();
+    s.setSurfacePorts('pty-1', [3000]);
+    s.setSurfacePorts('pty-2', [8080]);
+    s.updateWorkspaceMetadata('ws-1', { listeningPorts: [3000, 8080] });
+
+    useStore.getState().closeSurface('leaf', 's2', 'ws-1');
+
+    const ws = useStore.getState().workspaces.find((w) => w.id === 'ws-1');
+    expect(useStore.getState().surfacePorts['pty-2']).toBeUndefined();
+    expect(ws?.metadata?.listeningPorts).toEqual([3000]);
+  });
+
+  it('clears the chip entirely when the last port-owning surface closes', () => {
+    const s = useStore.getState();
+    s.setSurfacePorts('pty-2', [8080]);
+    s.updateWorkspaceMetadata('ws-1', { listeningPorts: [8080] });
+
+    useStore.getState().closeSurface('leaf', 's2', 'ws-1');
+
+    const ws = useStore.getState().workspaces.find((w) => w.id === 'ws-1');
+    expect(ws?.metadata?.listeningPorts).toEqual([]);
+  });
+});

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -31,6 +31,7 @@ import { clearNudgesFor } from '../../hooks/channelMentionRateLimit';
 import { panePrincipalId } from '../../../shared/principals';
 import { computePaneAutoName, paneDisplayName } from '../../utils/paneNaming';
 import { saveSessionNow } from '../../utils/sessionSaveBridge';
+import { recomputeWorkspacePorts } from './workspacePorts';
 
 // Per-workspace leaf cap. xterm.js + node-pty memory scales linearly with
 // pane count, and the project memory budget targets ~200 MB for 10 panes
@@ -845,6 +846,11 @@ export const createPaneSlice: StateCreator<StoreState, [['zustand/immer', never]
           }
         }
       }
+      // #1135: the sidebar's listening-port chip is a union over surfacePorts.
+      // Recompute it now that the closing pane's entries are gone, otherwise a
+      // closed pane's ports stay pinned on the workspace forever (no surviving
+      // surface's METADATA_UPDATE can subtract another surface's ports).
+      recomputeWorkspacePorts(state.workspaces, state.surfacePorts);
 
       const previousActiveId = ws.activePaneId;
       // Structural removal lives in detachPane (shared with movePane, #645);

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -10,6 +10,7 @@ import { saveSessionNow } from '../../utils/sessionSaveBridge';
 import { publishPaneClosed } from '../../events/publisher';
 import { panePrincipalId } from '../../../shared/principals';
 import { computePaneAutoName } from '../../utils/paneNaming';
+import { recomputeWorkspacePorts } from './workspacePorts';
 
 export interface SurfaceSlice {
   /** Add a terminal surface to a pane. `workspaceId` lets RPC / eager-spawn
@@ -305,7 +306,12 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     // Drop per-surface ports and agent status too (fleet-activity adversarial
     // review): without this, every closed surface leaves a dead ptyId entry
     // behind, and a REUSED ptyId inherits the previous surface's status.
-    if (closedPtyId && state.surfacePorts) delete state.surfacePorts[closedPtyId];
+    if (closedPtyId && state.surfacePorts) {
+      delete state.surfacePorts[closedPtyId];
+      // #1135: the workspace badge is a union over surfacePorts — recompute it
+      // here or the closed surface's ports stay on the sidebar forever.
+      recomputeWorkspacePorts(state.workspaces, state.surfacePorts);
+    }
     if (closedPtyId && state.surfaceAgentStatus) delete state.surfaceAgentStatus[closedPtyId];
     if (closedPtyId) clearNudgesFor(closedPtyId); // A5: free the rate-cap entry for a reusable ptyId
     // J3 F4: onExhausted 매핑도 이 ptyId 소멸과 함께 evict(무한 성장·재사용 ptyId 오염 방지).

--- a/src/renderer/stores/slices/workspacePorts.ts
+++ b/src/renderer/stores/slices/workspacePorts.ts
@@ -1,0 +1,31 @@
+import type { Workspace } from '../../../shared/types';
+import { getWorkspacePtyIds } from '../../../shared/paneUtils';
+
+/**
+ * #1135 — recompute `ws.metadata.listeningPorts` as the UNION of the
+ * per-surface `surfacePorts` map over the workspace's own ptyIds.
+ *
+ * The write path in `useNotificationListener` only recomputes this union when
+ * a METADATA_UPDATE carrying `listeningPorts` arrives for a pty that still
+ * belongs to the workspace. That means every way a port-owning surface can
+ * DISAPPEAR (pane/surface close, ptyId wipe) left the workspace-level badge
+ * frozen on the last value it ever saw: the daemon's PortWatcher drops the
+ * diff state for a vanished session and emits nothing more for it, and no
+ * surviving surface's update can subtract another surface's ports.
+ *
+ * Every teardown site that deletes `surfacePorts[ptyId]` calls this so the
+ * sidebar chip follows the map it is derived from.
+ */
+export function recomputeWorkspacePorts(
+  workspaces: Workspace[],
+  surfacePorts: Record<string, number[]>,
+): void {
+  for (const ws of workspaces) {
+    if (!ws.metadata || ws.metadata.listeningPorts === undefined) continue;
+    const merged = new Set<number>();
+    for (const id of getWorkspacePtyIds(ws)) {
+      for (const p of surfacePorts?.[id] ?? []) merged.add(p);
+    }
+    ws.metadata.listeningPorts = [...merged].sort((a, b) => a - b);
+  }
+}

--- a/src/renderer/stores/slices/workspacePorts.ts
+++ b/src/renderer/stores/slices/workspacePorts.ts
@@ -2,16 +2,33 @@ import type { Workspace } from '../../../shared/types';
 import { getWorkspacePtyIds } from '../../../shared/paneUtils';
 
 /**
- * #1135 — recompute `ws.metadata.listeningPorts` as the UNION of the
- * per-surface `surfacePorts` map over the workspace's own ptyIds.
+ * #1135 — the ONE definition of "a workspace's listening ports are the union
+ * of its surfaces' ports". The live write path (useNotificationListener) and
+ * the teardown paths (closeSurface / closePane) both go through this, so the
+ * value can never be computed one way going up and another way coming down.
+ */
+export function unionSurfacePorts(
+  ptyIds: readonly string[],
+  surfacePorts: Record<string, number[]> | undefined,
+): number[] {
+  const merged = new Set<number>();
+  for (const id of ptyIds) {
+    for (const p of surfacePorts?.[id] ?? []) merged.add(p);
+  }
+  return [...merged].sort((a, b) => a - b);
+}
+
+/**
+ * Re-derive `ws.metadata.listeningPorts` from the per-surface `surfacePorts`
+ * map for every workspace that currently shows a value.
  *
- * The write path in `useNotificationListener` only recomputes this union when
- * a METADATA_UPDATE carrying `listeningPorts` arrives for a pty that still
- * belongs to the workspace. That means every way a port-owning surface can
- * DISAPPEAR (pane/surface close, ptyId wipe) left the workspace-level badge
- * frozen on the last value it ever saw: the daemon's PortWatcher drops the
- * diff state for a vanished session and emits nothing more for it, and no
- * surviving surface's update can subtract another surface's ports.
+ * The live write path only recomputes the union when a METADATA_UPDATE
+ * carrying `listeningPorts` arrives for a pty that still belongs to the
+ * workspace. That means every way a port-owning surface can DISAPPEAR (pane /
+ * surface close, ptyId wipe) left the workspace-level badge frozen on the last
+ * value it ever saw: the daemon's PortWatcher drops the diff state for a
+ * vanished session, and no surviving surface's update can subtract another
+ * surface's ports.
  *
  * Every teardown site that deletes `surfacePorts[ptyId]` calls this so the
  * sidebar chip follows the map it is derived from.
@@ -22,10 +39,6 @@ export function recomputeWorkspacePorts(
 ): void {
   for (const ws of workspaces) {
     if (!ws.metadata || ws.metadata.listeningPorts === undefined) continue;
-    const merged = new Set<number>();
-    for (const id of getWorkspacePtyIds(ws)) {
-      for (const p of surfacePorts?.[id] ?? []) merged.add(p);
-    }
-    ws.metadata.listeningPorts = [...merged].sort((a, b) => a - b);
+    ws.metadata.listeningPorts = unionSurfacePorts(getWorkspacePtyIds(ws), surfacePorts);
   }
 }

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -867,6 +867,17 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         else delete ws.profile;
       }
 
+      // #1135: listening ports are a LIVE fact about running processes, never
+      // a saved one. A session written while a dev server was up otherwise
+      // restores its chip verbatim, and the daemon's PortWatcher never
+      // contradicts it — its very first observation of an empty port set for a
+      // session is deliberately a no-op ("nothing to clear"), so a stale chip
+      // survived full app restarts. Drop it on load; the surfacePorts map that
+      // feeds the union starts empty anyway.
+      for (const ws of data.workspaces) {
+        if (ws.metadata?.listeningPorts !== undefined) delete ws.metadata.listeningPorts;
+      }
+
       state.workspaces = data.workspaces;
       // The previous session's group cannot describe this one's workspaces.
       pruneMultiviewMembership(state);
@@ -1290,6 +1301,10 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       state.terminalBookmarks = {};
       // X1 per-surface port map is ptyId-keyed — same wipe contract.
       if (state.surfacePorts) state.surfacePorts = {};
+      // #1135: the workspace chip is a union over that map — wipe it with it.
+      for (const ws of state.workspaces) {
+        if (ws.metadata?.listeningPorts !== undefined) delete ws.metadata.listeningPorts;
+      }
       if (state.pendingDeadPaneRecoveryBySurfaceId) state.pendingDeadPaneRecoveryBySurfaceId = {};
       if (state.deadPaneRecoveryOfferByPtyId) state.deadPaneRecoveryOfferByPtyId = {};
 


### PR DESCRIPTION
Fixes #1135.

The sidebar's listening-port chip could outlive the ports — surviving even a full app restart. Three compounding leaks, all in the "how does this number ever go back down" direction:

1. **`listeningPorts` was persisted.** It rode along in workspace metadata into the session file and was restored verbatim on boot. Nothing ever contradicted it, because `PortWatcher` deliberately treats its first empty observation for a session as a no-op. This is what survived the reporter's v3.49.1 update restart.
2. **The workspace chip is a union over per-surface ports, and closing a pane/surface never recomputed it** — no surviving surface's update can subtract another surface's ports.
3. **A session whose process died was dropped silently** by the watcher, with no final empty emit.

Changes:
- `listeningPorts` is no longer persisted, and any already-saved value is stripped on session load (a stuck chip self-heals on first launch with this build).
- Both pane/surface teardown paths recompute the union via a new shared `recomputeWorkspacePorts`/`unionSurfacePorts` helper (single source of truth with the live write path).
- A vanished session emits one final empty port set before its diff state is dropped.
- Found while dogfooding: the daemon outlives the app, so a server already listening before an app restart was never re-announced to the new window (previously masked by the stale persisted value). `PortWatcher.resync()` now re-emits current port sets when a client subscribes.

Verified by unit tests (portWatch, store) and live dogfood in a sandboxed instance: kill-server / close-pane / restart-with-chip / hand-written stale session / app-only-restart-with-live-server all behave (clear ≤1 tick; recompute path 186 ms; resync 1 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale listening-port badges that could remain visible after ports closed.
  - Cleared outdated port indicators when closing panes, surfaces, or sessions.
  - Prevented listening-port information from persisting across app restarts.
  - Restored accurate port indicators for servers already running when the app reconnects.

- **Tests**
  - Added coverage for session restoration, teardown, badge clearing, and port resynchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->