### PR TITLE
fix(pane): directional focus picks the geometrically adjacent pane, not the tree-order one

### DIFF
--- a/changelog.d/1160.md
+++ b/changelog.d/1160.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Directional pane focus (prefix + arrows) now lands on the pane that is actually adjacent on screen.** Focus and move-pane navigation used tree order, so in nested layouts (e.g. a 2×2 grid) moving left from a top-right pane could land on the bottom-left one. Navigation is now geometric — nearest facing edge, then largest overlap — and respects custom pane sizes.

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -451,7 +451,7 @@ describe('PaneSlice', () => {
       // moving left, BL (y 80–100, overlap 20) loses to TL? No — TL spans
       // y 0–80, overlap with BR (20–100) is 60 → TL wins. The tree-order
       // walk would have picked BL (last leaf) regardless.
-      const { tl, bl, tr, br } = build2x2();
+      const { tl, bl, br } = build2x2();
       const ws = getActiveWorkspace(store);
       const root = ws.rootPane;
       if (root.type !== 'branch') throw new Error('expected branch root');
@@ -459,7 +459,6 @@ describe('PaneSlice', () => {
       if (leftCol.type !== 'branch' || rightCol.type !== 'branch') throw new Error('expected column branches');
       store.getState().updatePaneSizes(leftCol.id, [80, 20]);
       store.getState().updatePaneSizes(rightCol.id, [20, 80]);
-      void tr;
 
       store.getState().setActivePane(br);
       store.getState().focusPaneDirection('left');
@@ -468,6 +467,32 @@ describe('PaneSlice', () => {
       store.getState().setActivePane(bl);
       store.getState().focusPaneDirection('right');
       expect(getActiveWorkspace(store).activePaneId).toBe(br);
+    });
+
+    it('#1147: sizes that do not sum to 100 are treated as ratios (flexGrow parity)', () => {
+      // The screen renders sizes as flexGrow RATIOS, so [150, 50] means 75/25
+      // — the rects must agree or the far neighbour falls out of the
+      // direction filter and focus gets stuck.
+      const { tl, tr } = build2x2();
+      const ws = getActiveWorkspace(store);
+      const root = ws.rootPane;
+      if (root.type !== 'branch') throw new Error('expected branch root');
+      store.getState().updatePaneSizes(root.id, [150, 50]);
+
+      store.getState().setActivePane(tr);
+      store.getState().focusPaneDirection('left');
+      expect(getActiveWorkspace(store).activePaneId).toBe(tl);
+    });
+
+    it('#1147: moveActivePaneDirection shares the geometric pick (TR moved left displaces TL)', () => {
+      const { tl, tr } = build2x2();
+      store.getState().setActivePane(tr);
+      const moved = store.getState().moveActivePaneDirection('left');
+      expect(moved).toBe(true);
+      // The displaced neighbour must have been TL (row-aligned), not BL: the
+      // moved pane lands on TL's left edge, so TL is now to its right.
+      store.getState().focusPaneDirection('right');
+      expect(getActiveWorkspace(store).activePaneId).toBe(tl);
     });
   });
 

--- a/src/renderer/stores/slices/__tests__/paneSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/paneSlice.test.ts
@@ -412,6 +412,63 @@ describe('PaneSlice', () => {
       const wsAfterMove = getActiveWorkspace(store);
       expect(wsAfterMove.activePaneId).toBe(leaves[1].id);
     });
+
+    // #1147 — the repro: a 2×2 grid built as two vertical columns. The old
+    // tree-order walk sent focusLeft from TR to the sibling column's LAST
+    // leaf (BL); geometric navigation must land on the row-aligned TL.
+    const build2x2 = (): { tl: string; bl: string; tr: string; br: string } => {
+      const ws = getActiveWorkspace(store);
+      store.getState().splitPane(ws.rootPane.id, 'horizontal'); // [L, R]
+      let leaves = getLeafPanes(getActiveWorkspace(store).rootPane);
+      const [left, right] = [leaves[0].id, leaves[1].id];
+      store.getState().splitPane(left, 'vertical');  // L → [TL, BL]
+      store.getState().splitPane(right, 'vertical'); // R → [TR, BR]
+      leaves = getLeafPanes(getActiveWorkspace(store).rootPane);
+      expect(leaves).toHaveLength(4);
+      return { tl: left, bl: leaves[1].id, tr: right, br: leaves[3].id };
+    };
+
+    it('#1147 repro: focusLeft from TR of a 2×2 grid lands on TL, not BL', () => {
+      const { tl, tr } = build2x2();
+      store.getState().setActivePane(tr);
+      store.getState().focusPaneDirection('left');
+      expect(getActiveWorkspace(store).activePaneId).toBe(tl);
+    });
+
+    it('#1147: focusRight from BL lands on BR; focusDown from TR lands on BR', () => {
+      const { bl, tr, br } = build2x2();
+      store.getState().setActivePane(bl);
+      store.getState().focusPaneDirection('right');
+      expect(getActiveWorkspace(store).activePaneId).toBe(br);
+
+      store.getState().setActivePane(tr);
+      store.getState().focusPaneDirection('down');
+      expect(getActiveWorkspace(store).activePaneId).toBe(br);
+    });
+
+    it('#1147: custom sizes shift the perpendicular-overlap pick', () => {
+      // Left column split 80/20, right column 20/80: from BR (tall, y 20–100)
+      // moving left, BL (y 80–100, overlap 20) loses to TL? No — TL spans
+      // y 0–80, overlap with BR (20–100) is 60 → TL wins. The tree-order
+      // walk would have picked BL (last leaf) regardless.
+      const { tl, bl, tr, br } = build2x2();
+      const ws = getActiveWorkspace(store);
+      const root = ws.rootPane;
+      if (root.type !== 'branch') throw new Error('expected branch root');
+      const [leftCol, rightCol] = root.children;
+      if (leftCol.type !== 'branch' || rightCol.type !== 'branch') throw new Error('expected column branches');
+      store.getState().updatePaneSizes(leftCol.id, [80, 20]);
+      store.getState().updatePaneSizes(rightCol.id, [20, 80]);
+      void tr;
+
+      store.getState().setActivePane(br);
+      store.getState().focusPaneDirection('left');
+      expect(getActiveWorkspace(store).activePaneId).toBe(tl);
+
+      store.getState().setActivePane(bl);
+      store.getState().focusPaneDirection('right');
+      expect(getActiveWorkspace(store).activePaneId).toBe(br);
+    });
   });
 
   describe('cyclePane', () => {

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
-import type { Pane, PaneLeaf, PaneBranch, StashedPane, Workspace, AgentStatus } from '../../../shared/types';
+import type { Pane, PaneBranch, StashedPane, Workspace, AgentStatus } from '../../../shared/types';
 import type { AgentSlug } from '../../../shared/events';
 import {
   createLeafPane,
@@ -303,9 +303,17 @@ export function computeLeafRects(root: Pane): Map<string, LeafRect> {
       return;
     }
     const n = pane.children.length;
+    // Normalize by the actual sum, not an assumed 100: the screen renders
+    // sizes as flexGrow RATIOS, so a persisted/edited tree whose sizes don't
+    // sum to 100 still lays out proportionally — un-normalized fracs would
+    // let the last child's rect spill past the box (sum > 100, making the
+    // far neighbour fail the direction filter → focus stuck) or leave a
+    // phantom gap (sum < 100). Sum == 100 makes this a no-op.
+    const parts = pane.children.map((_, i) => pane.sizes?.[i] ?? 100 / n);
+    const sum = parts.reduce((a, b) => a + b, 0) || 1;
     let offset = 0;
     for (let i = 0; i < n; i++) {
-      const frac = (pane.sizes?.[i] ?? 100 / n) / 100;
+      const frac = parts[i] / sum;
       if (pane.direction === 'horizontal') walk(pane.children[i], x + offset * w, y, w * frac, h);
       else walk(pane.children[i], x, y + offset * h, w, h * frac);
       offset += frac;

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -284,50 +284,101 @@ const ATTENTION_STATUSES: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
   'awaiting_input',
 ]);
 
-/** First (leftmost/topmost) leaf of a subtree. */
-function firstLeaf(pane: Pane): PaneLeaf {
-  if (pane.type === 'leaf') return pane;
-  return firstLeaf(pane.children[0]);
-}
+/** Normalized leaf rectangle in a 0–100 coordinate space (both axes). */
+interface LeafRect { x: number; y: number; w: number; h: number }
 
-/** Last (rightmost/bottommost) leaf of a subtree. */
-function lastLeaf(pane: Pane): PaneLeaf {
-  if (pane.type === 'leaf') return pane;
-  return lastLeaf(pane.children[pane.children.length - 1]);
+/**
+ * #1147 — geometry of every leaf, derived purely from the tree: each branch
+ * splits its box along `direction` by `sizes` percentages, with the same
+ * `100 / children.length` fallback PaneContainer renders, so these rects match
+ * the screen without touching the DOM (navigateFrom is shared with
+ * moveActivePaneDirection and runs in jsdom-free store tests; a DOM read would
+ * also go stale for zoom-hidden panes).
+ */
+export function computeLeafRects(root: Pane): Map<string, LeafRect> {
+  const rects = new Map<string, LeafRect>();
+  const walk = (pane: Pane, x: number, y: number, w: number, h: number): void => {
+    if (pane.type === 'leaf') {
+      rects.set(pane.id, { x, y, w, h });
+      return;
+    }
+    const n = pane.children.length;
+    let offset = 0;
+    for (let i = 0; i < n; i++) {
+      const frac = (pane.sizes?.[i] ?? 100 / n) / 100;
+      if (pane.direction === 'horizontal') walk(pane.children[i], x + offset * w, y, w * frac, h);
+      else walk(pane.children[i], x, y + offset * h, w, h * frac);
+      offset += frac;
+    }
+  };
+  walk(root, 0, 0, 100, 100);
+  return rects;
 }
 
 /**
- * Tree-based spatial navigation: the leaf you reach by moving `dir` out of
- * `paneId`. Walks up until it finds an ancestor split along the requested axis
- * with a sibling on that side, then descends to the nearest leaf.
+ * Geometric spatial navigation (#1147): the leaf you reach by moving `dir` out
+ * of `paneId` — the candidate whose facing edge is nearest, tie-broken by the
+ * largest perpendicular overlap with the current pane, then by center
+ * distance (tmux's pick, roughly). Replaces the tree-order walk that, in a
+ * 2×2 grid built as [[TL,BL],[TR,BR]], sent focusLeft from TR to BL: the
+ * old code descended to the sibling column's LAST leaf regardless of where
+ * the cursor actually sat.
  *
- * Shared by `focusPaneDirection` and (issue #645) `moveActivePaneDirection`, so
- * "the pane to my right" means the same thing whether you are moving focus or
- * moving the pane itself. It is tree-order-based, not geometric — in deeply
- * nested asymmetric layouts the neighbour can differ from what is literally
- * adjacent on screen, which has always been true of focus movement here.
+ * Shared by `focusPaneDirection` and (issue #645) `moveActivePaneDirection`,
+ * so "the pane to my right" means the same thing whether you are moving focus
+ * or moving the pane itself. Returns null at the layout edge (no candidate).
  */
 function navigateFrom(root: Pane, paneId: string, dir: 'up' | 'down' | 'left' | 'right'): string | null {
-  const parent = findParent(root, paneId);
-  if (!parent) return null; // at root
+  const rects = computeLeafRects(root);
+  const cur = rects.get(paneId);
+  if (!cur) return null;
+  // Float slack: sizes come from resize events and rarely sum to exactly 100.
+  const EPS = 0.1;
 
-  const idx = parent.children.findIndex((c) => c.id === paneId);
-  const isAligned =
-    (parent.direction === 'horizontal' && (dir === 'left' || dir === 'right')) ||
-    (parent.direction === 'vertical' && (dir === 'up' || dir === 'down'));
+  let best: string | null = null;
+  let bestEdge = Infinity;
+  let bestOverlap = -Infinity;
+  let bestCenter = Infinity;
+  const curCx = cur.x + cur.w / 2;
+  const curCy = cur.y + cur.h / 2;
 
-  if (isAligned) {
-    const delta = dir === 'right' || dir === 'down' ? 1 : -1;
-    const nextIdx = idx + delta;
-    if (nextIdx >= 0 && nextIdx < parent.children.length) {
-      // Move to adjacent sibling — descend to nearest leaf
-      const sibling = parent.children[nextIdx];
-      return (delta > 0 ? firstLeaf(sibling) : lastLeaf(sibling)).id;
+  for (const [id, r] of rects) {
+    if (id === paneId) continue;
+    let edge: number;
+    if (dir === 'left') {
+      if (r.x + r.w > cur.x + EPS) continue;
+      edge = cur.x - (r.x + r.w);
+    } else if (dir === 'right') {
+      if (r.x < cur.x + cur.w - EPS) continue;
+      edge = r.x - (cur.x + cur.w);
+    } else if (dir === 'up') {
+      if (r.y + r.h > cur.y + EPS) continue;
+      edge = cur.y - (r.y + r.h);
+    } else {
+      if (r.y < cur.y + cur.h - EPS) continue;
+      edge = r.y - (cur.y + cur.h);
+    }
+    const overlap = dir === 'left' || dir === 'right'
+      ? Math.min(cur.y + cur.h, r.y + r.h) - Math.max(cur.y, r.y)
+      : Math.min(cur.x + cur.w, r.x + r.w) - Math.max(cur.x, r.x);
+    const center = dir === 'left' || dir === 'right'
+      ? Math.abs(r.y + r.h / 2 - curCy)
+      : Math.abs(r.x + r.w / 2 - curCx);
+
+    if (
+      edge < bestEdge - EPS ||
+      (Math.abs(edge - bestEdge) <= EPS && (
+        overlap > bestOverlap + EPS ||
+        (Math.abs(overlap - bestOverlap) <= EPS && center < bestCenter)
+      ))
+    ) {
+      best = id;
+      bestEdge = edge;
+      bestOverlap = overlap;
+      bestCenter = center;
     }
   }
-
-  // Direction not aligned or no sibling in that direction — go up
-  return navigateFrom(root, parent.id, dir);
+  return best;
 }
 
 /**


### PR DESCRIPTION
Fixes #1147.

`navigateFrom` walked the tree — ascend to an axis-aligned ancestor, descend to the sibling subtree's FIRST/LAST leaf — so in a 2×2 grid built as two vertical columns, focus-left from the top-right pane landed on the BOTTOM-left pane. It now computes every leaf's normalized rect purely from the tree (each branch splits its box along `direction` by `sizes` treated as flexGrow RATIOS — `PaneContainer`'s own rendering rule — with the same `100/n` fallback; no DOM reads, so the store function keeps working for `moveActivePaneDirection` and in jsdom-free tests) and picks the candidate with the nearest facing edge, tie-broken by largest perpendicular overlap, then center distance.

The issue's suggested DOM-rect approach was rejected: there is no `data-pane-id` on pane wrappers, and a DOM-dependent store function would break `moveActivePaneDirection`, zoom-hidden panes, and store-level tests.

**Review team (2-way, Codex 402):** GLM's P2 — sizes must be normalized by their SUM, not assumed to total 100, or a persisted/edited tree spills the last child's rect past the box and focus gets stuck — is folded in, plus its test-coverage P3s.

**Dogfood (live 2×2 grid over CDP, `-dog1147`):** TR+← lands on TL (the repro), BL+→→BR, TR+↓→BR, 80/20-resized overlap pick, 2-pane toggle, and edge no-op all PASS with before/after screenshots; 63 store tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6