### PR TITLE
feat(codex): report Codex turn boundaries from lifecycle hooks (#1107)

### DIFF
--- a/changelog.d/1144.md
+++ b/changelog.d/1144.md
@@ -1,0 +1,15 @@
+### Added
+
+- **Codex panes can report their turn boundaries from lifecycle hooks.** wmux
+  previously inferred whether a Codex pane was working by scraping its
+  terminal. A new hooks bridge lets Codex tell wmux directly when a session
+  starts, when a prompt is submitted, and when a turn ends. It needs
+  codex-cli 0.141.0 or newer, and the hook has to be trusted once in Codex —
+  see `integrations/codex/README.md` for setup.
+
+### Fixed
+
+- A lifecycle signal that arrived on the main pipe without a matching brain
+  pane was discarded before it could mark the pane as working, so the turn's
+  completion signal was discarded too — no notification, no lifecycle event.
+  (#1107, #1144)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -186,6 +186,25 @@ If you use this bridge, remove the `notify = [...]` line — otherwise every tur
 reports `agent.stop` twice. The `HookSignalRouter` dedup window swallows the
 duplicate, so nothing breaks, but the second spawn is pure waste.
 
+## Identity on the main pipe (#1111)
+
+Both bridges send `clientName: 'wmux-hook-bridge'` on every request. On the
+daemon control pipe it is ignored — there is no enforcer there. On the MAIN
+pipe it is load-bearing: `hooks.signal` is `wmux.internal`, so no declaration
+can ever grant it, and the enforcer instead recognises that exact name and
+allows that one method (`src/main/mcp/hookBridge.ts`). Without it the signal is
+refused as `identity-status:legacy` once the envelope-less grandfather closes,
+and turn-state reporting degrades **silently** — the failure this integration
+exists to remove.
+
+The name is a literal in each bridge rather than an import, because a bridge is
+a standalone `.mjs` outside the main build. `hookBridge.lockstep.test.ts` parses
+the bridge sources to keep the copies honest; this bridge additionally carries
+the same two assertions in `__tests__/codexHookEnvelope.test.ts`.
+
+`hooks.signal` is the only main-pipe method either bridge calls. Adding another
+means widening the lane in `hookBridge.ts` deliberately.
+
 ## Harmlessness
 
 Both bridges are covered by `scripts/lib/hookHarmlessness.mjs`, which runs each

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -162,14 +162,24 @@ login to design against.
 Until then, manual setup:
 
 1. Check your version: `codex --version` must be **0.141.0 or newer**.
-2. Get the block:
+2. Copy the bridge somewhere **stable** — not the repo checkout:
    ```sh
-   node -e "import('./integrations/codex/hooks/wmuxHooks.mjs').then(m=>console.log(m.renderCodexHooksToml(require('path').resolve('integrations/codex/bin/wmux-codex-hooks-bridge.mjs'))))"
+   mkdir -p ~/.wmux/bridges
+   cp integrations/codex/bin/wmux-codex-hooks-bridge.mjs ~/.wmux/bridges/
    ```
-3. Append it to `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`).
-4. Start Codex interactively and **approve the hooks when it asks**. If it never
-   asks, the hooks are not registered — re-check step 3.
-5. Confirm: run a turn, then look for `"outcome":"ok"` lines in
+   The path goes into `config.toml` and into the trust hash Codex records
+   against it. Pointing it at a working tree means moving, renaming, or
+   re-cloning the checkout silently un-trusts the hook — and an un-trusted hook
+   does not run and does not say so, which is the exact failure mode above.
+   Re-copy after a `git pull` that touches the bridge, then re-approve.
+3. Get the block (substitute the path you copied to):
+   ```sh
+   node -e "import('./integrations/codex/hooks/wmuxHooks.mjs').then(m=>console.log(m.renderCodexHooksToml(process.env.HOME + '/.wmux/bridges/wmux-codex-hooks-bridge.mjs')))"
+   ```
+4. Append it to `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`).
+5. Start Codex interactively and **approve the hooks when it asks**. If it never
+   asks, the hooks are not registered — re-check step 4.
+6. Confirm: run a turn, then look for `"outcome":"ok"` lines in
    `~/.wmux/codex-hooks.log`.
 
 If you use this bridge, remove the `notify = [...]` line — otherwise every turn

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -1,0 +1,187 @@
+# wmux ↔ Codex CLI
+
+Two independent bridges live here. They report the same turn boundary by
+different routes, and you want **one** of them, not both.
+
+| | `bin/wmux-codex-notify.mjs` | `bin/wmux-codex-hooks-bridge.mjs` |
+|---|---|---|
+| Registered as | `notify = [...]` in `config.toml` | `[[hooks.<Event>]]` in `config.toml` |
+| Payload arrives | last argv token | stdin |
+| Codex floor | any | **0.141.0** |
+| Reports | turn complete | turn complete, turn start, session start |
+| Needs operator approval | no | **yes** (trust gate) |
+| Installed by wmux | yes (`lifecycleIntegrations`) | no — see *Installation* |
+
+The notify program is what ships today. The hooks bridge is the replacement,
+and it is not wired into the installer yet for the reason in *Installation*.
+
+## Why the hooks bridge exists
+
+wmux decides "is this Codex pane done?" partly by scraping the terminal.
+`src/main/pty/AgentDetector.ts` matches `^codex>\s*$` for idle and three
+transcribed approval questions for `awaiting_input`. That holds until Codex
+changes its TUI. The answer feeds notifications, the orchestrator's count of
+what is still busy, and the blocking poll — so when it is wrong, the fleet
+sends work to a pane that never stopped.
+
+The notify program already reports turn-complete. What it cannot report is
+turn *start* or session start, so a pane that has begun working is still
+inferred rather than told.
+
+## What Codex measurably does and does not give us
+
+Measured live on **2026-08-31** against codex-cli **0.151.0** (and re-checked on
+0.145.0-alpha.2, 0.143.0, 0.141.0, 0.140.0, 0.135.0) driving a stub Responses
+endpoint, because the account on the measuring machine returns 402
+`deactivated_workspace` and cannot complete a real model turn. The stub only
+supplies the model's side of the wire; the hook machinery under test is
+entirely local.
+
+**Events in the enum** — `PreToolUse`, `PermissionRequest`, `PostToolUse`,
+`PreCompact`, `PostCompact`, `SessionStart`, `SessionEnd`, `UserPromptSubmit`,
+`SubagentStart`, `SubagentStop`, `Stop`, `Interrupt`.
+
+**Measured firing** — `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd`,
+`PreToolUse`. Everything else is an enum member nobody has watched fire, and
+none of those is mapped. An unmeasured event is not a signal.
+
+**`Stop` is a turn boundary, not a session one.** This was the question the
+whole spike existed to answer. Across two turns of one session, `Stop` fired
+once per turn carrying that turn's `turn_id`, and `SessionEnd` fired separately,
+once, with no `turn_id`. A first run whose model call failed produced
+`SessionStart` → `UserPromptSubmit` → `SessionEnd` with **no** `Stop` at all,
+which is the same fact from the other side: no completed turn, no `Stop`.
+
+**The payload envelope is Claude Code's, verbatim.** `session_id`,
+`transcript_path`, `cwd`, `hook_event_name`, `model`, `permission_mode`, plus
+`turn_id` on turn-scoped events. Codex even normalizes tool names into Claude's
+vocabulary — a shell call arrives as `tool_name: "Bash"`. A captured `Stop`:
+
+```json
+{"session_id":"01a0582a-…","turn_id":"01a0582a-…","transcript_path":"…/rollout-….jsonl",
+ "cwd":"D:\\wmux","hook_event_name":"Stop","model":"gpt-5.6-sol",
+ "permission_mode":"bypassPermissions","stop_hook_active":false,
+ "last_assistant_message":"hi"}
+```
+
+**Pane environment is inherited.** `WMUX_PTY_ID` set on the Codex process
+reaches the hook unchanged, so pane attribution works exactly as it does for
+Kiro and Claude.
+
+**Resume binding is possible**, unlike Kiro. `SessionStart.source` is
+`"startup"` on a fresh session and `"resume"` on `codex … resume`, with the
+**same** `session_id`. So the bridge keeps the notify program's resume spool.
+
+**The payloads carry content.** `prompt` (UserPromptSubmit),
+`last_assistant_message` (Stop), `tool_input` (PreToolUse). wmux's bridges are
+metadata-only, so none of it is read, logged, or forwarded — the allowlist in
+`buildCodexHookEnvelope` is the enforcement, and the test asserts on the
+serialized envelope so a future content-bearing field fails it too.
+
+**Exit code 2 blocks.** The binary carries `PreToolUse hook exited with code 2
+but did not write a blocking reason to stderr` and `hook returned invalid
+pre-tool-use JSON output`. The bridge writes nothing and always exits 0.
+
+### Two things that will waste your afternoon
+
+**1. The trust gate is silent.** Codex will not run a hook it has not been told
+to trust, and it does not say so. With an untrusted `[[hooks.Stop]]` in
+`config.toml`, `codex exec` printed no warning, no "hooks need review" line, and
+exited 0 — the hook simply never ran, and the config parsed clean. The only
+signal that anything was wrong was the absence of output from the hook itself.
+`HookStateToml { enabled, trusted_hash }` is the on-disk representation, and
+`--dangerously-bypass-hook-trust` is the escape hatch.
+
+**2. Neither the feature flag nor the CLI flag is a capability probe.**
+0.135.0 and 0.140.0 both report `hooks  stable  true` from
+`codex features list`, both accept `--dangerously-bypass-hook-trust`, both
+parse `[[hooks.*]]` without complaint — and both fire nothing. Bisected:
+
+| version | hooks fire? |
+|---|---|
+| 0.135.0 | no |
+| 0.140.0 | no |
+| **0.141.0** | **yes** |
+| 0.143.0 / 0.145.0-alpha.2 / 0.151.0 | yes |
+
+Only the version distinguishes them, which is why `codexSupportsHooks()` gates
+on the version and fails closed on anything it cannot parse.
+
+### Not verified
+
+`PermissionRequest` is the event that would let wmux retire the three
+transcribed approval regexes in `AgentDetector.ts`, and it is the one that could
+not be measured: `codex exec` forces `approval: never`, so no approval pause can
+occur in a non-interactive run, and no amount of config overrides it
+(`approval_policy = "untrusted"` is rejected outright in 0.151.0). Confirming it
+needs an interactive TUI session. Until then the event is unmapped and the
+screen regexes stay — mapping it now would mean guessing at its field names, and
+a wrong `awaiting_permission` is worse than none.
+
+## What the bridge reports
+
+| Codex event | wmux signal |
+|---|---|
+| `SessionStart` | `agent.session_start` (with `source`) |
+| `UserPromptSubmit` | `agent.user_prompt_submit` |
+| `Stop` | `agent.stop` |
+
+Deliberately unmapped, each for its own reason — the full argument is in the
+`EVENT_TO_KIND` comment in the bridge:
+
+- `PreToolUse` / `PostToolUse` — a spawn per tool call for a signal the server
+  already throttles. And `PreToolUse` must **not** become `awaiting_input` the
+  way Claude's does: Codex fires it on every tool call, gated or not, and has a
+  separate `PermissionRequest` for the approval pause. Conflating them is the
+  mistake #898 punished.
+- `PermissionRequest` — unverified, see above.
+- `SessionEnd` — measured, but there is no `AgentSignalKind` for "session
+  over", and `agent.stop` would be a lie.
+- `SubagentStart` / `SubagentStop` / `PreCompact` / `PostCompact` / `Interrupt`
+  — never observed firing.
+
+## Installation
+
+**Not wired up.** `installLifecycleIntegrations` writes the notify program and
+stops there.
+
+This is not an oversight, and it is a different shape of problem from Kiro's.
+For Kiro, writing the file *was* the whole job and only an account was missing.
+Here, writing the file is explicitly **not** the job: Codex requires an operator
+to trust the hook before it runs, it gives no warning when it has not been
+trusted, and a programmatic installer almost certainly should not be able to
+pre-trust its own hook. So an installer that wrote this block and reported
+success would be reporting a lie — the pane would go on being screen-scraped
+and nothing would say so.
+
+What an installer will have to do instead is write the block, then tell the
+operator to approve it in Codex, then verify it actually fires. The third step
+is the one that needs designing, and it needs a machine with a working Codex
+login to design against.
+
+Until then, manual setup:
+
+1. Check your version: `codex --version` must be **0.141.0 or newer**.
+2. Get the block:
+   ```sh
+   node -e "import('./integrations/codex/hooks/wmuxHooks.mjs').then(m=>console.log(m.renderCodexHooksToml(require('path').resolve('integrations/codex/bin/wmux-codex-hooks-bridge.mjs'))))"
+   ```
+3. Append it to `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`).
+4. Start Codex interactively and **approve the hooks when it asks**. If it never
+   asks, the hooks are not registered — re-check step 3.
+5. Confirm: run a turn, then look for `"outcome":"ok"` lines in
+   `~/.wmux/codex-hooks.log`.
+
+If you use this bridge, remove the `notify = [...]` line — otherwise every turn
+reports `agent.stop` twice. The `HookSignalRouter` dedup window swallows the
+duplicate, so nothing breaks, but the second spawn is pure waste.
+
+## Harmlessness
+
+Both bridges are covered by `scripts/lib/hookHarmlessness.mjs`, which runs each
+one against a fake daemon and requires it to classify identically to a no-op
+hook: byte-empty stdout, exit 0, no surviving process, inside the latency
+budget. The hooks bridge is exercised on all five measured events, including the
+two it ignores — "ignored" has to mean silent and fast, not a slow no-op, and
+`PreToolUse` fires on every tool call so a slow ignore there would be the most
+expensive kind.

--- a/integrations/codex/__tests__/codexHookEnvelope.test.ts
+++ b/integrations/codex/__tests__/codexHookEnvelope.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+// The bridge is plain .mjs (Codex spawns it directly); it exports the pure
+// envelope builder so this test can validate the shape without a live codex-cli.
+import { buildCodexHookEnvelope, shouldTryNextTarget } from '../bin/wmux-codex-hooks-bridge.mjs';
+import { isAgentSignal } from '../../shared/signal-types';
+
+// The payloads below are the ones codex-cli 0.151.0 actually sends, captured
+// live on 2026-08-31 against a stub Responses endpoint. Notably: the envelope
+// is Claude Code's verbatim, `Stop` carries a `turn_id` and `SessionEnd` does
+// not, and three of the events carry raw content.
+const STOP_PAYLOAD = {
+  session_id: '01a0582a-52b6-7a50-aaba-07e35bd05aba',
+  turn_id: '01a0582a-5333-7050-89d8-9a02a7993faa',
+  transcript_path: 'C:\\codex\\sessions\\rollout-01a0582a.jsonl',
+  cwd: 'D:\\work\\proj',
+  hook_event_name: 'Stop',
+  model: 'gpt-5.6-sol',
+  permission_mode: 'bypassPermissions',
+  stop_hook_active: false,
+  last_assistant_message: 'here is the answer, at length',
+};
+const SESSION_START_PAYLOAD = {
+  session_id: '01a0582a-52b6-7a50-aaba-07e35bd05aba',
+  transcript_path: 'C:\\codex\\sessions\\rollout-01a0582a.jsonl',
+  cwd: 'D:\\work\\proj',
+  hook_event_name: 'SessionStart',
+  model: 'gpt-5.6-sol',
+  permission_mode: 'bypassPermissions',
+  source: 'startup',
+};
+const PROMPT_PAYLOAD = {
+  session_id: '01a0582a-52b6-7a50-aaba-07e35bd05aba',
+  turn_id: '01a0582a-5333-7050-89d8-9a02a7993faa',
+  cwd: 'D:\\work\\proj',
+  hook_event_name: 'UserPromptSubmit',
+  prompt: 'the user typed this',
+};
+// Codex normalizes tool names into Claude Code's vocabulary — a shell call
+// arrives as `tool_name: "Bash"`. Measured, and deliberately unmapped.
+const PRE_TOOL_USE_PAYLOAD = {
+  session_id: '01a0582a-52b6-7a50-aaba-07e35bd05aba',
+  turn_id: '01a0582a-5333-7050-89d8-9a02a7993faa',
+  cwd: 'D:\\work\\proj',
+  hook_event_name: 'PreToolUse',
+  tool_name: 'Bash',
+  tool_input: { command: 'rm -rf /secret' },
+  tool_use_id: 'call_1',
+};
+
+const baseEnv = {
+  WMUX_PTY_ID: 'pty-123',
+  WMUX_WORKSPACE_ID: 'ws-abc',
+  WMUX_SURFACE_ID: 'surf-9',
+} as NodeJS.ProcessEnv;
+
+describe('buildCodexHookEnvelope', () => {
+  it('maps Stop to a canonical agent.stop envelope', () => {
+    expect(buildCodexHookEnvelope(STOP_PAYLOAD, { env: baseEnv, now: 42 })).toEqual({
+      kind: 'agent.stop',
+      agent: 'codex',
+      agentSessionId: '01a0582a-52b6-7a50-aaba-07e35bd05aba',
+      ptyId: 'pty-123',
+      workspaceId: 'ws-abc',
+      surfaceId: 'surf-9',
+      cwd: 'D:\\work\\proj',
+      payload: {
+        turn_id: '01a0582a-5333-7050-89d8-9a02a7993faa',
+        transcript_path: 'C:\\codex\\sessions\\rollout-01a0582a.jsonl',
+      },
+      ts: 42,
+    });
+  });
+
+  it('maps SessionStart to agent.session_start and keeps the resume marker', () => {
+    const envelope = buildCodexHookEnvelope(SESSION_START_PAYLOAD, { env: baseEnv, now: 1 });
+    expect(envelope?.kind).toBe('agent.session_start');
+    expect(envelope?.payload).toMatchObject({ source: 'startup' });
+  });
+
+  // A resumed session reports the SAME session_id with source "resume". That is
+  // what makes a resumed Codex pane identifiable without inspecting the
+  // transcript, so it is pinned rather than left to chance.
+  it('marks a resumed session without changing the session id', () => {
+    const envelope = buildCodexHookEnvelope(
+      { ...SESSION_START_PAYLOAD, source: 'resume' },
+      { env: baseEnv, now: 1 },
+    );
+    expect(envelope?.agentSessionId).toBe(SESSION_START_PAYLOAD.session_id);
+    expect(envelope?.payload).toMatchObject({ source: 'resume' });
+  });
+
+  // `source` is meaningful only on SessionStart. Carrying it on a turn boundary
+  // would invent a field Codex never sends there.
+  it('does not carry source on turn-scoped events', () => {
+    const envelope = buildCodexHookEnvelope(
+      { ...STOP_PAYLOAD, source: 'startup' },
+      { env: baseEnv, now: 1 },
+    );
+    expect(envelope?.payload).not.toHaveProperty('source');
+  });
+
+  it('maps UserPromptSubmit to agent.user_prompt_submit', () => {
+    expect(buildCodexHookEnvelope(PROMPT_PAYLOAD, { env: baseEnv, now: 1 })?.kind)
+      .toBe('agent.user_prompt_submit');
+  });
+
+  it('produces an envelope the wmux daemon accepts', () => {
+    for (const payload of [STOP_PAYLOAD, SESSION_START_PAYLOAD, PROMPT_PAYLOAD]) {
+      expect(isAgentSignal(buildCodexHookEnvelope(payload, { env: baseEnv, now: 1 }))).toBe(true);
+    }
+  });
+
+  // The privacy contract. Codex hands us the user's whole prompt, the model's
+  // whole reply and whole tool inputs; wmux's bridges are metadata-only, so
+  // none of it may survive into anything we send. Asserted on the SERIALIZED
+  // envelope, not field-by-field, so a future field that happens to carry
+  // content fails this too.
+  it('never carries the user prompt, the assistant reply or a tool input', () => {
+    const stop = JSON.stringify(buildCodexHookEnvelope(STOP_PAYLOAD, { env: baseEnv, now: 1 }));
+    expect(stop).not.toContain('here is the answer');
+    expect(stop).not.toContain('last_assistant_message');
+
+    const prompt = JSON.stringify(buildCodexHookEnvelope(PROMPT_PAYLOAD, { env: baseEnv, now: 1 }));
+    expect(prompt).not.toContain('the user typed this');
+    // The KEY, not the substring: `agent.user_prompt_submit` legitimately
+    // contains "prompt", so a bare toContain would fail on the kind itself.
+    expect(prompt).not.toContain('"prompt"');
+
+    const tool = JSON.stringify(buildCodexHookEnvelope(PRE_TOOL_USE_PAYLOAD, { env: baseEnv, now: 1 }));
+    expect(tool).toBe('null');
+  });
+
+  // Codex DOES supply a session id, unlike Kiro — but a session id is not a
+  // pane: two panes can hold two sessions in the same cwd. WMUX_PTY_ID stays
+  // the only thing that attributes a signal to a pane, and with none, dropping
+  // beats guessing.
+  it('drops the signal when the pane cannot be identified', () => {
+    expect(buildCodexHookEnvelope(STOP_PAYLOAD, { env: {}, now: 1 })).toBeNull();
+    expect(buildCodexHookEnvelope(STOP_PAYLOAD, { env: { WMUX_PTY_ID: '' }, now: 1 })).toBeNull();
+  });
+
+  // Every one of these is a real member of Codex's HookEventName enum. Three
+  // were measured firing (PreToolUse, SessionEnd) or are documented as
+  // unmeasured (PermissionRequest, the rest) — none is mapped, each for a
+  // reason recorded in the bridge's EVENT_TO_KIND comment. Pinning them keeps
+  // a later "while we're here" mapping from landing unnoticed.
+  it('ignores events wmux has no faithful mapping for', () => {
+    expect(buildCodexHookEnvelope(PRE_TOOL_USE_PAYLOAD, { env: baseEnv, now: 1 })).toBeNull();
+    for (const event of [
+      'PreToolUse', 'PermissionRequest', 'PostToolUse', 'PreCompact', 'PostCompact',
+      'SessionEnd', 'SubagentStart', 'SubagentStop', 'Interrupt', 'SomethingNew',
+    ]) {
+      expect(
+        buildCodexHookEnvelope({ hook_event_name: event, cwd: '/p' }, { env: baseEnv, now: 1 }),
+        event,
+      ).toBeNull();
+    }
+  });
+
+  // Lowercase is Kiro's spelling, not Codex's. A bridge that accepted both
+  // would quietly paper over a config pointed at the wrong agent.
+  it('does not accept Kiro-cased event names', () => {
+    for (const event of ['stop', 'sessionStart', 'userPromptSubmit']) {
+      expect(
+        buildCodexHookEnvelope({ hook_event_name: event, cwd: '/p' }, { env: baseEnv, now: 1 }),
+        event,
+      ).toBeNull();
+    }
+  });
+
+  it('survives payloads that are not the shape Codex documents', () => {
+    for (const bad of [null, undefined, 'a string', 42, [], {}, { hook_event_name: 5 }]) {
+      expect(buildCodexHookEnvelope(bad, { env: baseEnv, now: 1 })).toBeNull();
+    }
+  });
+
+  // A session id is what makes the resume binding possible, but a Stop without
+  // one is still a real turn boundary and must not be thrown away.
+  it('still reports the turn boundary when the session id is missing', () => {
+    const noSession: Record<string, unknown> = { ...STOP_PAYLOAD };
+    delete noSession.session_id;
+    const envelope = buildCodexHookEnvelope(noSession, { env: baseEnv, now: 1 });
+    expect(envelope?.kind).toBe('agent.stop');
+    expect(envelope).not.toHaveProperty('agentSessionId');
+  });
+
+  it('falls back to the process cwd when the payload omits one', () => {
+    const envelope = buildCodexHookEnvelope({ hook_event_name: 'Stop' }, { env: baseEnv, now: 1 });
+    expect(envelope?.cwd).toBe(process.cwd());
+  });
+
+  it('omits workspace and surface ids rather than emitting empty ones', () => {
+    const envelope = buildCodexHookEnvelope(STOP_PAYLOAD, { env: { WMUX_PTY_ID: 'p1' }, now: 1 });
+    expect(envelope).not.toHaveProperty('workspaceId');
+    expect(envelope).not.toHaveProperty('surfaceId');
+  });
+
+  // An event name that resolves through Object.prototype used to sail past the
+  // `!kind` guard in the Kiro bridge and produce an envelope whose kind was a
+  // function or `{}`, which then went to the daemon instead of being dropped.
+  it('drops event names that only exist on the prototype chain', () => {
+    for (const event of ['constructor', 'toString', 'valueOf', '__proto__', 'hasOwnProperty']) {
+      expect(
+        buildCodexHookEnvelope({ hook_event_name: event, cwd: 'C:/x' }, { env: { WMUX_PTY_ID: 'p1' }, now: 1 }),
+        event,
+      ).toBeNull();
+    }
+  });
+});
+
+describe('shouldTryNextTarget', () => {
+  it('stops on an answered call', () => {
+    expect(shouldTryNextTarget({ ok: true }, 'agent.stop')).toBe(false);
+  });
+
+  it('stops on an ambiguous write for a kind that is not idempotent', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false })).toBe(false);
+    expect(
+      shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false }, 'agent.activity'),
+    ).toBe(false);
+  });
+
+  // agent.user_prompt_submit is deliberately NOT idempotent here: the deck's
+  // brain-pty lane claims it against a "one turn at a time" contract, where a
+  // duplicate is not obviously free the way a repeated turn boundary is.
+  it('stops on an ambiguous write for agent.user_prompt_submit', () => {
+    expect(
+      shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false }, 'agent.user_prompt_submit'),
+    ).toBe(false);
+  });
+
+  it('keeps walking on an ambiguous write for an idempotent kind', () => {
+    for (const kind of ['agent.stop', 'agent.session_start']) {
+      expect(
+        shouldTryNextTarget({ ok: false, error: 'timeout', retryable: false }, kind),
+        kind,
+      ).toBe(true);
+    }
+  });
+
+  it('advances on a connect failure that never wrote', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'connect-error', retryable: true })).toBe(true);
+  });
+
+  it('advances on an explicit refusal from an older endpoint', () => {
+    expect(shouldTryNextTarget({ ok: false, error: 'Unknown method' })).toBe(true);
+  });
+});

--- a/integrations/codex/__tests__/codexHookEnvelope.test.ts
+++ b/integrations/codex/__tests__/codexHookEnvelope.test.ts
@@ -77,10 +77,12 @@ describe('buildCodexHookEnvelope', () => {
     expect(envelope?.payload).toMatchObject({ source: 'startup' });
   });
 
-  // A resumed session reports the SAME session_id with source "resume". That is
-  // what makes a resumed Codex pane identifiable without inspecting the
-  // transcript, so it is pinned rather than left to chance.
-  it('marks a resumed session without changing the session id', () => {
+  // `source` has NO CONSUMER in src/ today — nothing reads
+  // signal.payload.source. These two cases pin it as a future candidate, not
+  // as a working feature: they assert the bridge carries it faithfully, and
+  // claim nothing about a resumed pane being identified downstream, because
+  // today it is not.
+  it('carries the resume marker faithfully, though nothing reads it yet', () => {
     const envelope = buildCodexHookEnvelope(
       { ...SESSION_START_PAYLOAD, source: 'resume' },
       { env: baseEnv, now: 1 },

--- a/integrations/codex/__tests__/codexHookEnvelope.test.ts
+++ b/integrations/codex/__tests__/codexHookEnvelope.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 // The bridge is plain .mjs (Codex spawns it directly); it exports the pure
 // envelope builder so this test can validate the shape without a live codex-cli.
 import { buildCodexHookEnvelope, shouldTryNextTarget } from '../bin/wmux-codex-hooks-bridge.mjs';
@@ -246,5 +248,41 @@ describe('shouldTryNextTarget', () => {
 
   it('advances on an explicit refusal from an older endpoint', () => {
     expect(shouldTryNextTarget({ ok: false, error: 'Unknown method' })).toBe(true);
+  });
+});
+
+// #1111 lockstep, asserted locally.
+//
+// The canonical guard is src/main/mcp/__tests__/hookBridge.lockstep.test.ts,
+// which parses every bridge source against the enforcer's own constants. It
+// does not exist on this branch — #1111 is still in flight — and this bridge
+// still has to be added to its BRIDGES list when the two land together.
+//
+// Until then these two assertions stand in for it, deliberately duplicating
+// its logic rather than trusting the follow-up to remember: without the
+// clientName the enforcer refuses this bridge's main-pipe `hooks.signal` as
+// identity-status:legacy, and turn-state reporting degrades silently — which
+// is the exact failure mode #1107 exists to remove.
+describe('hook-bridge lane lockstep (#1111)', () => {
+  const SRC = fs.readFileSync(
+    path.join(__dirname, '..', 'bin', 'wmux-codex-hooks-bridge.mjs'),
+    'utf8',
+  );
+
+  it('declares the recognised clientName and puts it on the envelope', () => {
+    // The literal the lockstep test greps for. Spelled out here rather than
+    // imported: src/shared/rpc.ts is not reachable from a standalone bridge,
+    // and a drifting copy is precisely what both tests exist to catch.
+    expect(SRC).toContain("'wmux-hook-bridge'");
+    expect(/clientName:/.test(SRC)).toBe(true);
+  });
+
+  it('calls no main-pipe method outside the one-method lane', () => {
+    const found = new Set(
+      [...SRC.matchAll(/method:\s*'([a-zA-Z][A-Za-z0-9]*\.[A-Za-z0-9.]+)'/g)].map((m) => m[1]),
+    );
+    // `daemon.*` goes to the DaemonPipeServer, which has no enforcer.
+    const mainPipe = [...found].filter((m) => !m.startsWith('daemon.'));
+    expect(mainPipe).toEqual(['hooks.signal']);
   });
 });

--- a/integrations/codex/__tests__/codexHooksConfig.test.ts
+++ b/integrations/codex/__tests__/codexHooksConfig.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildCodexHooksConfig,
+  renderCodexHooksToml,
+  codexSupportsHooks,
+  CODEX_HOOK_EVENTS,
+  CODEX_HOOKS_MANAGED_MARKER,
+  CODEX_HOOKS_MIN_VERSION,
+  CODEX_HOOK_TIMEOUT_MS,
+} from '../hooks/wmuxHooks.mjs';
+
+const BRIDGE = 'C:\\Users\\me\\AppData\\Local\\wmux\\wmux-codex-hooks-bridge.mjs';
+
+describe('buildCodexHooksConfig', () => {
+  it('registers exactly the events the bridge maps', () => {
+    expect(Object.keys(buildCodexHooksConfig(BRIDGE)).sort())
+      .toEqual([...CODEX_HOOK_EVENTS].sort());
+  });
+
+  it('emits Codex handler shape with both command fields', () => {
+    const [group] = buildCodexHooksConfig(BRIDGE).Stop;
+    expect(group.matcher).toBe('*');
+    expect(group.hooks).toEqual([
+      {
+        type: 'command',
+        command: `node "${BRIDGE}"`,
+        commandWindows: `node "${BRIDGE}"`,
+        timeout: CODEX_HOOK_TIMEOUT_MS,
+        async: false,
+      },
+    ]);
+  });
+
+  // Synchronous on purpose: an async Stop can race the next turn's
+  // UserPromptSubmit and flip the pane's state backwards. The bridge's own 2s
+  // cap is what keeps sync cheap, and Codex's timeout is the backstop above it.
+  it('runs synchronously with a timeout above the bridge self-cap', () => {
+    for (const event of CODEX_HOOK_EVENTS) {
+      const [handler] = buildCodexHooksConfig(BRIDGE)[event][0].hooks;
+      expect(handler.async, event).toBe(false);
+      expect(handler.timeout, event).toBeGreaterThan(2000);
+    }
+  });
+});
+
+describe('renderCodexHooksToml', () => {
+  it('renders a wmux-owned block for every event', () => {
+    const toml = renderCodexHooksToml(BRIDGE);
+    expect(toml).toContain(`# ${CODEX_HOOKS_MANAGED_MARKER}`);
+    for (const event of CODEX_HOOK_EVENTS) {
+      expect(toml, event).toContain(`[[hooks.${event}]]`);
+      expect(toml, event).toContain(`[[hooks.${event}.hooks]]`);
+    }
+  });
+
+  // Windows paths are the whole reason this is JSON.stringify and not a bare
+  // template: an unescaped backslash makes the TOML parse as an escape and
+  // Codex rejects (or worse, silently mangles) the command.
+  it('escapes backslashes in the bridge path', () => {
+    expect(renderCodexHooksToml(BRIDGE)).toContain('node \\"C:\\\\Users\\\\me');
+  });
+});
+
+describe('codexSupportsHooks', () => {
+  // The bisected floor. 0.140.0 accepts the same config block, reports
+  // `hooks stable true`, offers --dangerously-bypass-hook-trust — and fires
+  // nothing. Only the version separates them.
+  it('accepts the measured-firing versions', () => {
+    for (const v of ['0.141.0', '0.143.0', '0.151.0', 'codex-cli 0.151.0', '1.0.0']) {
+      expect(codexSupportsHooks(v), v).toBe(true);
+    }
+  });
+
+  it('rejects the measured-silent versions', () => {
+    for (const v of ['0.135.0', '0.140.0', 'codex-cli 0.140.0', '0.99.0']) {
+      expect(codexSupportsHooks(v), v).toBe(false);
+    }
+  });
+
+  // 0.145.0-alpha.2 was measured firing, so a pre-release suffix must not
+  // demote the build below its own version.
+  it('treats a pre-release as its release version', () => {
+    expect(codexSupportsHooks('codex-cli 0.145.0-alpha.2')).toBe(true);
+    expect(codexSupportsHooks('0.140.0-alpha.1')).toBe(false);
+  });
+
+  // Fail closed. An unknown build that silently runs no hooks is exactly the
+  // failure this gate exists to prevent; falling back to the screen detector
+  // is the safe side.
+  it('treats an unreadable version as too old', () => {
+    for (const v of [undefined, null, '', 'unknown', 'codex-cli']) {
+      expect(codexSupportsHooks(v as unknown as string), String(v)).toBe(false);
+    }
+  });
+
+  it('pins the documented floor', () => {
+    expect(CODEX_HOOKS_MIN_VERSION).toBe('0.141.0');
+  });
+});

--- a/integrations/codex/__tests__/codexHooksConfig.test.ts
+++ b/integrations/codex/__tests__/codexHooksConfig.test.ts
@@ -77,11 +77,22 @@ describe('codexSupportsHooks', () => {
     }
   });
 
-  // 0.145.0-alpha.2 was measured firing, so a pre-release suffix must not
-  // demote the build below its own version.
-  it('treats a pre-release as its release version', () => {
+  // 0.145.0-alpha.2 was measured firing, and it is above the floor either way.
+  it('accepts a pre-release above the floor', () => {
     expect(codexSupportsHooks('codex-cli 0.145.0-alpha.2')).toBe(true);
     expect(codexSupportsHooks('0.140.0-alpha.1')).toBe(false);
+  });
+
+  // The case that actually matters: a pre-release AT the floor is a build made
+  // BEFORE 0.141.0 shipped, so it sits in the 0.140.0 silent-no-fire zone the
+  // floor exists to exclude. Ordering it as ">= 0.141.0" would let the one
+  // build class nobody can verify through the gate.
+  it('rejects a pre-release of the floor version itself', () => {
+    for (const v of ['0.141.0-alpha.0', 'codex-cli 0.141.0-rc.1', '0.141.0-nightly']) {
+      expect(codexSupportsHooks(v), v).toBe(false);
+    }
+    // The released floor itself still passes.
+    expect(codexSupportsHooks('0.141.0')).toBe(true);
   });
 
   // Fail closed. An unknown build that silently runs no hooks is exactly the

--- a/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
+++ b/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
@@ -94,6 +94,20 @@ const TRANSIENT_CONNECT_CODES = new Set([
 ]);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// #1111: the envelope-less `legacy` grandfather these hook RPCs used to ride
+// closes in the first release on or after 2026-09-30. `hooks.signal` on the
+// MAIN pipe is `wmux.internal`, so no declaration can ever grant it; the
+// enforcer instead recognises this exact clientName and allows that ONE method
+// (src/main/mcp/hookBridge.ts). Keep it in lockstep with
+// WMUX_HOOK_BRIDGE_CLIENT_NAME in src/shared/rpc.ts. Harmless on the daemon
+// control pipe, which has no enforcer and ignores the extra envelope field.
+//
+// A LITERAL, not an import: this bridge is a standalone .mjs outside the main
+// build and cannot import from src/. Every sibling bridge spells it the same
+// way for the same reason — hookBridge.lockstep.test.ts is what keeps the five
+// of them honest, by parsing these sources for this exact string.
+const WMUX_CLIENT_NAME = 'wmux-hook-bridge';
+
 // Codex payloads carry whole assistant replies and whole tool inputs, so cap
 // what we will even hold in memory. Anything past this is a payload this
 // bridge has no business reading. Matches the Kiro bridge's cap.
@@ -528,19 +542,13 @@ async function main() {
 
   // One id across the walk so a fallback is correlatable in the log; each
   // target carries its own method + token (see resolveTargets).
-  //
-  // TODO(#1111): this request sends no `clientName`, so the daemon sees it as
-  // an anonymous wmux.internal caller on `hooks.signal`. That is not a local
-  // omission — neither wmux-codex-notify.mjs nor wmux-kiro-bridge.mjs sends one
-  // either, and the lane closure needs ONE identification pattern across all
-  // the bridges rather than three. Deliberately not invented here; adopt
-  // whatever #1111 lands for the existing bridges.
   const requestId = `codex-hook-${randomUUID()}`;
   const { result: rpcResult, target } = await sendToTargets(targets, (t) => ({
     id: requestId,
     method: t.method,
     params: envelope,
     token: t.token,
+    clientName: WMUX_CLIENT_NAME,
   }), envelope.kind);
   const outerOk = rpcResult && rpcResult.ok === true;
   const innerOk = outerOk && rpcResult.result && rpcResult.result.ok === true;

--- a/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
+++ b/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
@@ -6,7 +6,7 @@
 //   matcher = "*"
 //   [[hooks.Stop.hooks]]
 //   type = "command"
-//   command = "node \"<abs path to this file>\" Stop"
+//   command = "node \"<abs path to this file>\""
 //
 // Codex spawns it on the event and writes the event JSON to STDIN. The spawned
 // process inherits the pane env, so WMUX_PTY_ID pins the signal to the exact
@@ -42,8 +42,10 @@
 //   * A session id IS present, unlike Kiro — so resume binding is possible and
 //     this bridge keeps the notify bridge's spool.
 //   * `SessionStart.source` is `"startup"` on a fresh session and `"resume"` on
-//     `codex ... resume`, with the SAME `session_id` — so a resumed pane is
-//     identifiable without guessing.
+//     `codex ... resume`, with the SAME `session_id`. Recorded as a
+//     FUTURE-CANDIDATE field only: nothing in src/ reads it today, so it
+//     identifies nothing yet. It rides along because it is free, measured, and
+//     metadata — not because a consumer is waiting for it.
 //   * The payload carries CONTENT: `prompt` (UserPromptSubmit),
 //     `last_assistant_message` (Stop), `tool_input` (PreToolUse). wmux's
 //     bridges are metadata-only, so those fields are never read, logged, or
@@ -445,9 +447,11 @@ export function buildCodexHookEnvelope(payload, { env = process.env, now = Date.
   const sessionId = nonEmptyStr(payload.session_id);
   const turnId = nonEmptyStr(payload.turn_id);
   const transcriptPath = nonEmptyStr(payload.transcript_path);
-  // `source` is "startup" | "resume" on SessionStart. It is pane state, not
-  // content, and it is the only thing that distinguishes a resumed session
-  // from a fresh one without inspecting the transcript.
+  // `source` is "startup" | "resume" on SessionStart. Metadata, not content.
+  // NO CONSUMER YET — nothing in src/ reads signal.payload.source; it is
+  // carried because it is the only field that distinguishes a resumed session
+  // from a fresh one without inspecting the transcript, and dropping it now
+  // would mean re-measuring later.
   const source = kind === 'agent.session_start' ? nonEmptyStr(payload.source) : undefined;
   const workspaceId = nonEmptyStr(env.WMUX_WORKSPACE_ID);
   const surfaceId = nonEmptyStr(env.WMUX_SURFACE_ID);
@@ -462,7 +466,8 @@ export function buildCodexHookEnvelope(payload, { env = process.env, now = Date.
     cwd: nonEmptyStr(payload.cwd) ?? process.cwd(),
     // Metadata only. `turn_id` correlates a Stop with its UserPromptSubmit;
     // `transcript_path` feeds the resume binding's liveness probe; `source`
-    // marks a resumed session. Nothing here is user or model text.
+    // marks a resumed session and currently has no reader. Nothing here is
+    // user or model text.
     payload: {
       ...(turnId ? { turn_id: turnId } : {}),
       ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
@@ -490,7 +495,11 @@ async function main() {
     // event wmux does not act on, or a pane we cannot identify.
     const event = nonEmptyStr(payload?.hook_event_name);
     const known = Boolean(event) && Object.hasOwn(EVENT_TO_KIND, event);
-    logEvent(known ? 'no-pty-id' : 'ignored-event', { event: known ? event : undefined });
+    // Log the event name in BOTH cases. An unmapped name is the single most
+    // useful thing in this log — it is how a Codex that renamed or added an
+    // event becomes visible — and a `hook_event_name` is metadata, never
+    // content. It is length-capped because the field is caller-controlled.
+    logEvent(known ? 'no-pty-id' : 'ignored-event', { event: event ? event.slice(0, 64) : undefined });
     return;
   }
 
@@ -498,8 +507,13 @@ async function main() {
   const sessionId = envelope.agentSessionId;
   if (targets.length === 0) {
     logEvent('no-auth-token', { paths: [getDaemonAuthTokenPath(), getAuthTokenPath()] });
-    // Still spool so a later daemon boot reconciles the capture.
-    if (sessionId) {
+    // Still spool so a later daemon boot reconciles the capture — but only for
+    // a turn boundary, same gate as the send-failure path below. The record is
+    // a RESUME BINDING; one written at SessionStart would name a session with
+    // no turn in it yet, and one written at UserPromptSubmit would name a turn
+    // that has not finished. Both would then win the don't-replace-newer rule
+    // against the real Stop for that same pty key.
+    if (sessionId && envelope.kind === 'agent.stop') {
       spoolResumeBinding({
         ptyId: envelope.ptyId,
         agent: 'codex',
@@ -514,6 +528,13 @@ async function main() {
 
   // One id across the walk so a fallback is correlatable in the log; each
   // target carries its own method + token (see resolveTargets).
+  //
+  // TODO(#1111): this request sends no `clientName`, so the daemon sees it as
+  // an anonymous wmux.internal caller on `hooks.signal`. That is not a local
+  // omission — neither wmux-codex-notify.mjs nor wmux-kiro-bridge.mjs sends one
+  // either, and the lane closure needs ONE identification pattern across all
+  // the bridges rather than three. Deliberately not invented here; adopt
+  // whatever #1111 lands for the existing bridges.
   const requestId = `codex-hook-${randomUUID()}`;
   const { result: rpcResult, target } = await sendToTargets(targets, (t) => ({
     id: requestId,

--- a/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
+++ b/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
@@ -1,0 +1,596 @@
+// wmux-managed: codex-hooks-bridge
+// wmux ↔ Codex CLI lifecycle-hook bridge.
+//
+// Registered in `$CODEX_HOME/config.toml` (see integrations/codex/hooks/wmuxHooks.mjs):
+//   [[hooks.Stop]]
+//   matcher = "*"
+//   [[hooks.Stop.hooks]]
+//   type = "command"
+//   command = "node \"<abs path to this file>\" Stop"
+//
+// Codex spawns it on the event and writes the event JSON to STDIN. The spawned
+// process inherits the pane env, so WMUX_PTY_ID pins the signal to the exact
+// pane and WMUX_DATA_SUFFIX pins every endpoint/file to that instance.
+//
+// This script:
+//   1. Reads the Codex hook payload from stdin (JSON).
+//   2. Maps `hook_event_name` to a canonical AgentSignal kind.
+//   3. Builds a METADATA-ONLY envelope and sends it to the first wmux endpoint
+//      that answers: the DAEMON control pipe (`daemon.hooks.signal`), else the
+//      MAIN pipe (`hooks.signal`). WMUX_HOOKS_TO_MAIN=1 forces main-only.
+//   4. On failure, spools a resume-binding record for the daemon's next boot.
+//   5. Exits 0 ALWAYS, under a hard timeout, so a wmux problem never stalls Codex.
+//
+// ----- What Codex measurably does and does not give us --------------------
+//       (2026-08-31, codex-cli 0.151.0 and 0.141.0, measured live against a
+//        stub Responses endpoint; see integrations/codex/README.md)
+//
+//   * Events in the enum: PreToolUse, PermissionRequest, PostToolUse,
+//     PreCompact, PostCompact, SessionStart, SessionEnd, UserPromptSubmit,
+//     SubagentStart, SubagentStop, Stop, Interrupt.
+//   * MEASURED FIRING: SessionStart, UserPromptSubmit, Stop, SessionEnd,
+//     PreToolUse. The rest are enum members this bridge has NOT seen fire, and
+//     none of them is mapped below — an unmeasured event is not a signal.
+//   * `Stop` is a TURN boundary, not a session one. Measured across two turns
+//     of one session: `Stop` fired once per turn carrying that turn's
+//     `turn_id`, and `SessionEnd` fired separately, once, with no `turn_id`.
+//     That is the whole reason this bridge exists.
+//   * Payload envelope is Claude Code's, verbatim: `session_id`,
+//     `transcript_path`, `cwd`, `hook_event_name`, `model`, `permission_mode`,
+//     plus `turn_id` on turn-scoped events. Codex even normalizes tool names
+//     into Claude's vocabulary (a shell call arrives as `tool_name: "Bash"`).
+//   * A session id IS present, unlike Kiro — so resume binding is possible and
+//     this bridge keeps the notify bridge's spool.
+//   * `SessionStart.source` is `"startup"` on a fresh session and `"resume"` on
+//     `codex ... resume`, with the SAME `session_id` — so a resumed pane is
+//     identifiable without guessing.
+//   * The payload carries CONTENT: `prompt` (UserPromptSubmit),
+//     `last_assistant_message` (Stop), `tool_input` (PreToolUse). wmux's
+//     bridges are metadata-only, so those fields are never read, logged, or
+//     forwarded. The allowlist in buildCodexHookEnvelope is the enforcement.
+//   * TRUST GATE — the one operational surprise. Codex will not run a hook it
+//     has not been told to trust, and it does so SILENTLY: with an untrusted
+//     `[[hooks.Stop]]` in config.toml, `codex exec` printed no warning, no
+//     "hooks need review" line, nothing — the hook simply never ran. Only
+//     `--dangerously-bypass-hook-trust` (or an operator approving it in the
+//     TUI) makes it fire. An installer therefore cannot make this work by
+//     writing a file; see README.md.
+//   * VERSION FLOOR 0.141.0, bisected. 0.140.0 and 0.135.0 both advertise
+//     `hooks` as a stable feature AND accept `--dangerously-bypass-hook-trust`
+//     AND parse `[[hooks.*]]` without complaint — and fire nothing. So the
+//     feature flag, the flag's presence, and a clean config parse are all
+//     useless as capability probes; only the version is load-bearing.
+//
+// SELF-CONTAINED: JS-only, Node built-ins only — no imports from src/ or
+// integrations/shared/. Mirrors integrations/codex/bin/wmux-codex-notify.mjs
+// and integrations/kiro/bin/wmux-kiro-bridge.mjs; the duplication across
+// bridges is by design (a bridge runs in the agent's runtime, where wmux's
+// TypeScript is unreachable).
+//
+// NO SHEBANG, deliberately — same reason as the Kiro bridge: Codex always
+// invokes this as `node "<path>"`, and Vitest cannot parse a `.mjs` that
+// starts with one, which would make the pure envelope builder untestable
+// except through a subprocess.
+
+import {
+  readFileSync, existsSync, mkdirSync, appendFileSync, writeFileSync, renameSync, unlinkSync,
+  realpathSync,
+} from 'node:fs';
+import { homedir, userInfo } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createConnection } from 'node:net';
+import { randomUUID } from 'node:crypto';
+
+const HOOK_TIMEOUT_MS = 2000; // hard cap so we never stall a Codex turn
+// Stamped on every codex-hooks.log line; bump on behavior changes.
+//   0.1.0 — initial: SessionStart + UserPromptSubmit + Stop, metadata-only.
+const BRIDGE_VERSION = '0.1.0';
+const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
+const TRANSIENT_CONNECT_CODES = new Set([
+  'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
+]);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Codex payloads carry whole assistant replies and whole tool inputs, so cap
+// what we will even hold in memory. Anything past this is a payload this
+// bridge has no business reading. Matches the Kiro bridge's cap.
+const MAX_STDIN_BYTES = 256 * 1024;
+
+// ----- Event → AgentSignal kind -------------------------------------------
+//
+// ONLY events measured firing, and only those wmux can act on.
+//
+// Deliberately absent, each for its own reason:
+//   * PreToolUse / PostToolUse — an activity stamp would cost a process spawn
+//     per tool call, the one path that actually makes anything heavier, for a
+//     signal the server already throttles. This is the Kiro judgement call and
+//     it applies unchanged. Critically, PreToolUse must NOT be mapped to
+//     agent.awaiting_input the way Claude's is: Codex fires PreToolUse on
+//     EVERY tool call, gated or not, and has a separate PermissionRequest
+//     event for the approval pause. Conflating them is the mistake #898
+//     punished.
+//   * PermissionRequest — the event that would retire the screen-scraped
+//     approval regexes in AgentDetector.ts, and the one this bridge could NOT
+//     measure: `codex exec` forces `approval: never`, so no approval pause can
+//     occur in a non-interactive run. It is in the enum; it has not been seen
+//     to fire, or its payload observed. Mapping it now would be guessing at
+//     the field names, and a wrong awaiting_permission is worse than none.
+//   * SessionEnd — measured firing, but there is no AgentSignalKind for
+//     "session over"; agent.stop would be a lie (it is not a turn boundary).
+//   * SubagentStart / SubagentStop / PreCompact / PostCompact / Interrupt —
+//     enum members never observed firing.
+const EVENT_TO_KIND = {
+  SessionStart: 'agent.session_start',
+  UserPromptSubmit: 'agent.user_prompt_submit',
+  Stop: 'agent.stop',
+};
+
+// ----- Path helpers (Node built-ins only) ---------------------------------
+//
+// Kept in lockstep with src/shared/constants.ts. A non-empty suffix is an
+// instance boundary: this bridge never probes production paths as a fallback
+// when its selected namespace is suffixed.
+function dataSuffix() {
+  return process.env.WMUX_DATA_SUFFIX || '';
+}
+
+function getHomeDir() {
+  return process.env.USERPROFILE || process.env.HOME || homedir();
+}
+
+function getWmuxHomeDir() {
+  return join(getHomeDir(), `.wmux${dataSuffix()}`);
+}
+
+function getAuthTokenPath() {
+  return join(getHomeDir(), `.wmux${dataSuffix()}-auth-token`);
+}
+
+function getPipeName() {
+  const override = process.env.WMUX_PIPE_NAME;
+  if (typeof override === 'string' && override.length > 0) return override;
+  if (process.platform === 'win32') {
+    const username = userInfo().username || 'default';
+    return `\\\\.\\pipe\\wmux${dataSuffix()}-${username}`;
+  }
+  return join(homedir() || '/tmp', `.wmux${dataSuffix()}.sock`);
+}
+
+function getDaemonAuthTokenPath() {
+  return join(getWmuxHomeDir(), 'daemon-auth-token');
+}
+
+// Prefer the suffix-scoped `daemon-pipe` hint the daemon writes at boot (the
+// name it ACTUALLY bound, which differs from the convention after a zombie-pipe
+// fallback rename), then derive a socket in that same namespace.
+function getDaemonPipeName() {
+  try {
+    const fromFile = readFileSync(join(getWmuxHomeDir(), 'daemon-pipe'), 'utf8').trim();
+    if (fromFile) return fromFile;
+  } catch {
+    // Hint file absent/unreadable — derive within the selected namespace.
+  }
+  if (process.platform === 'win32') {
+    const username = userInfo().username || 'default';
+    return `\\\\.\\pipe\\wmux-daemon${dataSuffix()}-${username}`;
+  }
+  return join(getWmuxHomeDir(), 'daemon.sock');
+}
+
+function readTokenFile(tokenPath) {
+  try {
+    const token = readFileSync(tokenPath, 'utf8').trim();
+    return token || null;
+  } catch {
+    return null;
+  }
+}
+
+// Ordered endpoints. A target with no token file is skipped (that endpoint has
+// never run). WMUX_HOOKS_TO_MAIN=1 and WMUX_PIPE_NAME both pin to main only.
+function resolveTargets() {
+  const mainToken = readTokenFile(getAuthTokenPath());
+  const pipeOverride = process.env.WMUX_PIPE_NAME;
+  if (typeof pipeOverride === 'string' && pipeOverride.length > 0) {
+    return mainToken ? [{ name: 'main', pipe: pipeOverride, token: mainToken, method: 'hooks.signal' }] : [];
+  }
+  const targets = [];
+  if (process.env.WMUX_HOOKS_TO_MAIN !== '1') {
+    const token = readTokenFile(getDaemonAuthTokenPath());
+    if (token) {
+      targets.push({ name: 'daemon', pipe: getDaemonPipeName(), token, method: 'daemon.hooks.signal' });
+    }
+  }
+  if (mainToken) {
+    targets.push({ name: 'main', pipe: getPipeName(), token: mainToken, method: 'hooks.signal' });
+  }
+  return targets;
+}
+
+function getLogPath() {
+  const dir = getWmuxHomeDir();
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch { /* appendFileSync below also fails → swallowed */ }
+  return join(dir, 'codex-hooks.log');
+}
+
+function logEvent(outcome, extra) {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    bridge: BRIDGE_VERSION,
+    pid: process.pid,
+    outcome,
+    ...(extra ?? {}),
+  });
+  try {
+    appendFileSync(getLogPath(), line + '\n', { encoding: 'utf8' });
+  } catch { /* no writable home → swallow */ }
+}
+
+// ----- Resume-binding spool (daemon drains on next boot) -------------------
+//
+// Same record shape + ptyId key + atomic temp→rename + don't-replace-newer rule
+// the daemon ingest expects (mirrors wmux-codex-notify.mjs). Unlike the Kiro
+// bridge this one HAS a spool, because Codex supplies a session id.
+function getResumeSpoolDir() {
+  const dir = join(getWmuxHomeDir(), 'resume-spool');
+  try {
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  } catch { /* writeFileSync below throws + is swallowed */ }
+  return dir;
+}
+
+function spoolResumeBinding(record) {
+  try {
+    if (!record || !record.ptyId || !record.sessionId) return;
+    const safe = String(record.ptyId).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 80);
+    if (!safe) return;
+    const dir = getResumeSpoolDir();
+    const file = join(dir, `${safe}.json`);
+    const tmp = join(dir, `${safe}.${process.pid}.${randomUUID()}.json.tmp`);
+    writeFileSync(tmp, JSON.stringify(record), { encoding: 'utf8', mode: 0o600 });
+    try {
+      if (existsSync(file)) {
+        const existing = JSON.parse(readFileSync(file, 'utf8'));
+        if (typeof existing?.ts === 'number' && existing.ts > record.ts) {
+          try { unlinkSync(tmp); } catch { /* ignore */ }
+          return;
+        }
+      }
+    } catch { /* replace a corrupt/unreadable existing spool */ }
+    renameSync(tmp, file);
+    logEvent('resume-spooled', { ptyId: record.ptyId, sessionId: record.sessionId });
+  } catch (err) {
+    logEvent('resume-spool-error', { error: String(err) });
+  }
+}
+
+// ----- stdin reader -------------------------------------------------------
+
+function readStdin() {
+  return new Promise((res, rej) => {
+    const chunks = [];
+    let total = 0;
+    process.stdin.on('data', (c) => {
+      if (total >= MAX_STDIN_BYTES) return; // keep draining; stop accumulating
+      chunks.push(c);
+      total += c.length;
+    });
+    process.stdin.on('end', () => {
+      const buf = Buffer.concat(chunks).toString('utf8').trim();
+      if (!buf) {
+        res(null);
+        return;
+      }
+      // Over the cap the JSON is truncated and will not parse; that lands in
+      // the reject path and exits 0 silently, which is the right outcome for a
+      // payload this bridge was never going to forward anyway.
+      try {
+        res(JSON.parse(buf));
+      } catch (err) {
+        rej(err);
+      }
+    });
+    process.stdin.on('error', rej);
+  });
+}
+
+// ----- RPC over named pipe (mirrors the notify + Kiro bridges) -------------
+
+function sendRpc(pipePath, request, timeoutMs = HOOK_TIMEOUT_MS) {
+  return new Promise((res) => {
+    const sock = createConnection(pipePath);
+    let buffer = '';
+    let settled = false;
+    let wrote = false;
+
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch { /* already dead */ }
+      res(result);
+    };
+
+    const timer = setTimeout(() => settle({ ok: false, error: 'timeout', retryable: !wrote }), timeoutMs);
+
+    sock.on('connect', () => {
+      sock.write(JSON.stringify(request) + '\n');
+      wrote = true;
+    });
+    sock.on('data', (chunk) => {
+      buffer += chunk.toString('utf8');
+      // Match OUR response by id and skip everything else: the daemon control
+      // pipe BROADCASTS session events (no `id`) to every connected socket, and
+      // one landing before the reply would otherwise be settled as the reply.
+      for (;;) {
+        const nl = buffer.indexOf('\n');
+        if (nl === -1) return;
+        const line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        let parsed;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (!parsed || parsed.id !== request.id) continue;
+        clearTimeout(timer);
+        settle(parsed);
+        return;
+      }
+    });
+    sock.on('error', (err) => {
+      clearTimeout(timer);
+      settle({ ok: false, error: 'connect-error', detail: err.code ?? err.message, retryable: !wrote });
+    });
+    sock.on('close', () => {
+      clearTimeout(timer);
+      settle({ ok: false, error: 'closed-without-response', retryable: !wrote });
+    });
+  });
+}
+
+// `deadline` is passed in so a multi-target walk shares ONE HOOK_TIMEOUT_MS budget.
+async function sendRpcWithRetry(pipePath, request, deadline = Date.now() + HOOK_TIMEOUT_MS) {
+  let attempt = 0;
+  let last = { ok: false, error: 'timeout' };
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return last;
+    last = await sendRpc(pipePath, request, remaining);
+    if (last.error !== 'connect-error') return last;
+    if (last.retryable === false
+        || !TRANSIENT_CONNECT_CODES.has(last.detail)
+        || attempt >= CONNECT_RETRY_BACKOFFS_MS.length) {
+      return last;
+    }
+    const backoff = CONNECT_RETRY_BACKOFFS_MS[attempt++];
+    if (Date.now() + backoff >= deadline) return last;
+    await sleep(backoff);
+  }
+}
+
+// Signals whose re-delivery cannot corrupt anything: each asserts a state
+// rather than appending a record, and wmux's HookSignalRouter keeps a dedup
+// ledger. See the Kiro bridge for the full argument — the trade is a possible
+// duplicate (deduped) against a possible minutes-long stall (not).
+//
+// agent.user_prompt_submit is NOT in the set: it is claimed by the deck's
+// brain-pty lane against a "one turn at a time" contract, where a duplicate is
+// not obviously free. It stops at the first ambiguous write.
+const IDEMPOTENT_KINDS = new Set(['agent.stop', 'agent.session_start']);
+
+export function shouldTryNextTarget(result, kind) {
+  if (result && result.ok === true) return false;
+  if (result && result.retryable === false) return IDEMPOTENT_KINDS.has(kind);
+  return true;
+}
+
+async function sendToTargets(targets, buildRequest, kind) {
+  const deadline = Date.now() + HOOK_TIMEOUT_MS;
+  let result = { ok: false, error: 'no-target' };
+  let target = null;
+  for (let i = 0; i < targets.length; i++) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    const candidate = targets[i];
+    target = candidate;
+    // Per-target slice, not the whole remaining budget: a pipe that accepts
+    // the connection and then hangs would otherwise spend every millisecond
+    // here and the fallback endpoint would never be tried at all.
+    const slice = Math.max(1, Math.floor(remaining / (targets.length - i)));
+    result = await sendRpcWithRetry(candidate.pipe, buildRequest(candidate), Date.now() + slice);
+    if (!shouldTryNextTarget(result, kind)) break;
+  }
+  return { result, target };
+}
+
+// ----- Envelope (pure — exported for unit testing) -------------------------
+
+function nonEmptyStr(v) {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/**
+ * Build the canonical wmux AgentSignal for a Codex hook payload.
+ *
+ * Returns null when the event is not one wmux acts on, or when the pane cannot
+ * be identified. Dropping beats guessing: a payload with no WMUX_PTY_ID cannot
+ * be attributed to a pane, and attaching it to the wrong one is worse than
+ * losing it. Codex DOES supply a session id, but a session id is not a pane —
+ * two panes can hold two sessions in the same cwd.
+ *
+ * The ONLY payload fields read are `hook_event_name`, `session_id`, `cwd`,
+ * `turn_id`, `transcript_path` and `source`. `prompt`, `last_assistant_message`
+ * and `tool_input` are user and model content; this bridge is metadata-only,
+ * and the allowlist here is where that is enforced.
+ */
+export function buildCodexHookEnvelope(payload, { env = process.env, now = Date.now() } = {}) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const event = nonEmptyStr(payload.hook_event_name);
+  // hasOwn, not a bare index: `constructor` / `toString` / `__proto__` resolve
+  // through the prototype chain to truthy values, sail past a `!kind` guard,
+  // and produce an envelope whose `kind` is a function or `{}`. Same trap the
+  // Kiro bridge documents.
+  const kind = event && Object.hasOwn(EVENT_TO_KIND, event)
+    ? EVENT_TO_KIND[event]
+    : undefined;
+  if (!kind) return null;
+
+  const ptyId = nonEmptyStr(env.WMUX_PTY_ID);
+  if (!ptyId) return null;
+
+  const sessionId = nonEmptyStr(payload.session_id);
+  const turnId = nonEmptyStr(payload.turn_id);
+  const transcriptPath = nonEmptyStr(payload.transcript_path);
+  // `source` is "startup" | "resume" on SessionStart. It is pane state, not
+  // content, and it is the only thing that distinguishes a resumed session
+  // from a fresh one without inspecting the transcript.
+  const source = kind === 'agent.session_start' ? nonEmptyStr(payload.source) : undefined;
+  const workspaceId = nonEmptyStr(env.WMUX_WORKSPACE_ID);
+  const surfaceId = nonEmptyStr(env.WMUX_SURFACE_ID);
+
+  return {
+    kind,
+    agent: 'codex',
+    ...(sessionId ? { agentSessionId: sessionId } : {}),
+    ptyId,
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(surfaceId ? { surfaceId } : {}),
+    cwd: nonEmptyStr(payload.cwd) ?? process.cwd(),
+    // Metadata only. `turn_id` correlates a Stop with its UserPromptSubmit;
+    // `transcript_path` feeds the resume binding's liveness probe; `source`
+    // marks a resumed session. Nothing here is user or model text.
+    payload: {
+      ...(turnId ? { turn_id: turnId } : {}),
+      ...(transcriptPath ? { transcript_path: transcriptPath } : {}),
+      ...(source ? { source } : {}),
+    },
+    ts: now,
+  };
+}
+
+// ----- Main ---------------------------------------------------------------
+
+async function main() {
+  let payload;
+  try {
+    payload = await readStdin();
+  } catch {
+    // Parse diagnostics can quote the input; never copy them to the log.
+    logEvent('malformed-stdin');
+    return;
+  }
+
+  const envelope = buildCodexHookEnvelope(payload);
+  if (!envelope) {
+    // Two reasons, and the log distinguishes them without echoing content: an
+    // event wmux does not act on, or a pane we cannot identify.
+    const event = nonEmptyStr(payload?.hook_event_name);
+    const known = Boolean(event) && Object.hasOwn(EVENT_TO_KIND, event);
+    logEvent(known ? 'no-pty-id' : 'ignored-event', { event: known ? event : undefined });
+    return;
+  }
+
+  const targets = resolveTargets();
+  const sessionId = envelope.agentSessionId;
+  if (targets.length === 0) {
+    logEvent('no-auth-token', { paths: [getDaemonAuthTokenPath(), getAuthTokenPath()] });
+    // Still spool so a later daemon boot reconciles the capture.
+    if (sessionId) {
+      spoolResumeBinding({
+        ptyId: envelope.ptyId,
+        agent: 'codex',
+        sessionId,
+        cwd: envelope.cwd,
+        transcriptPath: envelope.payload.transcript_path,
+        ts: envelope.ts,
+      });
+    }
+    return;
+  }
+
+  // One id across the walk so a fallback is correlatable in the log; each
+  // target carries its own method + token (see resolveTargets).
+  const requestId = `codex-hook-${randomUUID()}`;
+  const { result: rpcResult, target } = await sendToTargets(targets, (t) => ({
+    id: requestId,
+    method: t.method,
+    params: envelope,
+    token: t.token,
+  }), envelope.kind);
+  const outerOk = rpcResult && rpcResult.ok === true;
+  const innerOk = outerOk && rpcResult.result && rpcResult.result.ok === true;
+
+  if (innerOk) {
+    logEvent('ok', { kind: envelope.kind, target: target?.name });
+    return;
+  }
+
+  logEvent(outerOk ? 'rpc-rejected' : 'rpc-failed', {
+    kind: envelope.kind,
+    target: target?.name,
+    reason: rpcResult?.result?.reason,
+    error: rpcResult?.error,
+    detail: rpcResult?.detail,
+  });
+  // Anything but a durable success would lose the capture. Spool it (needs the
+  // exact per-pane key) so the daemon reconciles it on its next boot. Only
+  // agent.stop is spooled: the spool record is a RESUME BINDING, and a binding
+  // written at session start would name a session with no turn in it yet.
+  if (sessionId && envelope.kind === 'agent.stop') {
+    spoolResumeBinding({
+      ptyId: envelope.ptyId,
+      agent: 'codex',
+      sessionId,
+      cwd: envelope.cwd,
+      transcriptPath: envelope.payload.transcript_path,
+      ts: envelope.ts,
+    });
+  }
+}
+
+// Run only when Codex spawned this file as a script. Under `import` (the unit
+// tests, which exercise buildCodexHookEnvelope directly) the module must stay
+// inert. Fails OPEN: anything it cannot determine is treated as a real launch,
+// because a bridge that silently declines to run is the worse failure.
+function invokedAsScript() {
+  try {
+    if (!process.argv[1]) return true;
+    const self = fileURLToPath(import.meta.url);
+    const entry = resolve(process.argv[1]);
+    // realpath both sides before comparing. A textual match fails on a
+    // symlinked install, an 8.3 short path, or a `subst` drive — and the only
+    // symptom would be a bridge that silently never runs.
+    const real = (p) => {
+      try {
+        return realpathSync.native ? realpathSync.native(p) : realpathSync(p);
+      } catch {
+        return p;
+      }
+    };
+    const norm = (p) => (process.platform === 'win32' ? real(p).toLowerCase() : real(p));
+    return norm(self) === norm(entry);
+  } catch {
+    return true;
+  }
+}
+
+if (invokedAsScript()) {
+  // Self-enforced hard stop. HOOK_TIMEOUT_MS only bounds the SEND — a stdin
+  // that never reaches EOF would hang before that. `unref` so this never keeps
+  // the process alive on the normal path.
+  const watchdog = setTimeout(() => {
+    logEvent('watchdog-exit');
+    process.exit(0);
+  }, HOOK_TIMEOUT_MS * 2);
+  watchdog.unref?.();
+  main()
+    .catch((err) => logEvent('uncaught', { error: String(err) }))
+    // `process.exit(0)`, not just a resolved promise: this bridge never writes
+    // stdout, so there is no pending flush to lose, and an explicit 0 keeps a
+    // stray listener from holding the turn open.
+    .finally(() => process.exit(0));
+}

--- a/integrations/codex/hooks/wmuxHooks.mjs
+++ b/integrations/codex/hooks/wmuxHooks.mjs
@@ -120,23 +120,30 @@ export function renderCodexHooksToml(bridgeScript) {
  * True when a codex-cli version string is at or above the hooks floor.
  *
  * Accepts what `codex --version` prints (`codex-cli 0.151.0`) and bare
- * versions, and tolerates a pre-release suffix: `0.145.0-alpha.2` is a build
- * of 0.145.0 and was measured firing, so the suffix is dropped rather than
- * ordered. A version it cannot parse is treated as TOO OLD — an unknown build
+ * versions. A version it cannot parse is treated as TOO OLD — an unknown build
  * that silently runs no hooks is the failure this gate exists to prevent, and
  * falling back to the screen detector is the safe side of that call.
+ *
+ * Pre-release suffixes are ordered BELOW their own release, which is the
+ * semver rule and also the measurement: `0.145.0-alpha.2` fired, and it is
+ * above the floor either way. The case that matters is a pre-release AT the
+ * floor — `0.141.0-alpha.0` is a build made BEFORE 0.141.0 shipped, so it sits
+ * in exactly the 0.140.0 silent-no-fire zone this floor exists to exclude.
+ * Treating it as ">= 0.141.0" would let the one build class we cannot verify
+ * through the gate.
  */
 export function codexSupportsHooks(versionOutput, floor = CODEX_HOOKS_MIN_VERSION) {
   const parse = (text) => {
-    const m = /(\d+)\.(\d+)\.(\d+)/.exec(String(text ?? ''));
-    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+    const m = /(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?/.exec(String(text ?? ''));
+    return m ? { nums: [Number(m[1]), Number(m[2]), Number(m[3])], pre: Boolean(m[4]) } : null;
   };
   const found = parse(versionOutput);
   const want = parse(floor);
   if (!found || !want) return false;
   for (let i = 0; i < 3; i++) {
-    if (found[i] > want[i]) return true;
-    if (found[i] < want[i]) return false;
+    if (found.nums[i] > want.nums[i]) return true;
+    if (found.nums[i] < want.nums[i]) return false;
   }
-  return true;
+  // Numerically equal to the floor: a pre-release of it predates it.
+  return !found.pre;
 }

--- a/integrations/codex/hooks/wmuxHooks.mjs
+++ b/integrations/codex/hooks/wmuxHooks.mjs
@@ -1,0 +1,142 @@
+// The Codex `[hooks]` config block that carries wmux's lifecycle bridge.
+//
+// Codex hooks are TOML, not a hooks.json — they live under `[[hooks.<Event>]]`
+// in `$CODEX_HOME/config.toml` (default `~/.codex/config.toml`). The schema is
+// Claude Code's, transposed: an event name, a `matcher`, and a list of handlers
+// with `type` / `command` / `commandWindows` / `timeout` / `async`.
+//
+// Verified on codex-cli 0.151.0 (2026-08-31) by writing this block and watching
+// the bridge fire. Two things about it are not guessable from the schema:
+//
+//   1. TRUST. A hook Codex has not been told to trust does not run, and says
+//      nothing about it — no warning, no "needs review" line, no non-zero exit.
+//      Writing this block is therefore NOT installation; the operator must
+//      approve the hooks in Codex before they do anything. That is why there is
+//      no installer here, only a builder plus README instructions.
+//   2. VERSION. 0.140.0 accepts this exact block, advertises `hooks` as a
+//      stable feature, and fires nothing. 0.141.0 fires. Bisected; see
+//      CODEX_HOOKS_MIN_VERSION.
+//
+// This module is data only — it writes nothing. `integrations/codex/README.md`
+// owns the operator instructions.
+
+/** Marks the block as wmux-owned so an installer never clobbers a user's. */
+export const CODEX_HOOKS_MANAGED_MARKER = 'wmux-managed: codex-hooks-bridge';
+
+/**
+ * Lowest codex-cli that actually RUNS a configured hook.
+ *
+ * Bisected 2026-08-31 against a stub Responses endpoint, with
+ * `--dangerously-bypass-hook-trust` so the trust gate could not confound it:
+ *   0.135.0 — turn completed, zero hooks fired
+ *   0.140.0 — turn completed, zero hooks fired
+ *   0.141.0 — SessionStart + UserPromptSubmit + Stop all fired
+ *   0.143.0, 0.145.0-alpha.2, 0.151.0 — same as 0.141.0
+ *
+ * Note what is NOT a usable capability probe: `codex features list` reports
+ * `hooks  stable  true` on 0.135.0, and `--dangerously-bypass-hook-trust` is
+ * present in its `--help`. Both lie. Only the version distinguishes them.
+ */
+export const CODEX_HOOKS_MIN_VERSION = '0.141.0';
+
+/**
+ * Codex's own hook timeout. The bridge caps itself at 2s (HOOK_TIMEOUT_MS), so
+ * 2500 lets our cap fire first and leaves Codex a hard backstop that cannot
+ * hold a turn open if the bridge wedges. Same reasoning as Kiro's.
+ */
+export const CODEX_HOOK_TIMEOUT_MS = 2500;
+
+/**
+ * The events wmux registers. Kept in lockstep with EVENT_TO_KIND in
+ * bin/wmux-codex-hooks-bridge.mjs — registering an event the bridge drops
+ * would spawn a process per occurrence to do nothing.
+ */
+export const CODEX_HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'Stop'];
+
+/**
+ * Build the `hooks` value for config.toml as plain JS data.
+ *
+ * `commandWindows` is a sibling of `command` in Codex's own schema — that is
+ * how a cross-platform hook gets a different invocation per OS. Both are
+ * emitted with the same text here because `node "<abs path>"` is already
+ * correct on every platform; the field is set anyway so a Windows Codex never
+ * falls through to a POSIX-shaped default.
+ */
+export function buildCodexHooksConfig(bridgeScript) {
+  const command = `node "${bridgeScript}"`;
+  const hooks = {};
+  for (const event of CODEX_HOOK_EVENTS) {
+    hooks[event] = [
+      {
+        matcher: '*',
+        hooks: [
+          {
+            type: 'command',
+            command,
+            commandWindows: command,
+            timeout: CODEX_HOOK_TIMEOUT_MS,
+            // Synchronous. `async` would let Codex continue without waiting,
+            // which sounds free until a `Stop` races the next turn's
+            // `UserPromptSubmit` and the pane's state flips backwards. The
+            // bridge's own 2s cap is what keeps sync cheap.
+            async: false,
+          },
+        ],
+      },
+    ];
+  }
+  return hooks;
+}
+
+/**
+ * Render the block as the TOML text an operator pastes into config.toml.
+ *
+ * Hand-rolled rather than via a TOML library: this file has to stay dependency
+ * free for the same reason the bridge does, the shape is fixed and tiny, and
+ * the only values interpolated are a path we control and integers.
+ */
+export function renderCodexHooksToml(bridgeScript) {
+  const config = buildCodexHooksConfig(bridgeScript);
+  const lines = [`# ${CODEX_HOOKS_MANAGED_MARKER}`];
+  for (const event of CODEX_HOOK_EVENTS) {
+    const [group] = config[event];
+    const [handler] = group.hooks;
+    lines.push(
+      '',
+      `[[hooks.${event}]]`,
+      `matcher = ${JSON.stringify(group.matcher)}`,
+      `[[hooks.${event}.hooks]]`,
+      `type = ${JSON.stringify(handler.type)}`,
+      `command = ${JSON.stringify(handler.command)}`,
+      `commandWindows = ${JSON.stringify(handler.commandWindows)}`,
+      `timeout = ${handler.timeout}`,
+      `async = ${handler.async}`,
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * True when a codex-cli version string is at or above the hooks floor.
+ *
+ * Accepts what `codex --version` prints (`codex-cli 0.151.0`) and bare
+ * versions, and tolerates a pre-release suffix: `0.145.0-alpha.2` is a build
+ * of 0.145.0 and was measured firing, so the suffix is dropped rather than
+ * ordered. A version it cannot parse is treated as TOO OLD — an unknown build
+ * that silently runs no hooks is the failure this gate exists to prevent, and
+ * falling back to the screen detector is the safe side of that call.
+ */
+export function codexSupportsHooks(versionOutput, floor = CODEX_HOOKS_MIN_VERSION) {
+  const parse = (text) => {
+    const m = /(\d+)\.(\d+)\.(\d+)/.exec(String(text ?? ''));
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+  };
+  const found = parse(versionOutput);
+  const want = parse(floor);
+  if (!found || !want) return false;
+  for (let i = 0; i < 3; i++) {
+    if (found[i] > want[i]) return true;
+    if (found[i] < want[i]) return false;
+  }
+  return true;
+}

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -134,6 +134,19 @@ export const HOST_CONTRACTS = {
     if (exitCode !== 0) return 'nonzero-exit-tolerated-by-host';
     return 'none';
   },
+
+  // Codex CLI lifecycle hooks (0.151.0). Unlike the notify program, these run
+  // ON the turn and Codex reads both channels: the binary carries
+  // "PreToolUse hook exited with code 2 but did not write a blocking reason to
+  // stderr" and "hook returned invalid pre-tool-use JSON output", so exit 2 is
+  // a BLOCK and stdout can be parsed as a verdict. That makes the strictness
+  // load-bearing here rather than merely tidy — a wmux observation hook that
+  // printed or failed could actually stop a Codex turn.
+  codexHook(exitCode, stdout) {
+    if (stdout !== '') return 'stdout-noise';
+    if (exitCode !== 0) return 'nonzero-exit-blocks-host';
+    return 'none';
+  },
 };
 
 // ----- Case manifest ------------------------------------------------------
@@ -174,7 +187,7 @@ export function discoverHookManifests() {
 // appears in neither this map nor the discovery above is an adapter nobody
 // wired into the gate, and the coverage test says so rather than passing.
 export const NON_MANIFEST_INTEGRATIONS = {
-  codex: 'notify program registered in config.toml; payload arrives as argv, covered explicitly',
+  codex: 'notify program + lifecycle hooks registered in config.toml (TOML, not a hooks.json); covered explicitly',
   kiro: 'hooks live inside a wmux-owned agent config, not a hooks.json; covered explicitly',
   opencode: 'in-process plugin, not a spawned hook; measured separately',
   shared: 'not an agent — shared type declarations',
@@ -324,6 +337,66 @@ export function buildCases(payloadOpts) {
       args: [],
       stdin: 'none',
       argvPayload: payload,
+      payload,
+    });
+  }
+
+  // Codex's LIFECYCLE hooks (as opposed to the notify program above) are
+  // registered as `[[hooks.<Event>]]` in config.toml and take their payload on
+  // stdin, Claude-Code style. These are the payloads codex-cli 0.151.0
+  // actually sends, captured live (2026-08-31) — including the content fields
+  // (`prompt`, `last_assistant_message`, `tool_input`) the bridge must never
+  // forward, so the harness exercises the real shape rather than a sanitized
+  // one.
+  const codexHookScript = join(REPO_ROOT, 'integrations', 'codex', 'bin', 'wmux-codex-hooks-bridge.mjs');
+  const codexCwd = payloadOpts?.cwd ?? '/tmp/harness';
+  const codexSession = 'harness-session';
+  const codexTranscript = payloadOpts?.transcriptPath ?? '/tmp/harness/harness-session.jsonl';
+  for (const [label, payload] of [
+    ['Stop', {
+      session_id: codexSession,
+      turn_id: 'harness-turn',
+      transcript_path: codexTranscript,
+      cwd: codexCwd,
+      hook_event_name: 'Stop',
+      stop_hook_active: false,
+      last_assistant_message: 'the model said this',
+    }],
+    ['SessionStart', {
+      session_id: codexSession,
+      transcript_path: codexTranscript,
+      cwd: codexCwd,
+      hook_event_name: 'SessionStart',
+      source: 'startup',
+    }],
+    ['UserPromptSubmit', {
+      session_id: codexSession,
+      turn_id: 'harness-turn',
+      cwd: codexCwd,
+      hook_event_name: 'UserPromptSubmit',
+      prompt: 'the user typed this',
+    }],
+    // Events wmux deliberately does not map. "Ignored" must still mean silent
+    // and fast, not a slow no-op — and PreToolUse fires on EVERY Codex tool
+    // call, so a slow ignore there would be the most expensive kind.
+    ['PreToolUse', {
+      session_id: codexSession,
+      cwd: codexCwd,
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo hi' },
+    }],
+    ['SessionEnd', { session_id: codexSession, cwd: codexCwd, hook_event_name: 'SessionEnd', reason: 'other' }],
+  ]) {
+    cases.push({
+      agent: 'codex',
+      contract: 'codexHook',
+      id: `codex:hook[${label}]`,
+      event: label,
+      matcher: label,
+      script: codexHookScript,
+      args: [],
+      stdin: 'json',
       payload,
     });
   }

--- a/src/main/pipe/handlers/__tests__/hooks.rpc.alarm.test.ts
+++ b/src/main/pipe/handlers/__tests__/hooks.rpc.alarm.test.ts
@@ -165,6 +165,44 @@ describe('hooks.signal — local verdict gate (CompletionAlarm)', () => {
     expect(r.onClaudeTurnEnd).toHaveBeenCalledTimes(1);
   });
 
+  // #1107 regression. The Codex hooks bridge registers UserPromptSubmit on an
+  // ordinary pane and deliberately maps no PreToolUse/PostToolUse, so
+  // `agent.user_prompt_submit` is that pane's ONLY working cue. This path used
+  // to drop it before the alarm feed (on the premise that the brain lane was
+  // its only emitter), which made the turn gate swallow the same turn's stop.
+  // The daemon path never had the hole; this locks the main path symmetric.
+  it('arms the turn gate from agent.user_prompt_submit so the stop survives', async () => {
+    const r = rig();
+
+    // The ONLY cue before the stop — no activity, no tool_started.
+    await r.dispatch({ kind: 'agent.user_prompt_submit', agent: 'codex' });
+    // It is not an emit kind: no toast, no ledger write, no lifecycle tee.
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+    expect(r.recordHook).not.toHaveBeenCalled();
+    expect(pollLifecycle()).toHaveLength(0);
+
+    await r.dispatch({ kind: 'agent.stop', agent: 'codex' });
+    vi.advanceTimersByTime(DEFAULT_ALARM_WINDOW_MS);
+
+    // The stop passed the `!seenWorking` gate and fanned out exactly once.
+    expect(r.recordHook).toHaveBeenCalledTimes(1);
+    expect(sendNotificationMock).toHaveBeenCalledTimes(1);
+  });
+
+  // The other half of the same fix: session_start normalizes to a `session`
+  // cue that RESETS seenWorking. So a Codex pane whose only prior signal was
+  // SessionStart must still NOT announce — otherwise the gate is meaningless.
+  it('does not let agent.session_start alone arm the gate', async () => {
+    const r = rig();
+
+    await r.dispatch({ kind: 'agent.session_start', agent: 'codex' });
+    await r.dispatch({ kind: 'agent.stop', agent: 'codex' });
+    vi.advanceTimersByTime(DEFAULT_ALARM_WINDOW_MS);
+
+    expect(r.recordHook).not.toHaveBeenCalled();
+    expect(sendNotificationMock).not.toHaveBeenCalled();
+  });
+
   it('a working cue inside the window rebuts the stop — nothing fires, ledger untouched', async () => {
     const r = rig();
     await primeWorking(r);

--- a/src/main/pipe/handlers/hooks.rpc.ts
+++ b/src/main/pipe/handlers/hooks.rpc.ts
@@ -497,14 +497,30 @@ export function registerHooksRpc(
         ? { ok: true, block: { reason: brainVerdict.block } }
         : { ok: true };
     }
-    // A prompt-submit only ever means something to the brain lane above — it
-    // exists to open the foreign-turn flag. One arriving UNCLAIMED is a brain
-    // pty that already died (teardown raced the hook): letting it fall through
-    // would surface a "Prompt submitted" fleet notification for a pane the
-    // human never saw. Drop it silently.
-    if (signal.kind === 'agent.user_prompt_submit') {
-      return { ok: true };
-    }
+    // An unclaimed prompt-submit used to be dropped RIGHT HERE, on the premise
+    // that the brain lane was its only emitter, so an unclaimed one meant a
+    // brain pty that already died (teardown raced the hook). #1107 broke that
+    // premise: the Codex hooks bridge registers UserPromptSubmit on ordinary
+    // panes, and it is that pane's ONLY working cue — the bridge deliberately
+    // does not map PreToolUse/PostToolUse, and `agent.session_start` normalizes
+    // to a `session` cue that RESETS `seenWorking` rather than arming it. So a
+    // drop here made CompletionAlarm's turn gate (`!seenWorking` -> drop)
+    // swallow the same turn's `agent.stop`, and the pane never announced
+    // completion. The daemon path never had this hole: HookIngest feeds the
+    // alarm before it branches on kind.
+    //
+    // The drop is gone rather than relocated because the fall-through already
+    // does exactly what it was protecting: `agent.user_prompt_submit` is not an
+    // emit kind, so it returns at the `!isEmitKind` branch below — after the
+    // alarm feed, and before the ledger write, the EventBus tee and the toast.
+    // `buildTurnBoundaryMetadata` returns null for it and the activity
+    // broadcast is gated on `agent.activity`, so nothing user-visible fires on
+    // the way there. The "Prompt submitted" notification the old comment feared
+    // was never reachable from this path.
+    //
+    // It also stopped the signal from RELAYING: with a healthy daemon, a
+    // prompt-submit that arrived on the main pipe was dropped before
+    // `relayHookSignalToDaemon` and so never reached the daemon's alarm either.
 
     // 2. Latency observability runs BEFORE workspace match so that
     //    plugin signals from cwds outside any wmux workspace still

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -291,6 +291,13 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // the awaiting_input carve-out in PTYBridge/DaemonPTYBridge already
       // exempts these from hook-authority veto for exactly that reason.
       //
+      // #1107: codex-cli >= 0.141.0 also has a `PermissionRequest` lifecycle
+      // hook, which would replace these three regexes outright. It is NOT
+      // wired up: it is the one event the 2026-08-31 measurement could not
+      // make fire, because `codex exec` forces `approval: never` and an
+      // approval pause needs an interactive TUI. Confirming it is what would
+      // let these go; see integrations/codex/README.md.
+      //
       // Anchored to the whole line: the question occupies its own line in
       // the TUI (two-space indent, no box-drawing frame in Codex), whereas
       // a conversational mention would sit inside surrounding sentence text.


### PR DESCRIPTION
Addresses #1107. The spike is answered empirically, and the bridge is implemented — installation is deliberately not wired up (see below).

**How it was verified without a working Codex account.** A hook needs a completed *turn*, not a live account: codex-cli 0.151.0 was driven against a stub Responses endpoint on localhost with an isolated `CODEX_HOME`. The stub supplies only the model's side of the wire; the hook machinery under test is entirely local.

**Three of the issue's assumptions were wrong:**
- **Config is TOML, not `hooks.json`** — `[[hooks.<Event>]]` in `config.toml`. A `.codex/hooks/hooks.json` is inert.
- **Version floor is 0.141.0, not 0.149.1** (bisected). Worse, *no capability probe works*: 0.135.0 reports `hooks stable true`, accepts `--dangerously-bypass-hook-trust`, parses `[[hooks.*]]` clean — and fires nothing. Only the version distinguishes them, so `codexSupportsHooks()` gates on version and fails closed.
- **The trust gate is silent** — an untrusted hook does not run and `codex exec` prints no warning and exits 0.

**Confirmed:** `Stop` is a turn boundary, not a session one (fires once per turn with that turn's `turn_id`; a run whose model call failed produced SessionStart → UserPromptSubmit → SessionEnd and no `Stop`). The payload envelope is Claude Code's verbatim, `WMUX_PTY_ID` reaches the hook, and resume binding is possible (`source: "resume"`, stable `session_id`).

**Still blocked:** `PermissionRequest` — the event that would retire the three transcribed approval regexes in `AgentDetector.ts`. `codex exec` forces `approval: never`, so an approval pause needs an interactive TUI. Left unmapped rather than guessed at; the regexes stay, with a comment recording why.

**Bridge:** `SessionStart` / `UserPromptSubmit` / `Stop` → wmux signals, metadata-only (allowlist enforced in `buildCodexHookEnvelope`, asserted on the serialized envelope so a future content-bearing field fails the test). Identity follows the #1111 hook-bridge lane (`wmux-hook-bridge`, `hooks.signal` only), with a local lockstep guard; when #1111 lands, this bridge must be added to the canonical `hookBridge.lockstep.test.ts` BRIDGES list.

**A real bug found while wiring it up:** `hooks.rpc.ts` dropped an unclaimed `agent.user_prompt_submit` *before* the alarm feed, while the daemon path feeds it first. Since this bridge deliberately doesn't map PreToolUse, that is the only 'working' cue for a Codex pane — so the drop made CompletionAlarm's turn gate swallow the same turn's `agent.stop`, and it also blocked relaying to the daemon. Fixed with two non-vacuous regression tests.

Installation is not wired into the installer: Codex requires an operator to trust the hook and says nothing when they haven't, so an installer that wrote the block and reported success would be reporting a lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6