### PR TITLE
fix(sidebar): drop the remote mirror on every activeWorkspaceId assignment path (#1086)

### DIFF
--- a/changelog.d/1138.md
+++ b/changelog.d/1138.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- While a remote workspace mirror was on screen, some jumps back to the
+  already-active local workspace silently did nothing: Fleet View cards and
+  notification rows that target a workspace rather than a pane, OS toast
+  clicks, and the promotion that happens when a company or department is
+  torn down all left the mirror painted while the sidebar highlighted the
+  local workspace. One click now always surfaces the local tree. (#1086, #1138)

--- a/src/renderer/hooks/__tests__/useNotificationListener.test.ts
+++ b/src/renderer/hooks/__tests__/useNotificationListener.test.ts
@@ -524,6 +524,7 @@ describe('focusNotificationTarget', () => {
     activeWorkspaceId: string;
     notifications?: Array<{ id: string; read: boolean; surfaceId?: string }>;
     zoomedPaneId?: string | null;
+    activeRemoteKey?: string | null;
   }): JumpHarness {
     const spies = {
       setActiveWorkspace: vi.fn(),
@@ -538,6 +539,7 @@ describe('focusNotificationTarget', () => {
       activeWorkspaceId: opts.activeWorkspaceId,
       zoomedPaneId: opts.zoomedPaneId ?? null,
       notifications: opts.notifications ?? [],
+      activeRemoteKey: opts.activeRemoteKey ?? null,
       ...spies,
     };
     // setActiveWorkspace mutates the harness state the way zustand would,
@@ -545,6 +547,9 @@ describe('focusNotificationTarget', () => {
     // function is documented around) observes the new active workspace.
     spies.setActiveWorkspace.mockImplementation((id: string) => {
       state.activeWorkspaceId = id;
+      // The real action always calls clearRemoteSelection past its own
+      // existence guard — mirror that so the #1086 assertions are meaningful.
+      state.activeRemoteKey = null;
     });
     return { state, spies, getState: () => state };
   }
@@ -661,6 +666,22 @@ describe('focusNotificationTarget', () => {
     const handled = focusNotificationTarget(h.getState, { ptyId: null, workspaceId: 'ws-a' });
     expect(handled).toBe(true);
     expect(h.spies.setActiveWorkspace).not.toHaveBeenCalled();
+  });
+
+  // #1086: the workspaceId-only fallback carried the same bare `!==` guard
+  // that activatePaneTarget's AT4 covers. While a remote mirror is showing,
+  // activeWorkspaceId already equals the target, so the guard skipped the one
+  // call that drops the mirror and an app-level jump did nothing visible.
+  it('J7b: #1086 — workspaceId already active BUT a remote mirror is showing → switch fires and clears the mirror', () => {
+    const h = makeJumpHarness({
+      workspaces: [wsA()],
+      activeWorkspaceId: 'ws-a',
+      activeRemoteKey: 'remote-host-1',
+    });
+    const handled = focusNotificationTarget(h.getState, { ptyId: null, workspaceId: 'ws-a' });
+    expect(handled).toBe(true);
+    expect(h.spies.setActiveWorkspace).toHaveBeenCalledWith('ws-a');
+    expect(h.state.activeRemoteKey).toBeNull();
   });
 
   it('J8: unknown workspaceId → no-op, returns false', () => {

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -226,7 +226,12 @@ export function focusNotificationTarget(
   if (payload.workspaceId) {
     const ws = state.workspaces.find((w) => w.id === payload.workspaceId);
     if (ws) {
-      if (ws.id !== state.activeWorkspaceId) {
+      // #1086, same reason as activatePaneTarget above: while a remote mirror
+      // is on screen `activeWorkspaceId` already equals the target, so a bare
+      // `!==` guard skips setActiveWorkspace — the only call that drops the
+      // remote selection — and the jump silently does nothing. Fire on either
+      // condition so an app-level jump always surfaces the local tree.
+      if (ws.id !== state.activeWorkspaceId || state.activeRemoteKey) {
         state.setActiveWorkspace(ws.id);
       }
       return true;

--- a/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
 import { createRemoteWorkspacesSlice, mergePaneSets, type RemoteWorkspacesSlice, type AttachedRemoteWorkspace } from '../remoteWorkspacesSlice';
+import { createCompanySlice, type CompanySlice } from '../companySlice';
 import { createWorkspace, type SessionData } from '../../../../shared/types';
 
 // Minimal store: workspaceSlice + remoteWorkspacesSlice only. Mirrors the
@@ -10,7 +11,7 @@ import { createWorkspace, type SessionData } from '../../../../shared/types';
 // pulling in the full StoreState — channelsSlice's fire-and-forget daemon
 // calls touch `window`, which isn't defined under the node test environment,
 // and loadSession only needs the fields this test actually reads/writes.
-type TestState = WorkspaceSlice & RemoteWorkspacesSlice & {
+type TestState = WorkspaceSlice & RemoteWorkspacesSlice & CompanySlice & {
   multiviewIds: string[];
   sidebarVisible: boolean;
 };
@@ -23,6 +24,8 @@ function createTestStore() {
       ...createWorkspaceSlice(...args),
       // @ts-expect-error — minimal test store doesn't match full StoreState
       ...createRemoteWorkspacesSlice(...args),
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createCompanySlice(...args),
       multiviewIds: [],
       sidebarVisible: true,
     }))
@@ -134,6 +137,27 @@ describe('remoteWorkspacesSlice', () => {
     it('setActiveWorkspace', () => {
       const id = store.getState().workspaces[0].id;
       store.getState().setActiveWorkspace(id);
+      expect(store.getState().activeRemoteKey).toBeNull();
+    });
+
+    // #1086: destroyCompany/removeDepartment promote a surviving workspace by
+    // assigning activeWorkspaceId directly, bypassing setActiveWorkspace — so
+    // they must call clearRemoteSelection themselves, per the convention
+    // documented on the helper. Without it the mirror stayed on screen while
+    // the sidebar highlighted the promoted local workspace.
+    it('destroyCompany promoting a surviving workspace', () => {
+      const survivor = store.getState().workspaces[0].id;
+      store.getState().addWorkspace('Company WS');
+      store.setState((st) => {
+        const company = st.workspaces.find((w) => w.id !== survivor)!;
+        company.companyRole = 'lead';
+        st.activeWorkspaceId = company.id;
+      });
+      store.getState().attachRemoteWorkspace(makeRemote());
+      expect(store.getState().activeRemoteKey).not.toBeNull();
+
+      store.getState().destroyCompany();
+      expect(store.getState().activeWorkspaceId).toBe(survivor);
       expect(store.getState().activeRemoteKey).toBeNull();
     });
 

--- a/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteWorkspacesSlice.test.ts
@@ -6,11 +6,14 @@ import { createRemoteWorkspacesSlice, mergePaneSets, type RemoteWorkspacesSlice,
 import { createCompanySlice, type CompanySlice } from '../companySlice';
 import { createWorkspace, type SessionData } from '../../../../shared/types';
 
-// Minimal store: workspaceSlice + remoteWorkspacesSlice only. Mirrors the
-// workspaceSlice.coldPark.test.ts / loadSession.test.ts convention of NOT
-// pulling in the full StoreState — channelsSlice's fire-and-forget daemon
-// calls touch `window`, which isn't defined under the node test environment,
-// and loadSession only needs the fields this test actually reads/writes.
+// Minimal store: workspaceSlice + remoteWorkspacesSlice + companySlice.
+// Mirrors the workspaceSlice.coldPark.test.ts / loadSession.test.ts convention
+// of NOT pulling in the full StoreState — channelsSlice's fire-and-forget
+// daemon calls touch `window`, which isn't defined under the node test
+// environment, and loadSession only needs the fields this test actually
+// reads/writes. companySlice is in the set because destroyCompany and
+// removeDepartment are two of the activeWorkspaceId assignment sites the
+// clearRemoteSelection convention covers (#1086).
 type TestState = WorkspaceSlice & RemoteWorkspacesSlice & CompanySlice & {
   multiviewIds: string[];
   sidebarVisible: boolean;
@@ -157,6 +160,26 @@ describe('remoteWorkspacesSlice', () => {
       expect(store.getState().activeRemoteKey).not.toBeNull();
 
       store.getState().destroyCompany();
+      expect(store.getState().activeWorkspaceId).toBe(survivor);
+      expect(store.getState().activeRemoteKey).toBeNull();
+    });
+
+    it('removeDepartment promoting a surviving workspace', () => {
+      const survivor = store.getState().workspaces[0].id;
+      store.getState().addWorkspace('Member WS');
+      store.getState().createCompany('TestCorp');
+      store.getState().addDepartment('Engineering', 'CTO');
+      const deptId = store.getState().company!.departments[0].id;
+      const memberWsId = store.getState().workspaces.find((w) => w.id !== survivor)!.id;
+      store.setState((st) => {
+        st.company!.departments[0].members[0].workspaceId = memberWsId;
+        st.activeWorkspaceId = memberWsId;
+      });
+      store.getState().attachRemoteWorkspace(makeRemote());
+      expect(store.getState().activeRemoteKey).not.toBeNull();
+
+      store.getState().removeDepartment(deptId);
+      expect(store.getState().workspaces.some((w) => w.id === memberWsId)).toBe(false);
       expect(store.getState().activeWorkspaceId).toBe(survivor);
       expect(store.getState().activeRemoteKey).toBeNull();
     });

--- a/src/renderer/stores/slices/companySlice.ts
+++ b/src/renderer/stores/slices/companySlice.ts
@@ -12,7 +12,7 @@ import {
   MAX_INBOX_SIZE,
 } from '../../../shared/types';
 import type { QueuedMessage } from '../../company/MessageQueue';
-import { clearColdParkEntry, pruneMultiviewMembership } from './workspaceSlice';
+import { clearColdParkEntry, clearRemoteSelection, pruneMultiviewMembership } from './workspaceSlice';
 
 /** Maximum number of pending messages in the queue to prevent memory exhaustion. */
 const MAX_MESSAGE_QUEUE_SIZE = 500;
@@ -127,6 +127,10 @@ export const createCompanySlice: StateCreator<StoreState, [['zustand/immer', nev
     if (!state.workspaces.some((ws) => ws.id === state.activeWorkspaceId)) {
       state.activeWorkspaceId = state.workspaces[0]?.id || '';
       clearColdParkEntry(state, state.activeWorkspaceId); // keep promoted ws visible
+      // #1086: every site that assigns activeWorkspaceId must drop the remote
+      // mirror selection too, or WorkspaceCenter keeps showing the mirror while
+      // the sidebar highlights the newly-promoted local workspace.
+      clearRemoteSelection(state);
     }
     state.company = null;
     state.memberCosts = {};
@@ -171,6 +175,10 @@ export const createCompanySlice: StateCreator<StoreState, [['zustand/immer', nev
     if (!state.workspaces.some((ws) => ws.id === state.activeWorkspaceId)) {
       state.activeWorkspaceId = state.workspaces[0]?.id || '';
       clearColdParkEntry(state, state.activeWorkspaceId); // keep promoted ws visible
+      // #1086: every site that assigns activeWorkspaceId must drop the remote
+      // mirror selection too, or WorkspaceCenter keeps showing the mirror while
+      // the sidebar highlights the newly-promoted local workspace.
+      clearRemoteSelection(state);
     }
     // Remove department
     const idx = state.company.departments.findIndex((d) => d.id === deptId);


### PR DESCRIPTION
Closes the remaining click-return half of #1086 (bug 1). The rename/color/startup parity half (bug 2) stays open on the issue.

The reporter's root-cause analysis was correct and had already landed for one site (bb036898, #1089) — but the identical bare `!==` guard survived a second time in the same file, and two store sites violated the documented `clearRemoteSelection` contract:

- `focusNotificationTarget`'s workspaceId-only fallback (Fleet View cards that can't resolve by ptyId, workspace-level notification rows, OS toasts) silently did nothing while a remote mirror was showing and the target workspace was already active. The guard now also fires on `state.activeRemoteKey` (same fix shape as AT4).
- `companySlice.destroyCompany` / `removeDepartment` assign `activeWorkspaceId` directly when promoting a survivor and never called `clearRemoteSelection`, leaving the mirror painted while the sidebar highlighted the promoted local workspace.

Tests: new J7b case, symmetric destroyCompany/removeDepartment promotion cases (each fails on the pre-fix code in isolation). Live dogfood in a sandboxed instance with a real (seeded, boot-restored) remote attachment: all three scenarios pass, and an A/B run with only the production edits reverted reproduces both failures visibly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace navigation so selecting an already-active local workspace reliably switches away from a displayed remote mirror.
  * Corrected navigation from Fleet View cards, notifications, operating system alerts, and workspace promotion after company or department removal.
  * Ensured remote workspace selections are cleared when the active workspace changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->