### PR TITLE
fix(remote): AddRemotePaneModal closes on Escape and names the flow that opened it

### DIFF
--- a/changelog.d/1148.md
+++ b/changelog.d/1148.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The remote host-picker dialog closes on Escape and says which action opened it.** Escape now dismisses the dialog (backdrop click was the only way out), and its heading shows "Split right — remote" / "Split down — remote" when a #1141 split entry opened it instead of always reading "New remote pane".

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -1068,6 +1068,15 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
         <AddRemotePaneModal
           onClose={() => setAddRemoteModalOpen(false)}
           onCreated={handleRemoteCreated}
+          // Reading the ref during render is safe here: every handler that
+          // opens the modal writes the ref before setAddRemoteModalOpen(true),
+          // so by the render that mounts this it already names the flow — and
+          // it stays put until handleRemoteCreated/onClose unmounts us.
+          title={
+            remoteSplitDirectionRef.current === 'horizontal' ? t('pane.splitRightRemote')
+            : remoteSplitDirectionRef.current === 'vertical' ? t('pane.splitDownRemote')
+            : undefined
+          }
         />
       )}
 

--- a/src/renderer/components/Remote/AddRemotePaneModal.tsx
+++ b/src/renderer/components/Remote/AddRemotePaneModal.tsx
@@ -8,6 +8,11 @@ export interface AddRemotePaneModalProps {
    *  surface to its own pane; this component only picks the host and mints
    *  the remote session. */
   onCreated: (hostId: string, sessionId: string) => void;
+  /** Heading shown above the host list. The modal serves three menu entries
+   *  since #1140 (tab, split right, split down), and the heading is the only
+   *  place the dialog can say which one it is answering — omitted falls back
+   *  to the tab flow's "New remote pane". */
+  title?: string;
 }
 
 /**
@@ -18,11 +23,19 @@ export interface AddRemotePaneModalProps {
  * "workspace" at all, so a fresh id is minted purely to satisfy the
  * bootstrap contract and is never referenced again afterward.
  */
-export default function AddRemotePaneModal({ onClose, onCreated }: AddRemotePaneModalProps) {
+export default function AddRemotePaneModal({ onClose, onCreated, title }: AddRemotePaneModalProps) {
   const t = useT();
   const [hosts, setHosts] = useState<RemoteHostPublic[] | null>(null);
   const [creatingHostId, setCreatingHostId] = useState<string | null>(null);
   const [error, setError] = useState<string | undefined>(undefined);
+
+  // Escape closes, same listener AttachRemoteModal binds — until #1140 the
+  // backdrop click was the only way out of this dialog.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
 
   useEffect(() => {
     let cancelled = false;
@@ -74,7 +87,7 @@ export default function AddRemotePaneModal({ onClose, onCreated }: AddRemotePane
         onMouseDown={(e) => e.stopPropagation()}
       >
         <div className="text-sm font-medium mb-2" style={{ color: 'var(--text-main)' }}>
-          {t('pane.newRemote')}
+          {title ?? t('pane.newRemote')}
         </div>
         {error && (
           <div className="text-xs mb-2" style={{ color: 'var(--accent-red, #e5484d)' }}>{error}</div>

--- a/src/renderer/components/Remote/__tests__/AddRemotePaneModal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/AddRemotePaneModal.test.tsx
@@ -127,4 +127,37 @@ describe('AddRemotePaneModal', () => {
     expect(onCreated).toHaveBeenCalledWith('host-1', 'sess-1');
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('closes on Escape — the backdrop click must not be the only way out', async () => {
+    const onClose = vi.fn();
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      remote: { hostsList: vi.fn().mockResolvedValue([HOST]), workspaceCreate: vi.fn() },
+    };
+    const { unmount } = render(<AddRemotePaneModal onClose={onClose} onCreated={() => { /* noop */ }} />);
+    await flush();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    // Listener must not outlive the modal.
+    unmount();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the caller-provided title so the #1140 split flows can name themselves', async () => {
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      remote: { hostsList: vi.fn().mockResolvedValue([]), workspaceCreate: vi.fn() },
+    };
+    const { container, unmount } = render(
+      <AddRemotePaneModal onClose={() => { /* noop */ }} onCreated={() => { /* noop */ }} title="Split right — remote" />,
+    );
+    await flush();
+    expect(container.textContent).toContain('Split right — remote');
+    unmount();
+  });
 });


### PR DESCRIPTION
Two P3s surfaced by the #1141 dogfood run — both pre-existing from #1100, but the split flows tripled how often this dialog shows, so they are worth fixing now:

- **Escape closes the modal.** It binds the same document-level `keydown` listener `AttachRemoteModal` already uses; until now the backdrop click was the only way out.
- **The heading names the flow.** `AddRemotePaneModal` takes an optional `title` prop; `Pane.tsx` passes the menu label of whichever entry opened it ("Split right — remote" / "Split down — remote"), and the tab flow keeps the "New remote pane" default. No new i18n keys — the existing menu-label keys are reused.

Tests: two new cases in `AddRemotePaneModal.test.tsx` (Escape closes and the listener does not outlive the modal; caller-provided title renders). `tsc --noEmit`, ESLint, and the modal's 5 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The remote host-picker dialog can now be dismissed by pressing **Escape**.
  * Dialog headings now accurately describe the selected remote split action, such as “Split right — remote” or “Split down — remote”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->