### PR TITLE
feat(remote): split a remote session into its own pane, alongside the #1100 tab

### DIFF
--- a/changelog.d/1141.md
+++ b/changelog.d/1141.md
@@ -1,0 +1,3 @@
+### Added
+
+- **A remote session can now split into its own pane, not just a tab.** "Split right — remote" / "Split down — remote" join the pane's ⋮ menu alongside the existing "New remote pane" — same host picker, same minted session, attached to a fresh pane instead of another tab on the one you clicked from.

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { Panel, Group, Separator } from 'react-resizable-panels';
 import type { PaneLeaf, Workspace } from '../../../shared/types';
 import { maybeDelegateExternalBrowser } from '../../utils/browserPaneActions';
@@ -187,6 +187,29 @@ export function pickOverlaySurfaces<T extends { surfaceType?: string }>(
   );
 }
 
+/**
+ * #1140 — where a freshly minted remote session (from AddRemotePaneModal)
+ * gets attached, given which flow opened the modal.
+ *
+ * `null` direction is the #1100 tab flow: always the pane whose ⋮ menu opened
+ * the modal, unchanged. A direction is the new split flow: `splitResult` is
+ * whatever `splitPane()` already returned by the time this runs (the caller
+ * must call it BEFORE this, in the same synchronous tick as the eventual
+ * addRemoteSurface call — see handleRemoteCreated's own comment for why that
+ * ordering matters against EmptyLeafFunnel). `splitPane` returns `false` when
+ * blocked at the per-workspace pane cap; this surfaces that as `null` — attach
+ * nowhere — rather than silently falling back to the original pane, which
+ * would put a second surface where the user asked for a new one instead.
+ */
+export function resolveRemoteAttachPaneId(
+  direction: 'horizontal' | 'vertical' | null,
+  currentPaneId: string,
+  splitResult: string | false,
+): string | null {
+  if (direction === null) return currentPaneId;
+  return splitResult || null;
+}
+
 /** The side effect the reboot-recovery pill performs on one primary-button
  *  click: the exact string written to the PTY, plus the two follow-ups the
  *  handler must apply (clear the hint / advance the progressive stage) and
@@ -286,6 +309,13 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
   const addBrowserSurface = useStore((s) => s.addBrowserSurface);
   const addRemoteSurface = useStore((s) => s.addRemoteSurface);
   const [addRemoteModalOpen, setAddRemoteModalOpen] = useState(false);
+  // #1140: the SAME modal (pick a host, mint a session) serves both the
+  // existing "New remote pane" tab flow and the new split-into-a-pane flow.
+  // null → tab (add to THIS pane, unchanged #1100 behavior); a direction →
+  // split first, then attach the minted session to the freshly created pane.
+  // A ref, not state: read synchronously inside handleRemoteCreated, which
+  // fires from the modal's async onCreated — no render needs to observe it.
+  const remoteSplitDirectionRef = useRef<'horizontal' | 'vertical' | null>(null);
   const splitPane = useStore((s) => s.splitPane);
   const closeSurface = useStore((s) => s.closeSurface);
   const updateSurfacePtyId = useStore((s) => s.updateSurfacePtyId);
@@ -415,12 +445,39 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
   }, [addBrowserSurface, pane.id, workspace.id]);
 
   const handleAddRemote = useCallback(() => {
+    remoteSplitDirectionRef.current = null;
+    setAddRemoteModalOpen(true);
+  }, []);
+
+  // #1140: same modal, but split first — a fresh pane, not another tab on
+  // this one. Mirrors handleSplitHorizontal/handleSplitVertical's direction
+  // semantics (Ctrl+D right, Ctrl+Shift+D down).
+  const handleSplitRemoteHorizontal = useCallback(() => {
+    remoteSplitDirectionRef.current = 'horizontal';
+    setAddRemoteModalOpen(true);
+  }, []);
+  const handleSplitRemoteVertical = useCallback(() => {
+    remoteSplitDirectionRef.current = 'vertical';
     setAddRemoteModalOpen(true);
   }, []);
 
   const handleRemoteCreated = useCallback((hostId: string, sessionId: string) => {
-    addRemoteSurface(pane.id, hostId, sessionId, undefined, undefined, workspace.id);
-  }, [addRemoteSurface, pane.id, workspace.id]);
+    const direction = remoteSplitDirectionRef.current;
+    remoteSplitDirectionRef.current = null;
+    // splitPane (when direction is set) creates an EMPTY leaf; EmptyLeafFunnel
+    // would otherwise race to spawn a local PTY into it. It runs here, and
+    // addRemoteSurface right after (via resolveRemoteAttachPaneId below), in
+    // the same synchronous tick (no await between them) — the leaf already
+    // carries a surface by the time React commits and the funnel's effect
+    // can observe it. The null-direction branch never calls splitPane at all,
+    // so `pane.id` there is just a truthy placeholder resolveRemoteAttachPaneId
+    // ignores in favor of currentPaneId.
+    const splitResult: string | false = direction === null ? pane.id : splitPane(pane.id, direction, workspace.id);
+    const targetPaneId = resolveRemoteAttachPaneId(direction, pane.id, splitResult);
+    if (targetPaneId) {
+      addRemoteSurface(targetPaneId, hostId, sessionId, undefined, undefined, workspace.id);
+    }
+  }, [addRemoteSurface, pane.id, splitPane, workspace.id]);
 
   const closePane = useStore((s) => s.closePane);
 
@@ -957,6 +1014,8 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         onAddTerminal={handleAddTerminal}
         onAddBrowser={handleAddBrowser}
         onAddRemote={handleAddRemote}
+        onSplitHorizontalRemote={handleSplitRemoteHorizontal}
+        onSplitVerticalRemote={handleSplitRemoteVertical}
       />
       {addRemoteModalOpen && (
         <AddRemotePaneModal

--- a/src/renderer/components/Pane/SurfaceTabs.tsx
+++ b/src/renderer/components/Pane/SurfaceTabs.tsx
@@ -194,6 +194,12 @@ interface SurfaceTabsProps {
    *  callers/tests that mount this component standalone keep working
    *  unchanged — omitted just drops the menu item. */
   onAddRemote?: () => void;
+  /** #1140 — split this pane side-by-side into a fresh remote-terminal pane,
+   *  instead of a tab on this one. Same optionality reasoning as onAddRemote:
+   *  omitted just drops the menu item. */
+  onSplitHorizontalRemote?: () => void;
+  /** #1140 — split this pane stacked into a fresh remote-terminal pane. */
+  onSplitVerticalRemote?: () => void;
   /**
    * How the pane-action cluster renders. Pane.tsx owns this because it is the
    * Settings toggle AND the width check — the cluster is fixed-width and
@@ -217,6 +223,8 @@ export default function SurfaceTabs({
   onAddTerminal,
   onAddBrowser,
   onAddRemote,
+  onSplitHorizontalRemote,
+  onSplitVerticalRemote,
   actionsMode,
 }: SurfaceTabsProps) {
   const t = useT();
@@ -411,6 +419,18 @@ export default function SurfaceTabs({
       icon: <IconExternalLink size={14} />,
       onSelect: onAddRemote,
     }] : []),
+    ...(onSplitHorizontalRemote ? [{
+      key: 'split-right-remote',
+      label: t('pane.splitRightRemote'),
+      icon: <IconSplitRight size={14} />,
+      onSelect: onSplitHorizontalRemote,
+    }] : []),
+    ...(onSplitVerticalRemote ? [{
+      key: 'split-down-remote',
+      label: t('pane.splitDownRemote'),
+      icon: <IconSplitDown size={14} />,
+      onSelect: onSplitVerticalRemote,
+    }] : []),
     {
       key: 'rename-pane',
       label: t('pane.rename'),
@@ -439,7 +459,8 @@ export default function SurfaceTabs({
       onSelect: toggleZoom,
     },
   ], [
-    t, onSplitHorizontal, onSplitVertical, onAddBrowser, onAddRemote, startPaneRename,
+    t, onSplitHorizontal, onSplitVertical, onAddBrowser, onAddRemote,
+    onSplitHorizontalRemote, onSplitVerticalRemote, startPaneRename,
     stashChord, stashDisabled, stashTooltip, stashThisPane, isZoomed, toggleZoom,
   ]);
 

--- a/src/renderer/components/Pane/__tests__/Pane.splitVisibility.test.tsx
+++ b/src/renderer/components/Pane/__tests__/Pane.splitVisibility.test.tsx
@@ -16,7 +16,7 @@
  * Pane.notificationRing.test.tsx (the pure helper is the load-bearing piece).
  */
 import { describe, it, expect } from 'vitest';
-import { pickSplitShownSurfaces, pickOverlaySurfaces } from '../Pane';
+import { pickSplitShownSurfaces, pickOverlaySurfaces, resolveRemoteAttachPaneId } from '../Pane';
 
 const T = (id: string) => ({ id });
 
@@ -124,5 +124,27 @@ describe('pickOverlaySurfaces — F6 mixed-split diff/editor routing', () => {
       { id: 'r', surfaceType: 'remote-terminal' },
     ];
     expect(pickOverlaySurfaces(surfaces).map((s) => s.id)).toEqual(['r']);
+  });
+});
+
+describe('resolveRemoteAttachPaneId — #1140 split-into-a-pane vs the #1100 tab', () => {
+  it('null direction (the #1100 tab flow): always the pane the ⋮ menu opened on, regardless of splitResult', () => {
+    // splitPane is never even called on this path — the caller passes the
+    // clicking pane's own id as a placeholder, which must be ignored in favor
+    // of currentPaneId if it ever WAS read.
+    expect(resolveRemoteAttachPaneId(null, 'pane-A', 'pane-A')).toBe('pane-A');
+    expect(resolveRemoteAttachPaneId(null, 'pane-A', false)).toBe('pane-A');
+  });
+
+  it('a direction (the new split flow): targets the NEW pane splitPane returned, not the one that was split', () => {
+    expect(resolveRemoteAttachPaneId('horizontal', 'pane-A', 'pane-B')).toBe('pane-B');
+    expect(resolveRemoteAttachPaneId('vertical', 'pane-A', 'pane-B')).toBe('pane-B');
+  });
+
+  it('a direction but splitPane was blocked (per-workspace pane cap): attach nowhere, never fall back to the original pane', () => {
+    // Falling back to pane-A here would silently put a second surface on a
+    // pane the user explicitly asked to split away from — worse than doing
+    // nothing, since the cap warning already told them why the split refused.
+    expect(resolveRemoteAttachPaneId('horizontal', 'pane-A', false)).toBeNull();
   });
 });

--- a/src/renderer/components/Pane/__tests__/paneClusterWidth.test.ts
+++ b/src/renderer/components/Pane/__tests__/paneClusterWidth.test.ts
@@ -225,8 +225,12 @@ describe('the ⋮ menu offers exactly what the cluster does', () => {
     // cluster keeps to icon-sized layout actions. new-remote (#1086/#1091) is
     // the same kind of deliberate menu-only addition, conditionally rendered
     // (only when a caller passes onAddRemote) rather than promoted to the
-    // icon cluster.
+    // icon cluster. split-right-remote / split-down-remote (#1140) are the
+    // same pattern again — conditionally rendered on onSplitHorizontalRemote
+    // / onSplitVerticalRemote, menu-only rather than icon cluster.
     for (const key of cluster) expect(menu).toContain(key);
-    expect(menu.filter((k) => !cluster.includes(k))).toEqual(['new-remote', 'rename-pane']);
+    expect(menu.filter((k) => !cluster.includes(k))).toEqual([
+      'new-remote', 'rename-pane', 'split-down-remote', 'split-right-remote',
+    ]);
   });
 });

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -290,6 +290,8 @@ export const en = {
   'pane.newTerminal': 'New terminal',
   'pane.newBrowser': 'New browser',
   'pane.newRemote': 'New remote pane',
+  'pane.splitRightRemote': 'Split right — remote',
+  'pane.splitDownRemote': 'Split down — remote',
   // Label for the ⋮ that replaces the five-button cluster on a pane too
   // narrow to hold it, and for the header's right-click menu. Names the SET of
   // actions, not the glyph — it is the accessible name a screen reader reads.

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -296,6 +296,8 @@ export const pl = {
   'pane.newTerminal': 'Nowy terminal',
   'pane.newBrowser': 'Nowa przeglądarka',
   'pane.newRemote': 'Nowy panel zdalny',
+  'pane.splitRightRemote': 'Podziel w prawo — zdalnie',
+  'pane.splitDownRemote': 'Podziel w dół — zdalnie',
   // Label for the ⋮ that replaces the five-button cluster on a pane too
   // narrow to hold it, and for the header's right-click menu. Names the SET of
   // actions, not the glyph — it is the accessible name a screen reader reads.

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -754,6 +754,8 @@ export const zh = {
   'pane.newTerminal': '新建终端',
   'pane.newBrowser': '新建浏览器',
   'pane.newRemote': '新建远程面板',
+  'pane.splitRightRemote': '向右分割 — 远程',
+  'pane.splitDownRemote': '向下分割 — 远程',
   'pane.addSurface': '新建标签页',
   'pane.maxLeavesReached': '已达到面板数量上限（{count}）。请先关闭一个面板再分割。',
   'pane.maxLeavesReachedWithStash': '已达到面板数量上限（{count}，其中已收起 {stashed}）。请取回一个并关闭，或关闭一个可见面板。',


### PR DESCRIPTION
## Why

#1100 shipped remote-terminal as an ordinary Surface — a tab on an existing pane's tab strip, deliberately not a separate "attached remote workspace" entity (#1086/#1091). Real usage right after it shipped, on a paired VPS, surfaced one gap: local terminals can *also* be split into their own pane (a new layout region, independently resizable), and a remote session had no equivalent — only the tab.

Filed as #1140 with two asks. This PR is the first.

## What

**"Split right — remote" / "Split down — remote"** join the ⋮ menu, alongside the existing "New remote pane" (unchanged). Same `AddRemotePaneModal` (pick a host, mint a session) — the only difference is where the minted session gets attached:

- **New remote pane** (existing): the clicking pane, as another tab.
- **Split right/down — remote** (new): a freshly split pane, same as splitting a local terminal.

`resolveRemoteAttachPaneId` (new, pure, exported alongside the existing `pickSplitShownSurfaces`/`pickOverlaySurfaces`) is the whole decision:

```ts
export function resolveRemoteAttachPaneId(
  direction: 'horizontal' | 'vertical' | null,
  currentPaneId: string,
  splitResult: string | false,
): string | null {
  if (direction === null) return currentPaneId;
  return splitResult || null;
}
```

`null` direction is the #1100 tab flow, untouched. A direction targets whatever `splitPane()` already returned. `splitPane` creates an *empty* leaf pane — `EmptyLeafFunnel` would otherwise race to spawn a local PTY into it — so `addRemoteSurface` runs in the same synchronous tick as `splitPane` (no `await` between them), before React can commit and let the funnel's effect see an empty leaf. A blocked split (per-workspace pane cap, `splitPane` returns `false`) resolves to `null` — attach nowhere — rather than silently falling back onto the pane the user asked to split *away* from.

## What's NOT here

Issue #1140's second ask — count an agent-driving remote pane in the roster/"Agenci" — is not addressed. `workspaceAgentRoster.ts` keys agent detection on `ptyId`, fed by local PTY hook events (`PreToolUse`/`PostToolUse` etc. reported through the daemon's local IPC). Remote surfaces carry `ptyId: ''` by design (same as browser/editor), so there is no existing signal path a real agent running on the far end could report through — even removing the `surfaceType !== 'terminal'` filter changes nothing, since the very next line (`if (!ptyId...) return`) excludes it anyway. Building a heuristic on buffer content (scanning for CLI chrome, a rename command, etc.) would be fragile and guessed. Left for a direction call on #1140 rather than inventing a detection channel here.

## Test plan

- New: `resolveRemoteAttachPaneId` pure-function tests (`Pane.splitVisibility.test.tsx`) — tab flow ignores `splitResult`, split flow targets the new pane id, a blocked split resolves to `null` rather than falling back.
- Updated: `paneClusterWidth.test.ts`'s pinned menu-only-actions list now includes `split-right-remote`/`split-down-remote`.
- i18n: en/pl/zh (matching #1100's own scope for this feature's strings).
- `npx tsc --noEmit` clean, `eslint` clean on changed files.
- Full `npm run test:parallel`: 13195/13202 passed (7 pre-existing failures — playwright device presets, `deck.handler.loop` timing, `worktree.handler` git/EBUSY — reproduced identically on a clean `git stash` of this branch, unrelated to this diff).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to open remote sessions in a new pane split to the right or below.
  * Remote sessions now attach to the newly created pane after splitting.
  * Added localized labels for the new remote pane actions.
  * Added a warning when the pane limit prevents creating another split.

* **Bug Fixes**
  * Improved cleanup when remote session attachment or pane closure is interrupted.

* **Tests**
  * Added coverage for remote session attachment and split-menu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->