### PR TITLE
Give browser_smart_snapshot identity-stable refs and an auto-diff

### DIFF
--- a/changelog.d/1166.md
+++ b/changelog.d/1166.md
@@ -1,0 +1,19 @@
+### Changed
+
+- **`browser_smart_snapshot` returns a diff, and its refs hold still.** The
+  tool re-sent its whole indexed listing on every call, which on an
+  act-then-verify loop is the same few hundred lines over and over. A repeat
+  call now returns only what moved, against the same baseline machinery
+  `browser_snapshot` uses — with the same fallback to the full listing when the
+  diff stops being a saving, and a first line that always says which of the two
+  you got. Pass `full: true` for the complete listing.
+
+  What made that possible is a fix worth having on its own: smart refs were a
+  running count over the page, so one element appearing above another
+  renumbered it and everything after it. Replaying a ref you were given a
+  moment ago clicked the neighbouring element instead, and said nothing. A ref
+  is now tied to the element itself, so it means the same thing until that
+  element goes away — and it never comes back naming a different one. Clicking
+  by `smartRef` against a live page was broken outright and now works. In
+  packaged builds, where the underlying identity is not available, the listing
+  stays complete rather than diffed. (#1166)

--- a/changelog.d/1166.md
+++ b/changelog.d/1166.md
@@ -14,6 +14,12 @@
   moment ago clicked the neighbouring element instead, and said nothing. A ref
   is now tied to the element itself, so it means the same thing until that
   element goes away — and it never comes back naming a different one. Clicking
-  by `smartRef` against a live page was broken outright and now works. In
-  packaged builds, where the underlying identity is not available, the listing
-  stays complete rather than diffed. (#1166)
+  by `smartRef` against a live page was broken outright and now works, and a
+  ref that no longer names one element on the page you are looking at — the
+  page navigated or reloaded under it, the element went away, several elements
+  now answer to the same description, or the click is aimed at a different tab —
+  is refused with an explanation instead of clicking whatever moved into its
+  place. Saved flows record these clicks in a form that can actually be
+  replayed; before, the step always failed on replay while the live click
+  looked fine. In packaged builds, where the underlying identity is not
+  available, the listing stays complete rather than diffed. (#1166)

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "e82d7dfd4f92ab9425f69a2a5648f18c57ab64f9dbc4b56b948153d9311aa1a1",
+      "wireResultSha256": "d65b9f3f8bf957dd1095d1358bd3628911640c8c4595c6079669a68788811661",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/mcp/browser-replay/actionRing.ts
+++ b/src/mcp/browser-replay/actionRing.ts
@@ -10,6 +10,7 @@ import {
   refEntryToAxis,
   refMapShapeHash,
   stripUrlUserinfo,
+  type RefEntryLike,
   type ReplayableTool,
   type StepAxis,
   type TraceStep,
@@ -130,8 +131,19 @@ export interface RecordActionInput {
   ref?: string;
   /** Second ref, for browser_drag. */
   targetRef?: string;
-  /** CSS selector, when the action came from browser_smart_snapshot. */
+  /** CSS selector, when the action addressed one directly. */
   selector?: string;
+  /**
+   * Element identity supplied by the caller, for a lane that mints no RefEntry
+   * of its own.
+   *
+   * browser_smart_snapshot keeps its own ref map, and its CDP-lane "locator" is
+   * the SOURCE TEXT of a getByRole call — recorded as a css axis it could never
+   * be replayed, because `page.locator()` cannot parse it. Passing the identity
+   * instead puts the step on the same ref axis browser_snapshot records, which
+   * the replay runner already re-resolves against a live snapshot.
+   */
+  refEntry?: RefEntryLike;
   args?: Record<string, string | number | boolean>;
   /** Force a hole — the password case decides this before the value is known. */
   unrecordable?: UnrecordableReason;
@@ -139,10 +151,21 @@ export interface RecordActionInput {
   url?: string;
 }
 
-function axisFor(page: Page | null, ref: string | undefined, selector: string | undefined): {
+function axisFor(
+  page: Page | null,
+  ref: string | undefined,
+  selector: string | undefined,
+  refEntry?: RefEntryLike,
+): {
   axis: StepAxis;
   unrecordable?: UnrecordableReason;
 } {
+  if (refEntry !== undefined) {
+    const axis = refEntryToAxis(refEntry);
+    // No sound axis means no replayable step. An honest hole beats a step that
+    // reports success now and cannot run later.
+    return axis ? { axis } : { axis: NO_AXIS, unrecordable: 'unresolved-axis' };
+  }
   if (selector !== undefined) return { axis: { kind: 'css', selector } };
   if (ref === undefined) return { axis: NO_AXIS };
   // No page means the action went over the RPC lane, which resolves elements
@@ -199,7 +222,7 @@ export function recordAction(deps: BrowserToolDeps, input: RecordActionInput): v
   try {
     const ring = ringFor(deps);
     if (!ring) return;
-    const resolved = axisFor(input.page, input.ref, input.selector);
+    const resolved = axisFor(input.page, input.ref, input.selector, input.refEntry);
     const target = input.targetRef === undefined
       ? undefined
       : axisFor(input.page, input.targetRef, undefined);

--- a/src/mcp/connectionScope.ts
+++ b/src/mcp/connectionScope.ts
@@ -54,10 +54,10 @@ export interface ConnectionScope {
    * dom-intelligence smart-snapshot element cache (ref → locator), per
    * connection instead of per process — otherwise a second connection's
    * snapshot would overwrite the first's refs and browser_click({smartRef})
-   * would resolve against the wrong agent's page. Typed as unknown[] to avoid
+   * would resolve against the wrong agent's page. Typed as unknown to avoid
    * an import cycle (dom-intelligence imports this module); it owns the cast.
    */
-  elementCache?: unknown[];
+  elementCache?: unknown;
   /**
    * browser_snapshot auto-diff baselines (surface key → last snapshot), per
    * connection for the same reason as elementCache. Typed as unknown to avoid

--- a/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  clearElementCache,
+  getLocatorByRef,
+  getSmartSnapshot,
+  getSmartSnapshotViaEval,
+  resolveSmartRefLocator,
+} from '../dom-intelligence';
+
+// Smart-ref stability, mirroring snapshot.refstability.test.ts for
+// browser_snapshot. Smart refs used to be a running count over the a11y walk,
+// so one node inserted above an element shifted its ref and every ref after it:
+// replaying a smartRef clicked the neighbour, and browser_smart_snapshot could
+// not diff at all because a renumber rewrites every line.
+
+interface CdpNode {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+const role = (value: string) => ({ type: 'role', value });
+const name = (value: string) => ({ type: 'name', value });
+
+/** Root plus one interactive child per entry, backend ids fixed per child. */
+function tree(children: { backendId: number; role: string; name: string }[]): CdpNode[] {
+  const nodes: CdpNode[] = [
+    {
+      nodeId: '1',
+      backendDOMNodeId: 1,
+      role: role('RootWebArea'),
+      name: name('Page'),
+      childIds: children.map((c) => String(c.backendId)),
+    },
+  ];
+  for (const child of children) {
+    nodes.push({
+      nodeId: String(child.backendId),
+      backendDOMNodeId: child.backendId,
+      role: role(child.role),
+      name: name(child.name),
+      childIds: [],
+    });
+  }
+  return nodes;
+}
+
+interface FakePage {
+  nodes: CdpNode[];
+  currentUrl: string;
+  /** Every locator resolveSmartRefLocator asked for, as `role name#nth`. */
+  asked: string[];
+}
+
+function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
+  const page = {
+    nodes,
+    currentUrl: url,
+    asked: [] as string[],
+    url() {
+      return page.currentUrl;
+    },
+    title: async () => 'Page',
+    innerText: async () => 'body text',
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string) =>
+          method === 'Accessibility.getFullAXTree' ? { nodes: page.nodes } : {},
+        ),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    locator: (selector: string) => {
+      page.asked.push(selector);
+      return selector as never;
+    },
+    getByRole: (r: string, opts?: { name?: string }) => ({
+      nth: (i: number) => {
+        const handle = `${r} ${opts?.name ?? ''}#${i}`;
+        page.asked.push(handle);
+        return handle as never;
+      },
+    }),
+  };
+  return page as unknown as FakePage & Parameters<typeof getSmartSnapshot>[0];
+}
+
+function refOf(elements: { ref: number; name: string }[], needle: string): number | undefined {
+  return elements.find((e) => e.name === needle)?.ref;
+}
+
+describe('smart snapshot refs are keyed on DOM node identity', () => {
+  it('keeps every surviving ref when a node is inserted ahead of them', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 10, role: 'button', name: 'OK' },
+        { backendId: 11, role: 'link', name: 'Docs' },
+      ]),
+    );
+
+    const before = await getSmartSnapshot(page);
+    expect(refOf(before.elements, 'OK')).toBe(1);
+    expect(refOf(before.elements, 'Docs')).toBe(2);
+
+    // A click opened a banner above the pair — the exact shape that used to
+    // shift every ref by one.
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 12, role: 'button', name: 'Dismiss' },
+      { backendId: 10, role: 'button', name: 'OK' },
+      { backendId: 11, role: 'link', name: 'Docs' },
+    ]);
+    const after = await getSmartSnapshot(page);
+
+    expect(refOf(after.elements, 'OK')).toBe(1);
+    expect(refOf(after.elements, 'Docs')).toBe(2);
+    expect(refOf(after.elements, 'Dismiss')).toBe(3);
+  });
+
+  it('still clicks the element a ref was issued for after an insertion', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 10, role: 'button', name: 'OK' },
+        { backendId: 11, role: 'link', name: 'Docs' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 12, role: 'button', name: 'Dismiss' },
+      { backendId: 10, role: 'button', name: 'OK' },
+      { backendId: 11, role: 'link', name: 'Docs' },
+    ]);
+    await getSmartSnapshot(page);
+
+    // The ref the agent is holding from the first snapshot.
+    expect(resolveSmartRefLocator(page, 1)).toBe('button OK#0');
+    expect((page as unknown as FakePage).asked).toEqual(['button OK#0']);
+  });
+
+  it('pins the right instance when several elements share role and name', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 20, role: 'button', name: 'Row' },
+        { backendId: 21, role: 'button', name: 'Row' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    expect(resolveSmartRefLocator(page, 1)).toBe('button Row#0');
+    expect(resolveSmartRefLocator(page, 2)).toBe('button Row#1');
+  });
+
+  it('never reissues the number of a removed node', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 30, role: 'button', name: 'Gone' },
+        { backendId: 31, role: 'button', name: 'Stay' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 31, role: 'button', name: 'Stay' },
+      { backendId: 32, role: 'button', name: 'Fresh' },
+    ]);
+    const after = await getSmartSnapshot(page);
+
+    expect(refOf(after.elements, 'Stay')).toBe(2);
+    expect(refOf(after.elements, 'Fresh')).toBe(3);
+    // Ref 1 named the removed element and stays retired.
+    expect(after.elements.map((e) => e.ref)).not.toContain(1);
+    expect(getLocatorByRef(1)).toBeNull();
+  });
+
+  it('does not reissue old numbers on a different document', async () => {
+    clearElementCache();
+    const page = makePage(tree([{ backendId: 40, role: 'button', name: 'A' }]));
+    const before = await getSmartSnapshot(page);
+    expect(refOf(before.elements, 'A')).toBe(1);
+
+    (page as unknown as FakePage).currentUrl = 'https://example.test/b';
+    (page as unknown as FakePage).nodes = tree([{ backendId: 50, role: 'button', name: 'B' }]);
+    const after = await getSmartSnapshot(page);
+
+    expect(refOf(after.elements, 'B')).toBe(2);
+  });
+
+  it('treats a fragment change as the same document', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 60, role: 'button', name: 'Copy' },
+        { backendId: 61, role: 'link', name: 'API' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    (page as unknown as FakePage).currentUrl = 'https://example.test/a#section-4';
+    const after = await getSmartSnapshot(page);
+
+    expect(refOf(after.elements, 'Copy')).toBe(1);
+    expect(refOf(after.elements, 'API')).toBe(2);
+  });
+});
+
+describe('ref lookup no longer assumes a dense 1..n cache', () => {
+  it('finds an element by its stored ref, not by its position', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 70, role: 'button', name: 'Gone' },
+        { backendId: 71, role: 'button', name: 'Stay' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+    (page as unknown as FakePage).nodes = tree([{ backendId: 71, role: 'button', name: 'Stay' }]);
+    await getSmartSnapshot(page);
+
+    // The survivor is the only cache entry but still carries ref 2. Positional
+    // lookup (`cache[ref - 1]`) would miss it and hand back nothing.
+    expect(getLocatorByRef(2)).toBe("getByRole('button', { name: 'Stay' })");
+    expect(getLocatorByRef(1)).toBeNull();
+  });
+});
+
+describe('RPC lane keeps positional refs', () => {
+  it('resolves a smart ref through the data attribute it tagged', async () => {
+    clearElementCache();
+    // The RPC script cannot hold identity — browser_snapshot's RPC fallback
+    // strips data-wmux-ref document-wide — so refs stay 1-based walk order and
+    // resolve as a CSS selector rather than a role locator.
+    const evaluate = async () => ({
+      url: 'https://example.test/a',
+      title: 'Page',
+      content: '',
+      elements: [
+        { ref: 1, role: 'button', name: 'OK' },
+        { ref: 2, role: 'link', name: 'Docs' },
+      ],
+    });
+    const snapshot = await getSmartSnapshotViaEval(evaluate as never);
+    expect(snapshot.elements.map((e) => e.ref)).toEqual([1, 2]);
+
+    const page = makePage(tree([]));
+    expect(resolveSmartRefLocator(page, 2)).toBe('[data-wmux-ref="2"]');
+  });
+});

--- a/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
@@ -318,7 +318,7 @@ describe('smart snapshot refs are keyed on DOM node identity', () => {
     expect(second.elements).toEqual(first.elements);
   });
 
-  it('prunes nodes the walk no longer sees rather than growing forever', async () => {
+  it('gives a toggled element its old ref back — trimming waits for the cap', async () => {
     clearElementCache();
     const page = makePage(
       tree([
@@ -334,16 +334,17 @@ describe('smart snapshot refs are keyed on DOM node identity', () => {
     ]);
     await getSmartSnapshot(page);
 
-    // …and reopened. The pruned id gets a fresh number rather than its old one,
-    // which is the visible cost of not letting the map grow without bound.
+    // …and reopened. Forgetting the id while the map still fits would renumber
+    // the item on every open/close cycle — a diff line each time, and a ref the
+    // agent was holding gone for no reason.
     (page as unknown as FakePage).nodes = tree([
       { backendId: 100, role: 'button', name: 'Menu item' },
       { backendId: 101, role: 'button', name: 'Toggle' },
     ]);
     const back = await getSmartSnapshot(page);
 
+    expect(refOf(back.elements, 'Menu item')).toBe(1);
     expect(refOf(back.elements, 'Toggle')).toBe(2);
-    expect(refOf(back.elements, 'Menu item')).toBe(3);
   });
 
   it('reads one accessibility tree per snapshot, so refs come from one document', async () => {

--- a/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
@@ -2,9 +2,13 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   clearElementCache,
   getLocatorByRef,
+  getSmartElementByRef,
   getSmartSnapshot,
   getSmartSnapshotViaEval,
   resolveSmartRefLocator,
+  smartPageToken,
+  smartRefAxisEntry,
+  StaleSmartRefError,
 } from '../dom-intelligence';
 
 // Smart-ref stability, mirroring snapshot.refstability.test.ts for
@@ -12,6 +16,11 @@ import {
 // so one node inserted above an element shifted its ref and every ref after it:
 // replaying a smartRef clicked the neighbour, and browser_smart_snapshot could
 // not diff at all because a renumber rewrites every line.
+//
+// The resolution half mirrors resolveRefViaAxMap: a stable NUMBER only says the
+// element was not renumbered, not that it is still there, so every way the page
+// can move out from under a ref has to be caught and reported rather than
+// resolved to whatever now sits at that index.
 
 interface CdpNode {
   nodeId: string;
@@ -24,67 +33,112 @@ interface CdpNode {
 const role = (value: string) => ({ type: 'role', value });
 const name = (value: string) => ({ type: 'name', value });
 
+interface Child {
+  backendId?: number;
+  role: string;
+  name: string;
+}
+
 /** Root plus one interactive child per entry, backend ids fixed per child. */
-function tree(children: { backendId: number; role: string; name: string }[]): CdpNode[] {
+function tree(children: Child[]): CdpNode[] {
   const nodes: CdpNode[] = [
     {
       nodeId: '1',
       backendDOMNodeId: 1,
       role: role('RootWebArea'),
       name: name('Page'),
-      childIds: children.map((c) => String(c.backendId)),
+      childIds: children.map((c, i) => `c${c.backendId ?? `x${i}`}`),
     },
   ];
-  for (const child of children) {
+  children.forEach((child, i) => {
     nodes.push({
-      nodeId: String(child.backendId),
-      backendDOMNodeId: child.backendId,
+      nodeId: `c${child.backendId ?? `x${i}`}`,
+      ...(child.backendId !== undefined && { backendDOMNodeId: child.backendId }),
       role: role(child.role),
       name: name(child.name),
       childIds: [],
     });
-  }
+  });
   return nodes;
+}
+
+interface RoleQuery {
+  role: string;
+  name?: string;
+  exact?: boolean;
 }
 
 interface FakePage {
   nodes: CdpNode[];
   currentUrl: string;
-  /** Every locator resolveSmartRefLocator asked for, as `role name#nth`. */
-  asked: string[];
+  /** Live match count per `role|name` the locator should report. */
+  liveCounts: Map<string, number>;
+  /** Every getByRole query resolution made. */
+  queries: RoleQuery[];
+  /** Locators actually returned, as `role|name#nth`. */
+  picked: string[];
+  /** Fire a main-frame navigation the way Playwright would. */
+  navigate: (url?: string) => void;
+  axTreeCalls: unknown[][];
 }
 
 function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
+  const listeners: ((frame: unknown) => void)[] = [];
+  const mainFrame = { id: 'main' };
   const page = {
     nodes,
     currentUrl: url,
-    asked: [] as string[],
-    url() {
-      return page.currentUrl;
-    },
+    liveCounts: new Map<string, number>(),
+    queries: [] as RoleQuery[],
+    picked: [] as string[],
+    axTreeCalls: [] as unknown[][],
+    url: () => page.currentUrl,
     title: async () => 'Page',
     innerText: async () => 'body text',
+    on: (event: string, fn: (frame: unknown) => void) => {
+      if (event === 'framenavigated') listeners.push(fn);
+    },
+    mainFrame: () => mainFrame,
+    navigate: (next?: string) => {
+      if (next !== undefined) page.currentUrl = next;
+      for (const fn of listeners) fn(mainFrame);
+    },
     context: () => ({
       newCDPSession: async () => ({
-        send: vi.fn(async (method: string) =>
-          method === 'Accessibility.getFullAXTree' ? { nodes: page.nodes } : {},
-        ),
+        send: vi.fn(async (method: string, params?: unknown) => {
+          if (method !== 'Accessibility.getFullAXTree') return {};
+          page.axTreeCalls.push([method, params]);
+          return { nodes: page.nodes };
+        }),
         detach: vi.fn(() => Promise.resolve()),
       }),
     }),
     locator: (selector: string) => {
-      page.asked.push(selector);
+      page.picked.push(selector);
       return selector as never;
     },
-    getByRole: (r: string, opts?: { name?: string }) => ({
-      nth: (i: number) => {
-        const handle = `${r} ${opts?.name ?? ''}#${i}`;
-        page.asked.push(handle);
-        return handle as never;
-      },
-    }),
+    getByRole: (r: string, opts?: { name?: string; exact?: boolean }) => {
+      page.queries.push({ role: r, ...(opts?.name !== undefined && { name: opts.name }), ...(opts?.exact !== undefined && { exact: opts.exact }) });
+      const key = `${r}|${opts?.name ?? ''}`;
+      return {
+        count: async () => page.liveCounts.get(key) ?? countInTree(page.nodes, r, opts?.name),
+        nth: (i: number) => {
+          const handle = `${key}#${i}`;
+          page.picked.push(handle);
+          return handle as never;
+        },
+      };
+    },
   };
   return page as unknown as FakePage & Parameters<typeof getSmartSnapshot>[0];
+}
+
+/** What the live page would report for a role (+ optional exact name). */
+function countInTree(nodes: CdpNode[], r: string, wanted?: string): number {
+  return nodes.filter(
+    (n) =>
+      n.role?.value === r && (wanted === undefined || (n.name?.value ?? '') === wanted),
+  ).length;
 }
 
 function refOf(elements: { ref: number; name: string }[], needle: string): number | undefined {
@@ -137,55 +191,93 @@ describe('smart snapshot refs are keyed on DOM node identity', () => {
     await getSmartSnapshot(page);
 
     // The ref the agent is holding from the first snapshot.
-    expect(resolveSmartRefLocator(page, 1)).toBe('button OK#0');
-    expect((page as unknown as FakePage).asked).toEqual(['button OK#0']);
+    expect(await resolveSmartRefLocator(page, 1)).toBe('button|OK#0');
+  });
+
+  it('asks for an EXACT name match', async () => {
+    clearElementCache();
+    // getByRole's name filter is substring- and case-insensitive by default, so
+    // a ref for "Save" used to match "Save draft" too — and the index it was
+    // paired with then indexed into a population the snapshot never counted.
+    const page = makePage(
+      tree([
+        { backendId: 20, role: 'button', name: 'Save' },
+        { backendId: 21, role: 'button', name: 'Save draft' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    expect(await resolveSmartRefLocator(page, 1)).toBe('button|Save#0');
+    expect((page as unknown as FakePage).queries).toContainEqual({
+      role: 'button',
+      name: 'Save',
+      exact: true,
+    });
   });
 
   it('pins the right instance when several elements share role and name', async () => {
     clearElementCache();
     const page = makePage(
       tree([
-        { backendId: 20, role: 'button', name: 'Row' },
-        { backendId: 21, role: 'button', name: 'Row' },
+        { backendId: 30, role: 'button', name: 'Row' },
+        { backendId: 31, role: 'button', name: 'Row' },
       ]),
     );
     await getSmartSnapshot(page);
 
-    expect(resolveSmartRefLocator(page, 1)).toBe('button Row#0');
-    expect(resolveSmartRefLocator(page, 2)).toBe('button Row#1');
+    expect(await resolveSmartRefLocator(page, 1)).toBe('button|Row#0');
+    expect(await resolveSmartRefLocator(page, 2)).toBe('button|Row#1');
+  });
+
+  it('indexes an UNNAMED element against the whole role population', async () => {
+    clearElementCache();
+    // `getByRole('button')` counts the named siblings too, so the name-keyed
+    // index is not an index into what that locator returns.
+    const page = makePage(
+      tree([
+        { backendId: 40, role: 'button', name: 'Named' },
+        { backendId: 41, role: 'button', name: '' },
+      ]),
+    );
+    const snap = await getSmartSnapshot(page);
+    const unnamed = snap.elements.find((e) => e.name === '');
+
+    expect(unnamed?.sameNameIndex).toBe(0);
+    expect(unnamed?.roleIndex).toBe(1);
+    // Index 1 of the role population, not index 0 of the nameless one.
+    expect(await resolveSmartRefLocator(page, unnamed!.ref)).toBe('button|#1');
+    expect((page as unknown as FakePage).queries).toContainEqual({ role: 'button' });
   });
 
   it('never reissues the number of a removed node', async () => {
     clearElementCache();
     const page = makePage(
       tree([
-        { backendId: 30, role: 'button', name: 'Gone' },
-        { backendId: 31, role: 'button', name: 'Stay' },
+        { backendId: 50, role: 'button', name: 'Gone' },
+        { backendId: 51, role: 'button', name: 'Stay' },
       ]),
     );
     await getSmartSnapshot(page);
 
     (page as unknown as FakePage).nodes = tree([
-      { backendId: 31, role: 'button', name: 'Stay' },
-      { backendId: 32, role: 'button', name: 'Fresh' },
+      { backendId: 51, role: 'button', name: 'Stay' },
+      { backendId: 52, role: 'button', name: 'Fresh' },
     ]);
     const after = await getSmartSnapshot(page);
 
     expect(refOf(after.elements, 'Stay')).toBe(2);
     expect(refOf(after.elements, 'Fresh')).toBe(3);
-    // Ref 1 named the removed element and stays retired.
     expect(after.elements.map((e) => e.ref)).not.toContain(1);
-    expect(getLocatorByRef(1)).toBeNull();
   });
 
   it('does not reissue old numbers on a different document', async () => {
     clearElementCache();
-    const page = makePage(tree([{ backendId: 40, role: 'button', name: 'A' }]));
+    const page = makePage(tree([{ backendId: 60, role: 'button', name: 'A' }]));
     const before = await getSmartSnapshot(page);
     expect(refOf(before.elements, 'A')).toBe(1);
 
     (page as unknown as FakePage).currentUrl = 'https://example.test/b';
-    (page as unknown as FakePage).nodes = tree([{ backendId: 50, role: 'button', name: 'B' }]);
+    (page as unknown as FakePage).nodes = tree([{ backendId: 70, role: 'button', name: 'B' }]);
     const after = await getSmartSnapshot(page);
 
     expect(refOf(after.elements, 'B')).toBe(2);
@@ -195,8 +287,8 @@ describe('smart snapshot refs are keyed on DOM node identity', () => {
     clearElementCache();
     const page = makePage(
       tree([
-        { backendId: 60, role: 'button', name: 'Copy' },
-        { backendId: 61, role: 'link', name: 'API' },
+        { backendId: 80, role: 'button', name: 'Copy' },
+        { backendId: 81, role: 'link', name: 'API' },
       ]),
     );
     await getSmartSnapshot(page);
@@ -207,6 +299,68 @@ describe('smart snapshot refs are keyed on DOM node identity', () => {
     expect(refOf(after.elements, 'Copy')).toBe(1);
     expect(refOf(after.elements, 'API')).toBe(2);
   });
+
+  it('skips a node with no backendDOMNodeId instead of renumbering it forever', async () => {
+    clearElementCache();
+    // Such a node has nothing to key a ref on, so it drew a fresh number on
+    // every snapshot: the ref an agent read was never the one the next snapshot
+    // printed, and its line changed in every diff.
+    const page = makePage(
+      tree([
+        { role: 'button', name: 'Anonymous' },
+        { backendId: 90, role: 'button', name: 'Real' },
+      ]),
+    );
+    const first = await getSmartSnapshot(page);
+    expect(first.elements.map((e) => e.name)).toEqual(['Real']);
+
+    const second = await getSmartSnapshot(page);
+    expect(second.elements).toEqual(first.elements);
+  });
+
+  it('prunes nodes the walk no longer sees rather than growing forever', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 100, role: 'button', name: 'Menu item' },
+        { backendId: 101, role: 'button', name: 'Toggle' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    // The menu closed…
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 101, role: 'button', name: 'Toggle' },
+    ]);
+    await getSmartSnapshot(page);
+
+    // …and reopened. The pruned id gets a fresh number rather than its old one,
+    // which is the visible cost of not letting the map grow without bound.
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 100, role: 'button', name: 'Menu item' },
+      { backendId: 101, role: 'button', name: 'Toggle' },
+    ]);
+    const back = await getSmartSnapshot(page);
+
+    expect(refOf(back.elements, 'Toggle')).toBe(2);
+    expect(refOf(back.elements, 'Menu item')).toBe(3);
+  });
+
+  it('reads one accessibility tree per snapshot, so refs come from one document', async () => {
+    clearElementCache();
+    // getFullAXTree on a page target stops AT an <iframe> — childIds: [], the
+    // child document absent (snapshot.ts, measured on Chrome 141). Frame
+    // contents only arrive through an extra getFullAXTree({ frameId }), which
+    // this walk never makes: that is what keeps every backendDOMNodeId it sees
+    // inside one id space, and the sameNameIndex population the same set as the
+    // one page.getByRole sweeps.
+    const page = makePage(tree([{ backendId: 110, role: 'button', name: 'Outer' }]));
+    await getSmartSnapshot(page);
+
+    expect((page as unknown as FakePage).axTreeCalls).toEqual([
+      ['Accessibility.getFullAXTree', undefined],
+    ]);
+  });
 });
 
 describe('ref lookup no longer assumes a dense 1..n cache', () => {
@@ -214,27 +368,159 @@ describe('ref lookup no longer assumes a dense 1..n cache', () => {
     clearElementCache();
     const page = makePage(
       tree([
-        { backendId: 70, role: 'button', name: 'Gone' },
-        { backendId: 71, role: 'button', name: 'Stay' },
+        { backendId: 120, role: 'button', name: 'Gone' },
+        { backendId: 121, role: 'button', name: 'Stay' },
       ]),
     );
     await getSmartSnapshot(page);
-    (page as unknown as FakePage).nodes = tree([{ backendId: 71, role: 'button', name: 'Stay' }]);
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 121, role: 'button', name: 'Stay' },
+    ]);
     await getSmartSnapshot(page);
 
     // The survivor is the only cache entry but still carries ref 2. Positional
     // lookup (`cache[ref - 1]`) would miss it and hand back nothing.
     expect(getLocatorByRef(2)).toBe("getByRole('button', { name: 'Stay' })");
     expect(getLocatorByRef(1)).toBeNull();
+    expect(getSmartElementByRef(2)?.name).toBe('Stay');
+  });
+});
+
+describe('a stale smart ref is refused, never silently substituted', () => {
+  it('rejects every ref once the page has navigated', async () => {
+    clearElementCache();
+    const page = makePage(tree([{ backendId: 130, role: 'button', name: 'Save' }]));
+    await getSmartSnapshot(page);
+
+    (page as unknown as FakePage).currentUrl = 'https://example.test/elsewhere';
+
+    await expect(resolveSmartRefLocator(page, 1)).rejects.toBeInstanceOf(StaleSmartRefError);
+    await expect(resolveSmartRefLocator(page, 1)).rejects.toThrow(/navigated/);
+  });
+
+  it('rejects every ref after a reload of the SAME url', async () => {
+    clearElementCache();
+    // The URL comparison cannot see a reload, a back/forward, or a re-submitted
+    // form — and the new document's low backendDOMNodeIds would take the old
+    // document's refs.
+    const page = makePage(tree([{ backendId: 140, role: 'button', name: 'Submit' }]));
+    await getSmartSnapshot(page);
+
+    (page as unknown as FakePage).navigate();
+
+    await expect(resolveSmartRefLocator(page, 1)).rejects.toBeInstanceOf(StaleSmartRefError);
+    await expect(resolveSmartRefLocator(page, 1)).rejects.toThrow(/reloaded/);
+  });
+
+  it('gives the reloaded page a different baseline token', async () => {
+    clearElementCache();
+    const page = makePage(tree([{ backendId: 150, role: 'button', name: 'Submit' }]));
+    await getSmartSnapshot(page);
+    const before = smartPageToken(page);
+
+    (page as unknown as FakePage).navigate();
+    expect(smartPageToken(page)).not.toBe(before);
+  });
+
+  it('rejects a ref whose element the latest snapshot no longer lists', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 160, role: 'button', name: 'Gone' },
+        { backendId: 161, role: 'button', name: 'Stay' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+    (page as unknown as FakePage).nodes = tree([
+      { backendId: 161, role: 'button', name: 'Stay' },
+    ]);
+    await getSmartSnapshot(page);
+
+    await expect(resolveSmartRefLocator(page, 1)).rejects.toThrow(/no longer in the page snapshot/);
+  });
+
+  it('rejects when the role+name population moved under the ref', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 170, role: 'button', name: 'Row' },
+        { backendId: 171, role: 'button', name: 'Row' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    // One of the two rows went away without a fresh snapshot. Clamping onto the
+    // survivor is the silent wrong-element case.
+    (page as unknown as FakePage).liveCounts.set('button|Row', 1);
+
+    await expect(resolveSmartRefLocator(page, 2)).rejects.toThrow(/no longer identifies one element/);
+    expect((page as unknown as FakePage).picked).toEqual([]);
+  });
+
+  it('does not block a uniquely named ref when the page count differs', async () => {
+    clearElementCache();
+    // The snapshot enumerates an a11y tree; the locator sweeps the whole page.
+    // For a name the snapshot saw once the index is 0 either way.
+    const page = makePage(tree([{ backendId: 180, role: 'button', name: 'Copy' }]));
+    await getSmartSnapshot(page);
+    (page as unknown as FakePage).liveCounts.set('button|Copy', 3);
+
+    expect(await resolveSmartRefLocator(page, 1)).toBe('button|Copy#0');
+  });
+
+  it('refuses a click aimed at a different page than the snapshot', async () => {
+    clearElementCache();
+    // One connection can drive several tabs and surfaces; ref numbers restart
+    // at 1 per page and the cache holds only the last snapshot.
+    const tabA = makePage(tree([{ backendId: 190, role: 'button', name: 'Buy' }]));
+    const tabB = makePage(tree([{ backendId: 190, role: 'button', name: 'Delete' }]));
+    await getSmartSnapshot(tabA, { surfaceId: 'surf-a' });
+
+    await expect(resolveSmartRefLocator(tabB, 1)).rejects.toBeInstanceOf(StaleSmartRefError);
+    await expect(resolveSmartRefLocator(tabB, 1)).rejects.toThrow(/different page/);
+  });
+});
+
+describe('replay axis for a smart ref', () => {
+  it('carries the role/name/nth tuple the replay runner can re-resolve', async () => {
+    clearElementCache();
+    const page = makePage(
+      tree([
+        { backendId: 200, role: 'button', name: 'Row' },
+        { backendId: 201, role: 'button', name: 'Row' },
+      ]),
+    );
+    await getSmartSnapshot(page);
+
+    expect(smartRefAxisEntry(2)).toEqual({
+      role: 'button',
+      name: 'Row',
+      sameNameIndex: 1,
+      sameNameTotal: 2,
+      frameKey: '',
+    });
+  });
+
+  it('has no ref axis on the RPC lane, whose selector is a real one', async () => {
+    clearElementCache();
+    const evaluate = async () => ({
+      url: 'https://example.test/a',
+      title: 'Page',
+      content: '',
+      elements: [{ ref: 1, role: 'button', name: 'OK' }],
+    });
+    await getSmartSnapshotViaEval(evaluate as never);
+
+    expect(smartRefAxisEntry(1)).toBeNull();
+    expect(getLocatorByRef(1)).toBe('[data-wmux-ref="1"]');
   });
 });
 
 describe('RPC lane keeps positional refs', () => {
   it('resolves a smart ref through the data attribute it tagged', async () => {
     clearElementCache();
-    // The RPC script cannot hold identity — browser_snapshot's RPC fallback
-    // strips data-wmux-ref document-wide — so refs stay 1-based walk order and
-    // resolve as a CSS selector rather than a role locator.
+    // Identity cannot be held here: browser_snapshot's RPC fallback strips
+    // data-wmux-ref document-wide and renumbers from 0 on each of its scans.
     const evaluate = async () => ({
       url: 'https://example.test/a',
       title: 'Page',
@@ -247,7 +533,8 @@ describe('RPC lane keeps positional refs', () => {
     const snapshot = await getSmartSnapshotViaEval(evaluate as never);
     expect(snapshot.elements.map((e) => e.ref)).toEqual([1, 2]);
 
+    // No page was captured on this lane, so any page may resolve the selector.
     const page = makePage(tree([]));
-    expect(resolveSmartRefLocator(page, 2)).toBe('[data-wmux-ref="2"]');
+    expect(await resolveSmartRefLocator(page, 2)).toBe('[data-wmux-ref="2"]');
   });
 });

--- a/src/mcp/playwright/__tests__/dom-intelligence.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.test.ts
@@ -44,8 +44,11 @@ describe('getSmartSnapshotViaEval', () => {
     expect(snap.url).toBe('https://x.test/');
     expect(snap.title).toBe('X');
     expect(snap.content).toBe('hello');
+    // The populations are inert on this lane — its locator is a CSS selector
+    // naming one tagged element — but they are part of the shape.
+    const inert = { sameNameIndex: 0, sameNameTotal: 1, roleIndex: 0, roleTotal: 1 };
     expect(snap.elements).toEqual([
-      { ref: 1, role: 'button', name: 'OK', locator: '[data-wmux-ref="1"]' },
+      { ref: 1, role: 'button', name: 'OK', locator: '[data-wmux-ref="1"]', ...inert },
       {
         ref: 2,
         role: 'textbox',
@@ -53,6 +56,7 @@ describe('getSmartSnapshotViaEval', () => {
         value: 'q',
         description: 'main search',
         locator: '[data-wmux-ref="2"]',
+        ...inert,
       },
     ]);
   });

--- a/src/mcp/playwright/__tests__/extraction.diff.test.ts
+++ b/src/mcp/playwright/__tests__/extraction.diff.test.ts
@@ -87,13 +87,24 @@ const ROWS = Array.from({ length: 40 }, (_, i) => ({
   name: `Item ${i}`,
 }));
 
-function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
+function makePage(nodes: CdpNode[], url = 'https://example.test/a', body = 'body text') {
+  const listeners: ((frame: unknown) => void)[] = [];
+  const mainFrame = { id: 'main' };
   const page = {
     nodes,
     currentUrl: url,
+    body,
     url: () => page.currentUrl,
     title: async () => 'Page',
-    innerText: async () => 'body text',
+    innerText: async () => page.body,
+    on: (event: string, fn: (frame: unknown) => void) => {
+      if (event === 'framenavigated') listeners.push(fn);
+    },
+    mainFrame: () => mainFrame,
+    /** Fire a main-frame navigation the way Playwright would. */
+    navigate: () => {
+      for (const fn of listeners) fn(mainFrame);
+    },
     context: () => ({
       newCDPSession: async () => ({
         send: vi.fn(async (method: string) =>
@@ -106,6 +117,17 @@ function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
     getByRole: vi.fn(),
   };
   return page;
+}
+
+function rpcPayload(url = 'https://example.test/a') {
+  return {
+    value: {
+      url,
+      title: 'Page',
+      content: 'body text',
+      elements: ROWS.map((row, i) => ({ ref: i + 1, role: row.role, name: row.name })),
+    },
+  };
 }
 
 const tool = smartSnapshotTool();
@@ -190,19 +212,75 @@ describe('browser_smart_snapshot auto-diff (CDP lane)', () => {
 describe('browser_smart_snapshot auto-diff (RPC lane)', () => {
   it('always returns the full listing while refs are positional', async () => {
     getPage.mockResolvedValue(null);
-    mockSendRpc.mockResolvedValue({
-      value: {
-        url: 'https://example.test/a',
-        title: 'Page',
-        content: 'body text',
-        elements: ROWS.map((row, i) => ({ ref: i + 1, role: row.role, name: row.name })),
-      },
-    });
+    mockSendRpc.mockResolvedValue(rpcPayload());
 
     expect((await snapshot()).startsWith('[snapshot: full]')).toBe(true);
     // Second identical call: the CDP lane would answer "no changes" here.
     const second = await snapshot();
     expect(second.startsWith('[snapshot: full]')).toBe(true);
     expect(second).toContain('Item 30');
+  });
+
+  it('does not leave a baseline the CDP lane will diff against', async () => {
+    // The two lanes number their refs differently, so a positional listing is
+    // not a baseline an identity listing may be compared with. The lane marker
+    // in the attrs key is what keeps them apart.
+    getPage.mockResolvedValue(null);
+    mockSendRpc.mockResolvedValue(rpcPayload());
+    await snapshot();
+
+    getPage.mockResolvedValue(makePage(tree(ROWS)));
+    const onCdp = await snapshot();
+
+    expect(onCdp.startsWith('[snapshot: full]')).toBe(true);
+    expect(onCdp).toContain('Item 30');
+  });
+});
+
+describe('a diff never crosses a document or a page', () => {
+  it('returns the full listing after a reload of the same URL', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+    await snapshot();
+
+    // Same URL, new document: the URL guard sees nothing, and the new
+    // document's low backendDOMNodeIds take the old document's refs.
+    page.navigate();
+    const after = await snapshot();
+
+    expect(after.startsWith('[snapshot: full]')).toBe(true);
+    expect(after).not.toContain('no changes');
+  });
+
+  it('returns the full listing for a second tab on the same URL', async () => {
+    getPage.mockResolvedValue(makePage(tree(ROWS)));
+    await snapshot();
+
+    // A different page, same surface key and same URL — identical text, and
+    // "(no changes since previous snapshot)" would be about a page this call
+    // never compared against.
+    getPage.mockResolvedValue(makePage(tree(ROWS)));
+    const other = await snapshot();
+
+    expect(other.startsWith('[snapshot: full]')).toBe(true);
+    expect(other).toContain('Item 30');
+  });
+});
+
+describe('a truncated page text says the diff is partial', () => {
+  it('notes the cap when it answers with a diff', async () => {
+    const page = makePage(tree(ROWS), 'https://example.test/a', 'x'.repeat(5000));
+    getPage.mockResolvedValue(page);
+    await snapshot({ maxContentLength: 20 });
+
+    const second = await snapshot({ maxContentLength: 20 });
+    expect(second).toContain('(no changes since previous snapshot)');
+    expect(second).toContain('page text is capped at 20 characters');
+  });
+
+  it('stays quiet when nothing was cut', async () => {
+    getPage.mockResolvedValue(makePage(tree(ROWS)));
+    await snapshot();
+    expect(await snapshot()).not.toContain('page text is capped');
   });
 });

--- a/src/mcp/playwright/__tests__/extraction.diff.test.ts
+++ b/src/mcp/playwright/__tests__/extraction.diff.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({
+      getPageForScope: getPage,
+      drainLocalLifecycle: () => [],
+    }),
+  },
+}));
+
+import { registerExtractionTools } from '../tools/extraction';
+import { clearElementCache } from '../dom-intelligence';
+import { invalidateSnapshotBaseline } from '../snapshotCache';
+
+// browser_smart_snapshot's auto-diff. Refs are keyed on DOM node identity on
+// the Playwright/CDP lane (dom-intelligence.refstability.test.ts), which is
+// what makes a diff worth returning at all; the RPC lane still numbers by walk
+// position, so it never diffs.
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
+function smartSnapshotTool(): ToolHandler {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  };
+  registerExtractionTools(server as never, browserToolDeps);
+  const tool = tools.get('browser_smart_snapshot');
+  if (!tool) throw new Error('browser_smart_snapshot failed to register');
+  return tool;
+}
+
+interface CdpNode {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+/** Root plus one interactive child per entry, backend ids fixed per child. */
+function tree(children: { backendId: number; role: string; name: string }[]): CdpNode[] {
+  const nodes: CdpNode[] = [
+    {
+      nodeId: '1',
+      backendDOMNodeId: 1,
+      role: { type: 'role', value: 'RootWebArea' },
+      name: { type: 'name', value: 'Page' },
+      childIds: children.map((c) => String(c.backendId)),
+    },
+  ];
+  for (const child of children) {
+    nodes.push({
+      nodeId: String(child.backendId),
+      backendDOMNodeId: child.backendId,
+      role: { type: 'role', value: child.role },
+      name: { type: 'name', value: child.name },
+      childIds: [],
+    });
+  }
+  return nodes;
+}
+
+const ROWS = Array.from({ length: 40 }, (_, i) => ({
+  backendId: 100 + i,
+  role: 'link',
+  name: `Item ${i}`,
+}));
+
+function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
+  const page = {
+    nodes,
+    currentUrl: url,
+    url: () => page.currentUrl,
+    title: async () => 'Page',
+    innerText: async () => 'body text',
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string) =>
+          method === 'Accessibility.getFullAXTree' ? { nodes: page.nodes } : {},
+        ),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    locator: vi.fn(),
+    getByRole: vi.fn(),
+  };
+  return page;
+}
+
+const tool = smartSnapshotTool();
+
+async function snapshot(args: Record<string, unknown> = {}): Promise<string> {
+  const result = await tool({ surfaceId: 'surf-1', ...args });
+  expect(result.isError).toBeUndefined();
+  return result.content[0].text;
+}
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  getPage.mockReset();
+  clearElementCache();
+  invalidateSnapshotBaseline('ws-test', 'surf-1');
+});
+
+describe('browser_smart_snapshot auto-diff (CDP lane)', () => {
+  it('returns the full listing first and a diff on the repeat call', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+
+    const first = await snapshot();
+    expect(first.startsWith('[snapshot: full]')).toBe(true);
+    expect(first).toContain('Item 30');
+
+    page.nodes = tree([{ backendId: 999, role: 'button', name: 'Inserted' }, ...ROWS]);
+    const second = await snapshot();
+
+    expect(second.startsWith('[snapshot: diff vs previous')).toBe(true);
+    expect(second).toContain('+ ');
+    expect(second).toContain('Inserted');
+    // The untouched rows are omitted, which is the whole point.
+    expect(second).not.toContain('Item 30');
+  });
+
+  it('says so, rather than going quiet, when nothing changed', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+
+    await snapshot();
+    expect(await snapshot()).toContain('(no changes since previous snapshot)');
+  });
+
+  it('falls back to the full listing when the page navigated', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+    await snapshot();
+
+    page.currentUrl = 'https://example.test/b';
+    const after = await snapshot();
+
+    // The URL guard: a diff against a page that no longer exists is never
+    // valid, however small it would have been.
+    expect(after.startsWith('[snapshot: full]')).toBe(true);
+    expect(after).toContain('Item 30');
+  });
+
+  it('honours full:true and still refreshes the baseline', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+    await snapshot();
+
+    const forced = await snapshot({ full: true });
+    expect(forced.startsWith('[snapshot: full]')).toBe(true);
+    expect(forced).toContain('Item 30');
+
+    // full:true opts one call out of the diff; it does not switch it off.
+    expect(await snapshot()).toContain('(no changes since previous snapshot)');
+  });
+
+  it('does not diff across a different maxContentLength', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+    await snapshot();
+
+    const other = await snapshot({ maxContentLength: 500 });
+    expect(other.startsWith('[snapshot: full]')).toBe(true);
+  });
+});
+
+describe('browser_smart_snapshot auto-diff (RPC lane)', () => {
+  it('always returns the full listing while refs are positional', async () => {
+    getPage.mockResolvedValue(null);
+    mockSendRpc.mockResolvedValue({
+      value: {
+        url: 'https://example.test/a',
+        title: 'Page',
+        content: 'body text',
+        elements: ROWS.map((row, i) => ({ ref: i + 1, role: row.role, name: row.name })),
+      },
+    });
+
+    expect((await snapshot()).startsWith('[snapshot: full]')).toBe(true);
+    // Second identical call: the CDP lane would answer "no changes" here.
+    const second = await snapshot();
+    expect(second.startsWith('[snapshot: full]')).toBe(true);
+    expect(second).toContain('Item 30');
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.smartref.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.smartref.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({
+      getPageForScope: getPage,
+      drainLocalLifecycle: () => [],
+      resolveWorkspaceBackend: async () => 'playwright',
+    }),
+  },
+}));
+
+import { registerInteractionTools } from '../tools/interaction';
+import { ActionRing } from '../../browser-replay/actionRing';
+import { clearElementCache, getSmartSnapshot } from '../dom-intelligence';
+
+// browser_click({ smartRef }) on the Playwright lane. Two things it got wrong
+// before, both silent: the stored "locator" is the SOURCE TEXT of a getByRole
+// call, so `page.locator()` could not parse it (the click failed) and the
+// recorded css axis could never replay (the trace filled with dead steps).
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const ring = new ActionRing();
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test'), actionRing: ring };
+
+function clickTool(): ToolHandler {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  };
+  registerInteractionTools(server as never, browserToolDeps as never);
+  const tool = tools.get('browser_click');
+  if (!tool) throw new Error('browser_click failed to register');
+  return tool;
+}
+
+interface CdpNode {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+function tree(children: { backendId: number; role: string; name: string }[]): CdpNode[] {
+  const nodes: CdpNode[] = [
+    {
+      nodeId: '1',
+      backendDOMNodeId: 1,
+      role: { type: 'role', value: 'RootWebArea' },
+      name: { type: 'name', value: 'Page' },
+      childIds: children.map((c) => String(c.backendId)),
+    },
+  ];
+  for (const child of children) {
+    nodes.push({
+      nodeId: String(child.backendId),
+      backendDOMNodeId: child.backendId,
+      role: { type: 'role', value: child.role },
+      name: { type: 'name', value: child.name },
+      childIds: [],
+    });
+  }
+  return nodes;
+}
+
+function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
+  const clicked: string[] = [];
+  const page = {
+    nodes,
+    clicked,
+    currentUrl: url,
+    url: () => page.currentUrl,
+    title: async () => 'Page',
+    innerText: async () => 'body text',
+    on: () => {},
+    mainFrame: () => ({ id: 'main' }),
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string) =>
+          method === 'Accessibility.getFullAXTree' ? { nodes: page.nodes } : {},
+        ),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    locator: vi.fn(),
+    getByRole: (r: string, opts?: { name?: string }) => ({
+      count: async () => page.nodes.filter((n) => n.role?.value === r
+        && (opts?.name === undefined || (n.name?.value ?? '') === opts.name)).length,
+      nth: (i: number) => ({
+        click: async () => { clicked.push(`${r} ${opts?.name ?? ''}#${i}`); },
+        dblclick: async () => { clicked.push(`dbl ${r} ${opts?.name ?? ''}#${i}`); },
+      }),
+    }),
+  };
+  return page;
+}
+
+const click = clickTool();
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({});
+  getPage.mockReset();
+  ring.clear();
+  clearElementCache();
+});
+
+describe('browser_click({ smartRef }) on the Playwright lane', () => {
+  it('clicks the element the ref names', async () => {
+    const page = makePage(tree([
+      { backendId: 10, role: 'button', name: 'Row' },
+      { backendId: 11, role: 'button', name: 'Row' },
+    ]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+
+    const result = await click({ smartRef: 2, surfaceId: 'surf-1' });
+
+    expect(result.isError).toBeUndefined();
+    expect(page.clicked).toEqual(['button Row#1']);
+  });
+
+  it('records a REPLAYABLE ref axis, not the getByRole source text', async () => {
+    const page = makePage(tree([
+      { backendId: 20, role: 'button', name: 'Row' },
+      { backendId: 21, role: 'button', name: 'Row' },
+    ]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+    await click({ smartRef: 2, surfaceId: 'surf-1' });
+
+    const [recorded] = ring.all();
+    expect(recorded.step.axis).toEqual({
+      kind: 'ref',
+      role: 'button',
+      name: 'Row',
+      sameNameIndex: 1,
+      sameNameTotal: 2,
+      frameKey: '',
+    });
+    // The old shape: a css axis holding a string page.locator() cannot parse.
+    expect(recorded.step.axis.kind).not.toBe('css');
+    expect(recorded.step.unrecordable).toBeUndefined();
+  });
+
+  it('reports a stale ref instead of clicking a substitute', async () => {
+    const page = makePage(tree([{ backendId: 30, role: 'button', name: 'Save' }]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+
+    page.currentUrl = 'https://example.test/elsewhere';
+    const result = await click({ smartRef: 1, surfaceId: 'surf-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/stale/);
+    expect(page.clicked).toEqual([]);
+    expect(ring.all()).toEqual([]);
+  });
+});

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -313,13 +313,10 @@ interface SmartRefIdentity {
 }
 
 /**
- * Above this many remembered nodes the identity map is dropped (an SPA that
- * churns nodes forever would otherwise grow it without bound). `next` is NOT
- * rewound with it — recycling a number is the confusion this exists to
- * prevent — so the cost of hitting the cap is one renumbering of live nodes.
- *
- * In practice unreachable now that each snapshot prunes to the nodes it saw
- * (review ⑨); kept as the backstop it always was.
+ * How many remembered nodes the identity map may hold before it is trimmed (an
+ * SPA that churns nodes forever would otherwise grow it without bound). `next`
+ * is NOT rewound by any trim — recycling a number is exactly the confusion this
+ * exists to prevent. See capSmartRefIdentity for the order a trim takes.
  */
 const SMART_REF_IDENTITY_CAP = 5000;
 
@@ -427,7 +424,6 @@ function beginSmartRefGeneration(page: Page): SmartRefIdentity {
   } else if (identity.url !== undefined && url !== undefined && identity.url !== url) {
     identity.byBackendId.clear();
   }
-  if (identity.byBackendId.size > SMART_REF_IDENTITY_CAP) identity.byBackendId.clear();
   identity.url = url;
   identity.generation++;
   hookNavigation(page, identity);
@@ -435,22 +431,33 @@ function beginSmartRefGeneration(page: Page): SmartRefIdentity {
 }
 
 /**
- * Forget every node this walk did not see (review 9).
+ * Keep the identity map under SMART_REF_IDENTITY_CAP, in the order that costs
+ * the least (review 9).
  *
- * The map is otherwise append-only, so a long session on a churning SPA walks
- * it into SMART_REF_IDENTITY_CAP and the whole map is dropped at once —
- * renumbering every live element in one go, which is the loudest possible
- * outcome for the quietest possible cause. Pruning per snapshot keeps the map
- * the size of the page. The cost is deliberate and small: an element that
- * leaves the tree and comes back gets a NEW ref rather than its old one, which
- * is the answer the agent already gets for anything the last snapshot did not
- * list — and never a reused number.
+ * Nothing is forgotten while the map fits, and remembering a node the current
+ * walk did not see is the whole point of the map on this side of the cap: a
+ * menu that closes and reopens, a tab panel that swaps out and back, a row
+ * scrolled out of a virtualised list — each comes back to the ref it had, which
+ * keeps it out of the diff and keeps a ref the agent is holding valid. An
+ * earlier draft pruned to the walk on every snapshot and turned every one of
+ * those round trips into a renumber.
+ *
+ * Over the cap, the entries this walk did not see have the least claim to the
+ * space, so they go first; only if the live page ALONE still exceeds the cap is
+ * the map dropped whole. That last case renumbers every live element at once —
+ * loud, and correct: every outstanding ref goes stale rather than quietly
+ * meaning something new, and `next` is never rewound, so no number is reused.
+ *
+ * A document boundary is a different question and keeps its own answer: every
+ * backendDOMNodeId means nothing in a new document, so a changed URL and the
+ * `framenavigated` hook clear the map outright.
  */
-function pruneSmartRefIdentity(identity: SmartRefIdentity, seen: Set<number>): void {
-  if (identity.byBackendId.size === seen.size) return;
+function capSmartRefIdentity(identity: SmartRefIdentity, seen: Set<number>): void {
+  if (identity.byBackendId.size <= SMART_REF_IDENTITY_CAP) return;
   for (const backendId of [...identity.byBackendId.keys()]) {
     if (!seen.has(backendId)) identity.byBackendId.delete(backendId);
   }
+  if (identity.byBackendId.size > SMART_REF_IDENTITY_CAP) identity.byBackendId.clear();
 }
 
 /** The smart ref for this node, minting one the first time we see it. */
@@ -523,8 +530,8 @@ function buildLocatorString(role: string, name: string): string {
  * elements into the provided array, assigning refs out of the page's identity
  * number space (see SmartRefIdentity).
  *
- * `seen` collects every backendDOMNodeId this walk numbered, so the identity
- * map can be pruned back to the live page afterwards.
+ * `seen` collects every backendDOMNodeId this walk numbered, so an over-cap
+ * identity map can be trimmed back to the live page afterwards.
  */
 function collectInteractiveElements(
   nodeMap: Map<string, CdpAXNode>,
@@ -616,7 +623,7 @@ async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
     const elements: IndexedElement[] = [];
     const seen = new Set<number>();
     collectInteractiveElements(nodeMap, nodes[0], elements, passwordBackendIds, identity, seen);
-    pruneSmartRefIdentity(identity, seen);
+    capSmartRefIdentity(identity, seen);
     finalizeSmartPopulations(elements);
     return elements;
   } finally {

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -214,13 +214,17 @@ interface CdpAXNode {
  * cache is scoped to one (review 7): ref numbers restart at 1 per Page, the
  * cache is per CONNECTION, and one connection can drive several surfaces and
  * tabs. Without them, snapshotting tab A and then clicking on tab B resolves
- * A's ref against B's DOM and reports success. A WeakRef, so holding the cache
- * can never keep a closed page alive.
+ * A's ref against B's DOM and reports success.
+ *
+ * A plain reference, not a WeakRef: the record is replaced wholesale by the
+ * next smart snapshot and lives on the connection scope, so at most one closed
+ * Page is held, and only until that connection snapshots again or goes away.
+ * (WeakRef is also absent from the MCP build's ES2020 lib.)
  */
 interface SmartSnapshotRecord {
   elements: IndexedElement[];
   /** The page the snapshot was taken on. Absent on the RPC lane. */
-  page: WeakRef<Page> | null;
+  page: Page | null;
   /** Surface the snapshot was taken on, when the caller named one. */
   surfaceId: string | undefined;
   /** identity.generation at capture time — which snapshot minted these refs. */
@@ -682,7 +686,7 @@ export async function getSmartSnapshot(
   });
   setSnapshotRecord({
     elements,
-    page: new WeakRef(page),
+    page,
     surfaceId: options?.surfaceId,
     generation: identity?.generation ?? 0,
     documentEpoch: identity?.documentEpoch ?? 0,
@@ -881,8 +885,7 @@ export async function resolveSmartRefLocator(page: Page, ref: number): Promise<L
   // Wrong page, whatever the ref says. Checked before anything else: on the
   // CDP lane the refs belong to ONE page, and every check below would
   // otherwise be run against a DOM the snapshot never saw (review 7).
-  const capturedPage = record.page?.deref();
-  if (capturedPage !== undefined && capturedPage !== page) {
+  if (record.page !== null && record.page !== page) {
     throw new StaleSmartRefError(
       `smartRef=${ref} was taken on a different page than the one this click targets` +
         `${record.surfaceId ? ` (snapshot surface "${record.surfaceId}")` : ''}. ${RESNAPSHOT}`,

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright-core';
+import type { Locator, Page } from 'playwright-core';
 import type { JsonEvaluator } from './page-eval';
 import { getConnectionScope } from '../connectionScope';
 import {
@@ -103,7 +103,11 @@ export function buildDomSnapshotExpression(
 // ---------------------------------------------------------------------------
 
 export interface IndexedElement {
-  /** 1-based index */
+  /**
+   * Stable 1-based ref. On the Playwright/CDP lane the number is keyed on the
+   * element's DOM node, so it survives insertions above it (see
+   * SmartRefIdentity); on the RPC lane it is still the walk position.
+   */
   ref: number;
   /** Accessibility role: button, link, textbox, etc. */
   role: string;
@@ -115,6 +119,13 @@ export interface IndexedElement {
   description?: string;
   /** Playwright locator string to find this element */
   locator: string;
+  /**
+   * Position of this element among the same role+name population the snapshot
+   * saw, so `getByRole(role, { name }).nth(i)` picks the instance the ref was
+   * numbered against. Absent on the RPC lane, whose locator is a CSS selector
+   * that already names one element.
+   */
+  sameNameIndex?: number;
 }
 
 export interface SmartSnapshot {
@@ -194,6 +205,114 @@ function setElementCache(elements: IndexedElement[]): void {
 }
 
 // ---------------------------------------------------------------------------
+// Smart-ref identity — refs keyed on the DOM node, not on the walk position
+// ---------------------------------------------------------------------------
+
+/**
+ * Smart refs used to be a running 1-based count over the accessibility walk,
+ * so one node inserted above an element renumbered it and everything after it:
+ * replaying a ref from the previous smart snapshot clicked the neighbour, with
+ * nothing to notice. It also kept browser_smart_snapshot from ever diffing —
+ * a renumber rewrites near enough every line.
+ *
+ * Numbering off `backendDOMNodeId` — the id CDP keeps stable for a DOM node's
+ * lifetime — makes an unchanged node keep its ref. This mirrors RefIdentity in
+ * snapshot.ts, kept separate because the two number spaces are distinct (smart
+ * refs are 1-based, browser_snapshot's are 0-based) and were never
+ * interchangeable.
+ *
+ * Numbers are only ever handed out, never recycled, so a ref that named a
+ * removed element can never come back pointing at a different one.
+ */
+interface SmartRefIdentity {
+  /** backendDOMNodeId → the smart ref that node was given. */
+  byBackendId: Map<number, number>;
+  /** Next unused ref number (1-based). */
+  next: number;
+  /** URL the number space belongs to; a different document restarts it. */
+  url: string | undefined;
+}
+
+/**
+ * Above this many remembered nodes the identity map is dropped (an SPA that
+ * churns nodes forever would otherwise grow it without bound). `next` is NOT
+ * rewound with it — recycling a number is the confusion this exists to
+ * prevent — so the cost of hitting the cap is one renumbering of live nodes.
+ */
+const SMART_REF_IDENTITY_CAP = 5000;
+
+const pageSmartRefIdentity = new WeakMap<Page, SmartRefIdentity>();
+
+/**
+ * The part of the URL that decides whether this is still the same document.
+ *
+ * Fragment dropped for the same reason as snapshot.ts's documentKey: a docs
+ * page rewrites `location.hash` as you scroll, and counting that as a
+ * navigation would retire every ref mid-flow. Kept local rather than imported
+ * because snapshot.ts already imports this module — the reverse edge would
+ * close a cycle.
+ */
+function smartDocumentKey(page: Page): string | undefined {
+  let url: string | undefined;
+  try {
+    const raw = (page as { url?: () => string }).url?.();
+    url = typeof raw === 'string' && raw.length > 0 ? raw : undefined;
+  } catch {
+    return undefined;
+  }
+  if (url === undefined) return undefined;
+  const hash = url.indexOf('#');
+  return hash === -1 ? url : url.slice(0, hash);
+}
+
+/**
+ * Open a snapshot's number space, resetting it when the page has moved to a
+ * different document (its backendDOMNodeIds mean nothing there). `next` is not
+ * rewound on a document change: an agent still holding a ref from the old
+ * document must not be handed whatever now sits at that number.
+ */
+function beginSmartRefGeneration(page: Page): SmartRefIdentity {
+  const url = smartDocumentKey(page);
+  let identity = pageSmartRefIdentity.get(page);
+  if (!identity) {
+    identity = { byBackendId: new Map(), next: 1, url };
+    pageSmartRefIdentity.set(page, identity);
+  } else if (identity.url !== undefined && url !== undefined && identity.url !== url) {
+    identity.byBackendId.clear();
+  }
+  if (identity.byBackendId.size > SMART_REF_IDENTITY_CAP) identity.byBackendId.clear();
+  identity.url = url;
+  return identity;
+}
+
+/** The smart ref for this node, minting one the first time we see it. */
+function assignSmartRef(identity: SmartRefIdentity, backendDOMNodeId?: number): number {
+  if (backendDOMNodeId === undefined) return identity.next++;
+  const existing = identity.byBackendId.get(backendDOMNodeId);
+  if (existing !== undefined) return existing;
+  const ref = identity.next++;
+  identity.byBackendId.set(backendDOMNodeId, ref);
+  return ref;
+}
+
+/**
+ * Record, per element, its position among the same role+name population.
+ *
+ * resolveSmartRefLocator locates through `getByRole(...).nth(i)`, which is only
+ * sound against the population the snapshot saw — and a stable ref number says
+ * nothing about where the element now sits in that population.
+ */
+function finalizeSameNameIndices(elements: IndexedElement[]): void {
+  const seen = new Map<string, number>();
+  for (const element of elements) {
+    const key = `${element.role} ${element.name}`;
+    const index = seen.get(key) ?? 0;
+    element.sameNameIndex = index;
+    seen.set(key, index + 1);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
@@ -221,13 +340,15 @@ function buildLocatorString(role: string, name: string): string {
 
 /**
  * Recursively walk the CDP accessibility tree and collect interactive
- * elements into the provided array, assigning 1-based ref numbers.
+ * elements into the provided array, assigning refs out of the page's identity
+ * number space (see SmartRefIdentity).
  */
 function collectInteractiveElements(
   nodeMap: Map<string, CdpAXNode>,
   node: CdpAXNode,
   elements: IndexedElement[],
   passwordBackendIds: Set<number>,
+  identity: SmartRefIdentity,
 ): void {
   const role = node.role?.value ?? 'none';
   const name = node.name?.value ?? '';
@@ -238,7 +359,7 @@ function collectInteractiveElements(
   // here skipped the entire document. Same splice rule as buildTree() in
   // snapshot.ts — see the comment there for the measurement.
   if (!node.ignored && INTERACTIVE_ROLES.has(role)) {
-    const ref = elements.length + 1; // 1-based
+    const ref = assignSmartRef(identity, node.backendDOMNodeId);
     const element: IndexedElement = {
       ref,
       role,
@@ -267,7 +388,7 @@ function collectInteractiveElements(
     for (const childId of node.childIds) {
       const child = nodeMap.get(childId);
       if (child) {
-        collectInteractiveElements(nodeMap, child, elements, passwordBackendIds);
+        collectInteractiveElements(nodeMap, child, elements, passwordBackendIds, identity);
       }
     }
   }
@@ -298,7 +419,14 @@ async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
     for (const n of nodes) nodeMap.set(n.nodeId, n);
 
     const elements: IndexedElement[] = [];
-    collectInteractiveElements(nodeMap, nodes[0], elements, passwordBackendIds);
+    collectInteractiveElements(
+      nodeMap,
+      nodes[0],
+      elements,
+      passwordBackendIds,
+      beginSmartRefGeneration(page),
+    );
+    finalizeSameNameIndices(elements);
     return elements;
   } finally {
     await client.detach().catch(() => {
@@ -361,8 +489,16 @@ export async function getSmartSnapshot(
  * channel. Lower role fidelity than the AX tree (tag/role heuristic) — the
  * accepted packaged-mode degradation; the dev path keeps full fidelity.
  *
- * Refs are 1-based to match getSmartSnapshot() and getLocatorByRef()'s `ref-1`
- * lookup. Each interactive element is tagged `data-wmux-ref="<ref>"` with the
+ * Refs on this lane stay POSITIONAL (1-based walk order), unlike the CDP lane
+ * above. Identity cannot be held here: the only place to keep it is the
+ * `data-wmux-ref` attribute, and browser_snapshot's RPC fallback strips every
+ * one of those document-wide and renumbers from 0 on each of its own scans
+ * (buildDomSnapshotExpression, above). An interleaved browser_snapshot would
+ * therefore either wipe the identity or, worse, leave 0-based numbers behind
+ * for this scan to adopt as its own. browser_smart_snapshot skips diffing on
+ * this lane for exactly that reason (tools/extraction.ts).
+ *
+ * Each interactive element is tagged `data-wmux-ref="<ref>"` with the
  * SAME 1-based number, so:
  *   - RPC-mode click: browser_click({smartRef}) -> [data-wmux-ref="<smartRef>"].
  *   - page-mode click after getPage() recovers: getLocatorByRef returns
@@ -458,15 +594,44 @@ export async function getSmartSnapshotViaEval(
 }
 
 /**
- * Look up a Playwright locator string by the 1-based ref number assigned
- * during the most recent `getSmartSnapshot()` call.
+ * Look up the element carrying `ref` in the most recent smart snapshot.
  *
- * Returns `null` if the ref is out of range or no snapshot has been taken.
+ * Keyed on the stored ref, NOT on `cache[ref - 1]`: identity refs are no
+ * longer a dense 1..n range (a removed element retires its number for good),
+ * so positional indexing would return the wrong element or nothing at all.
+ */
+export function getSmartElementByRef(ref: number): IndexedElement | null {
+  return getElementCache().find((element) => element.ref === ref) ?? null;
+}
+
+/**
+ * Look up a Playwright locator string by the ref number assigned during the
+ * most recent smart snapshot.
+ *
+ * Returns `null` if no element carries that ref.
  */
 export function getLocatorByRef(ref: number): string | null {
-  const cache = getElementCache();
-  if (ref < 1 || ref > cache.length) return null;
-  return cache[ref - 1].locator;
+  return getSmartElementByRef(ref)?.locator ?? null;
+}
+
+/**
+ * Resolve a smart ref to a live Playwright locator.
+ *
+ * The two lanes store two different kinds of locator and only one of them is a
+ * selector: the RPC lane's `[data-wmux-ref="N"]` is CSS and goes straight to
+ * `page.locator()`, while the CDP lane's `getByRole('button', { name: 'OK' })`
+ * is a source snippet that `page.locator()` cannot parse at all. Rebuild the
+ * latter through the real `getByRole` API, pinned with `.nth()` to the
+ * instance the ref was numbered against.
+ */
+export function resolveSmartRefLocator(page: Page, ref: number): Locator | null {
+  const element = getSmartElementByRef(ref);
+  if (!element) return null;
+  if (element.locator.startsWith('[data-wmux-ref=')) return page.locator(element.locator);
+  const byRole = element.name
+    ? page.getByRole(element.role as Parameters<Page['getByRole']>[0], { name: element.name })
+    : page.getByRole(element.role as Parameters<Page['getByRole']>[0]);
+  return byRole.nth(element.sameNameIndex ?? 0);
 }
 
 /**

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -120,12 +120,24 @@ export interface IndexedElement {
   /** Playwright locator string to find this element */
   locator: string;
   /**
-   * Position of this element among the same role+name population the snapshot
-   * saw, so `getByRole(role, { name }).nth(i)` picks the instance the ref was
-   * numbered against. Absent on the RPC lane, whose locator is a CSS selector
-   * that already names one element.
+   * Position among the same role+name population the snapshot saw, so
+   * `getByRole(role, { name, exact: true }).nth(i)` picks the instance the ref
+   * was numbered against. Zeroed on the RPC lane, whose locator is a CSS
+   * selector that already names one element.
    */
-  sameNameIndex?: number;
+  sameNameIndex: number;
+  /** How many elements the snapshot listed with this role+name. */
+  sameNameTotal: number;
+  /**
+   * The same pair over the whole ROLE population, ignoring names.
+   *
+   * An unnamed element cannot be located with a name filter, and
+   * `getByRole(role)` with no filter counts the named siblings too — so the
+   * name-keyed index is not an index into the population that locator returns.
+   * Resolution uses this pair instead for an unnamed element (review ①).
+   */
+  roleIndex: number;
+  roleTotal: number;
 }
 
 export interface SmartSnapshot {
@@ -139,6 +151,12 @@ export interface SmartSnapshot {
 export interface SmartSnapshotOptions {
   /** Maximum length for the page text content (default 3000) */
   maxContentLength?: number;
+  /**
+   * Surface the snapshot was requested for. Stored with the cache so a later
+   * click on ANOTHER surface is refused rather than resolved against the wrong
+   * page — one connection can drive several (review 7).
+   */
+  surfaceId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -184,25 +202,62 @@ interface CdpAXNode {
 }
 
 // ---------------------------------------------------------------------------
-// Element cache — stores indexed elements from the last snapshot
+// Element cache — the last smart snapshot, and what it was taken against
 // ---------------------------------------------------------------------------
+
+/**
+ * The last smart snapshot this connection took, with everything a later
+ * `browser_click({ smartRef })` needs to prove the ref still means what the
+ * agent thinks it means.
+ *
+ * The page and surface are recorded because neither the ref number nor the
+ * cache is scoped to one (review 7): ref numbers restart at 1 per Page, the
+ * cache is per CONNECTION, and one connection can drive several surfaces and
+ * tabs. Without them, snapshotting tab A and then clicking on tab B resolves
+ * A's ref against B's DOM and reports success. A WeakRef, so holding the cache
+ * can never keep a closed page alive.
+ */
+interface SmartSnapshotRecord {
+  elements: IndexedElement[];
+  /** The page the snapshot was taken on. Absent on the RPC lane. */
+  page: WeakRef<Page> | null;
+  /** Surface the snapshot was taken on, when the caller named one. */
+  surfaceId: string | undefined;
+  /** identity.generation at capture time — which snapshot minted these refs. */
+  generation: number;
+  /** identity.documentEpoch at capture time. */
+  documentEpoch: number;
+}
+
+const EMPTY_RECORD: SmartSnapshotRecord = {
+  elements: [],
+  page: null,
+  surfaceId: undefined,
+  generation: 0,
+  documentEpoch: 0,
+};
 
 // Fallback store for single-child mode (no connection scope active). Under the
 // broker each connection keeps its OWN cache on its AsyncLocalStorage scope so
 // concurrent agents' smart refs never collide — see getElementCache/setElementCache.
-let moduleElementCache: IndexedElement[] = [];
+let moduleElementCache: SmartSnapshotRecord = EMPTY_RECORD;
 
-function getElementCache(): IndexedElement[] {
+function getSnapshotRecord(): SmartSnapshotRecord {
   const scope = getConnectionScope();
-  if (scope) return (scope.elementCache as IndexedElement[] | undefined) ?? [];
+  if (scope) return (scope.elementCache as SmartSnapshotRecord | undefined) ?? EMPTY_RECORD;
   return moduleElementCache;
 }
 
-function setElementCache(elements: IndexedElement[]): void {
-  const scope = getConnectionScope();
-  if (scope) scope.elementCache = elements;
-  else moduleElementCache = elements;
+function getElementCache(): IndexedElement[] {
+  return getSnapshotRecord().elements;
 }
+
+function setSnapshotRecord(record: SmartSnapshotRecord): void {
+  const scope = getConnectionScope();
+  if (scope) scope.elementCache = record;
+  else moduleElementCache = record;
+}
+
 
 // ---------------------------------------------------------------------------
 // Smart-ref identity — refs keyed on the DOM node, not on the walk position
@@ -223,6 +278,17 @@ function setElementCache(elements: IndexedElement[]): void {
  *
  * Numbers are only ever handed out, never recycled, so a ref that named a
  * removed element can never come back pointing at a different one.
+ *
+ * One level, not the frameKey-keyed two-level map RefIdentity uses, because
+ * this walk never leaves the main frame. `Accessibility.getFullAXTree` on a
+ * page target stops AT the `<iframe>` element — `childIds: []`, the child
+ * document's nodes simply absent, same-origin or not (measured on Chrome 141;
+ * see IFRAME_ROLES in snapshot.ts). browser_snapshot reaches frame contents
+ * only by grafting them with an explicit per-frame `getFullAXTree({ frameId })`,
+ * which is why it needs the second level; this walk makes no such call, so
+ * every backendDOMNodeId it ever sees was issued by one document. That is also
+ * what keeps the sameNameIndex population and the `page.getByRole` population
+ * the same set — both are main-frame-only.
  */
 interface SmartRefIdentity {
   /** backendDOMNodeId → the smart ref that node was given. */
@@ -231,6 +297,19 @@ interface SmartRefIdentity {
   next: number;
   /** URL the number space belongs to; a different document restarts it. */
   url: string | undefined;
+  /** Bumped once per snapshot. Names the snapshot a ref came from. */
+  generation: number;
+  /**
+   * Bumped on every main-frame navigation, reload included.
+   *
+   * The URL alone cannot see a reload, a back/forward to the same URL, or a
+   * re-submitted form: `smartDocumentKey` reads the same string on both sides
+   * while the document underneath is new and its low backendDOMNodeIds would
+   * be handed the refs of the old one (review ④). The epoch is what makes that
+   * boundary visible — it also lands in the diff baseline's attrs key, so the
+   * baseline for the old document can never be diffed against the new one.
+   */
+  documentEpoch: number;
 }
 
 /**
@@ -238,10 +317,78 @@ interface SmartRefIdentity {
  * churns nodes forever would otherwise grow it without bound). `next` is NOT
  * rewound with it — recycling a number is the confusion this exists to
  * prevent — so the cost of hitting the cap is one renumbering of live nodes.
+ *
+ * In practice unreachable now that each snapshot prunes to the nodes it saw
+ * (review ⑨); kept as the backstop it always was.
  */
 const SMART_REF_IDENTITY_CAP = 5000;
 
 const pageSmartRefIdentity = new WeakMap<Page, SmartRefIdentity>();
+
+/** What the last smart snapshot on this page was taken against. */
+interface SmartSnapshotStamp {
+  generation: number;
+  documentEpoch: number;
+  url: string | undefined;
+}
+
+const pageSmartStamps = new WeakMap<Page, SmartSnapshotStamp>();
+
+/** Pages already carrying the `framenavigated` listener below. */
+const navigationHooked = new WeakSet<Page>();
+
+/** Stable per-Page number, so a baseline key can name the page it describes. */
+const pageIds = new WeakMap<Page, number>();
+let nextPageId = 1;
+
+function pageId(page: Page): number {
+  const existing = pageIds.get(page);
+  if (existing !== undefined) return existing;
+  const id = nextPageId++;
+  pageIds.set(page, id);
+  return id;
+}
+
+/**
+ * Identity of the exact document this page is showing, for the diff baseline's
+ * attrs key.
+ *
+ * Two things the surface key alone cannot separate (review ④ and ⑦): a second
+ * tab or surface on the same URL, whose listing is a different page entirely,
+ * and a reload of the same URL, whose refs are a different number space. Both
+ * come back as a different token, and an attrs mismatch drops the baseline —
+ * so neither can be answered with "(no changes since previous snapshot)".
+ */
+export function smartPageToken(page: Page): string {
+  const identity = pageSmartRefIdentity.get(page);
+  return `p${pageId(page)}e${identity?.documentEpoch ?? 0}`;
+}
+
+/**
+ * Retire the number space when the page navigates, reload included.
+ *
+ * Playwright reports every main-frame commit here, which is the signal
+ * `smartDocumentKey` cannot supply on its own. Attached once per page and
+ * never removed: the listener outlives no more than the Page itself, and
+ * `page.on` is absent on the RPC lane and on test doubles, so its absence is
+ * tolerated rather than required.
+ */
+function hookNavigation(page: Page, identity: SmartRefIdentity): void {
+  if (navigationHooked.has(page)) return;
+  const on = (page as { on?: (event: string, fn: (frame: unknown) => void) => void }).on;
+  if (typeof on !== 'function') return;
+  navigationHooked.add(page);
+  try {
+    on.call(page, 'framenavigated', (frame: unknown) => {
+      const main = (page as { mainFrame?: () => unknown }).mainFrame?.();
+      if (main !== undefined && frame !== main) return;
+      identity.byBackendId.clear();
+      identity.documentEpoch++;
+    });
+  } catch {
+    /* a page that cannot take a listener keeps the URL check alone */
+  }
+}
 
 /**
  * The part of the URL that decides whether this is still the same document.
@@ -275,19 +422,39 @@ function beginSmartRefGeneration(page: Page): SmartRefIdentity {
   const url = smartDocumentKey(page);
   let identity = pageSmartRefIdentity.get(page);
   if (!identity) {
-    identity = { byBackendId: new Map(), next: 1, url };
+    identity = { byBackendId: new Map(), next: 1, url, generation: 0, documentEpoch: 0 };
     pageSmartRefIdentity.set(page, identity);
   } else if (identity.url !== undefined && url !== undefined && identity.url !== url) {
     identity.byBackendId.clear();
   }
   if (identity.byBackendId.size > SMART_REF_IDENTITY_CAP) identity.byBackendId.clear();
   identity.url = url;
+  identity.generation++;
+  hookNavigation(page, identity);
   return identity;
 }
 
+/**
+ * Forget every node this walk did not see (review 9).
+ *
+ * The map is otherwise append-only, so a long session on a churning SPA walks
+ * it into SMART_REF_IDENTITY_CAP and the whole map is dropped at once —
+ * renumbering every live element in one go, which is the loudest possible
+ * outcome for the quietest possible cause. Pruning per snapshot keeps the map
+ * the size of the page. The cost is deliberate and small: an element that
+ * leaves the tree and comes back gets a NEW ref rather than its old one, which
+ * is the answer the agent already gets for anything the last snapshot did not
+ * list — and never a reused number.
+ */
+function pruneSmartRefIdentity(identity: SmartRefIdentity, seen: Set<number>): void {
+  if (identity.byBackendId.size === seen.size) return;
+  for (const backendId of [...identity.byBackendId.keys()]) {
+    if (!seen.has(backendId)) identity.byBackendId.delete(backendId);
+  }
+}
+
 /** The smart ref for this node, minting one the first time we see it. */
-function assignSmartRef(identity: SmartRefIdentity, backendDOMNodeId?: number): number {
-  if (backendDOMNodeId === undefined) return identity.next++;
+function assignSmartRef(identity: SmartRefIdentity, backendDOMNodeId: number): number {
   const existing = identity.byBackendId.get(backendDOMNodeId);
   if (existing !== undefined) return existing;
   const ref = identity.next++;
@@ -296,19 +463,32 @@ function assignSmartRef(identity: SmartRefIdentity, backendDOMNodeId?: number): 
 }
 
 /**
- * Record, per element, its position among the same role+name population.
+ * Record, per element, the populations resolution counts it against.
  *
  * resolveSmartRefLocator locates through `getByRole(...).nth(i)`, which is only
- * sound against the population the snapshot saw — and a stable ref number says
- * nothing about where the element now sits in that population.
+ * sound against the population the snapshot saw — a stable ref number says
+ * nothing about where the element now sits in that population. Both pairs are
+ * stored because the locator differs by whether the element has a name: see
+ * IndexedElement.roleIndex.
  */
-function finalizeSameNameIndices(elements: IndexedElement[]): void {
-  const seen = new Map<string, number>();
+function finalizeSmartPopulations(elements: IndexedElement[]): void {
+  // NUL-separated (review 8): neither a role nor a name can contain one, so no
+  // role+name pair can be spelled two ways. A plain space let `button` + `a b`
+  // and `button a` + `b` collide into a single population.
+  const nameKey = (element: IndexedElement) => `${element.role}\u0000${element.name}`;
+  const nameCounts = new Map<string, number>();
+  const roleCounts = new Map<string, number>();
   for (const element of elements) {
-    const key = `${element.role} ${element.name}`;
-    const index = seen.get(key) ?? 0;
-    element.sameNameIndex = index;
-    seen.set(key, index + 1);
+    const byName = nameCounts.get(nameKey(element)) ?? 0;
+    element.sameNameIndex = byName;
+    nameCounts.set(nameKey(element), byName + 1);
+    const byRole = roleCounts.get(element.role) ?? 0;
+    element.roleIndex = byRole;
+    roleCounts.set(element.role, byRole + 1);
+  }
+  for (const element of elements) {
+    element.sameNameTotal = nameCounts.get(nameKey(element)) ?? 1;
+    element.roleTotal = roleCounts.get(element.role) ?? 1;
   }
 }
 
@@ -342,6 +522,9 @@ function buildLocatorString(role: string, name: string): string {
  * Recursively walk the CDP accessibility tree and collect interactive
  * elements into the provided array, assigning refs out of the page's identity
  * number space (see SmartRefIdentity).
+ *
+ * `seen` collects every backendDOMNodeId this walk numbered, so the identity
+ * map can be pruned back to the live page afterwards.
  */
 function collectInteractiveElements(
   nodeMap: Map<string, CdpAXNode>,
@@ -349,6 +532,7 @@ function collectInteractiveElements(
   elements: IndexedElement[],
   passwordBackendIds: Set<number>,
   identity: SmartRefIdentity,
+  seen: Set<number>,
 ): void {
   const role = node.role?.value ?? 'none';
   const name = node.name?.value ?? '';
@@ -358,23 +542,33 @@ function collectInteractiveElements(
   // (html → body → generic) directly under the RootWebArea, so returning early
   // here skipped the entire document. Same splice rule as buildTree() in
   // snapshot.ts — see the comment there for the measurement.
-  if (!node.ignored && INTERACTIVE_ROLES.has(role)) {
-    const ref = assignSmartRef(identity, node.backendDOMNodeId);
+  //
+  // A node with no backendDOMNodeId is passed over entirely (review 11). There
+  // is nothing to key its ref on, so it drew a fresh number out of the space on
+  // every single snapshot: the ref an agent read was never the ref the next
+  // snapshot would print, and its line changed in every diff, which is exactly
+  // the churn identity refs exist to stop. Listing an element the agent cannot
+  // hold on to is worse than not listing it.
+  if (!node.ignored && INTERACTIVE_ROLES.has(role) && node.backendDOMNodeId !== undefined) {
+    const backendId = node.backendDOMNodeId;
+    seen.add(backendId);
     const element: IndexedElement = {
-      ref,
+      ref: assignSmartRef(identity, backendId),
       role,
       name,
       locator: buildLocatorString(role, name),
+      // Filled in by finalizeSmartPopulations once the whole walk is known.
+      sameNameIndex: 0,
+      sameNameTotal: 0,
+      roleIndex: 0,
+      roleTotal: 0,
     };
 
     if (node.value?.value) {
       // A password field reports its name, role and ref as usual; only the
       // contents are withheld. Chrome pre-masks `type=password` here, but not a
       // `type=text` field marked autocomplete="new-password" — see redact.ts.
-      element.value =
-        node.backendDOMNodeId !== undefined && passwordBackendIds.has(node.backendDOMNodeId)
-          ? REDACTED_PASSWORD
-          : node.value.value;
+      element.value = passwordBackendIds.has(backendId) ? REDACTED_PASSWORD : node.value.value;
     }
     if (node.description?.value) {
       element.description = node.description.value;
@@ -388,7 +582,7 @@ function collectInteractiveElements(
     for (const childId of node.childIds) {
       const child = nodeMap.get(childId);
       if (child) {
-        collectInteractiveElements(nodeMap, child, elements, passwordBackendIds, identity);
+        collectInteractiveElements(nodeMap, child, elements, passwordBackendIds, identity, seen);
       }
     }
   }
@@ -399,6 +593,7 @@ function collectInteractiveElements(
  * elements.
  */
 async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
+  const identity = beginSmartRefGeneration(page);
   const client = await page.context().newCDPSession(page);
   try {
     const { nodes } = (await client.send('Accessibility.getFullAXTree' as any)) as {
@@ -419,14 +614,10 @@ async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
     for (const n of nodes) nodeMap.set(n.nodeId, n);
 
     const elements: IndexedElement[] = [];
-    collectInteractiveElements(
-      nodeMap,
-      nodes[0],
-      elements,
-      passwordBackendIds,
-      beginSmartRefGeneration(page),
-    );
-    finalizeSameNameIndices(elements);
+    const seen = new Set<number>();
+    collectInteractiveElements(nodeMap, nodes[0], elements, passwordBackendIds, identity, seen);
+    pruneSmartRefIdentity(identity, seen);
+    finalizeSmartPopulations(elements);
     return elements;
   } finally {
     await client.detach().catch(() => {
@@ -474,8 +665,21 @@ export async function getSmartSnapshot(
     getPageContent(page, maxContentLength),
   ]);
 
-  // Update element cache
-  setElementCache(elements);
+  // Stamp what these refs were minted against, so a later click can tell a
+  // live ref from one the page has moved out from under.
+  const identity = pageSmartRefIdentity.get(page);
+  pageSmartStamps.set(page, {
+    generation: identity?.generation ?? 0,
+    documentEpoch: identity?.documentEpoch ?? 0,
+    url: smartDocumentKey(page),
+  });
+  setSnapshotRecord({
+    elements,
+    page: new WeakRef(page),
+    surfaceId: options?.surfaceId,
+    generation: identity?.generation ?? 0,
+    documentEpoch: identity?.documentEpoch ?? 0,
+  });
 
   return { url, title, elements, content };
 }
@@ -579,11 +783,24 @@ export async function getSmartSnapshotViaEval(
     ...(e.value !== undefined && { value: e.value }),
     ...(e.description !== undefined && { description: e.description }),
     locator: `[data-wmux-ref="${e.ref}"]`,
+    // The populations are unused on this lane: its locator is a CSS selector
+    // naming one tagged element, so nothing counts a role or a name.
+    sameNameIndex: 0,
+    sameNameTotal: 1,
+    roleIndex: 0,
+    roleTotal: 1,
   }));
 
-  // Cache so browser_click({smartRef}) resolves via getLocatorByRef even if
-  // getPage() flips null->page between this snapshot and the click.
-  setElementCache(elements);
+  // Cache so browser_click({smartRef}) resolves via the data attribute even if
+  // getPage() flips null->page between this snapshot and the click. No page is
+  // recorded: this lane has none, and the attribute selector is page-agnostic.
+  setSnapshotRecord({
+    elements,
+    page: null,
+    surfaceId: options?.surfaceId,
+    generation: 0,
+    documentEpoch: 0,
+  });
 
   return {
     url: raw?.url ?? '',
@@ -615,23 +832,169 @@ export function getLocatorByRef(ref: number): string | null {
 }
 
 /**
+ * Thrown instead of resolving a smart ref that can be shown not to name what
+ * the caller thinks it names — the page navigated, the element is gone, the
+ * click is aimed at another page, or the population the ref indexes into has
+ * changed size.
+ *
+ * The sibling of snapshot.ts's StaleRefError, declared here rather than
+ * imported because snapshot.ts already imports this module. browser_click
+ * turns the message into its tool result, so the agent is told to re-snapshot
+ * instead of being handed a silently substituted element.
+ */
+export class StaleSmartRefError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StaleSmartRefError';
+  }
+}
+
+const RESNAPSHOT = 'Run browser_smart_snapshot to get current refs.';
+
+/**
  * Resolve a smart ref to a live Playwright locator.
  *
  * The two lanes store two different kinds of locator and only one of them is a
  * selector: the RPC lane's `[data-wmux-ref="N"]` is CSS and goes straight to
  * `page.locator()`, while the CDP lane's `getByRole('button', { name: 'OK' })`
  * is a source snippet that `page.locator()` cannot parse at all. Rebuild the
- * latter through the real `getByRole` API, pinned with `.nth()` to the
- * instance the ref was numbered against.
+ * latter through the real `getByRole` API, pinned with `.nth()` to the instance
+ * the ref was numbered against.
+ *
+ * Every check here mirrors resolveRefViaAxMap in snapshot.ts, and for the same
+ * reason: a stable ref number says the element has not been renumbered, not
+ * that it is still there. Before this, a ref replayed after the page moved
+ * resolved to whatever now sat at that index and reported a successful click
+ * (review 2) — the older positional locator at least failed to parse.
  */
-export function resolveSmartRefLocator(page: Page, ref: number): Locator | null {
-  const element = getSmartElementByRef(ref);
-  if (!element) return null;
+export async function resolveSmartRefLocator(page: Page, ref: number): Promise<Locator> {
+  const record = getSnapshotRecord();
+  const element = record.elements.find((e) => e.ref === ref);
+
+  // Wrong page, whatever the ref says. Checked before anything else: on the
+  // CDP lane the refs belong to ONE page, and every check below would
+  // otherwise be run against a DOM the snapshot never saw (review 7).
+  const capturedPage = record.page?.deref();
+  if (capturedPage !== undefined && capturedPage !== page) {
+    throw new StaleSmartRefError(
+      `smartRef=${ref} was taken on a different page than the one this click targets` +
+        `${record.surfaceId ? ` (snapshot surface "${record.surfaceId}")` : ''}. ${RESNAPSHOT}`,
+    );
+  }
+
+  const identity = pageSmartRefIdentity.get(page);
+  const stamp = pageSmartStamps.get(page);
+  if (stamp) {
+    const liveUrl = smartDocumentKey(page);
+    if (stamp.url !== undefined && liveUrl !== undefined && stamp.url !== liveUrl) {
+      throw new StaleSmartRefError(
+        `smartRef=${ref} is stale — the page navigated since snapshot #${stamp.generation} ` +
+          `(${stamp.url} → ${liveUrl}). ${RESNAPSHOT}`,
+      );
+    }
+    // Same URL, different document: a reload, a back/forward, or a re-submitted
+    // form. The URL comparison above cannot see any of them (review 4).
+    if (identity && identity.documentEpoch !== stamp.documentEpoch) {
+      throw new StaleSmartRefError(
+        `smartRef=${ref} is stale — the page reloaded since snapshot #${stamp.generation}, ` +
+          `so its refs name elements that no longer exist. ${RESNAPSHOT}`,
+      );
+    }
+  }
+
+  if (!element) {
+    // The number was handed out on this document but the latest snapshot does
+    // not list it: the element it named is gone. The number is never reissued,
+    // so retrying cannot help — only re-snapshotting can.
+    if (identity && ref >= 1 && ref < identity.next) {
+      throw new StaleSmartRefError(
+        `smartRef=${ref} is stale — the element it named is no longer in the page snapshot ` +
+          `(current snapshot #${identity.generation}). ${RESNAPSHOT}`,
+      );
+    }
+    throw new StaleSmartRefError(`Element with smartRef=${ref} not found. ${RESNAPSHOT}`);
+  }
+
   if (element.locator.startsWith('[data-wmux-ref=')) return page.locator(element.locator);
-  const byRole = element.name
-    ? page.getByRole(element.role as Parameters<Page['getByRole']>[0], { name: element.name })
-    : page.getByRole(element.role as Parameters<Page['getByRole']>[0]);
-  return byRole.nth(element.sameNameIndex ?? 0);
+
+  const role = element.role as Parameters<Page['getByRole']>[0];
+  // `exact: true` (review 1): getByRole's name filter is substring- and
+  // case-insensitive by default, so a ref for "Save" matched "Save draft" and
+  // the index it was paired with then indexed into a population the snapshot
+  // never counted.
+  //
+  // An unnamed element cannot use the name filter at all, and `getByRole(role)`
+  // sweeps the named siblings too — so it is counted against the whole-role
+  // population instead, which is the population that locator actually returns.
+  const named = element.name.length > 0;
+  const locator = named
+    ? page.getByRole(role, { name: element.name, exact: true })
+    : page.getByRole(role);
+  const index = named ? element.sameNameIndex : element.roleIndex;
+  const total = named ? element.sameNameTotal : element.roleTotal;
+
+  let count: number;
+  try {
+    count = await locator.count();
+  } catch {
+    throw new StaleSmartRefError(
+      `smartRef=${ref} (${element.role} "${element.name}") could not be located. ${RESNAPSHOT}`,
+    );
+  }
+  if (count === 0) {
+    throw new StaleSmartRefError(
+      `smartRef=${ref} is stale — no ${element.role} element` +
+        `${named ? ` named "${element.name}"` : ''} is on the page any more. ${RESNAPSHOT}`,
+    );
+  }
+
+  // The nth-match below is only sound while the page still holds the elements
+  // the snapshot numbered. Narrow on purpose, exactly as resolveRefViaAxMap is:
+  // a population of one indexes to 0 either way, so comparing counts there buys
+  // no safety and only costs false rejections.
+  if (total > 1 && count !== total) {
+    throw new StaleSmartRefError(
+      `smartRef=${ref} is stale — the page now has ${count} ${element.role} element(s)` +
+        `${named ? ` named "${element.name}"` : ''}, not the ${total} the last snapshot ` +
+        `listed, so the ref no longer identifies one element. ${RESNAPSHOT}`,
+    );
+  }
+
+  return locator.nth(Math.min(index, count - 1));
+}
+
+/**
+ * The identity of a smart ref, in the shape the replay recorder stores.
+ *
+ * browser_click recorded its smartRef steps as a CSS axis built from
+ * IndexedElement.locator, which on the CDP lane is the SOURCE TEXT of a
+ * getByRole call — `page.locator()` cannot parse it, so every such step failed
+ * on replay while the live click succeeded, quietly filling traces with steps
+ * that could never run (review 6). The ref axis carries the same 4-tuple
+ * browser_snapshot records, which the replay runner already knows how to
+ * re-resolve.
+ *
+ * Returns null for the RPC lane, whose CSS selector is a real selector and is
+ * recorded as one.
+ */
+export function smartRefAxisEntry(ref: number): {
+  role: string;
+  name: string;
+  sameNameIndex: number;
+  sameNameTotal: number;
+  frameKey: string;
+} | null {
+  const element = getSmartElementByRef(ref);
+  if (!element || element.locator.startsWith('[data-wmux-ref=')) return null;
+  const named = element.name.length > 0;
+  return {
+    role: element.role,
+    name: element.name,
+    sameNameIndex: named ? element.sameNameIndex : element.roleIndex,
+    sameNameTotal: named ? element.sameNameTotal : element.roleTotal,
+    // Always the main frame: this walk never leaves it (see SmartRefIdentity).
+    frameKey: '',
+  };
 }
 
 /**
@@ -639,5 +1002,5 @@ export function resolveSmartRefLocator(page: Page, ref: number): Locator | null 
  * to avoid stale refs.
  */
 export function clearElementCache(): void {
-  setElementCache([]);
+  setSnapshotRecord(EMPTY_RECORD);
 }

--- a/src/mcp/playwright/snapshotCache.ts
+++ b/src/mcp/playwright/snapshotCache.ts
@@ -27,7 +27,9 @@ export interface SnapshotBaseline {
 // Bounds: a handful of surfaces per agent is the realistic ceiling; TTL is a
 // backstop against diffing a snapshot from a long-abandoned page state when a
 // navigation event was missed (e.g. main lacked browser.lifecycle.get).
-const MAX_BASELINES = 8;
+// 16, not 8: entries are per surface AND per tool now, so the old cap would
+// have halved the surfaces a diff can survive across.
+const MAX_BASELINES = 16;
 const BASELINE_TTL_MS = 5 * 60 * 1000;
 
 let moduleBaselines: Map<string, SnapshotBaseline> | undefined;
@@ -45,9 +47,35 @@ function getStore(): Map<string, SnapshotBaseline> {
   return moduleBaselines;
 }
 
-/** Surface key mirroring PlaywrightEngine.resolveSelectionContext. */
-export function snapshotSurfaceKey(workspaceId: string | undefined, surfaceId: string | undefined): string {
-  return `ws:${workspaceId ?? ''}:surf:${surfaceId ?? ''}`;
+/**
+ * Surface key mirroring PlaywrightEngine.resolveSelectionContext.
+ *
+ * `tool` namespaces the baseline so browser_snapshot and browser_smart_snapshot
+ * do not clobber each other's on a shared surface. The attrs guard would keep
+ * the output correct either way, but alternating the two tools would then mean
+ * neither ever diffs. browser_snapshot keeps the bare key it always had.
+ */
+export function snapshotSurfaceKey(
+  workspaceId: string | undefined,
+  surfaceId: string | undefined,
+  tool?: string,
+): string {
+  const base = `ws:${workspaceId ?? ''}:surf:${surfaceId ?? ''}`;
+  return tool === undefined ? base : `${base}:tool:${tool}`;
+}
+
+/**
+ * Every key for one surface, whatever tool wrote it. Membership, not a plain
+ * `startsWith`: the bare key of surface `s` is also a prefix of surface `s2`.
+ */
+function surfaceKeys(
+  store: Map<string, SnapshotBaseline>,
+  workspaceId: string | undefined,
+  surfaceId: string | undefined,
+): string[] {
+  const base = snapshotSurfaceKey(workspaceId, surfaceId);
+  const prefix = `${base}:tool:`;
+  return [...store.keys()].filter((key) => key === base || key.startsWith(prefix));
 }
 
 export function getSnapshotBaseline(
@@ -86,9 +114,10 @@ export function setSnapshotBaseline(
   }
 }
 
-/** Drop the baseline for a surface (drained `navigated`/`closed` event). */
+/** Drop every baseline for a surface (drained `navigated`/`closed` event). */
 export function invalidateSnapshotBaseline(workspaceId: string | undefined, surfaceId: string | undefined): void {
-  getStore().delete(snapshotSurfaceKey(workspaceId, surfaceId));
+  const store = getStore();
+  for (const key of surfaceKeys(store, workspaceId, surfaceId)) store.delete(key);
 }
 
 /**
@@ -109,9 +138,10 @@ export function invalidateSnapshotBaselineIfStale(
   currentUrl: string | undefined,
 ): void {
   const store = getStore();
-  const key = snapshotSurfaceKey(workspaceId, surfaceId);
-  const entry = store.get(key);
-  if (!entry) return;
-  if (entry.url !== undefined && currentUrl !== undefined && entry.url === currentUrl) return;
-  store.delete(key);
+  for (const key of surfaceKeys(store, workspaceId, surfaceId)) {
+    const entry = store.get(key);
+    if (!entry) continue;
+    if (entry.url !== undefined && currentUrl !== undefined && entry.url === currentUrl) continue;
+    store.delete(key);
+  }
 }

--- a/src/mcp/playwright/tools/extraction.ts
+++ b/src/mcp/playwright/tools/extraction.ts
@@ -5,6 +5,8 @@ import { withAutomationLease } from '../automationLease';
 import { getSmartSnapshot, getSmartSnapshotViaEval } from '../dom-intelligence';
 import { extractMarkdown, extractStructuredData } from '../markdown-extractor';
 import { resolveEvaluator, rpcEvaluator } from '../page-eval';
+import { formatSnapshotResult } from '../snapshotDiff';
+import { getSnapshotBaseline, setSnapshotBaseline, snapshotSurfaceKey } from '../snapshotCache';
 import { allowScopedRpcFallback, type BrowserToolDeps } from '../browserScope';
 import { describeToolError } from '../toolError';
 
@@ -21,6 +23,7 @@ const BROWSER_SMART_SNAPSHOT_SHAPE = {
     .number()
     .optional()
     .describe('Content summary cap in characters (default 3000).'),
+  full: z.boolean().optional().describe('Force the complete tree instead of a diff.'),
   surfaceId: optionalSurfaceId,
 };
 
@@ -66,9 +69,9 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
   // -----------------------------------------------------------------------
   server.tool(
     'browser_smart_snapshot',
-    'Indexed interactive elements plus clean page text. Pass a returned ref to browser_click as smartRef.',
+    'Indexed interactive elements plus clean page text. Pass a returned ref to browser_click as smartRef. A repeat call returns a diff; pass full:true for the whole listing.',
     BROWSER_SMART_SNAPSHOT_SHAPE,
-    async ({ maxContentLength, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ maxContentLength, full, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         // Playwright path uses the CDP accessibility tree; when no Page is
         // available (packaged builds, issue #105) fall back to a DOM-based
@@ -97,8 +100,28 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
           lines.push(snapshot.content);
         }
 
+        const text = lines.join('\n');
+
+        // Auto-diff, same machinery and same 50%/800-line fallback as
+        // browser_snapshot (snapshotDiff.ts): a repeat call with the same
+        // attributes on the same URL returns only what moved, and the first
+        // line always declares which of the two it is.
+        //
+        // Only the CDP lane may diff. The RPC lane still numbers refs by walk
+        // position (see getSmartSnapshotViaEval), so a single insertion
+        // renumbers the whole listing and a "diff" there is noise dressed up
+        // as a saving. It still writes its baseline: the contract is a diff
+        // against the last listing this tool returned, whichever lane produced
+        // it.
+        const key = snapshotSurfaceKey(scope.workspaceId, scope.surfaceId, 'smart');
+        const attrs = `smart|${maxContentLength ?? 3000}`;
+        const baseline =
+          full || !page ? null : getSnapshotBaseline(key, attrs, snapshot.url || undefined);
+        const rendered = formatSnapshotResult(baseline?.text ?? null, text);
+        setSnapshotBaseline(key, attrs, text, snapshot.url || undefined);
+
         return {
-          content: [{ type: 'text' as const, text: lines.join('\n') }],
+          content: [{ type: 'text' as const, text: rendered.text }],
         };
       } catch (error) {
         const message = describeToolError(error);

--- a/src/mcp/playwright/tools/extraction.ts
+++ b/src/mcp/playwright/tools/extraction.ts
@@ -2,7 +2,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
-import { getSmartSnapshot, getSmartSnapshotViaEval } from '../dom-intelligence';
+import { getSmartSnapshot, getSmartSnapshotViaEval, smartPageToken } from '../dom-intelligence';
 import { extractMarkdown, extractStructuredData } from '../markdown-extractor';
 import { resolveEvaluator, rpcEvaluator } from '../page-eval';
 import { formatSnapshotResult } from '../snapshotDiff';
@@ -77,9 +77,13 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
         // available (packaged builds, issue #105) fall back to a DOM-based
         // snapshot over the RPC channel.
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
+        const capLength = maxContentLength ?? 3000;
         const snapshot = page
-          ? await getSmartSnapshot(page, { maxContentLength: maxContentLength ?? 3000 })
-          : await getSmartSnapshotViaEval(rpcEvaluator(scope), { maxContentLength: maxContentLength ?? 3000 });
+          ? await getSmartSnapshot(page, { maxContentLength: capLength, surfaceId: scope.surfaceId })
+          : await getSmartSnapshotViaEval(rpcEvaluator(scope), {
+              maxContentLength: capLength,
+              surfaceId: scope.surfaceId,
+            });
 
         // Format the snapshot output: indexed elements + content summary
         const lines: string[] = [];
@@ -113,15 +117,34 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
         // as a saving. It still writes its baseline: the contract is a diff
         // against the last listing this tool returned, whichever lane produced
         // it.
+        //
+        // The attrs key carries the lane and, on the CDP lane, the page token
+        // (review 5 and 7 and 4). The lane, because the two number their refs
+        // differently and a positional listing is not a baseline an identity
+        // listing may be diffed against. The token, because one surface key
+        // covers every tab on that surface and survives a reload — and neither
+        // a second tab on the same URL nor a fresh document is something the
+        // URL guard alone can see, so both would have been answered with
+        // "(no changes since previous snapshot)" about a page never compared.
         const key = snapshotSurfaceKey(scope.workspaceId, scope.surfaceId, 'smart');
-        const attrs = `smart|${maxContentLength ?? 3000}`;
+        const attrs = page
+          ? `smart|cdp|${smartPageToken(page)}|${capLength}`
+          : `smart|rpc|${capLength}`;
         const baseline =
           full || !page ? null : getSnapshotBaseline(key, attrs, snapshot.url || undefined);
         const rendered = formatSnapshotResult(baseline?.text ?? null, text);
         setSnapshotBaseline(key, attrs, text, snapshot.url || undefined);
 
+        // The content summary is cut at maxContentLength, so a diff — "(no
+        // changes)" most of all — speaks only for what fits (review 10).
+        const truncated = snapshot.content.endsWith('... (truncated)');
+        const note =
+          rendered.usedDiff && truncated
+            ? `\n(page text is capped at ${capLength} characters; anything past the cut is not compared)`
+            : '';
+
         return {
-          content: [{ type: 'text' as const, text: rendered.text }],
+          content: [{ type: 'text' as const, text: rendered.text + note }],
         };
       } catch (error) {
         const message = describeToolError(error);

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -9,7 +9,7 @@ import {
   isOutstandingFrameRef,
   resolveRef,
 } from '../snapshot';
-import { getLocatorByRef } from '../dom-intelligence';
+import { getLocatorByRef, resolveSmartRefLocator } from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
 import { describeToolError } from '../toolError';
 import {
@@ -460,13 +460,18 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
           try {
             if (smartRef !== undefined) {
+              // Ref-keyed, not `cache[smartRef - 1]`: smart refs are keyed on
+              // DOM node identity now, so the cache is no longer a dense 1..n
+              // range. `selector` stays whatever the snapshot stored — that is
+              // what the trace has always recorded — while the click itself
+              // goes through the locator resolveSmartRefLocator rebuilds.
               const selector = getLocatorByRef(smartRef);
-              if (!selector) {
+              const locator = resolveSmartRefLocator(page, smartRef);
+              if (!selector || !locator) {
                 throw new Error(
                   `Element with smartRef=${smartRef} not found. Run browser_smart_snapshot to get current refs.`,
                 );
               }
-              const locator = page.locator(selector);
               if (double) await locator.dblclick();
               else await locator.click();
               recordAction(deps, {

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -9,7 +9,7 @@ import {
   isOutstandingFrameRef,
   resolveRef,
 } from '../snapshot';
-import { getLocatorByRef, resolveSmartRefLocator } from '../dom-intelligence';
+import { getLocatorByRef, resolveSmartRefLocator, smartRefAxisEntry } from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
 import { describeToolError } from '../toolError';
 import {
@@ -462,23 +462,23 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             if (smartRef !== undefined) {
               // Ref-keyed, not `cache[smartRef - 1]`: smart refs are keyed on
               // DOM node identity now, so the cache is no longer a dense 1..n
-              // range. `selector` stays whatever the snapshot stored — that is
-              // what the trace has always recorded — while the click itself
-              // goes through the locator resolveSmartRefLocator rebuilds.
-              const selector = getLocatorByRef(smartRef);
-              const locator = resolveSmartRefLocator(page, smartRef);
-              if (!selector || !locator) {
-                throw new Error(
-                  `Element with smartRef=${smartRef} not found. Run browser_smart_snapshot to get current refs.`,
-                );
-              }
+              // range. Throws StaleSmartRefError rather than clicking a
+              // substitute when the ref no longer names one live element.
+              const locator = await resolveSmartRefLocator(page, smartRef);
               if (double) await locator.dblclick();
               else await locator.click();
+              // A ref axis, not the css axis this used to record: the CDP
+              // lane's stored "locator" is getByRole SOURCE TEXT, which
+              // page.locator() cannot parse, so every replay of such a step
+              // failed while the live click succeeded. The RPC lane's selector
+              // is a real one and stays a css axis.
+              const axisEntry = smartRefAxisEntry(smartRef);
+              const selector = axisEntry ? undefined : getLocatorByRef(smartRef) ?? undefined;
               recordAction(deps, {
                 scope,
                 tool: 'browser_click',
                 page,
-                selector,
+                ...(axisEntry ? { refEntry: axisEntry } : { selector }),
                 ...(double && { args: { double: true } }),
               });
               return {


### PR DESCRIPTION
## What

`browser_smart_snapshot` now numbers its refs off DOM node identity (Playwright/CDP lane) and returns a diff against its previous output instead of the whole indexed listing every time. `full: true` opts a call out.

Two ordered commits, because the second is only worth having once the first lands:

1. **Identity-stable smart refs.** Refs were a running 1-based count over the accessibility walk, so one node inserted above an element renumbered it and everything after it. An agent replaying a `smartRef` from the previous snapshot clicked the neighbour, with nothing to notice. Refs are now minted off `backendDOMNodeId` — the same identity `browser_snapshot` adopted in #1124 — so an unchanged node keeps its ref, and numbers are retired rather than recycled when an element goes away.
2. **Auto-diff.** Reuses the existing baseline store (`snapshotCache.ts`) and the existing formatter (`formatSnapshotResult` in `snapshotDiff.ts`) — no diff logic is duplicated — so the same 50% / 800-line fallback applies and the first line always declares whether a full listing or a diff came back.

## Why

`browser_snapshot`'s auto-diff only became worth adopting once refs held still: a renumber rewrites near enough every line, and nothing came in under the "is this diff actually smaller" ratio. `browser_smart_snapshot` was still on positional refs and still re-sending its whole listing, which on an act-then-verify loop is the same few hundred lines over and over.

Ref stability is also a correctness fix in its own right, independent of the diff.

### Lanes

Only the Playwright/CDP lane gets identity refs and diffing. The RPC lane (packaged build, no Playwright `Page`) keeps positional refs: the only place it could hold identity is the `data-wmux-ref` attribute, and `browser_snapshot`'s RPC fallback strips every one of those document-wide and renumbers from 0 on each of its own scans (`buildDomSnapshotExpression`). An interleaved `browser_snapshot` would therefore either wipe the identity or leave 0-based numbers behind for the next smart scan to adopt as its own. That lane always returns the full listing; it still writes its baseline, because the contract is a diff against the last listing the tool returned, whichever lane produced it.

### Two things worth a second look

- **`browser_click({ smartRef })` on the CDP lane was broken.** `getSmartSnapshot` stores a locator as the source snippet `getByRole('button', { name: 'OK' })`, and `interaction.ts` handed that string to `page.locator()`, which parses it as CSS. Resolution goes through a new `resolveSmartRefLocator`, which rebuilds the call through the real `getByRole` API pinned with `.nth()` to the instance the ref was numbered against. It had to change with `getLocatorByRef` anyway — the cache is no longer a dense `1..n` range, so `cache[ref - 1]` is wrong.
- **Baselines are namespaced by tool.** The store held one entry per surface, so the two snapshot tools evicted each other on a shared surface. The attrs guard kept the output correct, but alternating them would have meant neither ever diffed. The per-surface cap doubles (8 -> 16) so the split does not halve the surfaces a diff survives across.

`browser_extract_text` is deliberately untouched.

## How tested

- New `src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts` (20 cases), mirroring `snapshot.refstability.test.ts` and `resolveRefViaAxMap`: an insertion above leaves surviving refs alone, a removed node's number is never reissued, a different document does not rewind, a fragment change is the same document, the name filter is exact, an unnamed element indexes against the whole-role population, `.nth()` pins the right instance among duplicate role+name, lookup is by stored ref rather than position, a node with no `backendDOMNodeId` is skipped, a toggled element keeps its ref, one accessibility tree is read per snapshot, and every staleness case (navigated, reloaded, element gone, population resized, wrong page) is refused rather than resolved.
- New `src/mcp/playwright/__tests__/extraction.diff.test.ts` (11 cases): the first call is full and the repeat is a diff, an unchanged page says so, a URL change falls back to full, `full: true` forces full without switching the diff off, a changed `maxContentLength` does not diff across, the RPC lane never diffs and never leaves a baseline the CDP lane will use, a same-URL reload and a second tab on the same URL both fall back to full, and a diff over truncated page text says so.
- New `src/mcp/playwright/__tests__/interaction.smartref.test.ts` (3 cases): the click lands on the element the ref names, the recorded axis is a replayable ref axis rather than the `getByRole` source text, and a stale ref is reported instead of clicking a substitute.
- Full local run of the CI `validate` job: `tsc --noEmit`, relay `tsc --noEmit`, lockfile lineage guard (no-op), `npm run build:mcp && npm run probe:mcp`, `npm run build:daemon`, `npm test` — 13,711 parallel tests and 197 runtime tests pass.
- MCP protocol baseline regenerated for the one changed tool description and the added `full` param. Full profile: 76,563 bytes against the 78,000 budget (was 76,410).

## Review round

A three-model panel read the first two commits; the third commit answers it, and the fourth is a follow-up correction. Both are in the diff above.

- **A stable ref number is not a stable element.** Every check `resolveRefViaAxMap` makes for `browser_snapshot` is now mirrored: the name filter runs with `exact: true` (a ref for "Save" was matching "Save draft"), an unnamed element is counted against the whole-role population that `getByRole(role)` actually returns, and a ref whose page navigated or reloaded, whose element is gone, or whose population changed size is refused with `StaleSmartRefError`. A click aimed at a page other than the one the snapshot was taken on is refused too — ref numbers restart per page and the cache is per connection.
- **Recorded clicks are replayable.** A smartRef click stored the source text of a `getByRole` call as a css axis, which `page.locator()` cannot parse: the live click succeeded and every replay of that step failed. It records the same ref axis `browser_snapshot` does.
- **A diff never crosses a lane, a document, or a page.** The attrs key carries the lane and, on the CDP lane, a page token that changes on every main-frame navigation.
- **The identity map is trimmed at the cap, not on every snapshot.** An intermediate version pruned to the nodes each walk saw, which charged for the bound on every ordinary interaction: a menu that closes and reopens, or a row scrolled out of a virtualised list, came back with a new ref — a diff line per cycle. The trim now waits for `SMART_REF_IDENTITY_CAP`; over it, entries the walk did not see go first, and only a live page that alone exceeds the cap drops the map whole. Document boundaries still clear it outright.
- **Frames need no change here, and that is measured, not assumed.** `Accessibility.getFullAXTree` on a page target stops at the `<iframe>` element — `childIds: []`, the child document absent, same-origin or not (snapshot.ts, measured on Chrome 141). `browser_snapshot` reaches frame contents only by grafting them with an extra per-frame call, which this walk never makes. So every `backendDOMNodeId` it sees came from one document (the flat identity map is right) and its `sameNameIndex` population is the same set `page.getByRole` sweeps. A test pins the single `getFullAXTree` call.
- Smaller: nodes with no `backendDOMNodeId` are skipped rather than drawing a fresh number every snapshot, the population key is NUL-separated, and a diff over a page text cut at `maxContentLength` says the comparison is partial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Smart snapshots now return indexed-listing diffs between calls, with complete-listing fallbacks when needed.
  - Use `full: true` to request a complete snapshot and refresh the comparison baseline.
  - Snapshot responses indicate whether they contain a full listing or a diff.
  - Smart references remain tied to page elements across updates and support replayable saved flows.
  - Clicking elements by smart reference now works reliably on live pages.

- **Bug Fixes**
  - Stale or ambiguous references are now rejected instead of targeting the wrong element.
  - Complete listings are preserved when element identity is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
