### PR TITLE
fix(remote): closing a remote-terminal tab destroys the session it minted (#1129)

### DIFF
--- a/changelog.d/1143.md
+++ b/changelog.d/1143.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Closing a remote-terminal tab only detached from the session, so the shell
+  it started — and the one-shot `remote-pane-*` workspace row derived from
+  it — kept running on the remote host forever. Closing the tab (or its
+  pane, or its workspace, by any route) now destroys the session it minted.
+  A tab that merely views a session started elsewhere is never destructive,
+  and sessions leaked before this fix are left for host-side cleanup, since
+  their ownership cannot be proven retroactively. (#1129, #1143)

--- a/src/main/ipc/handlers/__tests__/remote.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/remote.handler.test.ts
@@ -551,7 +551,7 @@ describe('remote.handler — sessionClose (#1129)', () => {
     expect(client.closeSession).toHaveBeenCalledWith('web-9');
   });
 
-  it('detaches every live stream on that session first — no reconnect target left behind', async () => {
+  it('detaches every live stream on that session once the destroy SUCCEEDS — no reconnect target left behind', async () => {
     const store = fakeStore([host]);
     const client = fakeClient(host);
     registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
@@ -579,6 +579,27 @@ describe('remote.handler — sessionClose (#1129)', () => {
 
     expect(res.ok).toBe(false);
     expect(res.error).toMatch(/closing a pane destroys running work/);
+  });
+
+  // The failure-destructive ordering bug: a detach-first close that then fails
+  // leaves the session alive with every mirror of it cut and nothing to retry
+  // from. The destroy must land before anything is torn down.
+  it('leaves every attach INTACT when the destroy fails', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    client.closeSession.mockRejectedValueOnce(new Error('host offline'));
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+    const sender = fakeSender(1);
+    await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'web-9');
+
+    await getHandler(IPC.REMOTE_SESSION_CLOSE)({}, 'h1', 'web-9');
+
+    expect(client.detach).not.toHaveBeenCalled();
+    // …and the attach is still idempotently addressable, so a retry (or the
+    // renderer's own detach) still has a handle to work with.
+    const again = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender }, 'h1', 'web-9') as { ok: true; attachId: string };
+    expect(again.ok).toBe(true);
+    expect(client.attach).toHaveBeenCalledTimes(1); // same stream, not a second one
   });
 
   it('reports unknown host without touching a client', async () => {

--- a/src/main/ipc/handlers/__tests__/remote.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/remote.handler.test.ts
@@ -110,6 +110,7 @@ function fakeClient(host: RemoteHost) {
     write: vi.fn(async () => undefined),
     listWorkspaces: vi.fn(async (): Promise<RemoteWorkspacesResponse> => ({ workspaces: [] })),
     createWorkspace: vi.fn(async (): Promise<{ sessionId: string }> => ({ sessionId: 'web-1' })),
+    closeSession: vi.fn(async (): Promise<void> => undefined),
     onMeta: vi.fn((cb: (e: RemoteMetaEvent) => void) => { metaCbs.push(cb); }),
     onResize: vi.fn((cb: (e: RemoteResizeEvent) => void) => { resizeCbs.push(cb); }),
     onData: vi.fn((cb: (e: RemoteDataEvent) => void) => { dataCbs.push(cb); }),
@@ -127,6 +128,7 @@ function fakeClient(host: RemoteHost) {
     write: ReturnType<typeof vi.fn>;
     listWorkspaces: ReturnType<typeof vi.fn>;
     createWorkspace: ReturnType<typeof vi.fn>;
+    closeSession: ReturnType<typeof vi.fn>;
     emitMeta: (e: RemoteMetaEvent) => void;
     emitResize: (e: RemoteResizeEvent) => void;
     emitData: (e: RemoteDataEvent) => void;
@@ -530,6 +532,60 @@ describe('remote.handler — workspaceCreate (#1001)', () => {
     registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never });
 
     const res = await getHandler(IPC.REMOTE_WORKSPACE_CREATE)({}, 'missing', 'ws-1') as { ok: boolean; error?: string };
+
+    expect(res).toEqual({ ok: false, error: 'unknown host' });
+  });
+});
+
+describe('remote.handler — sessionClose (#1129)', () => {
+  const host: RemoteHost = { id: 'h1', label: 'box', origin: 'https://box:9600', token: 't', addedAt: 0 };
+
+  it('destroys the session on the host', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+
+    const res = await getHandler(IPC.REMOTE_SESSION_CLOSE)({}, 'h1', 'web-9');
+
+    expect(res).toEqual({ ok: true });
+    expect(client.closeSession).toHaveBeenCalledWith('web-9');
+  });
+
+  it('detaches every live stream on that session first — no reconnect target left behind', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+    const senderA = fakeSender(1);
+    const senderB = fakeSender(2);
+    const a = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender: senderA }, 'h1', 'web-9') as { attachId: string };
+    const b = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender: senderB }, 'h1', 'web-9') as { attachId: string };
+    const other = await getHandler(IPC.REMOTE_PANE_ATTACH)({ sender: senderA }, 'h1', 'web-other') as { attachId: string };
+
+    await getHandler(IPC.REMOTE_SESSION_CLOSE)({}, 'h1', 'web-9');
+
+    expect(client.detach).toHaveBeenCalledWith(a.attachId);
+    expect(client.detach).toHaveBeenCalledWith(b.attachId);
+    // An attach on a DIFFERENT session on the same host is untouched.
+    expect(client.detach).not.toHaveBeenCalledWith(other.attachId);
+  });
+
+  it('maps a refused close ({ok:false}) rather than throwing', async () => {
+    const store = fakeStore([host]);
+    const client = fakeClient(host);
+    client.closeSession.mockRejectedValueOnce(new Error('closing a pane destroys running work'));
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never, clientFactory: () => client });
+
+    const res = await getHandler(IPC.REMOTE_SESSION_CLOSE)({}, 'h1', 'web-9') as { ok: false; error: string };
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/closing a pane destroys running work/);
+  });
+
+  it('reports unknown host without touching a client', async () => {
+    const store = fakeStore([]);
+    registerRemoteHandlers({ store: store as never, attachments: fakeAttachments() as never });
+
+    const res = await getHandler(IPC.REMOTE_SESSION_CLOSE)({}, 'missing', 'web-9');
 
     expect(res).toEqual({ ok: false, error: 'unknown host' });
   });

--- a/src/main/ipc/handlers/remote.handler.ts
+++ b/src/main/ipc/handlers/remote.handler.ts
@@ -498,20 +498,26 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
       const session = assertString(sessionId, 'sessionId');
       const client = getOrCreateClient(id);
       if (!client) return { ok: false, error: 'unknown host' };
-      // Drop every live attach on this (host, session) FIRST — for any
-      // sender, since a session can legitimately be mirrored from more than
-      // one place. A stream left open against a session we are about to
-      // destroy would just feed the client's reconnect loop a target that no
-      // longer exists.
-      for (const [attachId, record] of [...attachRecords.entries()]) {
-        if (record.hostId === id && record.sessionId === session) detachAttach(attachId);
-      }
+      // DESTROY FIRST, DETACH AFTER — order matters, and the intuitive order
+      // is the wrong one. Detaching first would be failure-destructive: if
+      // the DELETE then fails (host offline, or a 403 after --allow-input was
+      // revoked), the session is still alive but every mirror of it has been
+      // cut, with no live attach left to retry from. The remote daemon's
+      // handleSessionDelete does not refuse a delete while SSE streams are
+      // open, so there is nothing to gain by going the other way.
       try {
         await client.closeSession(session);
-        return { ok: true };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
+      // The session is gone. Drop every live attach on this (host, session) —
+      // for any sender, since a session can legitimately be mirrored from
+      // more than one place — so nothing is left feeding the client's
+      // reconnect loop a target that no longer exists.
+      for (const [attachId, record] of [...attachRecords.entries()]) {
+        if (record.hostId === id && record.sessionId === session) detachAttach(attachId);
+      }
+      return { ok: true };
     }));
 
   // Attach descriptors — the persistence half of "attachments survive a

--- a/src/main/ipc/handlers/remote.handler.ts
+++ b/src/main/ipc/handlers/remote.handler.ts
@@ -483,6 +483,37 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
       }
     }));
 
+  // #1129 — the teardown twin of REMOTE_WORKSPACE_CREATE. Closing a
+  // remote-terminal tab detaches its SSE stream; without this the shell it
+  // minted (and the one-shot workspace row the daemon derives from that
+  // session's WMUX_WORKSPACE_ID) outlives the tab forever.
+  ipcMain.removeHandler(IPC.REMOTE_SESSION_CLOSE);
+  ipcMain.handle(IPC.REMOTE_SESSION_CLOSE, wrapHandler(IPC.REMOTE_SESSION_CLOSE,
+    async (
+      _e: IpcMainInvokeEvent,
+      hostId: unknown,
+      sessionId: unknown,
+    ): Promise<{ ok: true } | { ok: false; error: string }> => {
+      const id = assertString(hostId, 'hostId');
+      const session = assertString(sessionId, 'sessionId');
+      const client = getOrCreateClient(id);
+      if (!client) return { ok: false, error: 'unknown host' };
+      // Drop every live attach on this (host, session) FIRST — for any
+      // sender, since a session can legitimately be mirrored from more than
+      // one place. A stream left open against a session we are about to
+      // destroy would just feed the client's reconnect loop a target that no
+      // longer exists.
+      for (const [attachId, record] of [...attachRecords.entries()]) {
+        if (record.hostId === id && record.sessionId === session) detachAttach(attachId);
+      }
+      try {
+        await client.closeSession(session);
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }));
+
   // Attach descriptors — the persistence half of "attachments survive a
   // reload". Deliberately independent of the SSE attach lifecycle below: the
   // reload teardown in installSenderCleanup still kills every live stream (a
@@ -599,6 +630,7 @@ export function registerRemoteHandlers(deps: RegisterRemoteHandlersDeps): () => 
     ipcMain.removeHandler(IPC.REMOTE_HOSTS_REMOVE);
     ipcMain.removeHandler(IPC.REMOTE_WORKSPACES_LIST);
     ipcMain.removeHandler(IPC.REMOTE_WORKSPACE_CREATE);
+    ipcMain.removeHandler(IPC.REMOTE_SESSION_CLOSE);
     ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_LIST);
     ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_ADD);
     ipcMain.removeHandler(IPC.REMOTE_ATTACHMENTS_REMOVE);

--- a/src/main/remote/RemoteHostClient.ts
+++ b/src/main/remote/RemoteHostClient.ts
@@ -241,6 +241,44 @@ export class RemoteHostClient implements RemotePaneEvents {
     return { sessionId };
   }
 
+  /**
+   * Destroy one session on this host — `DELETE /api/sessions/:id` (#1129).
+   *
+   * The teardown half of {@link createWorkspace}: the desktop mints a session
+   * (and with it the workspace row the daemon derives from that session's
+   * `WMUX_WORKSPACE_ID` — the daemon keeps no registry of its own), so the
+   * desktop is the only thing that can end it. Detaching closes the SSE
+   * stream and nothing else; the shell keeps running on the host forever.
+   *
+   * A 404 resolves rather than throws: the session already being gone is the
+   * outcome the caller asked for, and a close racing the shell's own exit is
+   * the normal case, not an error. Every other non-2xx throws with the
+   * daemon's own wording — notably 403 on a host running without
+   * `--allow-input`, where closing a pane is refused for the same reason
+   * typing is.
+   */
+  async closeSession(sessionId: string): Promise<void> {
+    const res = await this.fetchImpl(
+      `${this.host.origin}/api/sessions/${encodeURIComponent(sessionId)}`,
+      {
+        method: 'DELETE',
+        headers: this.authHeaders(),
+        redirect: 'error',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      },
+    );
+    if (res.ok || res.status === 404) return;
+    let message = `closeSession failed: HTTP ${res.status}`;
+    try {
+      const parsed = (await res.json()) as { error?: string; detail?: string };
+      if (parsed?.detail) message = parsed.detail;
+      else if (parsed?.error) message = parsed.error;
+    } catch {
+      /* body wasn't JSON — fall back to the generic message */
+    }
+    throw new Error(message);
+  }
+
   async listWorkspaces(): Promise<RemoteWorkspacesResponse> {
     const res = await this.fetchImpl(`${this.host.origin}/api/workspaces`, {
       headers: this.authHeaders(),

--- a/src/main/remote/RemoteHostClient.ts
+++ b/src/main/remote/RemoteHostClient.ts
@@ -6,8 +6,13 @@
 // relying on EventSource's query-string token, and it drives the pane state
 // for Task 5's IPC handler instead of a DOM terminal.
 //
-// This class is observer + input only: it never calls a destroy/delete
-// endpoint on the remote host.
+// Observe + input + exactly ONE destructive verb (#1129): `closeSession`
+// (`DELETE /api/sessions/:id`), the teardown twin of `createWorkspace`. This
+// class mints sessions on the remote host, so it is also what must end them —
+// closing a remote-terminal tab would otherwise leave the shell (and the
+// workspace row the daemon derives from it) running forever. Nothing else
+// here deletes anything on the remote; `detach`/`detachAll` are LOCAL stream
+// teardown and leave the remote session untouched, on purpose.
 
 import * as crypto from 'crypto';
 import type {

--- a/src/main/remote/__tests__/RemoteHostClient.test.ts
+++ b/src/main/remote/__tests__/RemoteHostClient.test.ts
@@ -128,6 +128,71 @@ describe('RemoteHostClient', () => {
     });
   });
 
+  describe('closeSession (#1129)', () => {
+    it('DELETEs /api/sessions/:id with the Bearer token and no redirect following', async () => {
+      const fetchImpl = vi.fn(async () => ({ ok: true, status: 204 }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await client.closeSession('web-1');
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchImpl.mock.calls[0] as unknown as [string, RequestInit];
+      expect(url).toBe(`${host.origin}/api/sessions/web-1`);
+      expect(init.method).toBe('DELETE');
+      expect((init.headers as Record<string, string>)?.Authorization).toBe(`Bearer ${host.token}`);
+      expect(init.redirect).toBe('error');
+      expect(init.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('percent-encodes the session id into the path', async () => {
+      const fetchImpl = vi.fn(async () => ({ ok: true, status: 204 }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await client.closeSession('a/../b');
+
+      expect((fetchImpl.mock.calls[0] as unknown as [string])[0])
+        .toBe(`${host.origin}/api/sessions/a%2F..%2Fb`);
+    });
+
+    it('resolves on 404 — already gone is the outcome the caller asked for', async () => {
+      const fetchImpl = vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: 'session not found' }),
+      }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.closeSession('web-gone')).resolves.toBeUndefined();
+    });
+
+    it('rejects with the daemon detail when the host refuses the close (no --allow-input)', async () => {
+      const fetchImpl = vi.fn(async () => ({
+        ok: false,
+        status: 403,
+        json: async () => ({
+          error: 'input-not-allowed',
+          detail: 'closing a pane destroys running work — it requires the same grant as typing',
+        }),
+      }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.closeSession('web-1')).rejects.toThrow(
+        'closing a pane destroys running work — it requires the same grant as typing',
+      );
+    });
+
+    it('rejects with a generic message when the error body is not JSON', async () => {
+      const fetchImpl = vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        json: async () => { throw new Error('not json'); },
+      }) as unknown as Response);
+      const client = new RemoteHostClient(host, fetchImpl as unknown as typeof fetch);
+
+      await expect(client.closeSession('web-1')).rejects.toThrow('closeSession failed: HTTP 500');
+    });
+  });
+
   describe('listWorkspaces', () => {
     it('sends Authorization: Bearer <token> and parses the body', async () => {
       const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) => {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1389,6 +1389,10 @@ document.addEventListener('DOMContentLoaded', () => {
     ipcRenderer.invoke(IPC.REMOTE_WORKSPACE_CREATE, hostId, workspaceId, cwd) as Promise<
       { ok: true; sessionId: string } | { ok: false; error: string }
     >,
+  sessionClose: (hostId: string, sessionId: string) =>
+    ipcRenderer.invoke(IPC.REMOTE_SESSION_CLOSE, hostId, sessionId) as Promise<
+      { ok: true } | { ok: false; error: string }
+    >,
   attachmentsList: () =>
     ipcRenderer.invoke(IPC.REMOTE_ATTACHMENTS_LIST) as Promise<RemoteAttachmentDescriptor[]>,
   attachmentsAdd: (descriptor: RemoteAttachmentDescriptor) =>

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -3,6 +3,7 @@ import { Panel, Group, Separator } from 'react-resizable-panels';
 import type { PaneLeaf, Workspace } from '../../../shared/types';
 import { maybeDelegateExternalBrowser } from '../../utils/browserPaneActions';
 import { createTerminalSurface } from '../../utils/createTerminalSurface';
+import { destroySurfaceRemoteSession } from '../../utils/remoteSessionTeardown';
 import { useIpc } from '../../hooks/useIpc';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
@@ -419,7 +420,10 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
   }, []);
 
   const handleRemoteCreated = useCallback((hostId: string, sessionId: string) => {
-    addRemoteSurface(pane.id, hostId, sessionId, undefined, undefined, workspace.id);
+    // owned: true — AddRemotePaneModal MINTED this session (and the one-shot
+    // `remote-pane-*` workspace row derived from it), so this tab is what has
+    // to destroy it on close (#1129). Nothing else on the host ever will.
+    addRemoteSurface(pane.id, hostId, sessionId, undefined, undefined, workspace.id, true);
   }, [addRemoteSurface, pane.id, workspace.id]);
 
   const closePane = useStore((s) => s.closePane);
@@ -512,6 +516,12 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
     if (surface?.ptyId) {
       window.electronAPI.pty.dispose(surface.ptyId);
     }
+    // #1129 — a remote-terminal tab carries no ptyId, so the dispose above is
+    // structurally blind to it. Closing the tab must also end the session
+    // this desktop minted on the host (and with it the one-shot workspace row
+    // derived from it); a tab merely viewing somebody else's session is left
+    // alone by destroySurfaceRemoteSession itself.
+    destroySurfaceRemoteSession(surface);
     closeSurface(pane.id, surfaceId);
 
     // 마지막 Surface가 닫히면 Pane도 자동 제거

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../contrastSafety';
 import type { CustomThemeColors, NotificationCategory, Workspace, XtermThemeColors } from '../../../shared/types';
 import { getWorkspacePtyIds } from '../../../shared/paneUtils';
+import { destroyWorkspaceRemoteSessions } from '../../utils/remoteSessionTeardown';
 import type { ChromePreset } from '../../../shared/chromePresets';
 import { NOTIFICATION_CATEGORIES } from '../../../shared/types';
 import { ORCH_ROLES, launcherSupportsModelFlag } from '../../../shared/orchestratorRole';
@@ -626,6 +627,9 @@ function ResetSection() {
  *  behind the one action whose whole promise is a clean slate. */
 function disposeWorkspacePtys(ws: Workspace) {
   for (const ptyId of getWorkspacePtyIds(ws)) window.electronAPI.pty.dispose(ptyId);
+  // #1129 — remote-terminal surfaces have no ptyId; a "clean slate" that
+  // leaves sessions running on a paired host is not one.
+  destroyWorkspaceRemoteSessions(ws);
 }
 
 // ─── Orchestrator (deck brain) settings ──────────────────────────────────────

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import MissionsSection from './MissionsSection';
 import PresetPicker from './PresetPicker';
 import type { Workspace } from '../../../shared/types';
 import { getWorkspacePtyIds } from '../../../shared/paneUtils';
+import { destroyWorkspaceRemoteSessions } from '../../utils/remoteSessionTeardown';
 import { useT } from '../../hooks/useT';
 import { buildWorkspaceMarkdown } from '../../utils/sessionInfoMarkdown';
 import { tokenAttrs } from '../../themes';
@@ -26,6 +27,10 @@ import { COMPANY_MODE_ENABLED } from '../../../shared/featureFlags';
 // daemon session burning tokens with no window left to show it.
 function disposeAllPtys(ws: Workspace) {
   for (const ptyId of getWorkspacePtyIds(ws)) window.electronAPI.pty.dispose(ptyId);
+  // #1129 — a remote-terminal surface owns a session on another machine and
+  // carries no ptyId, so the walk above is blind to it. Same orphan argument
+  // as the stash: nothing else on the host will ever reap it.
+  destroyWorkspaceRemoteSessions(ws);
 }
 
 export default function Sidebar() {

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -7,6 +7,11 @@ import { t } from '../i18n';
 import { pastePtyChunked } from '../utils/clipboardChunk';
 import { createTerminalSurface } from '../utils/createTerminalSurface';
 import { openUrlInBrowserPane } from '../utils/browserPaneActions';
+import {
+  destroyPaneTreeRemoteSessions,
+  destroySurfaceRemoteSession,
+  destroyWorkspaceRemoteSessions,
+} from '../utils/remoteSessionTeardown';
 
 // Lightweight bookmark toast — reuses the same DOM element pattern as showCopyToast
 let bookmarkToastTimer: ReturnType<typeof setTimeout> | null = null;
@@ -74,9 +79,12 @@ export function ctrlByteForKeyCode(code: string): string | null {
   return String.fromCharCode(m[1].charCodeAt(0) - 64);
 }
 
-/** Dispose all PTYs inside a pane tree */
+/** Dispose all PTYs inside a pane tree — plus every remote session the tree
+ *  owns (#1129), which carries no ptyId and would otherwise survive the pane
+ *  that was running it. */
 function disposePanePtys(pane: import('../../shared/types').Pane): void {
   for (const ptyId of collectPaneTreePtyIds(pane)) window.electronAPI.pty.dispose(ptyId);
+  destroyPaneTreeRemoteSessions(pane);
 }
 
 /**
@@ -165,6 +173,9 @@ export function createPrefixActions(deps: PrefixActionDeps): Record<string, () =
   // injected electronAPI, not the window global) stays local.
   const disposeTree = (pane: import('../../shared/types').Pane): void => {
     for (const ptyId of collectPaneTreePtyIds(pane)) electronAPI.pty.dispose(ptyId);
+    // #1129 — remote-terminal surfaces have no ptyId; the walk above cannot
+    // see them, so the sessions this desktop minted need their own teardown.
+    destroyPaneTreeRemoteSessions(pane);
   };
 
   return {
@@ -241,6 +252,7 @@ export function createPrefixActions(deps: PrefixActionDeps): Record<string, () =
       // Workspace-wide (#977) — see Sidebar.disposeAllPtys: a stashed pane's
       // session dies with its workspace or it becomes an orphan.
       for (const ptyId of getWorkspacePtyIds(ws)) electronAPI.pty.dispose(ptyId);
+      destroyWorkspaceRemoteSessions(ws); // #1129 — same reasoning, no ptyId
       state.removeWorkspace(state.activeWorkspaceId);
     },
     showCheatSheet: () => {
@@ -442,6 +454,7 @@ export function useKeyboard() {
           // killWorkspace action: a stashed session outliving its workspace is
           // an orphan nothing can reach.
           for (const ptyId of getWorkspacePtyIds(ws)) window.electronAPI.pty.dispose(ptyId);
+          destroyWorkspaceRemoteSessions(ws); // #1129 — same reasoning, no ptyId
         }
         state.removeWorkspace(state.activeWorkspaceId);
         return;
@@ -569,6 +582,10 @@ export function useKeyboard() {
           if (surface?.ptyId) {
             window.electronAPI.pty.dispose(surface.ptyId);
           }
+          // #1129 — the tab-strip X does the same (Pane.handleCloseSurface);
+          // the two close paths must not diverge on what closing a remote tab
+          // means.
+          destroySurfaceRemoteSession(surface);
           const wasLastSurface = activePane.surfaces.length <= 1;
           state.closeSurface(activePane.id, activePane.activeSurfaceId);
           if (wasLastSurface) {

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -33,7 +33,7 @@ import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
 import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, REPLY_SUPPRESS_HINTS, countRoundTrips, maxSideMessages, REPLY_ROUND_CAP, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
 import { resolveWorkspaceTarget } from './workspaceTargeting';
-import { destroyRemoteSessions, destroySurfaceRemoteSession } from '../utils/remoteSessionTeardown';
+import { destroyRemoteSessions, destroySurfaceRemoteSession, destroyWorkspaceRemoteSessions } from '../utils/remoteSessionTeardown';
 import { collectPaneTreeRemoteSessions } from '../../shared/paneUtils';
 import { findActivePtyId, buildWorkspaceListEntries } from './workspaceMirrorSnapshot';
 
@@ -664,6 +664,14 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
         void window.electronAPI.pty.dispose(ptyId).catch(() => { /* best-effort */ });
       } catch { /* best-effort */ }
     }
+    // #1129 — the remote half of the same teardown, and the same "one of the
+    // two paths forgot" bug class the comment above describes. A
+    // remote-terminal surface carries no ptyId, so the loop above cannot see
+    // it; and once removeWorkspace drops the workspace, its `remoteOwned`
+    // records go with it and the session becomes permanently unreapable.
+    // Placed under the same guards as the dispose loop: it only runs where
+    // the removal will actually happen.
+    destroyWorkspaceRemoteSessions(ws);
     store.removeWorkspace(id);
     // Confirm the removal actually landed before acknowledging it. Today this
     // cannot fail: nothing awaits between the guards above and here, so two

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -33,6 +33,8 @@ import { submitBracketedPasteToPty } from '../utils/ptyMessageDelivery';
 import { publishA2aTask } from '../events/publisher';
 import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, REPLY_SUPPRESS_HINTS, countRoundTrips, maxSideMessages, REPLY_ROUND_CAP, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, findLeafPanes, type PaneAddress } from './a2aAddressing';
 import { resolveWorkspaceTarget } from './workspaceTargeting';
+import { destroyRemoteSessions, destroySurfaceRemoteSession } from '../utils/remoteSessionTeardown';
+import { collectPaneTreeRemoteSessions } from '../../shared/paneUtils';
 import { findActivePtyId, buildWorkspaceListEntries } from './workspaceMirrorSnapshot';
 
 // ---------------------------------------------------------------------------
@@ -1066,8 +1068,12 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
       return { error: 'pane.close: cannot close the root pane' };
     }
     const ptyIds = pane.surfaces.map((s) => s.ptyId).filter((p): p is string => !!p);
+    // #1129 — remote-terminal surfaces carry no ptyId, so they are invisible
+    // to the dispose loop below; collect them before the pane leaves the tree.
+    const remoteSessions = collectPaneTreeRemoteSessions(pane);
 
     store.closePane(paneId, targetWs.id);
+    destroyRemoteSessions(remoteSessions);
 
     for (const ptyId of ptyIds) {
       try { await window.electronAPI.pty.dispose(ptyId); } catch { /* best-effort */ }
@@ -1139,6 +1145,12 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const ptyId = surface?.ptyId;
 
     store.closeSurface(targetLeaf.id, surfaceId, targetWs.id);
+
+    // #1129 — a remote-terminal surface has no ptyId, so the dispose below
+    // would silently do nothing and leave the session running on the host.
+    // Same semantics as the tab X and Ctrl+W: close destroys what this
+    // desktop minted, never a session it is only viewing.
+    destroySurfaceRemoteSession(surface);
 
     if (ptyId) {
       try {

--- a/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/surfaceSlice.test.ts
@@ -720,6 +720,22 @@ describe('surfaceSlice.addRemoteSurface (#1086/#1091)', () => {
     expect(pane.surfaces[0].title).toBe('Remote');
   });
 
+  // #1129 — ownership decides whether closing the tab destroys the session.
+  it('marks the surface owned only when the caller says it minted the session', () => {
+    const { state, slice } = createHarness();
+    const paneId = state.workspaces[0].rootPane.id;
+
+    slice.addRemoteSurface(paneId, 'host-abc', 'minted', undefined, undefined, undefined, true);
+    slice.addRemoteSurface(paneId, 'host-abc', 'viewed');
+
+    const pane = state.workspaces[0].rootPane;
+    if (pane.type !== 'leaf') throw new Error('expected leaf pane');
+    expect(pane.surfaces[0].remoteOwned).toBe(true);
+    // Not merely false — absent, so a persisted surface from before #1129
+    // reads the same as an explicit "not mine".
+    expect(pane.surfaces[1].remoteOwned).toBeUndefined();
+  });
+
   it('is a no-op when the target pane does not exist', () => {
     const { state, slice } = createHarness();
 

--- a/src/renderer/stores/slices/surfaceSlice.ts
+++ b/src/renderer/stores/slices/surfaceSlice.ts
@@ -26,7 +26,7 @@ export interface SurfaceSlice {
    * splitPane, then calls this to populate it. ptyId stays '' (see
    * createRemoteSurface), so every ptyId-gated check already treats this
    * surface as non-local without further changes. */
-  addRemoteSurface: (paneId: string, hostId: string, sessionId: string, shell?: string, cwd?: string, workspaceId?: string) => void;
+  addRemoteSurface: (paneId: string, hostId: string, sessionId: string, shell?: string, cwd?: string, workspaceId?: string, owned?: boolean) => void;
   addEditorSurface: (paneId: string, filePath: string) => void;
   /** J2 — diff 리뷰 서피스 추가. taskId만 영속(diff 내용은 파생 데이터).
    * 같은 taskId가 이미 열려 있으면 그 탭으로 전환. editor/browser처럼 ptyId 없음. */
@@ -160,13 +160,13 @@ export const createSurfaceSlice: StateCreator<StoreState, [['zustand/immer', nev
     pane.activeSurfaceId = surface.id;
   }),
 
-  addRemoteSurface: (paneId, hostId, sessionId, shell, cwd, workspaceId) => set((state: StoreState) => {
+  addRemoteSurface: (paneId, hostId, sessionId, shell, cwd, workspaceId, owned) => set((state: StoreState) => {
     const targetWsId = workspaceId || state.activeWorkspaceId;
     const ws = state.workspaces.find((w: Workspace) => w.id === targetWsId);
     if (!ws) return;
     const pane = findLeafPane(ws.rootPane, paneId);
     if (!pane) return;
-    const surface = createRemoteSurface(hostId, sessionId, shell || '', cwd || '');
+    const surface = createRemoteSurface(hostId, sessionId, shell || '', cwd || '', owned === true);
     pane.surfaces.push(surface);
     pane.activeSurfaceId = surface.id;
   }),

--- a/src/renderer/utils/__tests__/remoteSessionTeardown.test.ts
+++ b/src/renderer/utils/__tests__/remoteSessionTeardown.test.ts
@@ -105,6 +105,7 @@ describe('every explicit close path is wired to the teardown', () => {
     ['hooks/useKeyboard.ts', /destroyWorkspaceRemoteSessions\(/],
     ['hooks/useRpcBridge.ts', /destroySurfaceRemoteSession\(/],
     ['hooks/useRpcBridge.ts', /destroyRemoteSessions\(/],
+    ['hooks/useRpcBridge.ts', /destroyWorkspaceRemoteSessions\(/],
     ['components/Sidebar/Sidebar.tsx', /destroyWorkspaceRemoteSessions\(/],
     ['components/Settings/SettingsPanel.tsx', /destroyWorkspaceRemoteSessions\(/],
   ];
@@ -116,11 +117,44 @@ describe('every explicit close path is wired to the teardown', () => {
 });
 
 describe('failure handling', () => {
-  it('swallows a rejected close — the tab is already gone, there is nothing to report to', async () => {
+  it('never rejects into the caller on a thrown close, but leaves a trace', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => { /* keep the test output clean */ });
     sessionClose.mockRejectedValue(new Error('host offline'));
+
     expect(() => destroyRemoteSessions([{ hostId: 'h1', sessionId: 'web-1' }])).not.toThrow();
     // Let the rejection settle; an unhandled one would fail the run.
     await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('web-1');
+    expect(warn.mock.calls[0][0]).toContain('h1');
+    expect(warn.mock.calls[0][0]).toContain('host offline');
+    warn.mockRestore();
+  });
+
+  // The orphan case: the surface (and its remoteOwned record) is already gone,
+  // so a refusal that logged nothing would be a session nobody can explain.
+  it('logs a refused close ({ ok: false }) too, not just a thrown one', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => { /* keep the test output clean */ });
+    sessionClose.mockResolvedValue({ ok: false, error: 'input-not-allowed' });
+
+    destroyRemoteSessions([{ hostId: 'h1', sessionId: 'web-1' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('input-not-allowed');
+    warn.mockRestore();
+  });
+
+  it('stays quiet on success', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => { /* keep the test output clean */ });
+    destroyRemoteSessions([{ hostId: 'h1', sessionId: 'web-1' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it('is a no-op when the preload bridge is absent', () => {

--- a/src/renderer/utils/__tests__/remoteSessionTeardown.test.ts
+++ b/src/renderer/utils/__tests__/remoteSessionTeardown.test.ts
@@ -1,0 +1,130 @@
+// #1129 — the close-destroys-the-remote-session policy. The walks it builds
+// on are covered in shared/__tests__/paneUtils.test.ts; what is tested here is
+// the POLICY: only an owned session is destroyed, a failure never rejects into
+// the caller, and a missing bridge is a no-op rather than a crash.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  destroyRemoteSessions,
+  destroySurfaceRemoteSession,
+  destroyPaneTreeRemoteSessions,
+  destroyWorkspaceRemoteSessions,
+} from '../remoteSessionTeardown';
+import type { PaneLeaf, Surface } from '../../../shared/types';
+
+function remoteSurface(over: Partial<Surface> = {}): Surface {
+  return {
+    id: 's1',
+    ptyId: '',
+    title: '',
+    shell: '',
+    cwd: '',
+    surfaceType: 'remote-terminal',
+    remoteHostId: 'h1',
+    remoteSessionId: 'web-1',
+    remoteOwned: true,
+    ...over,
+  };
+}
+
+let sessionClose: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  sessionClose = vi.fn().mockResolvedValue({ ok: true });
+  (globalThis as unknown as { window: unknown }).window = { electronAPI: { remote: { sessionClose } } };
+});
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+});
+
+describe('destroySurfaceRemoteSession', () => {
+  it('closes the session an owned remote tab points at', () => {
+    destroySurfaceRemoteSession(remoteSurface());
+    expect(sessionClose).toHaveBeenCalledWith('h1', 'web-1');
+  });
+
+  it('leaves a tab that only VIEWS somebody else\'s session alone', () => {
+    destroySurfaceRemoteSession(remoteSurface({ remoteOwned: undefined }));
+    expect(sessionClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores a local terminal surface and an absent one', () => {
+    destroySurfaceRemoteSession({ id: 's', ptyId: 'pty-1', title: '', shell: '', cwd: '' });
+    destroySurfaceRemoteSession(undefined);
+    expect(sessionClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores an owned surface with no session pointer', () => {
+    destroySurfaceRemoteSession(remoteSurface({ remoteSessionId: undefined }));
+    expect(sessionClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('destroyPaneTreeRemoteSessions / destroyWorkspaceRemoteSessions', () => {
+  const leaf: PaneLeaf = {
+    id: 'leaf-1',
+    type: 'leaf',
+    activeSurfaceId: 's1',
+    surfaces: [
+      remoteSurface(),
+      remoteSurface({ id: 's2', remoteSessionId: 'web-2', remoteOwned: undefined }),
+    ],
+  };
+
+  it('closes every owned session under a pane subtree, and only those', () => {
+    destroyPaneTreeRemoteSessions(leaf);
+    expect(sessionClose).toHaveBeenCalledTimes(1);
+    expect(sessionClose).toHaveBeenCalledWith('h1', 'web-1');
+  });
+
+  it('reaches stashed panes at the workspace level', () => {
+    const stashed: PaneLeaf = {
+      id: 'leaf-x',
+      type: 'leaf',
+      activeSurfaceId: 'sx',
+      surfaces: [remoteSurface({ id: 'sx', remoteSessionId: 'web-stashed' })],
+    };
+    destroyWorkspaceRemoteSessions({ rootPane: leaf, stashedPanes: [{ pane: stashed }] });
+    expect(sessionClose.mock.calls).toEqual([['h1', 'web-1'], ['h1', 'web-stashed']]);
+  });
+});
+
+// A source scan, in the style of useKeyboard.test.ts's shortcut checks: the
+// leak in #1129 was not a broken helper, it was close paths that never called
+// one. Rendering the whole Pane to prove that costs far more than it is worth,
+// so this pins the wiring instead — a new close path that disposes PTYs and
+// forgets the remote half is exactly the regression to catch.
+describe('every explicit close path is wired to the teardown', () => {
+  const cases: Array<[string, RegExp]> = [
+    ['components/Pane/Pane.tsx', /destroySurfaceRemoteSession\(/],
+    ['hooks/useKeyboard.ts', /destroySurfaceRemoteSession\(/],
+    ['hooks/useKeyboard.ts', /destroyPaneTreeRemoteSessions\(/],
+    ['hooks/useKeyboard.ts', /destroyWorkspaceRemoteSessions\(/],
+    ['hooks/useRpcBridge.ts', /destroySurfaceRemoteSession\(/],
+    ['hooks/useRpcBridge.ts', /destroyRemoteSessions\(/],
+    ['components/Sidebar/Sidebar.tsx', /destroyWorkspaceRemoteSessions\(/],
+    ['components/Settings/SettingsPanel.tsx', /destroyWorkspaceRemoteSessions\(/],
+  ];
+
+  it.each(cases)('%s calls %s', (relPath, pattern) => {
+    const src = readFileSync(join(__dirname, '..', '..', relPath), 'utf8');
+    expect(src).toMatch(pattern);
+  });
+});
+
+describe('failure handling', () => {
+  it('swallows a rejected close — the tab is already gone, there is nothing to report to', async () => {
+    sessionClose.mockRejectedValue(new Error('host offline'));
+    expect(() => destroyRemoteSessions([{ hostId: 'h1', sessionId: 'web-1' }])).not.toThrow();
+    // Let the rejection settle; an unhandled one would fail the run.
+    await Promise.resolve();
+  });
+
+  it('is a no-op when the preload bridge is absent', () => {
+    (globalThis as unknown as { window: unknown }).window = {};
+    expect(() => destroyRemoteSessions([{ hostId: 'h1', sessionId: 'web-1' }])).not.toThrow();
+  });
+});

--- a/src/renderer/utils/remoteSessionTeardown.ts
+++ b/src/renderer/utils/remoteSessionTeardown.ts
@@ -22,6 +22,10 @@ import {
  *     minted. A tab that merely views a session started elsewhere is left
  *     strictly alone — closing your view of somebody's running work must
  *     never end it.
+ *     NO CONFIRMATION PROMPT (decided, not an oversight): closing a remote
+ *     tab destroys immediately, exactly as closing a local pane disposes its
+ *     PTY without asking. `remoteOwned` IS the safety boundary — a prompt
+ *     would be asking the user to re-authorize a close they just performed.
  *  2. CLOSE, NOT UNMOUNT. These are called from the explicit close paths
  *     (tab X, Ctrl+W, pane/workspace teardown) only, never from a React
  *     cleanup: a remount, a reload, a tab switch, or a workspace switch must
@@ -31,7 +35,12 @@ import {
  * Best-effort by design, like `pty.dispose`: the tab is already gone from the
  * layout by the time the DELETE lands, so a failure (host offline, or a host
  * running without `--allow-input`, which refuses a close) has nothing to
- * report to and must not reject into the caller.
+ * report to and must not reject into the caller. Best-effort is NOT silent,
+ * though: the surface carrying the `remoteOwned` record is gone, so a failed
+ * close orphans that session for good — one transient network blip with no
+ * trace is a session nobody can explain later. Every failure, refused
+ * (`{ ok: false }`) or thrown, is logged with the host and session it was
+ * about.
  */
 export function destroyRemoteSessions(refs: readonly RemoteSessionRef[]): void {
   // `typeof window` rather than a bare reference: createPrefixActions (the
@@ -41,7 +50,21 @@ export function destroyRemoteSessions(refs: readonly RemoteSessionRef[]): void {
   const remote = typeof window === 'undefined' ? undefined : window.electronAPI?.remote;
   if (!remote?.sessionClose) return;
   for (const ref of refs) {
-    void remote.sessionClose(ref.hostId, ref.sessionId).catch(() => { /* see doc comment */ });
+    void remote
+      .sessionClose(ref.hostId, ref.sessionId)
+      .then((res) => {
+        if (res.ok) return;
+        console.warn(
+          `[remote] could not close session ${ref.sessionId} on host ${ref.hostId} — ` +
+          `it is still running there: ${res.error}`,
+        );
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          `[remote] close of session ${ref.sessionId} on host ${ref.hostId} failed — ` +
+          `it may still be running there: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
   }
 }
 

--- a/src/renderer/utils/remoteSessionTeardown.ts
+++ b/src/renderer/utils/remoteSessionTeardown.ts
@@ -1,0 +1,65 @@
+import type { Pane, Surface } from '../../shared/types';
+import {
+  collectPaneTreeRemoteSessions,
+  getWorkspaceRemoteSessions,
+  type RemoteSessionRef,
+  type WorkspacePaneOwner,
+} from '../../shared/paneUtils';
+
+/**
+ * #1129 — the remote half of "closing this destroys what it was running".
+ *
+ * A remote-terminal surface has no ptyId, so every `pty.dispose` teardown path
+ * in the renderer walks straight past it: closing the tab detached the SSE
+ * stream and left the shell — and the one-shot `remote-pane-*` workspace row
+ * the remote daemon derives from that shell's `WMUX_WORKSPACE_ID` — alive on
+ * the host with nothing that would ever reap it.
+ *
+ * TWO DELIBERATE LIMITS, both from #1091's direction call ("tab = mine to
+ * operate, mirror = watching"):
+ *
+ *  1. ONLY OWNED SESSIONS. `Surface.remoteOwned` marks a session THIS desktop
+ *     minted. A tab that merely views a session started elsewhere is left
+ *     strictly alone — closing your view of somebody's running work must
+ *     never end it.
+ *  2. CLOSE, NOT UNMOUNT. These are called from the explicit close paths
+ *     (tab X, Ctrl+W, pane/workspace teardown) only, never from a React
+ *     cleanup: a remount, a reload, a tab switch, or a workspace switch must
+ *     keep the session alive — that constraint is what makes the surface
+ *     model re-attachable at all.
+ *
+ * Best-effort by design, like `pty.dispose`: the tab is already gone from the
+ * layout by the time the DELETE lands, so a failure (host offline, or a host
+ * running without `--allow-input`, which refuses a close) has nothing to
+ * report to and must not reject into the caller.
+ */
+export function destroyRemoteSessions(refs: readonly RemoteSessionRef[]): void {
+  // `typeof window` rather than a bare reference: createPrefixActions (the
+  // one caller that takes an injected electronAPI) is unit-tested in a node
+  // environment with no window at all, and a teardown detail must not be what
+  // decides whether a keyboard action can run there.
+  const remote = typeof window === 'undefined' ? undefined : window.electronAPI?.remote;
+  if (!remote?.sessionClose) return;
+  for (const ref of refs) {
+    void remote.sessionClose(ref.hostId, ref.sessionId).catch(() => { /* see doc comment */ });
+  }
+}
+
+/** Destroy the remote session behind ONE surface, if it owns one. */
+export function destroySurfaceRemoteSession(surface: Surface | undefined): void {
+  if (!surface) return;
+  if (surface.surfaceType !== 'remote-terminal') return;
+  if (!surface.remoteOwned || !surface.remoteHostId || !surface.remoteSessionId) return;
+  destroyRemoteSessions([{ hostId: surface.remoteHostId, sessionId: surface.remoteSessionId }]);
+}
+
+/** Destroy every owned remote session under a pane subtree (pane teardown). */
+export function destroyPaneTreeRemoteSessions(pane: Pane): void {
+  destroyRemoteSessions(collectPaneTreeRemoteSessions(pane));
+}
+
+/** Destroy every owned remote session a workspace holds — visible tree plus
+ *  stash — for the workspace-delete paths. */
+export function destroyWorkspaceRemoteSessions(ws: WorkspacePaneOwner): void {
+  destroyRemoteSessions(getWorkspaceRemoteSessions(ws));
+}

--- a/src/shared/__tests__/clonePaneTreeFresh.test.ts
+++ b/src/shared/__tests__/clonePaneTreeFresh.test.ts
@@ -92,12 +92,15 @@ describe('clonePaneTreeFresh', () => {
 
   it('#1100 CodeRabbit round 1 — strips remoteHostId/remoteSessionId so the clone does not double-attach the source\'s live remote session', () => {
     const src = leaf(
-      [surface({ id: 's1', surfaceType: 'remote-terminal', remoteHostId: 'host-a', remoteSessionId: 'sess-live-1' })],
+      [surface({ id: 's1', surfaceType: 'remote-terminal', remoteHostId: 'host-a', remoteSessionId: 'sess-live-1', remoteOwned: true })],
       's1',
     );
     const clone = clonePaneTreeFresh(src) as PaneLeaf;
     expect(clone.surfaces[0].remoteHostId).toBeUndefined();
     expect(clone.surfaces[0].remoteSessionId).toBeUndefined();
+    // #1129 — the ownership claim goes with the pointer, or the clone would
+    // offer to destroy a session it does not point at.
+    expect(clone.surfaces[0].remoteOwned).toBeUndefined();
     // surfaceType itself is preserved — this is an empty remote-terminal
     // placeholder, not silently downgraded to a plain terminal.
     expect(clone.surfaces[0].surfaceType).toBe('remote-terminal');

--- a/src/shared/__tests__/paneUtils.test.ts
+++ b/src/shared/__tests__/paneUtils.test.ts
@@ -8,6 +8,8 @@ import {
   getWorkspaceLeafPanes,
   collectPaneTreePtyIds,
   getWorkspacePtyIds,
+  collectPaneTreeRemoteSessions,
+  getWorkspaceRemoteSessions,
 } from '../paneUtils';
 import type { Pane, PaneLeaf, PaneBranch } from '../types';
 
@@ -171,5 +173,55 @@ describe('collectPaneTreePtyIds / getWorkspacePtyIds', () => {
     expect(getWorkspacePtyIds({ rootPane: surfaced })).toEqual(['pty-1', 'pty-2']);
     expect(getWorkspacePtyIds({ rootPane: surfaced, stashedPanes: [{ pane: stashed }] }))
       .toEqual(['pty-1', 'pty-2', 'pty-stashed']);
+  });
+});
+
+// #1129 — the remote counterpart of the PTY walks. A remote-terminal surface
+// carries no ptyId, so the walks above are structurally blind to it.
+describe('collectPaneTreeRemoteSessions / getWorkspaceRemoteSessions', () => {
+  const remoteLeaf: PaneLeaf = {
+    id: 'leaf-r',
+    type: 'leaf',
+    activeSurfaceId: 'r1',
+    surfaces: [
+      // owned — this desktop minted it
+      { id: 'r1', ptyId: '', title: '', shell: '', cwd: '', surfaceType: 'remote-terminal', remoteHostId: 'h1', remoteSessionId: 'web-1', remoteOwned: true },
+      // a VIEW of somebody else's session — never a destroy target
+      { id: 'r2', ptyId: '', title: '', shell: '', cwd: '', surfaceType: 'remote-terminal', remoteHostId: 'h1', remoteSessionId: 'web-2' },
+      // an ordinary local terminal shares the leaf
+      { id: 'r3', ptyId: 'pty-9', title: '', shell: '', cwd: '' },
+    ],
+  };
+
+  it('collects only the sessions this desktop owns', () => {
+    expect(collectPaneTreeRemoteSessions(remoteLeaf)).toEqual([{ hostId: 'h1', sessionId: 'web-1' }]);
+  });
+
+  it('returns nothing for a tree with no remote surfaces', () => {
+    expect(collectPaneTreeRemoteSessions(surfaced)).toEqual([]);
+  });
+
+  it('skips an owned surface whose host/session pointer is missing', () => {
+    const broken: PaneLeaf = {
+      id: 'leaf-b',
+      type: 'leaf',
+      activeSurfaceId: 'b1',
+      surfaces: [{ id: 'b1', ptyId: '', title: '', shell: '', cwd: '', surfaceType: 'remote-terminal', remoteOwned: true }],
+    };
+    expect(collectPaneTreeRemoteSessions(broken)).toEqual([]);
+  });
+
+  it('includes stashed panes at the workspace level', () => {
+    const stashed: PaneLeaf = {
+      id: 'leaf-x',
+      type: 'leaf',
+      activeSurfaceId: 'sx',
+      surfaces: [{ id: 'sx', ptyId: '', title: '', shell: '', cwd: '', surfaceType: 'remote-terminal', remoteHostId: 'h2', remoteSessionId: 'web-stashed', remoteOwned: true }],
+    };
+    expect(getWorkspaceRemoteSessions({ rootPane: remoteLeaf })).toEqual([{ hostId: 'h1', sessionId: 'web-1' }]);
+    expect(getWorkspaceRemoteSessions({ rootPane: remoteLeaf, stashedPanes: [{ pane: stashed }] })).toEqual([
+      { hostId: 'h1', sessionId: 'web-1' },
+      { hostId: 'h2', sessionId: 'web-stashed' },
+    ]);
   });
 });

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -567,6 +567,12 @@ export const IPC = {
   // as an operator-authenticated caller (WebTerminalServer.rejectWorkspaceId's
   // one exception). See RemoteHostClient.createWorkspace.
   REMOTE_WORKSPACE_CREATE: 'remote:workspace:create',
+  // Destroy a session the desktop minted on a remote host (#1129) —
+  // `DELETE /api/sessions/:id`. The teardown half of REMOTE_WORKSPACE_CREATE:
+  // closing a remote-terminal tab detaches the stream, and without this the
+  // shell (and the one-shot workspace row the daemon derives from it) would
+  // outlive the tab forever. See RemoteHostClient.closeSession.
+  REMOTE_SESSION_CLOSE: 'remote:session:close',
   // Persisted attach descriptors (see RemoteAttachmentsStore). The renderer's
   // remote-workspace slice is memory-only, so these are what survive a reload
   // and an app restart; panes are never stored, only re-fetched.

--- a/src/shared/electron.d.ts
+++ b/src/shared/electron.d.ts
@@ -223,6 +223,16 @@ declare global {
         workspaceCreate: (hostId: string, workspaceId: string, cwd?: string) => Promise<
           { ok: true; sessionId: string } | { ok: false; error: string }
         >;
+        /** Destroy a session on `hostId` — the teardown twin of
+         *  `workspaceCreate` (#1129). Detaches every live stream on that
+         *  session first, then `DELETE /api/sessions/:id`. Resolves
+         *  `{ ok: true }` when the session is gone (a 404 counts: already
+         *  gone is the requested outcome), `{ ok: false }` with the daemon's
+         *  own wording otherwise — notably on a host running without
+         *  `--allow-input`, which refuses a close. Never rejects. */
+        sessionClose: (hostId: string, sessionId: string) => Promise<
+          { ok: true } | { ok: false; error: string }
+        >;
         /** Persisted attach descriptors — read on renderer boot to restore
          *  the attachments a reload/restart wiped out of the memory-only
          *  slice. Panes are never part of a descriptor: they are re-fetched

--- a/src/shared/paneUtils.ts
+++ b/src/shared/paneUtils.ts
@@ -103,6 +103,44 @@ export function getWorkspacePtyIds(ws: WorkspacePaneOwner): string[] {
   );
 }
 
+/**
+ * #1129 — every remote session a pane tree OWNS (this desktop minted it, see
+ * `Surface.remoteOwned`), in tree order. The remote counterpart of
+ * {@link collectPaneTreePtyIds}: a remote-terminal surface carries no ptyId,
+ * so the PTY walks above are structurally blind to it and a teardown path
+ * that only disposes PTYs leaves the remote shell — plus the one-shot
+ * workspace row the daemon derives from it — running forever.
+ *
+ * Surfaces that merely VIEW a session somebody else started are excluded by
+ * construction: no `remoteOwned`, no destroy.
+ */
+export function collectPaneTreeRemoteSessions(root: Pane): RemoteSessionRef[] {
+  return getLeafPanes(root).flatMap((leaf) => ownedRemoteSessionsOf(leaf));
+}
+
+/**
+ * Every owned remote session a workspace holds — visible tree plus stash. The
+ * workspace-level counterpart of {@link collectPaneTreeRemoteSessions}, for
+ * the same reason {@link getWorkspacePtyIds} exists.
+ */
+export function getWorkspaceRemoteSessions(ws: WorkspacePaneOwner): RemoteSessionRef[] {
+  return getWorkspaceLeafPanes(ws).flatMap((leaf) => ownedRemoteSessionsOf(leaf));
+}
+
+/** One owned remote session, addressed the way `remote.sessionClose` wants it. */
+export interface RemoteSessionRef {
+  hostId: string;
+  sessionId: string;
+}
+
+function ownedRemoteSessionsOf(leaf: PaneLeaf): RemoteSessionRef[] {
+  return leaf.surfaces.flatMap((s) =>
+    s.surfaceType === 'remote-terminal' && s.remoteOwned && s.remoteHostId && s.remoteSessionId
+      ? [{ hostId: s.remoteHostId, sessionId: s.remoteSessionId }]
+      : [],
+  );
+}
+
 // ─── Not consolidated here (deliberate) ──────────────────────────────────────
 //
 // The walks below look like the ones above but diverge in signature or in what

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -72,6 +72,20 @@ export interface Surface {
    */
   remoteHostId?: string;
   remoteSessionId?: string;
+  /**
+   * #1129 — did THIS desktop mint `remoteSessionId`, or is the tab merely a
+   * view onto a session that already existed on the host?
+   *
+   * Only an owned session is destroyed when its tab closes. The distinction
+   * is the whole safety of that teardown: the "add remote pane" flow mints a
+   * one-shot session (and, with it, the workspace row the daemon derives from
+   * its `WMUX_WORKSPACE_ID`) that nothing else will ever reap, whereas the
+   * planned "open this mirror session as a tab" bridge (#1091's direction
+   * call) points at somebody's running work — closing a view of it must not
+   * end it. Absent/false means not owned, so any future construction site is
+   * non-destructive by default.
+   */
+  remoteOwned?: boolean;
   /** J2 — diff 서피스: 대상 태스크 id. diff 내용은 파생 데이터(열 때마다 재계산). */
   diffTaskId?: string;
   /**
@@ -1125,7 +1139,17 @@ export function createSurface(ptyId: string, shell: string, cwd: string): Surfac
  *  in an ordinary local workspace's own pane tree (not a separate remote
  *  workspace). `ptyId: ''` mirrors the `browser` surface convention so every
  *  existing ptyId-gated check already treats it as non-local without edits. */
-export function createRemoteSurface(hostId: string, sessionId: string, shell: string, cwd: string): Surface {
+export function createRemoteSurface(
+  hostId: string,
+  sessionId: string,
+  shell: string,
+  cwd: string,
+  /** #1129 — true only when this desktop minted `sessionId` and is therefore
+   *  the thing responsible for destroying it when the tab closes. Defaults to
+   *  false so a future attach-to-existing caller is non-destructive unless it
+   *  says otherwise. */
+  owned = false,
+): Surface {
   return {
     id: generateId('surface'),
     ptyId: '',
@@ -1135,6 +1159,7 @@ export function createRemoteSurface(hostId: string, sessionId: string, shell: st
     surfaceType: 'remote-terminal',
     remoteHostId: hostId,
     remoteSessionId: sessionId,
+    ...(owned ? { remoteOwned: true } : {}),
   };
 }
 
@@ -1218,6 +1243,10 @@ export function clonePaneTreeFresh(pane: Pane): Pane {
       // fresh on mount" contract a local terminal's reset ptyId gets).
       delete next.remoteHostId;
       delete next.remoteSessionId;
+      // …and with the session pointer gone, the ownership claim over it must
+      // go too (#1129): a clone that kept `remoteOwned` would offer to
+      // destroy a session it does not point at.
+      delete next.remoteOwned;
       return next;
     });
     // Preserve which surface was active by POSITION, since ids changed.


### PR DESCRIPTION
Fixes #1129 (follow-up to #1100/#1091).

**Root cause.** `Pane.handleCloseSurface` disposes `surface.ptyId` and nothing else, and a `remote-terminal` surface's ptyId is `''` by design — so closing the tab was detach-only. The `remote-pane-*` accumulation is the same bug seen from the host: the daemon derives `/api/workspaces` from live sessions' `WMUX_WORKSPACE_ID`, so the phantom workspace row lives exactly as long as the never-destroyed session. Ending the session reaps the row.

**Semantics.** Close destroys, unmount never does — wired into the explicit close paths only (tab ✕, Ctrl+W, prefix kill-pane/kill-workspace, workspace delete in sidebar and settings, the `surface.close`/`pane.close`/`workspace.close` RPCs), never a React cleanup, so remount/reload/tab-switch still re-attach. Only sessions this desktop minted are destroyed: a new `Surface.remoteOwned` flag set by the mint path and absent everywhere else, so a tab merely viewing someone else's session is non-destructive by construction. Decisions recorded in code: no confirmation prompt (local-pane semantics; ownership is the safety boundary), and sessions leaked before this fix are not auto-reaped (ownership can't be proven retroactively — clean host-side).

**Primitive.** `RemoteHostClient.closeSession` (`DELETE /api/sessions/:id`, the #1094 extraction the #1091 direction call asked for) behind a `remote:session:close` IPC. Destroy-first, detach-after: tearing streams down before the DELETE would be failure-destructive. Best-effort at call sites but observable — a refused/failed close warns with host and session id.

**Verified live** against a real paired headless host (`wmux web --allow-input`): mint → close via tab ✕ / Ctrl+W / sidebar workspace close / `workspace.close` RPC each destroyed the session and its `remote-pane-*` row on the host (host's own API read before/after each step); an unowned view survived its close while an owned tab closed in the same shot removed only its own session; host-offline close left the tab closed, one warning logged, and the session intact after the host returned. Suites: 88 files / 1,246 tests green; tsc/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing remote-terminal tabs, panes, workspaces, or derived workspaces now cleans up sessions created by the desktop.
  * Sessions started externally and viewed in the desktop remain available when their tabs are closed.
  * Failed cleanup attempts preserve active connections so they can be retried safely.
  * Missing or already-removed sessions are handled without disrupting the desktop.
  * Existing leaked sessions from earlier versions require manual host-side cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->