### PR TITLE
fix(updater): hide the install waiter behind a wscript launcher (#1136)

### DIFF
--- a/changelog.d/1142.md
+++ b/changelog.d/1142.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- On Windows 11 with Windows Terminal set as the default terminal, clicking
+  Install flashed a visible terminal window while the updater's install
+  waiter launched. The waiter now starts through a hidden GUI-subsystem
+  launcher that never allocates a console, with the previous transports kept
+  as fallbacks for machines where Windows Script Host is disabled. (#1136, #1142)

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -36,6 +36,40 @@ function q(p: string): string {
   return `'${p.replace(/'/g, "''")}'`;
 }
 
+// #1136 — is Windows Script Host actually usable on this machine?
+//
+// WSH being disabled by enterprise policy is an explicitly SUPPORTED case:
+// the hidden transport fails and the cmd.exe trampoline behind it carries the
+// install (a visible window is cosmetic, a refused install is not). So the
+// "the hidden transport wins" assertion below is only meaningful where WSH
+// runs, and asserting it unconditionally would turn a correctly-working
+// fallback into a red test. Probed by actually running a script rather than
+// by reading the registry: the policy lives in two hives plus a per-extension
+// association, and only an execution answers the question the test is asking.
+function wshUsable(): boolean {
+  if (!onWindows) return false;
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-wsh-probe-'));
+  try {
+    const out = path.join(dir, 'ok.txt');
+    const vbs = path.join(dir, 'probe.vbs');
+    fs.writeFileSync(vbs, '\uFEFF' +
+      `Set fso = CreateObject("Scripting.FileSystemObject")\r\n` +
+      `fso.CreateTextFile("${out}").Close\r\n`, 'utf16le');
+    const r = spawnSync(
+      path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'wscript.exe'),
+      ['//B', '//Nologo', vbs],
+      { windowsHide: true, timeout: 30_000 },
+    );
+    return r.status === 0 && fs.existsSync(out);
+  } catch {
+    return false;
+  } finally {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
+}
+
+const WSH_USABLE = wshUsable();
+
 describe.skipIf(!onWindows)('install waiter (real processes, real locks)', () => {
   let sandbox: string;
   let root: string;
@@ -503,7 +537,7 @@ describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWa
     }
   }, 120_000);
 
-  it('#1136 — the hidden wscript transport is the one that carries the install', () => {
+  it.skipIf(!WSH_USABLE)('#1136 — the hidden wscript transport is the one that carries the install', () => {
     // The defect: the cmd.exe trampoline is spawned `detached`, and
     // DETACHED_PROCESS overrides the CREATE_NO_WINDOW that `windowsHide: true`
     // asks for. The child then allocates its own console, that allocation goes

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -442,7 +442,7 @@ describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWa
       const dirLike = launchedDir.replace(/'/g, "''");
       try {
         execFileSync(PS, ['-NoProfile', '-NonInteractive', '-Command',
-          `Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='cmd.exe'" | Where-Object { $_.CommandLine -like '*${dirLike}*' } | ForEach-Object { taskkill /PID $_.ProcessId /T /F } | Out-Null`,
+          `Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='cmd.exe' OR Name='wscript.exe'" | Where-Object { $_.CommandLine -like '*${dirLike}*' } | ForEach-Object { taskkill /PID $_.ProcessId /T /F } | Out-Null`,
         ], { windowsHide: true, timeout: 20_000 });
       } catch { /* nothing left to reap */ }
       try { fs.rmSync(launchedDir, { recursive: true, force: true }); } catch { /* lock lingers */ }
@@ -501,5 +501,35 @@ describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWa
       process.env.TEMP = saved.TEMP;
       process.env.TMP = saved.TMP;
     }
+  }, 120_000);
+
+  it('#1136 — the hidden wscript transport is the one that carries the install', () => {
+    // The defect: the cmd.exe trampoline is spawned `detached`, and
+    // DETACHED_PROCESS overrides the CREATE_NO_WINDOW that `windowsHide: true`
+    // asks for. The child then allocates its own console, that allocation goes
+    // through the Win11 default-terminal delegation, and Windows Terminal opens
+    // a real visible window. A/B measured on a Win11 26200 box with WT as the
+    // default host: the same cmd.exe with `detached: true` produced a visible
+    // WindowsTerminal window, without it produced none.
+    //
+    // What this asserts is transport IDENTITY, not window count. A global
+    // visible-window diff was tried first and rejected: it goes red for any
+    // console window that happens to open on the box during the sample (a
+    // parallel test file, another tool), so it reports the machine's mood
+    // rather than this code's behaviour. The identity check is exact — the
+    // per-transport script name is already distinct because each transport
+    // needs its own launch stamp — and it is the property that actually
+    // matters: on a machine where the hidden transport works, it must be the
+    // one that runs, never the visible fallback behind it.
+    const written = spawnInstallWaiter(mkPlan());
+    expect(written).not.toBeNull();
+    launchedDir = path.dirname(written as string);
+    expect(path.basename(written as string)).toBe('wait-and-install-w.ps1');
+
+    // ...and it is a REAL waiter, not just a process that stamped and died:
+    // the same end-to-end proof the transport suite's first test makes.
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline && !fs.existsSync(envStamp)) sleep200();
+    expect(fs.existsSync(envStamp)).toBe(true);
   }, 120_000);
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -17,6 +17,7 @@ import {
   selectOwnTreePids,
   parseProcessRows,
   buildWaiterScript,
+  buildWaiterVbsLauncher,
   readDaemonPid,
   terminatePids,
   readAbortMarker,
@@ -699,5 +700,50 @@ describe('waitForWaiterHeartbeat (#1056)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('buildWaiterVbsLauncher (#1136 — the hidden transport)', () => {
+  const PS = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+  const ARGS = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File'];
+
+  it('runs the waiter hidden AND waits on it', () => {
+    const vbs = buildWaiterVbsLauncher(PS, ARGS, 'C:\\Temp\\w.ps1') as string;
+    expect(vbs).not.toBeNull();
+    // 0 = SW_HIDE. True = bWaitOnReturn: wscript stays parked as the waiter's
+    // parent, which is what keeps the refusal path's `taskkill /T` able to
+    // reach the PowerShell child. Flipping either brings the whole bug back.
+    expect(vbs).toContain(', 0, True');
+    expect(vbs).toContain('WScript.Shell');
+  });
+
+  it('quotes both paths and leaves the switches bare', () => {
+    const vbs = buildWaiterVbsLauncher(PS, ARGS, "C:\\tmp o'brien\\w.ps1") as string;
+    // VBScript escapes a double quote by doubling it, so a quoted path inside
+    // the literal reads as ""...""; an apostrophe is inert (the O'Brien TEMP
+    // the cmd transport is separately pinned on).
+    expect(vbs).toContain(`""${PS}""`);
+    expect(vbs).toContain(`""C:\\tmp o'brien\\w.ps1""`);
+    // A quoted switch would make CreateProcess hunt for a file called
+    // `"-NoProfile"`.
+    expect(vbs).toContain(' -NoProfile -NonInteractive ');
+    expect(vbs).not.toContain('""-NoProfile""');
+  });
+
+  it('is a two-statement script with CRLF line endings', () => {
+    const vbs = buildWaiterVbsLauncher(PS, ARGS, 'C:\\Temp\\w.ps1') as string;
+    expect(vbs.split('\r\n').filter((l) => l.length > 0)).toHaveLength(2);
+    expect(vbs).not.toMatch(/[^\r]\n/);
+  });
+
+  it('fails closed on a quote or a newline rather than emitting a broken script', () => {
+    // Same rule as buildWaiterScript's stamp-path check: a path that could
+    // break out of the literal builds nothing, so the caller falls through to
+    // transport A instead of running something malformed.
+    expect(buildWaiterVbsLauncher(PS, ARGS, 'C:\\Temp\\a"b.ps1')).toBeNull();
+    expect(buildWaiterVbsLauncher(PS, ARGS, 'C:\\Temp\\a\nb.ps1')).toBeNull();
+    expect(buildWaiterVbsLauncher(PS, ARGS, 'C:\\Temp\\a\rb.ps1')).toBeNull();
+    expect(buildWaiterVbsLauncher('', ARGS, 'C:\\Temp\\w.ps1')).toBeNull();
+    expect(buildWaiterVbsLauncher(PS, ['-No"Profile'], 'C:\\Temp\\w.ps1')).toBeNull();
   });
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -746,4 +746,17 @@ describe('buildWaiterVbsLauncher (#1136 — the hidden transport)', () => {
     expect(buildWaiterVbsLauncher('', ARGS, 'C:\\Temp\\w.ps1')).toBeNull();
     expect(buildWaiterVbsLauncher(PS, ['-No"Profile'], 'C:\\Temp\\w.ps1')).toBeNull();
   });
+
+  it('rejects a switch containing whitespace, because switches go in bare', () => {
+    // The paths are quoted, so a space in them is safe (the O'Brien TEMP above
+    // has one). The switches are NOT quoted, so a space inside one would
+    // silently split it into two arguments — a waiter running with the WRONG
+    // arguments, which is worse than no waiter, since transport A behind this
+    // one is a working fallback.
+    expect(buildWaiterVbsLauncher(PS, ['-No Profile'], 'C:\\Temp\\w.ps1')).toBeNull();
+    expect(buildWaiterVbsLauncher(PS, ['-NoProfile\t'], 'C:\\Temp\\w.ps1')).toBeNull();
+    expect(buildWaiterVbsLauncher(PS, ['-NoProfile', ''], 'C:\\Temp\\w.ps1')).toBeNull();
+    // A space in either PATH stays legal — that is the whole point of quoting.
+    expect(buildWaiterVbsLauncher(PS, ARGS, 'C:\\Program Files\\w.ps1')).not.toBeNull();
+  });
 });

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -131,6 +131,57 @@ function psQuote(p: string): string {
 }
 
 /**
+ * #1136 — the VBScript launcher for the hidden waiter transport.
+ *
+ * Root cause it exists for, measured on this box (Win11 26200, default
+ * terminal = "Let Windows decide" → Windows Terminal): libuv turns
+ * `windowsHide: true` into `CREATE_NO_WINDOW`, but `detached: true` also sets
+ * `DETACHED_PROCESS` — and the two are mutually exclusive console-creation
+ * flags, so `DETACHED_PROCESS` wins. The console child then allocates its own
+ * console, that allocation goes through the Win11 default-terminal delegation,
+ * and Windows Terminal opens a real, visible window. Proven by A/B: the SAME
+ * `cmd.exe`, same `windowsHide: true`, produced a visible `WindowsTerminal`
+ * window with `detached: true` and none without it. So this is specific to the
+ * detached waiter transports; the module's non-detached `execFileSync` calls
+ * (probeVolume, terminatePids) are unaffected and are left alone.
+ *
+ * `wscript.exe` is a GUI-subsystem host: it never allocates a console, so
+ * nothing reaches the delegation layer. It then starts PowerShell through
+ * `WshShell.Run(cmd, 0, True)`:
+ *   - window style 0 = hidden, and because wscript already owns no console the
+ *     child's console is created hidden rather than delegated,
+ *   - `bWaitOnReturn = True` keeps wscript parked as the waiter's parent for
+ *     its whole life. That is deliberate and NOT a cost regression: it is the
+ *     same shape as the cmd.exe trampoline it replaces (one idle host process),
+ *     and it is what keeps the refusal path's `taskkill /T` able to reach the
+ *     PowerShell child. With `False` the launcher would exit immediately and
+ *     orphan a waiter no tree-kill could find.
+ *
+ * VBScript string literals are double-quoted with `""` as the escape, so an
+ * apostrophe in TEMP (the `O'Brien` case the cmd transport is pinned on) is
+ * inert here. A literal `"` cannot occur in a Windows path, but rather than
+ * rely on that this returns null for one — same fail-closed rule as
+ * buildWaiterScript's stamp-path check.
+ */
+export function buildWaiterVbsLauncher(
+  powershellPath: string,
+  psArgs: readonly string[],
+  scriptPath: string,
+): string | null {
+  const parts = [powershellPath, ...psArgs, scriptPath];
+  if (!parts.every((p) => p.length > 0 && !/["\r\n]/.test(p))) return null;
+  // Quote only the two paths; the switches are literal and space-free, and
+  // quoting them would make CreateProcess look for a file named `"-NoProfile"`.
+  const q = (p: string) => `""${p}""`;
+  const cmd = [q(powershellPath), ...psArgs, q(scriptPath)].join(' ');
+  return [
+    `Set sh = CreateObject("WScript.Shell")`,
+    `sh.Run "${cmd}", 0, True`,
+    '',
+  ].join('\r\n');
+}
+
+/**
  * Volume-aware free-space check. The staging download and the install root can
  * live on different volumes (a redirected AppData, a mapped drive), so a single
  * "is there room" number is meaningless — each volume is budgeted separately
@@ -749,6 +800,17 @@ function waitForLaunchStamp(stampPath: string, budgetMs: number): boolean {
 // runs after A already burned its window. Total ≤8s of synchronous wait, and
 // nothing is armed yet — the 20s before-quit deadline only exists once the
 // caller reaches app.quit().
+// #1136 adds W ahead of both. Same generosity as A, and for the same reason:
+// its critical path is a wscript host start plus the same PS 5.1 cold start
+// and AMSI scan of a freshly written .ps1. Measured on a Win11 box with
+// Windows Terminal as the default host, W stamps in ~440ms (A: ~585ms), so
+// the budget is >10x the observed cost; it is only ever spent in full on a
+// machine where WSH is disabled by policy, and there `//B` makes wscript fail
+// fast and silently rather than pop a dialog. Worst case is now three burned
+// windows (~14s) before the refusal instead of two (~8s) — paid only on the
+// path that was already going to end in a refusal dialog, and nothing is
+// armed yet (the 20s before-quit deadline starts at app.quit()).
+const LAUNCH_STAMP_BUDGET_W_MS = 6_000;
 const LAUNCH_STAMP_BUDGET_A_MS = 6_000;
 const LAUNCH_STAMP_BUDGET_B_MS = 2_000;
 
@@ -768,10 +830,18 @@ const LAUNCH_STAMP_BUDGET_B_MS = 2_000;
  * nothing on stderr, no AV detection — while the same PowerShell created by
  * a detached cmd.exe survives and runs to completion. So:
  *
+ *   transport W — #1136, PREFERRED. wscript.exe (GUI subsystem, so it never
+ *       touches the Win11 default-terminal delegation that made the cmd.exe
+ *       trampoline flash a visible Windows Terminal window) running a VBS
+ *       one-liner that starts the same PowerShell hidden and waits on it.
+ *       See buildWaiterVbsLauncher for the measured root cause.
  *   transport A — cmd.exe trampoline. argv-array: libuv does the CRT
  *       quoting, and cmd /c's strip-first-and-last-quote rule cannot fire
  *       because the first token after /c (the System32 powershell path)
- *       carries no spaces and is unquoted.
+ *       carries no spaces and is unquoted. Kept unchanged as the fallback for
+ *       machines where Windows Script Host is disabled by policy — visible
+ *       window and all, because a visible window is a cosmetic defect and a
+ *       refused install is not.
  *   transport B — today's direct detached spawn, kept for machines where A
  *       is somehow unavailable but the direct spawn still works.
  *   Both with cwd pinned OUTSIDE the install root — an inherited cwd inside
@@ -789,11 +859,14 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
   if (process.platform !== 'win32') return null;
   try {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-install-waiter-'));
+    const stampW = path.join(dir, 'launched-w.txt');
     const stampA = path.join(dir, 'launched-a.txt');
     const stampB = path.join(dir, 'launched-b.txt');
+    const scriptW = buildWaiterScript(plan, stampW);
     const scriptA = buildWaiterScript(plan, stampA);
     const scriptB = buildWaiterScript(plan, stampB);
-    if (!scriptA || !scriptB) return null;
+    if (!scriptW || !scriptA || !scriptB) return null;
+    const scriptPathW = path.join(dir, 'wait-and-install-w.ps1');
     const scriptPathA = path.join(dir, 'wait-and-install.ps1');
     const scriptPathB = path.join(dir, 'wait-and-install-b.ps1');
     // The BOM is load-bearing. Windows PowerShell 5.1 decodes a BOM-less file
@@ -802,6 +875,7 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
     // Measured: with `C:\Users\홍길동\...` the BOM-less script still exits 0
     // while writing to the wrong path, which is the worst shape a failure can
     // take here (silent success). With the BOM it behaves.
+    fs.writeFileSync(scriptPathW, '\uFEFF' + scriptW, 'utf-8');
     fs.writeFileSync(scriptPathA, '\uFEFF' + scriptA, 'utf-8');
     fs.writeFileSync(scriptPathB, '\uFEFF' + scriptB, 'utf-8');
 
@@ -811,6 +885,42 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
     );
     const psArgs = ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File'];
     const spawnedPids: number[] = [];
+    // Named per transport rather than indexed off spawnedPids: with three
+    // transports an index is a silent mis-attribution waiting to happen, and
+    // this log line is the field evidence for which one carried the install.
+    let pidW: number | undefined;
+    let pidA: number | undefined;
+    let pidB: number | undefined;
+
+    // #1136 — transport W, tried first because it is the only one that stays
+    // invisible under the Win11 default-terminal delegation.
+    const vbs = buildWaiterVbsLauncher(powershell, psArgs, scriptPathW);
+    if (vbs !== null) {
+      // UTF-16LE with a BOM, for the same reason scriptA/B carry one: a
+      // BOM-less script is decoded as the system ANSI code page, and every
+      // path embedded here (TEMP, so the user profile) mangles on a non-Latin
+      // install — the silent-wrong-path failure #1056 already paid for once.
+      // wscript reads UTF-16LE unambiguously.
+      const vbsPath = path.join(dir, 'launch-waiter.vbs');
+      try {
+        fs.writeFileSync(vbsPath, '﻿' + vbs, 'utf16le');
+        const w = spawn(
+          path.join(systemRoot, 'System32', 'wscript.exe'),
+          // //B: batch mode. Without it a machine with Windows Script Host
+          // disabled by policy shows an error DIALOG — the exact class of
+          // visible window this transport exists to remove. With it, wscript
+          // fails silently and the gate falls through to transport A.
+          ['//B', '//Nologo', vbsPath],
+          { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
+        );
+        w.unref();
+        if (typeof w.pid === 'number') { spawnedPids.push(w.pid); pidW = w.pid; }
+      } catch { /* WSH unavailable — A still gets its window */ }
+      if (waitForLaunchStamp(stampW, LAUNCH_STAMP_BUDGET_W_MS)) {
+        console.log(`[installTeardown] waiter verified via hidden wscript launcher (pid ${pidW ?? '?'}): ${scriptPathW}`);
+        return scriptPathW;
+      }
+    }
 
     try {
       const a = spawn(
@@ -819,10 +929,10 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
         { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
       );
       a.unref();
-      if (typeof a.pid === 'number') spawnedPids.push(a.pid);
+      if (typeof a.pid === 'number') { spawnedPids.push(a.pid); pidA = a.pid; }
     } catch { /* transport A unavailable — B still gets its window */ }
     if (waitForLaunchStamp(stampA, LAUNCH_STAMP_BUDGET_A_MS)) {
-      console.log(`[installTeardown] waiter verified via cmd trampoline (pid ${spawnedPids[0] ?? '?'}): ${scriptPathA}`);
+      console.log(`[installTeardown] waiter verified via cmd trampoline (pid ${pidA ?? '?'}): ${scriptPathA}`);
       return scriptPathA;
     }
 
@@ -833,10 +943,10 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
         { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
       );
       b.unref();
-      if (typeof b.pid === 'number') spawnedPids.push(b.pid);
+      if (typeof b.pid === 'number') { spawnedPids.push(b.pid); pidB = b.pid; }
     } catch { /* fall through to the refusal below */ }
     if (waitForLaunchStamp(stampB, LAUNCH_STAMP_BUDGET_B_MS)) {
-      console.log(`[installTeardown] waiter verified via direct spawn (pid ${spawnedPids[spawnedPids.length - 1] ?? '?'}): ${scriptPathB}`);
+      console.log(`[installTeardown] waiter verified via direct spawn (pid ${pidB ?? '?'}): ${scriptPathB}`);
       return scriptPathB;
     }
 

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -55,7 +55,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { spawn, execFileSync } from 'child_process';
+import { spawn, execFileSync, type ChildProcess } from 'child_process';
 
 /**
  * Marker the waiter writes when it refuses to launch, relative to userData.
@@ -168,10 +168,16 @@ export function buildWaiterVbsLauncher(
   psArgs: readonly string[],
   scriptPath: string,
 ): string | null {
-  const parts = [powershellPath, ...psArgs, scriptPath];
-  if (!parts.every((p) => p.length > 0 && !/["\r\n]/.test(p))) return null;
-  // Quote only the two paths; the switches are literal and space-free, and
-  // quoting them would make CreateProcess look for a file named `"-NoProfile"`.
+  // The two paths are QUOTED in the emitted command, so whitespace in them is
+  // safe and only a quote or a line break could break out of the literal.
+  if (![powershellPath, scriptPath].every((p) => p.length > 0 && !/["\r\n]/.test(p))) return null;
+  // The switches are inserted BARE (quoting them would make CreateProcess look
+  // for a file named `"-NoProfile"`), so they carry a stricter rule: any
+  // whitespace would silently token-split one switch into two, which is the
+  // kind of failure that produces a waiter running with the WRONG arguments
+  // rather than no waiter at all. Fail closed instead — the caller falls
+  // through to transport A.
+  if (!psArgs.every((a) => a.length > 0 && !/[\s"]/.test(a))) return null;
   const q = (p: string) => `""${p}""`;
   const cmd = [q(powershellPath), ...psArgs, q(scriptPath)].join(' ');
   return [
@@ -781,6 +787,25 @@ function sleepStepMs(ms: number): void {
   }
 }
 
+/**
+ * Attach a no-op 'error' handler to a spawned waiter transport.
+ *
+ * `spawn` reports a failure to create the process ASYNCHRONOUSLY, by emitting
+ * 'error' on the returned ChildProcess — the synchronous try/catch around the
+ * call does NOT cover it. An 'error' event with no listener is re-thrown by
+ * EventEmitter as an uncaught exception, which in the main process means a
+ * crash at the single worst moment available: mid install-handoff, after the
+ * app has committed to quitting. The transport gate already treats "no launch
+ * stamp" as failure, so there is nothing for a handler to decide here — its
+ * only job is to keep the failure a fall-through instead of a crash.
+ *
+ * The listener must be attached BEFORE unref(): unref only stops the child
+ * from holding the event loop open, it does not stop the emit.
+ */
+function swallowSpawnError(child: ChildProcess): void {
+  child.on('error', () => { /* the launch-stamp gate is the real verdict */ });
+}
+
 /** True once `stampPath` exists, polling every 50ms up to `budgetMs`. */
 function waitForLaunchStamp(stampPath: string, budgetMs: number): boolean {
   const deadline = Date.now() + budgetMs;
@@ -891,6 +916,8 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
     let pidW: number | undefined;
     let pidA: number | undefined;
     let pidB: number | undefined;
+    let spawnedA = false;
+    let spawnedB = false;
 
     // #1136 — transport W, tried first because it is the only one that stays
     // invisible under the Win11 default-terminal delegation.
@@ -902,8 +929,9 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
       // install — the silent-wrong-path failure #1056 already paid for once.
       // wscript reads UTF-16LE unambiguously.
       const vbsPath = path.join(dir, 'launch-waiter.vbs');
+      let spawnedW = false;
       try {
-        fs.writeFileSync(vbsPath, '﻿' + vbs, 'utf16le');
+        fs.writeFileSync(vbsPath, '\uFEFF' + vbs, 'utf16le');
         const w = spawn(
           path.join(systemRoot, 'System32', 'wscript.exe'),
           // //B: batch mode. Without it a machine with Windows Script Host
@@ -913,10 +941,16 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
           ['//B', '//Nologo', vbsPath],
           { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
         );
+        swallowSpawnError(w);
         w.unref();
+        spawnedW = true;
         if (typeof w.pid === 'number') { spawnedPids.push(w.pid); pidW = w.pid; }
       } catch { /* WSH unavailable — A still gets its window */ }
-      if (waitForLaunchStamp(stampW, LAUNCH_STAMP_BUDGET_W_MS)) {
+      // Only poll for a stamp a process was actually asked to write. Without
+      // this gate a spawn that threw still burned the full 6s budget waiting
+      // on a file nothing could ever create, delaying the fallback transports
+      // for no information.
+      if (spawnedW && waitForLaunchStamp(stampW, LAUNCH_STAMP_BUDGET_W_MS)) {
         console.log(`[installTeardown] waiter verified via hidden wscript launcher (pid ${pidW ?? '?'}): ${scriptPathW}`);
         return scriptPathW;
       }
@@ -928,10 +962,12 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
         ['/d', '/c', powershell, ...psArgs, scriptPathA],
         { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
       );
+      swallowSpawnError(a);
       a.unref();
+      spawnedA = true;
       if (typeof a.pid === 'number') { spawnedPids.push(a.pid); pidA = a.pid; }
     } catch { /* transport A unavailable — B still gets its window */ }
-    if (waitForLaunchStamp(stampA, LAUNCH_STAMP_BUDGET_A_MS)) {
+    if (spawnedA && waitForLaunchStamp(stampA, LAUNCH_STAMP_BUDGET_A_MS)) {
       console.log(`[installTeardown] waiter verified via cmd trampoline (pid ${pidA ?? '?'}): ${scriptPathA}`);
       return scriptPathA;
     }
@@ -942,10 +978,12 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
         [...psArgs, scriptPathB],
         { detached: true, stdio: 'ignore', windowsHide: true, cwd: systemRoot },
       );
+      swallowSpawnError(b);
       b.unref();
+      spawnedB = true;
       if (typeof b.pid === 'number') { spawnedPids.push(b.pid); pidB = b.pid; }
     } catch { /* fall through to the refusal below */ }
-    if (waitForLaunchStamp(stampB, LAUNCH_STAMP_BUDGET_B_MS)) {
+    if (spawnedB && waitForLaunchStamp(stampB, LAUNCH_STAMP_BUDGET_B_MS)) {
       console.log(`[installTeardown] waiter verified via direct spawn (pid ${pidB ?? '?'}): ${scriptPathB}`);
       return scriptPathB;
     }


### PR DESCRIPTION
Fixes #1136.

**Root cause (measured, not inferred).** `windowsHide: true` was never the deciding flag: libuv maps it to `CREATE_NO_WINDOW`, but `detached: true` also sets `DETACHED_PROCESS` — the two are mutually exclusive console-creation flags, and `DETACHED_PROCESS` wins. The detached `cmd.exe` trampoline therefore allocates its own console, the allocation goes through Win11's default-terminal delegation, and Windows Terminal opens a real window. A/B on a Win11 26200 box with WT default: same `cmd.exe`, same `windowsHide: true` — `detached: true` → visible `WindowsTerminal` window, without → none. Only the two detached waiter transports are affected; the module's non-detached `execFileSync` calls are untouched.

**Fix.** New transport W tried ahead of A/B: `wscript.exe //B //Nologo` running a two-line VBScript that starts the same PowerShell via `WshShell.Run(cmd, 0, True)`. wscript is a GUI-subsystem host — nothing reaches the delegation layer. `bWaitOnReturn = True` keeps wscript parked as the waiter's parent so the refusal path's `taskkill /T` still reaches the PowerShell child. The #1056 provable-launch property is preserved: W has its own launch stamp, script, and budget; A and B are byte-identical behind it (a machine with WSH disabled by policy falls through — a visible window is cosmetic, a refused install is not; `//B` keeps that fallback silent instead of popping WSH's error dialog). `conhost.exe --headless` was tried first and rejected: it exits 0 without ever launching the child, in every argument form.

Review hardening in the second commit: `'error'` listeners on all three transport spawns (an unlistened async spawn failure was an uncaught exception at install-handoff time), stamp waits gated on spawn success, stricter bare-argument validation in the VBS builder, the BOM as an explicit escape, and a WSH-availability skipIf on the runtime identity test.

**Evidence on the reporting hardware** (Win11 26200, WT default): transport W shows no visible window, stamps in ~440 ms, runs to completion, survives the parent's exit, and is reachable by `taskkill /T`; the unchanged cmd transport reproduces the visible window; direct-spawn B never stamps (reproducing #1056). With W force-disabled, the runtime identity test goes red and the cmd-trampoline end-to-end proof still passes — the fallback is intact. `src/main/updater` suites: 177 passed; tsc/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows 11 installations with Windows Terminal set as the default terminal so no visible terminal window flashes during installation.
  * Improved updater fallback behavior when Windows Script Host is unavailable.
  * Prevented failed background launch attempts from interrupting the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->