### PR TITLE
feat(shortcuts): built-in shortcuts can be switched off, letting the key reach the terminal

### DIFF
--- a/changelog.d/1162.md
+++ b/changelog.d/1162.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Built-in shortcuts can be switched off.** Every advertised row in Settings → Shortcuts now has a checkbox; unchecking it fully unbinds the combo and the key reaches the terminal instead — Ctrl+T then opens Codex's own transcript rather than a new wmux tab. Custom keybindings rebound onto a disabled combo still fire, and the setting survives restarts.

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -365,6 +365,7 @@ function buildSessionData(dumped: Map<string, boolean>): SessionData {
     anthropicUsageEnabled: state.anthropicUsageEnabled,
     mutedNotificationCategories: state.mutedNotificationCategories,
     customKeybindings: state.customKeybindings,
+    disabledShortcuts: state.disabledShortcuts,
     autoUpdateEnabled: state.autoUpdateEnabled,
     customThemeColors: state.customThemeColors ?? undefined,
     onboardingCompleted: state.onboardingCompleted,

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -487,15 +487,44 @@ function SectionLabel({ id, label }: { id?: string; label: string }) {
 
 // ─── Keyboard shortcut badge ──────────────────────────────────────────────────
 
-function KbdRow({ keys, description }: { keys: string; description: string }) {
+function KbdRow({ keys, description, disabled, onToggleDisabled, toggleTitle }: {
+  keys: string;
+  description: string;
+  /** #1152 — undefined hides the toggle (rows that cannot be disabled). */
+  disabled?: boolean;
+  onToggleDisabled?: () => void;
+  toggleTitle?: string;
+}) {
   return (
     <div className="flex items-center justify-between py-1.5 px-3 rounded-lg hover:bg-[color:var(--bg-mantle)] transition-colors">
-      <span className="text-[12px] text-[color:var(--text-sub)]">{description}</span>
       <span
-        className="text-[10px] font-mono tabular-nums px-2 py-0.5 rounded"
-        style={{ backgroundColor: 'var(--bg-surface)', color: 'var(--accent-blue)', border: '1px solid var(--bg-overlay)' }}
+        className="text-[12px] text-[color:var(--text-sub)]"
+        style={disabled ? { textDecoration: 'line-through', opacity: 0.5 } : undefined}
       >
-        {keys}
+        {description}
+      </span>
+      <span className="flex items-center gap-2">
+        <span
+          className="text-[10px] font-mono tabular-nums px-2 py-0.5 rounded"
+          style={{
+            backgroundColor: 'var(--bg-surface)',
+            color: disabled ? 'var(--text-subtle)' : 'var(--accent-blue)',
+            border: '1px solid var(--bg-overlay)',
+            ...(disabled ? { textDecoration: 'line-through' } : {}),
+          }}
+        >
+          {keys}
+        </span>
+        {onToggleDisabled !== undefined && (
+          <input
+            type="checkbox"
+            checked={!disabled}
+            onChange={onToggleDisabled}
+            title={toggleTitle}
+            aria-label={toggleTitle}
+            className="cursor-pointer"
+          />
+        )}
       </span>
     </div>
   );
@@ -4174,6 +4203,8 @@ function TabShortcuts() {
   const addKeybinding = useStore((s) => s.addKeybinding);
   const updateKeybinding = useStore((s) => s.updateKeybinding);
   const removeKeybinding = useStore((s) => s.removeKeybinding);
+  const disabledShortcuts = useStore((s) => s.disabledShortcuts);
+  const toggleShortcutDisabled = useStore((s) => s.toggleShortcutDisabled);
   const prefixConfig = useStore((s) => s.prefixConfig);
   const setPrefixKey = useStore((s) => s.setPrefixKey);
   const setPrefixBinding = useStore((s) => s.setPrefixBinding);
@@ -4201,10 +4232,13 @@ function TabShortcuts() {
   // tmux/bookmark family. prefixKeyDisplay always renders as literal Ctrl
   // because the prefix combo stays on Ctrl across every OS.
   const shortcuts = [
-    { keys: prefixKeyDisplay, description: t('settings.prefixMode') },
+    // The prefix row keeps its own config below — no toggle (combo: undefined).
+    { keys: prefixKeyDisplay, description: t('settings.prefixMode'), combo: undefined as string | undefined },
     ...ADVERTISED_SHORTCUTS.map((entry) => ({
       keys: shortcutLabel(entry),
       description: t(entry.descriptionKey as Parameters<typeof t>[0]),
+      // #1152 — the storage-form combo keys the disable toggle.
+      combo: entry.combo as string | undefined,
     })),
   ];
 
@@ -4216,7 +4250,16 @@ function TabShortcuts() {
         style={{ backgroundColor: 'var(--bg-mantle)', border: '1px solid var(--bg-surface)' }}
       >
         {shortcuts.map((s) => (
-          <KbdRow key={s.keys} keys={s.keys} description={s.description} />
+          <KbdRow
+            key={s.keys}
+            keys={s.keys}
+            description={s.description}
+            // #1152 — advertised built-ins can be switched off; the key then
+            // passes through to the terminal (Codex Ctrl+T et al.).
+            disabled={s.combo ? disabledShortcuts.includes(s.combo) : undefined}
+            onToggleDisabled={s.combo ? () => toggleShortcutDisabled(s.combo as string) : undefined}
+            toggleTitle={t('settings.shortcutDisableHint')}
+          />
         ))}
       </div>
       {/* Prefix mode configuration */}

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -521,7 +521,9 @@ function KbdRow({ keys, description, disabled, onToggleDisabled, toggleTitle }: 
             checked={!disabled}
             onChange={onToggleDisabled}
             title={toggleTitle}
-            aria-label={toggleTitle}
+            // Unique per row — thirteen checkboxes all reading the same hint
+            // would be indistinguishable to a screen reader.
+            aria-label={`${description} (${keys})`}
             className="cursor-pointer"
           />
         )}
@@ -4221,8 +4223,11 @@ function TabShortcuts() {
   // never fired. Derived from WMUX_KEYMAP now (#818), and resolved for the
   // running platform — on macOS a built-in that fires on ⌘ cannot collide with
   // a custom binding, which is matched on literal Ctrl.
-  const BUILTIN_KEYS = builtinCombosFor(
-    window.electronAPI?.platform === 'darwin' ? 'darwin' : 'win32',
+  // #1152 — a disabled built-in no longer claims its combo, so a custom
+  // keybinding on it is a deliberate rebind, not a conflict to warn about.
+  const BUILTIN_KEYS = new Set(
+    [...builtinCombosFor(window.electronAPI?.platform === 'darwin' ? 'darwin' : 'win32')]
+      .filter((c) => !disabledShortcuts.includes(c)),
   );
 
   const prefixKeyDisplay = `Ctrl+${keyCodeToDisplay(prefixConfig.key)}`;

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -5,6 +5,7 @@ import { collectPaneTreePtyIds, findLeaf, getLeafPanes, getWorkspacePtyIds } fro
 import { terminalRegistry } from './useTerminal';
 import { t } from '../i18n';
 import { pastePtyChunked } from '../utils/clipboardChunk';
+import { matchesDisabledShortcut } from '../../shared/keymap';
 import { createTerminalSurface } from '../utils/createTerminalSurface';
 import { openUrlInBrowserPane } from '../utils/browserPaneActions';
 import {
@@ -325,21 +326,65 @@ export function useKeyboard() {
       // Read prefix mode from store (fresh, no stale closure)
       const prefixMode = store.getState().prefixMode;
 
-      // #1152 — a built-in the user disabled (Settings → Shortcuts) must act
-      // as if it were never bound: no preventDefault, no handler, so the key
-      // falls through to whatever has focus. useTerminal stops bubbling
-      // disabled combos, so inside a terminal the byte reaches the PTY —
-      // Ctrl+T then opens Codex's own transcript instead of a new surface.
-      // Prefix-mode SUB-commands are not top-level combos and stay unaffected;
-      // matching covers e.key and the physical code (IME layouts) the same
-      // way the individual handlers below do.
-      if (!prefixMode && (cmdOrCtrl || literalCtrl)) {
-        const disabled = store.getState().disabledShortcuts;
-        if (disabled.length > 0) {
-          const byKey = formatKeyCombo(true, shift, alt, key);
-          const byCode = code.startsWith('Key') ? formatKeyCombo(true, shift, alt, code.slice(3)) : null;
-          if (disabled.includes(byKey) || (byCode !== null && disabled.includes(byCode))) return;
+      // Custom-keybinding dispatch, extracted so BOTH exits can reach it: the
+      // normal tail (after every built-in declined) and the #1152 disabled
+      // gate below — disabling a built-in must still let a custom macro the
+      // user rebound onto that combo fire, not silently die with it.
+      const dispatchCustomKeybinding = (): boolean => {
+        // Custom keybindings are stored in literal "Ctrl+…" form for cross-OS
+        // consistency; match against literalCtrl so user-defined combos behave
+        // identically on Windows / Linux / macOS.
+        const { customKeybindings } = store.getState();
+        if (customKeybindings.length === 0) return false;
+        const pressed = formatKeyCombo(literalCtrl, shift, alt, key);
+        const match = customKeybindings.find((kb) => kb.key === pressed);
+        if (!match) return false;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        const state = store.getState();
+        const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
+        if (ws) {
+          const leaf = findLeaf(ws.rootPane, ws.activePaneId);
+          if (leaf) {
+            const surface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
+            if (surface?.ptyId) {
+              const text = match.sendEnter ? match.command + '\r' : match.command;
+              // Route through the paste chunker. User-authored keybinding
+              // commands can contain multi-line shell snippets pasted into
+              // the settings field; chunking normalizes CRLF, paces IPC,
+              // and keeps the payload under the 100KB backstop. The
+              // trailing `\r` from `sendEnter` is preserved by the
+              // normalizer (lone `\r` is left alone).
+              const surfacePtyId = surface.ptyId;
+              void pastePtyChunked(
+                (d) => window.electronAPI.pty.write(surfacePtyId, d),
+                text,
+                null,
+              ).catch((err) => console.error('[wmux:keybinding] chunk write failed:', err));
+            }
+          }
         }
+        return true;
+      };
+
+      // #1152 — a built-in the user disabled (Settings → Shortcuts) skips
+      // every built-in handler below. A custom macro rebound onto the combo
+      // still fires; otherwise the event leaves with no preventDefault, so
+      // the key falls through to whatever has focus — useTerminal's twin
+      // gate (matchesDisabledShortcut, the SAME function) then lets xterm
+      // encode it for the PTY, and Ctrl+T opens Codex's own transcript
+      // instead of a new surface. Prefix-mode SUB-commands stay unaffected.
+      // The CURRENT prefix trigger is exempt: a user who moved the prefix
+      // onto an advertised combo (prefixConfig.key is free-form) and then
+      // disabled that combo's built-in must still be able to enter prefix
+      // mode — losing the trigger would strand every prefix binding at once.
+      const isPrefixTrigger =
+        literalCtrl && !shift && !alt && code === store.getState().prefixConfig.key;
+      if (!prefixMode && !isPrefixTrigger && matchesDisabledShortcut(
+        store.getState().disabledShortcuts, e, isMac ? 'darwin' : 'win32',
+      )) {
+        dispatchCustomKeybinding();
+        return;
       }
 
       // ─── Prefix mode: intercept the next key ───────────────────────
@@ -852,42 +897,8 @@ export function useKeyboard() {
       }
 
       // ─── Custom keybindings → terminal input ─────────────────────────
-      // Custom keybindings are stored in literal "Ctrl+…" form for cross-OS
-      // consistency; match against literalCtrl so user-defined combos behave
-      // identically on Windows / Linux / macOS.
-      const { customKeybindings } = store.getState();
-      if (customKeybindings.length > 0) {
-        const pressed = formatKeyCombo(literalCtrl, shift, alt, key);
-        const match = customKeybindings.find((kb) => kb.key === pressed);
-        if (match) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          const state = store.getState();
-          const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
-          if (ws) {
-            const leaf = findLeaf(ws.rootPane, ws.activePaneId);
-            if (leaf) {
-              const surface = leaf.surfaces.find((s) => s.id === leaf.activeSurfaceId);
-              if (surface?.ptyId) {
-                const text = match.sendEnter ? match.command + '\r' : match.command;
-                // Route through the paste chunker. User-authored keybinding
-                // commands can contain multi-line shell snippets pasted into
-                // the settings field; chunking normalizes CRLF, paces IPC,
-                // and keeps the payload under the 100KB backstop. The
-                // trailing `\r` from `sendEnter` is preserved by the
-                // normalizer (lone `\r` is left alone).
-                const surfacePtyId = surface.ptyId;
-                void pastePtyChunked(
-                  (d) => window.electronAPI.pty.write(surfacePtyId, d),
-                  text,
-                  null,
-                ).catch((err) => console.error('[wmux:keybinding] chunk write failed:', err));
-              }
-            }
-          }
-          return;
-        }
-      }
+      // Custom keybindings (extracted above so the #1152 gate can share it).
+      dispatchCustomKeybinding();
     };
 
     // Use capture phase so we run BEFORE xterm's stopPropagation

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -325,6 +325,23 @@ export function useKeyboard() {
       // Read prefix mode from store (fresh, no stale closure)
       const prefixMode = store.getState().prefixMode;
 
+      // #1152 — a built-in the user disabled (Settings → Shortcuts) must act
+      // as if it were never bound: no preventDefault, no handler, so the key
+      // falls through to whatever has focus. useTerminal stops bubbling
+      // disabled combos, so inside a terminal the byte reaches the PTY —
+      // Ctrl+T then opens Codex's own transcript instead of a new surface.
+      // Prefix-mode SUB-commands are not top-level combos and stay unaffected;
+      // matching covers e.key and the physical code (IME layouts) the same
+      // way the individual handlers below do.
+      if (!prefixMode && (cmdOrCtrl || literalCtrl)) {
+        const disabled = store.getState().disabledShortcuts;
+        if (disabled.length > 0) {
+          const byKey = formatKeyCombo(true, shift, alt, key);
+          const byCode = code.startsWith('Key') ? formatKeyCombo(true, shift, alt, code.slice(3)) : null;
+          if (disabled.includes(byKey) || (byCode !== null && disabled.includes(byCode))) return;
+        }
+      }
+
       // ─── Prefix mode: intercept the next key ───────────────────────
       if (prefixMode) {
         e.preventDefault();

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1619,6 +1619,22 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // Ctrl+K(kill-line) 등 readline 컨트롤 문자가 PTY에도 못 가고 죽는다
       // (owner-reported 2026-07-19). mac에서는 literal-Ctrl 바인딩만(b=프리픽스,
       // m=북마크, Ctrl+Arrow) 버블시키고 나머지는 xterm→PTY로 통과.
+      // #1152 — a combo the user disabled in Settings → Shortcuts must reach
+      // the PTY like any other terminal byte: return true so xterm PROCESSES
+      // the key (encoding e.g. Ctrl+T as 0x14) instead of bubbling it to
+      // useKeyboard, whose own disabled-gate would drop it without
+      // preventDefault — leaving the key dead in both worlds.
+      {
+        const disabledShortcuts = useStore.getState().disabledShortcuts;
+        if (disabledShortcuts.length > 0 && e.ctrlKey && !e.altKey) {
+          const mods = e.shiftKey ? 'Ctrl+Shift+' : 'Ctrl+';
+          const byKey = e.key.length === 1 ? mods + e.key.toUpperCase() : mods + e.key;
+          const byCode = e.code.startsWith('Key') ? mods + e.code.slice(3) : null;
+          if (disabledShortcuts.includes(byKey) || (byCode !== null && disabledShortcuts.includes(byCode))) {
+            return true;
+          }
+        }
+      }
       const bubbleKeys = isMac
         ? ['b', 'm', 'ArrowUp', 'ArrowDown']
         : [',', 'b', 'd', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'];

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { SearchAddon } from '@xterm/addon-search';
 import { applyUnicodeWidthModel } from '../../shared/terminalUnicode';
+import { matchesDisabledShortcut } from '../../shared/keymap';
 import { xtermWindowsBuildNumber } from '../../shared/conptyWindows';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { useStore } from '../stores';
@@ -1623,17 +1624,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // the PTY like any other terminal byte: return true so xterm PROCESSES
       // the key (encoding e.g. Ctrl+T as 0x14) instead of bubbling it to
       // useKeyboard, whose own disabled-gate would drop it without
-      // preventDefault — leaving the key dead in both worlds.
-      {
-        const disabledShortcuts = useStore.getState().disabledShortcuts;
-        if (disabledShortcuts.length > 0 && e.ctrlKey && !e.altKey) {
-          const mods = e.shiftKey ? 'Ctrl+Shift+' : 'Ctrl+';
-          const byKey = e.key.length === 1 ? mods + e.key.toUpperCase() : mods + e.key;
-          const byCode = e.code.startsWith('Key') ? mods + e.code.slice(3) : null;
-          if (disabledShortcuts.includes(byKey) || (byCode !== null && disabledShortcuts.includes(byCode))) {
-            return true;
-          }
-        }
+      // preventDefault — leaving the key dead in both worlds. Same shared
+      // matcher as that gate, so the two can never disagree about which
+      // combos are off.
+      if (matchesDisabledShortcut(
+        useStore.getState().disabledShortcuts, e, isMac ? 'darwin' : 'win32',
+      )) {
+        return true;
       }
       const bubbleKeys = isMac
         ? ['b', 'm', 'ArrowUp', 'ArrowDown']

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -674,6 +674,9 @@ export const en = {
   'accounts.notLoggedIn': 'not logged in',
   'accounts.newTerminalsNote': 'Applies to new terminals; running ones keep their account.',
   'settings.shortcuts': 'Keyboard Shortcuts',
+  // #1152 — checkbox on each advertised row; unchecked = the built-in is
+  // unbound and the key passes through to the terminal (e.g. Codex Ctrl+T).
+  'settings.shortcutDisableHint': 'On: wmux handles this key. Off: the key goes to the terminal instead.',
   'settings.tabGeneral': 'General',
   'settings.tabTerminal': 'Terminal',
   'settings.tabAppearance': 'Appearance',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -287,6 +287,7 @@ export const ko = {
   'settings.updateAvailable': '업데이트 있음',
   'settings.close': '닫기',
   'settings.shortcuts': '단축키',
+  'settings.shortcutDisableHint': '켜짐: wmux가 이 키를 처리합니다. 꺼짐: 키가 터미널로 전달됩니다.',
   'settings.tabGeneral': '일반',
   'settings.tabTerminal': '터미널',
   'settings.tabAppearance': '외관',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -680,6 +680,7 @@ export const pl = {
   'accounts.notLoggedIn': 'nie zalogowano',
   'accounts.newTerminalsNote': 'Dotyczy nowych terminali; działające zachowują swoje konto.',
   'settings.shortcuts': 'Skróty klawiszowe',
+  'settings.shortcutDisableHint': 'Wł.: wmux obsługuje ten klawisz. Wył.: klawisz trafia do terminala.',
   'settings.tabGeneral': 'Ogólne',
   'settings.tabTerminal': 'Terminal',
   'settings.tabAppearance': 'Wygląd',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -336,6 +336,7 @@ export const zh = {
   'accounts.notLoggedIn': '未登录',
   'accounts.newTerminalsNote': '仅对新终端生效；正在运行的终端保持原账号。',
   'settings.shortcuts': '键盘快捷键',
+  'settings.shortcutDisableHint': '开：wmux 处理该按键。关：按键将传递给终端。',
   'settings.tabGeneral': '常规',
   'settings.tabAppearance': '外观',
   'settings.tabNotifications': '通知',

--- a/src/renderer/stores/slices/__tests__/disabledShortcuts.load.test.ts
+++ b/src/renderer/stores/slices/__tests__/disabledShortcuts.load.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
+import { createWorkspace, type SessionData, type Workspace } from '../../../../shared/types';
+
+// #1152 — loadSession must whitelist disabledShortcuts against the CURRENT
+// keymap: a stale session (or a hand-edited session.json) must not carry a
+// combo that no longer exists into the disabled set forever, and junk types
+// must not poison the string array. Same combo-store harness as
+// paneOrdinal.test.ts.
+type ComboState = WorkspaceSlice & PaneSlice & {
+  zoomedPaneId: string | null;
+  pushToast: ReturnType<typeof vi.fn>;
+  multiviewIds: string[];
+  sidebarVisible: boolean;
+  disabledShortcuts: string[];
+};
+
+function createComboStore() {
+  const seed: Workspace[] = [createWorkspace('Test', 1)];
+  return create<ComboState>()(
+    immer((...args) => ({
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createWorkspaceSlice(...args),
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createPaneSlice(...args),
+      workspaces: seed,
+      activeWorkspaceId: seed[0].id,
+      nextWorkspaceOrdinal: 2,
+      zoomedPaneId: null,
+      pushToast: vi.fn(),
+      multiviewIds: [],
+      sidebarVisible: false,
+      disabledShortcuts: [],
+    })),
+  );
+}
+
+const baseSession = (): SessionData => ({
+  workspaces: [createWorkspace('Loaded', 1)],
+  activeWorkspaceId: '',
+  sidebarVisible: false,
+});
+
+describe('#1152 loadSession — disabledShortcuts whitelist', () => {
+  it('keeps known combos, drops unknown ones and non-strings', () => {
+    const store = createComboStore();
+    store.getState().loadSession({
+      ...baseSession(),
+      disabledShortcuts: [
+        'Ctrl+T',            // real keymap entry — kept
+        'Ctrl+Shift+D',      // real keymap entry — kept
+        'Ctrl+Alt+Delete',   // not in WMUX_KEYMAP — dropped
+        42 as unknown as string, // junk from a hand-edited file — dropped
+      ],
+    });
+    expect(store.getState().disabledShortcuts).toEqual(['Ctrl+T', 'Ctrl+Shift+D']);
+  });
+
+  it('leaves the current value alone when the session has no field (older save)', () => {
+    const store = createComboStore();
+    store.setState({ disabledShortcuts: ['Ctrl+T'] });
+    store.getState().loadSession(baseSession());
+    expect(store.getState().disabledShortcuts).toEqual(['Ctrl+T']);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/uiSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/uiSlice.test.ts
@@ -736,3 +736,21 @@ describe('UISlice — browser backend mirror (#517)', () => {
     expect(store.getState().browserBackendHydrated).toBe(true);
   });
 });
+
+describe('UISlice — #1152 disabled built-in shortcuts', () => {
+  let store: ReturnType<typeof createTestStore>;
+  beforeEach(() => { store = createTestStore(); });
+
+  it('starts with nothing disabled', () => {
+    expect(store.getState().disabledShortcuts).toEqual([]);
+  });
+
+  it('toggleShortcutDisabled adds, then removes, a combo', () => {
+    store.getState().toggleShortcutDisabled('Ctrl+T');
+    expect(store.getState().disabledShortcuts).toEqual(['Ctrl+T']);
+    store.getState().toggleShortcutDisabled('Ctrl+D');
+    expect(store.getState().disabledShortcuts).toEqual(['Ctrl+T', 'Ctrl+D']);
+    store.getState().toggleShortcutDisabled('Ctrl+T');
+    expect(store.getState().disabledShortcuts).toEqual(['Ctrl+D']);
+  });
+});

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -6,6 +6,7 @@ import { MAX_PANES_PER_WORKSPACE } from './paneSlice';
 import { markRetentionMigrationDone } from '../retentionMigration';
 import { DEFAULT_BROWSER_BACKEND, isBrowserBackend, type BrowserBackend } from '../../../shared/browserBackend';
 import { CHROME_PRESET_VALUES } from '../../../shared/chromePresets';
+import { ADVERTISED_SHORTCUTS } from '../../../shared/keymap';
 
 /**
  * #517: read main's authoritative browser backend synchronously at store-module
@@ -1450,6 +1451,11 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
   disabledShortcuts: [],
 
   toggleShortcutDisabled: (combo) => set((state) => {
+    // Same whitelist the session loader applies (advertised rows only) —
+    // otherwise a programmatic caller could disable a combo the UI renders
+    // no re-enable toggle for, and the state would silently revert on the
+    // next load anyway.
+    if (!ADVERTISED_SHORTCUTS.some((k) => k.combo === combo)) return;
     state.disabledShortcuts = state.disabledShortcuts.includes(combo)
       ? state.disabledShortcuts.filter((c) => c !== combo)
       : [...state.disabledShortcuts, combo];

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -544,6 +544,15 @@ export interface UISlice {
   addKeybinding: (kb: Omit<CustomKeybinding, 'id'>) => void;
   updateKeybinding: (id: string, kb: Partial<Omit<CustomKeybinding, 'id'>>) => void;
   removeKeybinding: (id: string) => void;
+  /**
+   * #1152 — built-in combos (WMUX_KEYMAP storage form, e.g. 'Ctrl+T') the
+   * user has switched OFF. A disabled combo is fully unbound: useKeyboard
+   * skips its handler and useTerminal stops bubbling it, so the key reaches
+   * the PTY like any other terminal byte (Ctrl+T then opens Codex's own
+   * transcript instead of a new wmux surface). Persisted in session.json.
+   */
+  disabledShortcuts: string[];
+  toggleShortcutDisabled: (combo: string) => void;
 
   // ─── File tree ────────────────────────────────────────────────────────
   fileTreeVisible: boolean;
@@ -1436,6 +1445,14 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
 
   removeKeybinding: (id) => set((state) => {
     state.customKeybindings = state.customKeybindings.filter((k) => k.id !== id);
+  }),
+
+  disabledShortcuts: [],
+
+  toggleShortcutDisabled: (combo) => set((state) => {
+    state.disabledShortcuts = state.disabledShortcuts.includes(combo)
+      ? state.disabledShortcuts.filter((c) => c !== combo)
+      : [...state.disabledShortcuts, combo];
   }),
 
   // ─── File tree ────────────────────────────────────────────────────────

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -2,7 +2,7 @@ import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
 import { createWorkspace, clonePaneTreeFresh, assignPaneOrdinals, generateId, BUILTIN_TEMPLATES, DEFAULT_PREFIX_CONFIG, buildDefaultCustomKeybindings, upgradeDefaultKeybindingsForPlatform, TERMINAL_STATES, NOTIFICATION_CATEGORIES, type Pane, type PaneLeaf, type SessionData, type StashedPane, type Workspace, type WorkspaceMetadata, type WorkspaceProfile } from '../../../shared/types';
 import { normalizeWorkspaceProfile } from '../../../shared/workspaceProfile';
-import { WMUX_KEYMAP } from '../../../shared/keymap';
+import { ADVERTISED_SHORTCUTS } from '../../../shared/keymap';
 import { normalizeWorkspaceColor, type WorkspaceColorId } from '../../../shared/workspaceColors';
 import { normalizeRoleBindings } from '../../../shared/orchestratorRole';
 import { getPresetById } from '../../../shared/layoutPresets';
@@ -1182,10 +1182,12 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         state.customKeybindings = [...migrated, ...missingDefaults.map((k) => ({ ...k }))];
       }
       if (Array.isArray(data.disabledShortcuts)) {
-        // #1152 — whitelist against the CURRENT keymap so a stale session
-        // can't carry a combo that no longer exists (or junk from a hand-
-        // edited file) into the disabled set forever.
-        const known = new Set(WMUX_KEYMAP.map((k) => k.combo));
+        // #1152 — whitelist against the ADVERTISED rows only, not the whole
+        // keymap: only advertised rows render a re-enable toggle, so an
+        // unadvertised combo (Ctrl+B prefix, Ctrl+Tab, …) planted by a
+        // hand-edited or future-version session would be OFF with no way
+        // back short of editing session.json.
+        const known = new Set(ADVERTISED_SHORTCUTS.map((k) => k.combo));
         state.disabledShortcuts = data.disabledShortcuts.filter(
           (c): c is string => typeof c === 'string' && known.has(c),
         );

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from 'zustand';
 import type { StoreState } from '../index';
 import { createWorkspace, clonePaneTreeFresh, assignPaneOrdinals, generateId, BUILTIN_TEMPLATES, DEFAULT_PREFIX_CONFIG, buildDefaultCustomKeybindings, upgradeDefaultKeybindingsForPlatform, TERMINAL_STATES, NOTIFICATION_CATEGORIES, type Pane, type PaneLeaf, type SessionData, type StashedPane, type Workspace, type WorkspaceMetadata, type WorkspaceProfile } from '../../../shared/types';
 import { normalizeWorkspaceProfile } from '../../../shared/workspaceProfile';
+import { WMUX_KEYMAP } from '../../../shared/keymap';
 import { normalizeWorkspaceColor, type WorkspaceColorId } from '../../../shared/workspaceColors';
 import { normalizeRoleBindings } from '../../../shared/orchestratorRole';
 import { getPresetById } from '../../../shared/layoutPresets';
@@ -1179,6 +1180,15 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
           (k) => !savedIds.has(k.id) && !savedKeys.has(k.key),
         );
         state.customKeybindings = [...migrated, ...missingDefaults.map((k) => ({ ...k }))];
+      }
+      if (Array.isArray(data.disabledShortcuts)) {
+        // #1152 — whitelist against the CURRENT keymap so a stale session
+        // can't carry a combo that no longer exists (or junk from a hand-
+        // edited file) into the disabled set forever.
+        const known = new Set(WMUX_KEYMAP.map((k) => k.combo));
+        state.disabledShortcuts = data.disabledShortcuts.filter(
+          (c): c is string => typeof c === 'string' && known.has(c),
+        );
       }
       if (data.autoUpdateEnabled != null) {
         state.autoUpdateEnabled = data.autoUpdateEnabled;

--- a/src/shared/__tests__/keymap.test.ts
+++ b/src/shared/__tests__/keymap.test.ts
@@ -104,3 +104,50 @@ describe('ADVERTISED_SHORTCUTS', () => {
     expect(ADVERTISED_SHORTCUTS.map((e) => e.combo)).toEqual(expected);
   });
 });
+
+// ─── #1152 matchesDisabledShortcut ───────────────────────────────────────────
+
+import { matchesDisabledShortcut, type ShortcutKeyEventLike } from '../keymap';
+
+const ev = (over: Partial<ShortcutKeyEventLike>): ShortcutKeyEventLike => ({
+  key: 't', code: 'KeyT', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false, ...over,
+});
+
+describe('matchesDisabledShortcut (#1152)', () => {
+  it('matches a disabled combo on Windows by e.key', () => {
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({}), 'win32')).toBe(true);
+  });
+
+  it('matches by physical code under an IME (e.key is a composed glyph)', () => {
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({ key: 'ㅅ' }), 'win32')).toBe(true);
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({ key: 'Process' }), 'win32')).toBe(true);
+  });
+
+  it('matches Ctrl+` by the Backquote code (non-Key* physical code)', () => {
+    expect(matchesDisabledShortcut(['Ctrl+`'], ev({ key: 'Process', code: 'Backquote' }), 'win32')).toBe(true);
+  });
+
+  it('shift combos are distinct from their base combo', () => {
+    expect(matchesDisabledShortcut(['Ctrl+Shift+D'], ev({ key: 'D', code: 'KeyD', shiftKey: true }), 'win32')).toBe(true);
+    expect(matchesDisabledShortcut(['Ctrl+Shift+D'], ev({ key: 'd', code: 'KeyD' }), 'win32')).toBe(false);
+    expect(matchesDisabledShortcut(['Ctrl+D'], ev({ key: 'D', code: 'KeyD', shiftKey: true }), 'win32')).toBe(false);
+  });
+
+  it('macOS: a cmdOrCtrl-family combo matches ⌘, NOT literal Ctrl (readline bytes stay alive)', () => {
+    // Disabling "Ctrl+T" (rendered ⌘T on mac) must catch Cmd+T…
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({ ctrlKey: false, metaKey: true }), 'darwin')).toBe(true);
+    // …and must NOT catch literal Ctrl+T, which was never an app shortcut on
+    // mac — swallowing it would kill readline control bytes and any custom
+    // literal-Ctrl keybinding the user defined.
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({}), 'darwin')).toBe(false);
+  });
+
+  it('does not match with Alt held or with no Ctrl/⌘ at all', () => {
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({ altKey: true }), 'win32')).toBe(false);
+    expect(matchesDisabledShortcut(['Ctrl+T'], ev({ ctrlKey: false }), 'win32')).toBe(false);
+  });
+
+  it('empty disabled list is a cheap no-op', () => {
+    expect(matchesDisabledShortcut([], ev({}), 'win32')).toBe(false);
+  });
+});

--- a/src/shared/keymap.ts
+++ b/src/shared/keymap.ts
@@ -167,6 +167,78 @@ export function builtinCombosFor(platform: NodeJS.Platform): ReadonlySet<string>
  * binding is literal-Ctrl on every OS. Mirrors `shortcutLabel()`'s old inline
  * logic in SettingsPanel and the `cmdOrCtrl` split in useKeyboard.ts.
  */
+/** The subset of KeyboardEvent both disabled-shortcut gates match against. */
+export interface ShortcutKeyEventLike {
+  key: string;
+  code: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+// Physical-code → combo character, for the non-letter keys the keymap owns.
+// Letters/digits are derived from the Key*/Digit* prefix; these are the rest.
+const CODE_TO_COMBO_CHAR: Record<string, string> = {
+  Backquote: '`',
+  Comma: ',',
+  Minus: '-',
+  Equal: '=',
+};
+
+function comboCharFromCode(code: string): string | null {
+  if (code.startsWith('Key')) return code.slice(3);
+  if (code.startsWith('Digit')) return code.slice(5);
+  return CODE_TO_COMBO_CHAR[code] ?? null;
+}
+
+/**
+ * #1152 — does this keydown match a user-disabled built-in combo?
+ *
+ * ONE function shared by BOTH gates (useKeyboard's capture handler and
+ * useTerminal's xterm handler) so they can never disagree about which keys
+ * are off — a combo caught by only one side would die in both worlds
+ * (swallowed by the other gate) or stay half-bound.
+ *
+ * Combos are stored in WMUX_KEYMAP's cross-OS form ('Ctrl+T'), which on
+ * macOS means ⌘ for the cmdOrCtrl family and literal Ctrl only for
+ * `literalCtrl` rows — the same platform reading `builtinCombosFor` and the
+ * individual useKeyboard handlers apply. Matching literal Ctrl for
+ * everything on mac would swallow readline bytes (Ctrl+D EOF et al.) that
+ * were never app shortcuts there.
+ *
+ * Matches by e.key AND by physical code (KeyX, DigitN, Backquote, Comma, …)
+ * so a Hangul / non-Latin IME — where e.key is a composed glyph or
+ * 'Process' — disables the same keys a Latin layout does.
+ */
+export function matchesDisabledShortcut(
+  disabled: readonly string[],
+  e: ShortcutKeyEventLike,
+  platform: NodeJS.Platform,
+): boolean {
+  if (disabled.length === 0 || e.altKey) return false;
+  if (!e.ctrlKey && !e.metaKey) return false;
+
+  const mods = e.shiftKey ? 'Ctrl+Shift+' : 'Ctrl+';
+  const candidates: string[] = [];
+  if (e.key.length === 1) candidates.push(mods + e.key.toUpperCase());
+  else if (e.key !== 'Process' && e.key !== 'Dead') candidates.push(mods + e.key);
+  const byCode = comboCharFromCode(e.code);
+  if (byCode !== null) candidates.push(mods + byCode);
+
+  const mac = platform === 'darwin';
+  for (const combo of candidates) {
+    if (!disabled.includes(combo)) continue;
+    const entry = WMUX_KEYMAP.find((k) => k.combo === combo);
+    const wantsLiteralCtrl = entry?.literalCtrl === true;
+    const modifierMatches = mac
+      ? (wantsLiteralCtrl ? e.ctrlKey && !e.metaKey : e.metaKey)
+      : e.ctrlKey;
+    if (modifierMatches) return true;
+  }
+  return false;
+}
+
 export function macDisplayCombo(entry: KeymapEntry): string {
   return entry.literalCtrl ? entry.combo : entry.combo.replace(/Ctrl/g, '⌘');
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -813,6 +813,8 @@ export interface SessionData {
   /** Categories whose surface actions are suppressed (#516). */
   mutedNotificationCategories?: NotificationCategory[];
   customKeybindings?: CustomKeybinding[];
+  /** #1152 — built-in combos (WMUX_KEYMAP storage form) the user disabled. */
+  disabledShortcuts?: string[];
   autoUpdateEnabled?: boolean;
   customThemeColors?: CustomThemeColors;
   sidebarMode?: 'workspaces' | 'company';


### PR DESCRIPTION
First half of #1152 (the Ctrl+T ask; the Shift+Enter half is a separate keyboard-protocol change and stays open on the issue).

Codex's TUI binds Ctrl+T, but wmux owned it unconditionally — useKeyboard preventDefault'ed it into "new surface" and useTerminal bubbled it past xterm, so the byte never reached the PTY and there was no way to opt out. Each advertised row in Settings → Shortcuts now carries a checkbox; unchecking fully unbinds the combo and the key goes to the terminal (Ctrl+T becomes 0x14 → Codex's own transcript opens). Persisted as `SessionData.disabledShortcuts`, whitelisted to advertised rows at load AND toggle.

Both gates share one matcher, `matchesDisabledShortcut` (shared/keymap.ts): per-platform `literalCtrl` resolution (disabling ⌘T on mac does not swallow literal Ctrl+T readline bytes) and physical-code fallbacks (KeyX/DigitN/Backquote/Comma) for IME layouts. A custom keybinding rebound onto a disabled combo still fires, the conflict warning treats such a rebind as deliberate, and the current prefix trigger is exempt from the gate.

**Review team (2-way: independent context-free Opus + GLM-5.3; Codex 402):** the two independently converged on the same core defects — gate asymmetry between useKeyboard/useTerminal (both P1/P2) and the custom-keybinding/prefix interactions — all folded in, plus per-row aria-labels. Deferred with eyes open: the cheat-sheet overlay doesn't yet strike through disabled rows; the raw checkbox skips design-system styling.

**Dogfood (`-dog1152`, CDP, raw-mode byte probe):** baseline Ctrl+T makes a surface with no PTY byte; after unchecking, no surface and the probe prints `BYTE [ 20 ]`; Ctrl+D and prefix-mode focus unaffected; survives an app restart (`disabledShortcuts: ["Ctrl+T"]` in session.json); re-enabling restores the built-in. 17 screenshots. The run also re-confirmed #1157's guard: production agent configs byte-identical after the isolated boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6