### PR TITLE
Opt into the core MCP tool profile, and stop overwriting the choice

### DIFF
--- a/changelog.d/1167.md
+++ b/changelog.d/1167.md
@@ -1,0 +1,24 @@
+### Added
+
+- **The `core` MCP tool profile can now be selected: `wmux mcp register --profile core`.**
+  The profile itself shipped earlier, but nothing could actually choose it — every
+  registration path wrote the full entry regardless. `core` drops the `browser_*`
+  family, cutting roughly 27 KB of schema off the `tools/list` an agent reads
+  before it does any work; it is an optimization, not a permission boundary, so a
+  core-mode agent keeps exactly the authority an ordinary one has. Use it for
+  hosts doing terminal, pane, workspace, channel, and delegation work that never
+  touch the browser. `--profile full` moves a host back.
+
+  The default is unchanged and stays `full`: the browser tools are first-class,
+  and an agent driving the workspace browser works with nothing to wire up
+  precisely because the default registration carries them.
+
+### Fixed
+
+- **A profile you chose is no longer overwritten the next time wmux registers.**
+  Re-registration happens on its own — at app boot, and whenever an upgrade moves
+  the bundle path — and it used to rewrite the entry as the full profile every
+  time, silently undoing a hand-added `--core`. Registration without an explicit
+  `--profile` now preserves whatever profile the entry already carries, and only a
+  brand-new entry gets the default. `--commander` entries are preserved the same
+  way.

--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -156,6 +156,18 @@ The full list lives in `src/shared/rpc.ts` (`ALL_RPC_METHODS`). For the MCP-faci
 
 The wmux MCP server (hosted in-process, named-pipe transport to the daemon) exposes a curated subset of the RPC surface as MCP tools. Tool names match `mcp__wmux__<tool>` when used from a Claude Desktop / Claude Code client.
 
+### Tool profiles
+
+The surface a server registers is chosen once, by a launch argument in the host config's `args` — never by an environment variable, so an env-stripping host cannot silently change it.
+
+| Profile | Launch arg | Contents |
+|---|---|---|
+| `full` | *(none)* | Every tool. **The default every registration writes.** |
+| `core` | `--core` | `full` minus `browser_*` (and any `company_*`), for agents that never touch the browser. Saves roughly 27 KB of `tools/list` schema per session. An optimization, not a permission boundary — a core-mode agent has exactly the authority an ordinary one does. |
+| `commander` | `--commander` | The orchestrator role surface. Set by the deck brain adapters at spawn time, not by host-config registration. |
+
+`wmux mcp register --profile core` opts a host into the smaller surface; `--profile full` moves it back. Registration without `--profile` **preserves** whatever profile the entry already carries, so an automatic re-registration (app boot, bundle-path refresh after an upgrade) never undoes the choice.
+
 ### Substrate surface (stable in v3.0)
 
 | MCP tool | Backs RPC method | Notes |

--- a/src/cli/commands/__tests__/mcp.test.ts
+++ b/src/cli/commands/__tests__/mcp.test.ts
@@ -21,7 +21,7 @@ vi.mock('net', () => ({ connect: connectMock, default: { connect: connectMock } 
 vi.mock('fs');
 
 import * as fs from 'fs';
-import { canConnectBrokerPipe, resolveWmuxScript } from '../mcp';
+import { canConnectBrokerPipe, resolveWmuxScript, selectedProfile } from '../mcp';
 
 const existsSyncMock = fs.existsSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -155,5 +155,28 @@ describe('canConnectBrokerPipe', () => {
   it('resolves false on connection error and never rejects', async () => {
     scriptConnect('error');
     await expect(canConnectBrokerPipe(300)).resolves.toBe(false);
+  });
+});
+
+describe('selectedProfile — `wmux mcp register --profile`', () => {
+  it('is undefined when the flag is absent (= preserve what is on disk)', () => {
+    // Not 'full': "no flag" must NOT mean "write the default", or every
+    // re-register would undo an opted-in --core.
+    expect(selectedProfile(['register'])).toBeUndefined();
+    expect(selectedProfile(['register', '--target', 'claude', '--json'])).toBeUndefined();
+  });
+
+  it('parses both valid values, anywhere in the argv', () => {
+    expect(selectedProfile(['register', '--profile', 'core'])).toBe('core');
+    expect(selectedProfile(['register', '--profile', 'full'])).toBe('full');
+    expect(selectedProfile(['register', '--profile', 'core', '--json'])).toBe('core');
+    expect(selectedProfile(['register', '--json', '--profile', 'full'])).toBe('full');
+  });
+
+  it('returns null for an unknown or missing value so the caller can error out', () => {
+    // A typo must not silently register the default over someone's --core.
+    expect(selectedProfile(['register', '--profile', 'cores'])).toBeNull();
+    expect(selectedProfile(['register', '--profile', 'commander'])).toBeNull();
+    expect(selectedProfile(['register', '--profile'])).toBeNull();
   });
 });

--- a/src/cli/commands/__tests__/mcp.test.ts
+++ b/src/cli/commands/__tests__/mcp.test.ts
@@ -173,6 +173,17 @@ describe('selectedProfile — `wmux mcp register --profile`', () => {
     expect(selectedProfile(['register', '--json', '--profile', 'full'])).toBe('full');
   });
 
+  it('parses the attached --profile=<value> form', () => {
+    // The form most people reach for first. Parsing only the separated one let
+    // `--profile=core` fall through as "no flag" and print a success message
+    // for a registration that ignored the request.
+    expect(selectedProfile(['register', '--profile=core'])).toBe('core');
+    expect(selectedProfile(['register', '--profile=full'])).toBe('full');
+    expect(selectedProfile(['register', '--profile=core', '--json'])).toBe('core');
+    expect(selectedProfile(['register', '--profile=cores'])).toBeNull();
+    expect(selectedProfile(['register', '--profile='])).toBeNull();
+  });
+
   it('returns null for an unknown or missing value so the caller can error out', () => {
     // A typo must not silently register the default over someone's --core.
     expect(selectedProfile(['register', '--profile', 'cores'])).toBeNull();

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -15,6 +15,7 @@ import {
   unregisterTarget,
   type TargetRegStatus,
 } from '../../shared/mcpRegistration';
+import type { WmuxMcpEntryProfile } from '../../shared/configIO';
 
 /**
  * `wmux mcp …` — inspect / manage MCP registration across the installed agent
@@ -52,6 +53,14 @@ SUBCOMMANDS
 
 OPTIONS
   --target <id>  Limit to one agent: claude | codex | gemini (default: all).
+  --profile <p>  register only. Tool surface the registered server launches
+                 with: full | core (default: full).
+                   full  every tool, including the browser family.
+                   core  drops browser_* — about 27 KB less tools/list schema
+                         for agents that never touch the browser.
+                 Without this flag an existing entry KEEPS the profile it
+                 already has, so re-registering never undoes your choice.
+                 Pass --profile full to move a core entry back.
   --json         Output raw JSON (useful for scripting).
 `.trimStart();
 
@@ -68,6 +77,18 @@ function selectedTargets(args: string[]): McpTarget[] | null {
   const id = args[i + 1];
   const t = MCP_TARGETS.find((x) => x.id === id);
   return t ? [t] : null;
+}
+
+// The explicit `--profile` choice for `register`. `undefined` when the flag is
+// absent — that is "no opinion", and registerTarget then PRESERVES whatever
+// profile the config already carries. Returns null for an unrecognized value so
+// the caller can error out rather than silently registering the default: a
+// `--profile cores` typo must not quietly write `full` over someone's `core`.
+export function selectedProfile(args: string[]): WmuxMcpEntryProfile | null | undefined {
+  const i = args.indexOf('--profile');
+  if (i === -1) return undefined;
+  const value = args[i + 1];
+  return value === 'full' || value === 'core' ? value : null;
 }
 
 function formatModified(d: Date | null): string {
@@ -374,6 +395,13 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
     }
 
     case 'register': {
+      const profile = selectedProfile(args);
+      if (profile === null) {
+        const pi = args.indexOf('--profile');
+        console.error(`Unknown --profile "${args[pi + 1] ?? ''}". Valid: full, core.`);
+        process.exit(1);
+        return;
+      }
       // #1151 — explicit user action, so warn rather than skip: the target
       // configs are suffix-blind, so this writes the PRODUCTION entries even
       // when this CLI itself runs inside an isolated instance.
@@ -397,7 +425,7 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
       // issues are 'malformed'); capture them per-target so one failure neither
       // aborts the rest nor is silently swallowed.
       const results = targets.map((t) => {
-        try { return { target: t, result: registerTarget(t, home, wmuxScript), error: null as string | null }; }
+        try { return { target: t, result: registerTarget(t, home, wmuxScript, undefined, profile), error: null as string | null }; }
         catch (e) { return { target: t, result: null, error: e instanceof Error ? e.message : String(e) }; }
       });
       if (jsonMode) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -85,10 +85,27 @@ function selectedTargets(args: string[]): McpTarget[] | null {
 // the caller can error out rather than silently registering the default: a
 // `--profile cores` typo must not quietly write `full` over someone's `core`.
 export function selectedProfile(args: string[]): WmuxMcpEntryProfile | null | undefined {
+  const value = profileArgValue(args);
+  if (value === undefined) return undefined;
+  return value === 'full' || value === 'core' ? value : null;
+}
+
+/** The raw `--profile` value exactly as typed, or undefined when the flag is
+ *  absent. Accepts BOTH `--profile core` and `--profile=core`: the attached form
+ *  is what most people reach for, and parsing only the separated one meant
+ *  `--profile=core` silently fell through as "no flag" and printed a success
+ *  message for a registration that ignored the request. Exported so the error
+ *  path can echo the value back. */
+export function profileArgValue(args: string[]): string | undefined {
+  const inline = args.find((a) => a.startsWith('--profile='));
+  if (inline !== undefined) return inline.slice('--profile='.length);
   const i = args.indexOf('--profile');
   if (i === -1) return undefined;
-  const value = args[i + 1];
-  return value === 'full' || value === 'core' ? value : null;
+  // Present but with nothing after it (`wmux mcp register --profile`) is an
+  // ERROR, not an absent flag: `?? ''` keeps it distinguishable from undefined
+  // so it takes the same "unknown value" exit as a typo, rather than silently
+  // registering the default.
+  return args[i + 1] ?? '';
 }
 
 function formatModified(d: Date | null): string {
@@ -112,8 +129,11 @@ function printCheck(statuses: TargetRegStatus[], jsonMode: boolean): void {
       console.log(`  not detected — ${s.configPath}`);
       continue;
     }
-    const fmt = (srv: { registered: boolean; path: string | null }) =>
-      srv.registered ? `registered → ${srv.path}` : 'NOT REGISTERED';
+    // Show the profile alongside the path: the surface an entry launches with
+    // is invisible otherwise, and "registered" alone cannot answer "did my
+    // --profile core actually take?".
+    const fmt = (srv: { registered: boolean; path: string | null; profile: string | null }) =>
+      srv.registered ? `registered (${srv.profile}) → ${srv.path}` : 'NOT REGISTERED';
     console.log(`  wmux:   ${fmt(s.wmux)}`);
     console.log(`  config: ${s.configPath} (${formatModified(s.configModified)})`);
   }
@@ -397,8 +417,7 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
     case 'register': {
       const profile = selectedProfile(args);
       if (profile === null) {
-        const pi = args.indexOf('--profile');
-        console.error(`Unknown --profile "${args[pi + 1] ?? ''}". Valid: full, core.`);
+        console.error(`Unknown --profile "${profileArgValue(args) ?? ''}". Valid: full, core.`);
         process.exit(1);
         return;
       }
@@ -451,9 +470,12 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
         }
         if (result.wrote.length > 0) {
           wroteAny = true;
-          console.log(`${target.displayName}: wrote ${result.wrote.join(', ')} → ${result.configPath}`);
+          // Name the profile: without it there is no way to confirm a
+          // `--profile core` landed, or to notice that a profile-less register
+          // preserved a `core` you forgot about.
+          console.log(`${target.displayName}: wrote ${result.wrote.join(', ')} (${result.profile}) → ${result.configPath}`);
         } else {
-          console.log(`${target.displayName}: already up to date`);
+          console.log(`${target.displayName}: already up to date${result.profile ? ` (${result.profile})` : ''}`);
         }
         if (result.foreign.length > 0) {
           console.warn(`  left foreign key(s) ${result.foreign.join(', ')} untouched`);

--- a/src/main/mcp/McpRegistrar.ts
+++ b/src/main/mcp/McpRegistrar.ts
@@ -202,6 +202,10 @@ export class McpRegistrar {
 
       for (const target of MCP_TARGETS) {
         try {
+          // No profile argument on purpose. This is the AUTOMATIC path (boot,
+          // path refresh), and it must never overrule a profile the user chose
+          // with `wmux mcp register --profile`: omitting it preserves whatever
+          // the config already carries. Only that CLI flag sets one explicitly.
           const result = registerTarget(target, this.home, mcpScript, this.ownedFor(target.id));
           if (result.wrote.length > 0) {
             console.log(`[McpRegistrar] ${target.displayName}: wrote ${result.wrote.join(', ')} → ${result.configPath}`);

--- a/src/main/mcp/__tests__/McpRegistrar.test.ts
+++ b/src/main/mcp/__tests__/McpRegistrar.test.ts
@@ -51,7 +51,7 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
     for (const t of status.targets) {
       expect(t.configExists).toBe(false);
       expect(t.configModified).toBeNull();
-      expect(t.wmux).toEqual({ registered: false, path: null });
+      expect(t.wmux).toEqual({ registered: false, path: null, profile: null });
     }
     expect(target(status, 'claude').configPath).toBe(claudeJson());
     expect(target(status, 'codex').configPath).toBe(codexToml());
@@ -75,7 +75,7 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
     const claude = target(new McpRegistrar().getStatus(), 'claude');
     expect(claude.configExists).toBe(true);
     expect(claude.configModified).toBeInstanceOf(Date);
-    expect(claude.wmux).toEqual({ registered: true, path: '/abs/mcp-bundle/index.js' });
+    expect(claude.wmux).toEqual({ registered: true, path: '/abs/mcp-bundle/index.js', profile: 'full' });
   });
 
   it('extracts registered script paths from Codex TOML (mcp_servers table)', () => {
@@ -88,7 +88,7 @@ describe('McpRegistrar.getStatus (multi-target)', () => {
     const codex = target(new McpRegistrar().getStatus(), 'codex');
     expect(codex.configExists).toBe(true);
     expect(codex.format).toBe('toml');
-    expect(codex.wmux).toEqual({ registered: true, path: 'C:\\w\\index.js' });
+    expect(codex.wmux).toEqual({ registered: true, path: 'C:\\w\\index.js', profile: 'full' });
   });
 
   it('treats malformed entries / corrupt configs as not registered (no throw)', () => {

--- a/src/shared/__tests__/configIO.test.ts
+++ b/src/shared/__tests__/configIO.test.ts
@@ -12,6 +12,9 @@ import {
   upsertNotifyToml,
   removeNotifyToml,
   wmuxMcpEntry,
+  wmuxEntryArgs,
+  entryProfileFlags,
+  DEFAULT_HOST_PROFILE,
 } from '../configIO';
 
 // ── TOML (Codex) — surgical block, must preserve every other byte ────────────
@@ -275,5 +278,90 @@ describe('wmuxMcpEntry', () => {
       command: 'node',
       args: ['/opt/wmux/mcp.js', '--core'],
     });
+  });
+
+  it('defaults to the one profile constant every writer resolves through', () => {
+    // Pin the product default so flipping it is a deliberate one-line change
+    // that shows up here, not something a caller can drift into.
+    expect(DEFAULT_HOST_PROFILE).toBe('full');
+    expect(wmuxMcpEntry('/x.js').args).toEqual(wmuxMcpEntry('/x.js', DEFAULT_HOST_PROFILE).args);
+  });
+});
+
+// ── Profile threading + preservation ────────────────────────────────────────
+
+describe('wmuxEntryArgs / entryProfileFlags', () => {
+  it('reads the profile flags back off an existing entry', () => {
+    expect(entryProfileFlags(null)).toEqual([]);
+    expect(entryProfileFlags({ command: 'node', args: ['/x.js'] })).toEqual([]);
+    expect(entryProfileFlags({ command: 'node', args: ['/x.js', '--core'] })).toEqual(['--core']);
+    expect(entryProfileFlags({ command: 'node', args: ['/x.js', '--commander'] })).toEqual(['--commander']);
+    // A non-profile argv token is not mistaken for one.
+    expect(entryProfileFlags({ command: 'node', args: ['/x.js', '--verbose'] })).toEqual([]);
+  });
+
+  it('an explicit profile wins; omitting one preserves the existing entry', () => {
+    const core = { command: 'node', args: ['/old.js', '--core'] };
+    // explicit core / full
+    expect(wmuxEntryArgs('/x.js', 'core')).toEqual(['/x.js', '--core']);
+    expect(wmuxEntryArgs('/x.js', 'full')).toEqual(['/x.js']);
+    // explicit full walks a core entry back — the opt-in must be reversible
+    expect(wmuxEntryArgs('/x.js', 'full', core)).toEqual(['/x.js']);
+    // no opinion + existing core → preserved (this is the overwrite bug)
+    expect(wmuxEntryArgs('/x.js', undefined, core)).toEqual(['/x.js', '--core']);
+    // no opinion + no existing entry → the default
+    expect(wmuxEntryArgs('/x.js', undefined, null)).toEqual(['/x.js']);
+  });
+});
+
+describe('upsertMcpServer — launch profile', () => {
+  it('writes the default (full) entry when no profile is given', () => {
+    const json = JSON.parse(upsertMcpServer('', 'json', 'wmux', '/abs/index.js')) as
+      { mcpServers: Record<string, { args: string[] }> };
+    expect(json.mcpServers.wmux.args).toEqual(['/abs/index.js']);
+    expect(upsertMcpServer('', 'toml', 'wmux', '/abs/index.js')).toContain('args = ["/abs/index.js"]');
+  });
+
+  it('writes --core when the caller opts in (json + toml)', () => {
+    const json = JSON.parse(upsertMcpServer('', 'json', 'wmux', '/abs/index.js', 'core')) as
+      { mcpServers: Record<string, { command: string; args: string[] }> };
+    expect(json.mcpServers.wmux).toEqual({ command: 'node', args: ['/abs/index.js', '--core'] });
+    expect(upsertMcpServer('', 'toml', 'wmux', '/abs/index.js', 'core'))
+      .toContain('args = ["/abs/index.js", "--core"]');
+  });
+
+  it('PRESERVES a hand-edited --core across a profile-less rewrite (json)', () => {
+    // The regression this locks: an automatic re-registration (new bundle path
+    // on upgrade) used to rewrite the entry as `full`, silently undoing the
+    // user's opt-in on the next app launch.
+    const seeded = upsertMcpServer('', 'json', 'wmux', '/old/index.js', 'core');
+    const refreshed = JSON.parse(upsertMcpServer(seeded, 'json', 'wmux', '/new/index.js')) as
+      { mcpServers: Record<string, { args: string[] }> };
+    expect(refreshed.mcpServers.wmux.args).toEqual(['/new/index.js', '--core']);
+  });
+
+  it('PRESERVES a hand-edited --core across a profile-less rewrite (toml)', () => {
+    const seeded = upsertMcpServer(CODEX_CONFIG, 'toml', 'wmux', '/old/index.js', 'core');
+    expect(seeded).toContain('"--core"');
+    const refreshed = upsertMcpServer(seeded, 'toml', 'wmux', '/new/index.js');
+    expect(refreshed).toContain('args = ["/new/index.js", "--core"]');
+    // and the surgical-write guarantee still holds
+    expect(refreshed).toContain("[projects.'d:\\wmux']");
+  });
+
+  it('PRESERVES --commander, which no host writer ever emits itself', () => {
+    const seeded = JSON.stringify({
+      mcpServers: { wmux: { command: 'node', args: ['/old.js', '--commander'] } },
+    });
+    const refreshed = JSON.parse(upsertMcpServer(seeded, 'json', 'wmux', '/new.js')) as
+      { mcpServers: Record<string, { args: string[] }> };
+    expect(refreshed.mcpServers.wmux.args).toEqual(['/new.js', '--commander']);
+  });
+
+  it('an explicit full profile walks a --core entry back', () => {
+    const seeded = upsertMcpServer('', 'json', 'wmux', '/x.js', 'core');
+    const back = JSON.parse(upsertMcpServer(seeded, 'json', 'wmux', '/x.js', 'full')) as
+      { mcpServers: Record<string, { args: string[] }> };
+    expect(back.mcpServers.wmux.args).toEqual(['/x.js']);
   });
 });

--- a/src/shared/__tests__/configIO.test.ts
+++ b/src/shared/__tests__/configIO.test.ts
@@ -312,6 +312,26 @@ describe('wmuxEntryArgs / entryProfileFlags', () => {
     // no opinion + no existing entry → the default
     expect(wmuxEntryArgs('/x.js', undefined, null)).toEqual(['/x.js']);
   });
+
+  it('carries unrecognized argv tokens through instead of dropping them', () => {
+    // Only PROFILE_FLAGS are rewritten. Anything else — a user's own addition,
+    // or a flag from a newer wmux sharing this config — must survive, or every
+    // automatic re-registration would quietly delete it.
+    const custom = { command: 'node', args: ['/old.js', '--core', '--verbose'] };
+    expect(wmuxEntryArgs('/x.js', undefined, custom)).toEqual(['/x.js', '--core', '--verbose']);
+    // an explicit profile replaces the PROFILE flag only
+    expect(wmuxEntryArgs('/x.js', 'full', custom)).toEqual(['/x.js', '--verbose']);
+    expect(wmuxEntryArgs('/x.js', 'core', custom)).toEqual(['/x.js', '--core', '--verbose']);
+    // residual survives even with no profile flag present at all
+    expect(wmuxEntryArgs('/x.js', undefined, { command: 'node', args: ['/old.js', '--future-flag'] }))
+      .toEqual(['/x.js', '--future-flag']);
+  });
+
+  it('de-duplicates a hand-edited repeated profile flag', () => {
+    const dupe = { command: 'node', args: ['/old.js', '--core', '--core'] };
+    expect(entryProfileFlags(dupe)).toEqual(['--core']);
+    expect(wmuxEntryArgs('/x.js', undefined, dupe)).toEqual(['/x.js', '--core']);
+  });
 });
 
 describe('upsertMcpServer — launch profile', () => {

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -66,6 +66,46 @@ describe('registerTarget — Claude (json, createIfMissing)', () => {
   });
 });
 
+describe('registerTarget — launch profile', () => {
+  const argsOf = (): string[] => {
+    const parsed = JSON.parse(fs.readFileSync(claudeTarget.configPath(home), 'utf8')) as
+      { mcpServers: Record<string, { args: string[] }> };
+    return parsed.mcpServers.wmux.args;
+  };
+
+  it('registers the full surface by default', () => {
+    registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    expect(argsOf()).toEqual([WMUX_SCRIPT]);
+  });
+
+  it('registers --core when the caller opts in', () => {
+    registerTarget(claudeTarget, home, WMUX_SCRIPT, undefined, 'core');
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--core']);
+  });
+
+  it('a profile-less re-register PRESERVES an opted-in --core', () => {
+    registerTarget(claudeTarget, home, WMUX_SCRIPT, undefined, 'core');
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    expect(r.wrote).toEqual([]); // unchanged → still idempotent
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--core']);
+  });
+
+  it('a profile-less PATH refresh keeps --core while updating the script', () => {
+    registerTarget(claudeTarget, home, 'C:\\old\\index.js', undefined, 'core');
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    expect(r.wrote).toContain('wmux');
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--core']);
+  });
+
+  it('switching profile is a WRITE even when the script path is unchanged', () => {
+    // args[0] alone would call this "already up to date" and drop the change.
+    registerTarget(claudeTarget, home, WMUX_SCRIPT, undefined, 'core');
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT, undefined, 'full');
+    expect(r.wrote).toEqual(['wmux']);
+    expect(argsOf()).toEqual([WMUX_SCRIPT]);
+  });
+});
+
 describe('registerTarget — Codex (toml, only if installed)', () => {
   it('SKIPS when ~/.codex/config.toml does not exist (never created)', () => {
     const r = registerTarget(codexTarget, home, WMUX_SCRIPT);

--- a/src/shared/__tests__/mcpRegistration.test.ts
+++ b/src/shared/__tests__/mcpRegistration.test.ts
@@ -30,7 +30,7 @@ describe('registerTarget — Claude (json, createIfMissing)', () => {
     const r = registerTarget(claudeTarget, home, WMUX_SCRIPT);
     expect(r.skipped).toBeNull();
     expect(r.wrote).toEqual(['wmux']);
-    expect(readTargetStatus(claudeTarget, home).wmux).toEqual({ registered: true, path: WMUX_SCRIPT });
+    expect(readTargetStatus(claudeTarget, home).wmux).toEqual({ registered: true, path: WMUX_SCRIPT, profile: 'full' });
   });
 
   it('is idempotent — re-register writes nothing the second time', () => {
@@ -104,6 +104,76 @@ describe('registerTarget — launch profile', () => {
     expect(r.wrote).toEqual(['wmux']);
     expect(argsOf()).toEqual([WMUX_SCRIPT]);
   });
+
+  it('reports the profile in the register result and in readTargetStatus', () => {
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT, undefined, 'core');
+    expect(r.profile).toBe('core');
+    expect(readTargetStatus(claudeTarget, home).wmux.profile).toBe('core');
+    // a profile-less re-register still reports what is actually on disk
+    expect(registerTarget(claudeTarget, home, WMUX_SCRIPT).profile).toBe('core');
+  });
+
+  it('PRESERVES a custom argv token across a profile-less re-register, and stays idempotent', () => {
+    // The whole-array comparison must not turn "an arg we do not recognize"
+    // into "rewrite the entry without it" on every app boot.
+    const p = claudeTarget.configPath(home);
+    fs.writeFileSync(p, JSON.stringify({
+      mcpServers: { wmux: { command: 'node', args: [WMUX_SCRIPT, '--core', '--verbose'] } },
+    }), 'utf8');
+
+    const first = registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    expect(first.wrote).toEqual([]); // nothing to change → no write at all
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--core', '--verbose']);
+
+    const second = registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    expect(second.wrote).toEqual([]); // and it does not oscillate
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--core', '--verbose']);
+  });
+
+  it('keeps a custom argv token when a PATH refresh rewrites the entry', () => {
+    const p = claudeTarget.configPath(home);
+    fs.writeFileSync(p, JSON.stringify({
+      mcpServers: { wmux: { command: 'node', args: ['C:\\\\old\\\\index.js', '--verbose'] } },
+    }), 'utf8');
+    registerTarget(claudeTarget, home, WMUX_SCRIPT);
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--verbose']);
+  });
+
+  it('an explicit --profile full drops only --core, never a custom token', () => {
+    const p = claudeTarget.configPath(home);
+    fs.writeFileSync(p, JSON.stringify({
+      mcpServers: { wmux: { command: 'node', args: [WMUX_SCRIPT, '--core', '--verbose'] } },
+    }), 'utf8');
+    const r = registerTarget(claudeTarget, home, WMUX_SCRIPT, undefined, 'full');
+    expect(r.wrote).toEqual(['wmux']);
+    expect(argsOf()).toEqual([WMUX_SCRIPT, '--verbose']);
+  });
+});
+
+describe('registerTarget — launch profile on the TOML (Codex) target', () => {
+  const tomlArgs = (): string[] => {
+    const text = fs.readFileSync(codexTarget.configPath(home), 'utf8');
+    const m = text.match(/^args = \[(.*)\]$/m);
+    return m ? (JSON.parse(`[${m[1]}]`) as string[]) : [];
+  };
+
+  beforeEach(() => {
+    fs.mkdirSync(path.dirname(codexTarget.configPath(home)), { recursive: true });
+    fs.writeFileSync(codexTarget.configPath(home), 'model = "gpt-5.5"\n', 'utf8');
+  });
+
+  it('registers --core when the caller opts in', () => {
+    registerTarget(codexTarget, home, WMUX_SCRIPT, undefined, 'core');
+    expect(tomlArgs()).toEqual([WMUX_SCRIPT, '--core']);
+  });
+
+  it('a profile-less PATH refresh PRESERVES --core in the surgical TOML rewrite', () => {
+    registerTarget(codexTarget, home, 'C:\\old\\index.js', undefined, 'core');
+    registerTarget(codexTarget, home, WMUX_SCRIPT);
+    expect(tomlArgs()).toEqual([WMUX_SCRIPT, '--core']);
+    // the surrounding config is still byte-preserved
+    expect(fs.readFileSync(codexTarget.configPath(home), 'utf8')).toContain('model = "gpt-5.5"');
+  });
 });
 
 describe('registerTarget — Codex (toml, only if installed)', () => {
@@ -126,7 +196,7 @@ describe('registerTarget — Codex (toml, only if installed)', () => {
     expect(after).toContain('# hand-written');
     expect(after).toContain(`[projects.'d:\\wmux']`); // backslash key NOT corrupted
     expect(after).toContain('[mcp_servers.wmux]');
-    expect(readTargetStatus(codexTarget, home).wmux).toEqual({ registered: true, path: WMUX_SCRIPT });
+    expect(readTargetStatus(codexTarget, home).wmux).toEqual({ registered: true, path: WMUX_SCRIPT, profile: 'full' });
   });
 
   it('leaves a malformed config.toml untouched (never clobbers)', () => {

--- a/src/shared/configIO.ts
+++ b/src/shared/configIO.ts
@@ -15,14 +15,22 @@
 //          a surgical append; this matches it.)
 //
 //   ┌─ upsertMcpServer ────────────────────────────────────────────────┐
-//   │ json:  parse → mcpServers[key] = {command:'node',args:[script]}   │
+//   │ resolve args = [script, ...profile flags]  (wmuxEntryArgs)         │
+//   │ json:  parse → mcpServers[key] = {command:'node', args}            │
 //   │        → JSON.stringify(2-space)                                   │
 //   │ toml:  find [mcp_servers.<key>] block → replace, else append       │
 //   └────────────────────────────────────────────────────────────────────┘
+//
+// PROFILE — the surface the registered server launches with (DEFAULT_HOST_
+// PROFILE below) is threaded through upsertMcpServer to every writer, so one
+// constant decides what a fresh registration gets. An explicit caller profile
+// wins; omitting it preserves the profile already on disk, which is what keeps
+// an automatic re-registration from undoing a user's `--core`.
 
 import { parse as parseTomlText } from 'smol-toml';
 import type { McpConfigFormat } from './mcpTargets';
 import { CORE_MODE_ARG } from './coreSurface';
+import { COMMANDER_MODE_ARG } from './commanderSurface';
 
 /** Thrown when a config file is present but unparseable. Callers choose: abort
  *  a write (never clobber a file we can't understand) vs. report "not
@@ -42,27 +50,76 @@ export interface McpServerEntry {
 // The wmux MCP entry shape written into every target. `node` (not the Electron
 // execPath) + the absolute bundle script. No `env` field — Claude Code may
 // replace rather than merge the subprocess environment.
-// Optional launch-time surface profile. Omitted (or 'full') keeps the
-// compatibility default; 'core' appends CORE_MODE_ARG so the child registers
-// the browser-free / company-free surface. The flag lives in `args` rather
-// than `env` on purpose: Claude Code may replace the subprocess environment,
-// so an env-carried profile could silently change between launches.
 //
-// NOT YET THREADED THROUGH THE WRITERS. upsertMcpServer takes no profile, so
-// every registration path still writes the `full` entry — which also means a
-// hand-added `--core` in a user's config is replaced on the next upsert. Wiring
-// a profile choice through mcpTargets and the settings UI is deliberately a
-// separate change; this signature exists so the flag has one owner when that
-// lands, not so callers can half-use it today.
+// The launch-time surface profile rides in `args`, not `env`, on purpose:
+// Claude Code may replace the subprocess environment, so an env-carried profile
+// could silently change between launches.
 export type WmuxMcpEntryProfile = 'full' | 'core';
+
+/**
+ * The profile every registration path writes unless the user asks for another.
+ *
+ * `full`, deliberately: the browser tools are first-class here — an agent
+ * driving the workspace browser is a headline capability, and it works with
+ * nothing to wire up precisely because the default registration carries
+ * `browser_*`. `core` is an opt-in for hosts that do not need the browser
+ * surface and would rather not pay ~27 KB of `tools/list` schema for it.
+ *
+ * ONE owner for the value: every writer resolves through here, so changing the
+ * product default is a one-line change rather than an audit of each caller.
+ */
+export const DEFAULT_HOST_PROFILE: WmuxMcpEntryProfile = 'full';
+
+/** Every argv flag that selects a launch profile. Used to READ a profile back
+ *  off an existing entry, which is what makes a rewrite preserve the user's
+ *  choice. `--commander` is included because it must survive a rewrite too,
+ *  even though no host-config writer ever emits it (the deck brain adapters
+ *  pass it at spawn time). */
+const PROFILE_FLAGS: readonly string[] = [CORE_MODE_ARG, COMMANDER_MODE_ARG];
+
+/** The argv flags a profile contributes. `full` is the bare surface — it adds
+ *  no flag at all, which is also why it stays wire-compatible with every entry
+ *  wmux has ever written. */
+function profileFlags(profile: WmuxMcpEntryProfile): string[] {
+  return profile === 'core' ? [CORE_MODE_ARG] : [];
+}
+
+/** The profile flags an already-written entry carries, in argv order. Empty for
+ *  a `full` entry, a missing entry, or a foreign one. */
+export function entryProfileFlags(entry: McpServerEntry | null): string[] {
+  if (!entry) return [];
+  return entry.args.filter((arg) => PROFILE_FLAGS.includes(arg));
+}
+
+/**
+ * The full `args` array for a wmux entry: the script, then the profile flags.
+ *
+ * `profile` is the CALLER'S EXPLICIT CHOICE and always wins — that is how
+ * `wmux mcp register --profile full` walks a config back off `core`. Omitting
+ * it means "I have no opinion", which is the case for every automatic
+ * re-registration (app boot, path refresh). Those PRESERVE whatever profile the
+ * entry already carries and fall back to {@link DEFAULT_HOST_PROFILE} only for
+ * an entry that does not exist yet. Without that, a routine path refresh would
+ * silently undo a user's `--core` on the next launch.
+ */
+export function wmuxEntryArgs(
+  scriptPath: string,
+  profile?: WmuxMcpEntryProfile,
+  existing?: McpServerEntry | null,
+): string[] {
+  const flags = profile
+    ? profileFlags(profile)
+    : (entryProfileFlags(existing ?? null).length > 0
+        ? entryProfileFlags(existing ?? null)
+        : profileFlags(DEFAULT_HOST_PROFILE));
+  return [scriptPath, ...flags];
+}
 
 export function wmuxMcpEntry(
   scriptPath: string,
-  profile: WmuxMcpEntryProfile = 'full',
+  profile: WmuxMcpEntryProfile = DEFAULT_HOST_PROFILE,
 ): McpServerEntry & { command: string } {
-  const args = [scriptPath];
-  if (profile === 'core') args.push(CORE_MODE_ARG);
-  return { command: 'node', args };
+  return { command: 'node', args: wmuxEntryArgs(scriptPath, profile) };
 }
 
 /** The container key that holds MCP server definitions for a given format.
@@ -140,12 +197,12 @@ export function isWmuxOwnedEntry(entry: McpServerEntry | null): boolean {
 
 // ── JSON writers (object round-trip — lossless, JSON has no comments) ────────
 
-function upsertJson(text: string, key: string, scriptPath: string): string {
+function upsertJson(text: string, key: string, args: string[]): string {
   const config = parseConfig(text, 'json');
   const servers = (config.mcpServers && typeof config.mcpServers === 'object'
     ? config.mcpServers
     : (config.mcpServers = {})) as Record<string, unknown>;
-  servers[key] = wmuxMcpEntry(scriptPath);
+  servers[key] = { command: 'node', args };
   return JSON.stringify(config, null, 2) + '\n';
 }
 
@@ -258,24 +315,23 @@ function tomlKeySegment(key: string): string {
 }
 
 /** The canonical wmux block text (no leading/trailing blank lines). */
-function tomlBlock(key: string, scriptPath: string, eol: string): string {
+function tomlBlock(key: string, args: string[], eol: string): string {
   // JSON.stringify yields a valid TOML basic string for the path (escapes \ and
   // " the same way TOML does), so Windows backslash paths round-trip correctly.
-  // Derive args from wmuxMcpEntry rather than restating `[scriptPath]`: the
-  // JSON writer already goes through it, and two hand-kept arg lists would let
-  // a TOML host and a JSON host end up on different surfaces.
-  const entry = wmuxMcpEntry(scriptPath);
+  // Both writers are handed the SAME resolved `args` by upsertMcpServer rather
+  // than each rebuilding one: two hand-kept arg lists would let a TOML host and
+  // a JSON host end up on different surfaces.
   return [
     `[mcp_servers.${tomlKeySegment(key)}]`,
-    `command = ${JSON.stringify(entry.command)}`,
-    `args = [${entry.args.map((arg) => JSON.stringify(arg)).join(', ')}]`,
+    `command = ${JSON.stringify('node')}`,
+    `args = [${args.map((arg) => JSON.stringify(arg)).join(', ')}]`,
   ].join(eol);
 }
 
-function upsertToml(text: string, key: string, scriptPath: string): string {
+function upsertToml(text: string, key: string, args: string[]): string {
   const eol = detectEol(text);
   const lines = text.split(/\r?\n/);
-  const blockLines = tomlBlock(key, scriptPath, eol).split(eol);
+  const blockLines = tomlBlock(key, args, eol).split(eol);
   const range = findTomlBlockRange(lines, key);
   let result: string[];
   if (range) {
@@ -311,17 +367,22 @@ function removeToml(text: string, keys: string[]): string {
 // ── Unified text→text API used by McpRegistrar + CLI ─────────────────────────
 
 /** Return new file text with `key` set to the wmux `node <script>` entry.
- *  Throws ConfigParseError if the existing text is malformed (caller aborts). */
+ *  Throws ConfigParseError if the existing text is malformed (caller aborts).
+ *
+ *  `profile` is the caller's explicit choice; omit it to preserve whatever
+ *  profile the existing entry carries (see {@link wmuxEntryArgs}). */
 export function upsertMcpServer(
   text: string,
   format: McpConfigFormat,
   key: string,
   scriptPath: string,
+  profile?: WmuxMcpEntryProfile,
 ): string {
   // Validate parseability up-front so a malformed file aborts instead of being
   // clobbered (TOML append would otherwise blindly tack a block onto garbage).
-  parseConfig(text, format);
-  const out = format === 'json' ? upsertJson(text, key, scriptPath) : upsertToml(text, key, scriptPath);
+  const parsed = parseConfig(text, format);
+  const args = wmuxEntryArgs(scriptPath, profile, getMcpServerEntry(parsed, format, key));
+  const out = format === 'json' ? upsertJson(text, key, args) : upsertToml(text, key, args);
   // Never RETURN invalid TOML: the line-based surgical editor can't target an
   // inline-table entry (`wmux = { ... }` under `[mcp_servers]`) and would append
   // a duplicate table. Validate the output and throw rather than hand a caller a

--- a/src/shared/configIO.ts
+++ b/src/shared/configIO.ts
@@ -15,7 +15,7 @@
 //          a surgical append; this matches it.)
 //
 //   ┌─ upsertMcpServer ────────────────────────────────────────────────┐
-//   │ resolve args = [script, ...profile flags]  (wmuxEntryArgs)         │
+//   │ resolve args = [script, ...profile flags, ...residual] (wmuxEntryArgs) │
 //   │ json:  parse → mcpServers[key] = {command:'node', args}            │
 //   │        → JSON.stringify(2-space)                                   │
 //   │ toml:  find [mcp_servers.<key>] block → replace, else append       │
@@ -84,15 +84,26 @@ function profileFlags(profile: WmuxMcpEntryProfile): string[] {
   return profile === 'core' ? [CORE_MODE_ARG] : [];
 }
 
-/** The profile flags an already-written entry carries, in argv order. Empty for
- *  a `full` entry, a missing entry, or a foreign one. */
+/** The profile flags an already-written entry carries, in argv order,
+ *  de-duplicated (a hand-edited `--core --core` collapses to one). Empty for a
+ *  `full` entry, a missing entry, or a foreign one. args[0] is the script path,
+ *  never a flag, so it is skipped. */
 export function entryProfileFlags(entry: McpServerEntry | null): string[] {
   if (!entry) return [];
-  return entry.args.filter((arg) => PROFILE_FLAGS.includes(arg));
+  return [...new Set(entry.args.slice(1).filter((arg) => PROFILE_FLAGS.includes(arg)))];
+}
+
+/** Everything after the script path that is NOT a profile flag: a token the
+ *  user added by hand, or one written by a NEWER wmux than the one rewriting
+ *  this file. */
+function entryResidualArgs(entry: McpServerEntry | null): string[] {
+  if (!entry) return [];
+  return entry.args.slice(1).filter((arg) => !PROFILE_FLAGS.includes(arg));
 }
 
 /**
- * The full `args` array for a wmux entry: the script, then the profile flags.
+ * The full `args` array for a wmux entry: the script, the profile flags, then
+ * every other token the existing entry carried.
  *
  * `profile` is the CALLER'S EXPLICIT CHOICE and always wins — that is how
  * `wmux mcp register --profile full` walks a config back off `core`. Omitting
@@ -101,18 +112,25 @@ export function entryProfileFlags(entry: McpServerEntry | null): string[] {
  * entry already carries and fall back to {@link DEFAULT_HOST_PROFILE} only for
  * an entry that does not exist yet. Without that, a routine path refresh would
  * silently undo a user's `--core` on the next launch.
+ *
+ * RESIDUAL TOKENS PASS THROUGH VERBATIM, and that is load-bearing: this
+ * function REWRITES only the args it recognises. Rebuilding the array from a
+ * whitelist instead would make every automatic re-registration quietly delete a
+ * token wmux did not put there — a user's own addition, or a flag from a newer
+ * wmux sharing the config (two installs, or a downgrade). The registration path
+ * is not a place to have opinions about argv it does not own.
  */
 export function wmuxEntryArgs(
   scriptPath: string,
   profile?: WmuxMcpEntryProfile,
   existing?: McpServerEntry | null,
 ): string[] {
+  const entry = existing ?? null;
+  const existingFlags = entryProfileFlags(entry);
   const flags = profile
     ? profileFlags(profile)
-    : (entryProfileFlags(existing ?? null).length > 0
-        ? entryProfileFlags(existing ?? null)
-        : profileFlags(DEFAULT_HOST_PROFILE));
-  return [scriptPath, ...flags];
+    : (existingFlags.length > 0 ? existingFlags : profileFlags(DEFAULT_HOST_PROFILE));
+  return [scriptPath, ...flags, ...entryResidualArgs(entry)];
 }
 
 export function wmuxMcpEntry(

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -21,6 +21,8 @@ import {
   type McpTarget,
   type McpConfigFormat,
 } from './mcpTargets';
+import { CORE_MODE_ARG } from './coreSurface';
+import { COMMANDER_MODE_ARG } from './commanderSurface';
 import {
   parseConfig,
   getMcpServerEntry,
@@ -28,16 +30,24 @@ import {
   isWmuxOwnedEntry,
   upsertMcpServer,
   wmuxEntryArgs,
+  entryProfileFlags,
   removeMcpServers,
   isWmuxOwnedNotify,
   upsertNotifyToml,
   removeNotifyToml,
   type WmuxMcpEntryProfile,
+  type McpServerEntry,
 } from './configIO';
+
+/** The surface a registered entry launches with, read back off its argv. Null
+ *  when nothing is registered. `commander` can appear even though no host
+ *  writer emits it — a hand-edited or externally-managed entry can carry it. */
+export type RegisteredProfile = 'full' | 'core' | 'commander';
 
 export interface ServerRegState {
   registered: boolean;
   path: string | null;
+  profile: RegisteredProfile | null;
 }
 
 export interface TargetRegStatus {
@@ -82,10 +92,14 @@ export function readTargetStatus(target: McpTarget, home: string): TargetRegStat
   }
 
   let wmuxPath: string | null = null;
+  let wmuxProfile: RegisteredProfile | null = null;
   if (configExists) {
     try {
       const parsed = parseConfig(fs.readFileSync(configPath, 'utf8'), target.format);
       wmuxPath = getMcpServerScript(parsed, target.format, WMUX_SERVER_KEY);
+      if (wmuxPath !== null) {
+        wmuxProfile = profileOf(getMcpServerEntry(parsed, target.format, WMUX_SERVER_KEY));
+      }
     } catch {
       // corrupted → not registered
     }
@@ -99,8 +113,19 @@ export function readTargetStatus(target: McpTarget, home: string): TargetRegStat
     configExists,
     configModified,
     verified: target.verified,
-    wmux: { registered: wmuxPath !== null, path: wmuxPath },
+    wmux: { registered: wmuxPath !== null, path: wmuxPath, profile: wmuxProfile },
   };
+}
+
+/** Name the surface an entry's argv selects. `commander` wins over `core` the
+ *  same way the server itself resolves a contradictory launch (see
+ *  src/mcp/index.ts): the security role beats the optimization flag. An entry
+ *  with no profile flag is `full`. */
+export function profileOf(entry: McpServerEntry | null): RegisteredProfile {
+  const flags = entryProfileFlags(entry);
+  if (flags.includes(COMMANDER_MODE_ARG)) return 'commander';
+  if (flags.includes(CORE_MODE_ARG)) return 'core';
+  return 'full';
 }
 
 export function readAllTargetStatuses(home: string): TargetRegStatus[] {
@@ -119,6 +144,10 @@ export interface RegisterTargetResult {
   wrote: string[];
   /** keys left untouched because a foreign (non-node) entry occupies them. */
   foreign: string[];
+  /** The surface the wmux entry carries AFTER this call — what the caller
+   *  asked for, or what was preserved. Null when nothing was registered
+   *  (skipped / foreign), so "no entry" is distinguishable from "full". */
+  profile: RegisteredProfile | null;
 }
 
 /**
@@ -140,7 +169,7 @@ export function registerTarget(
   const configPath = target.configPath(home);
   const exists = fs.existsSync(configPath);
   if (!exists && !target.createIfMissing) {
-    return { configPath, skipped: 'absent', wrote: [], foreign: [] };
+    return { configPath, skipped: 'absent', wrote: [], foreign: [], profile: null };
   }
 
   let text = '';
@@ -148,7 +177,7 @@ export function registerTarget(
     try {
       text = fs.readFileSync(configPath, 'utf8');
     } catch {
-      return { configPath, skipped: 'malformed', wrote: [], foreign: [] };
+      return { configPath, skipped: 'malformed', wrote: [], foreign: [], profile: null };
     }
   }
 
@@ -156,12 +185,15 @@ export function registerTarget(
   try {
     parsed = parseConfig(text, target.format);
   } catch {
-    return { configPath, skipped: 'malformed', wrote: [], foreign: [] };
+    return { configPath, skipped: 'malformed', wrote: [], foreign: [], profile: null };
   }
 
   let newText = text;
   const wrote: string[] = [];
   const foreign: string[] = [];
+  // The surface the entry ends up on. Stays null for a foreign key so callers
+  // can tell "we left someone else's entry alone" from "it is on full".
+  let resultProfile: RegisteredProfile | null = null;
   // Build + validate the new text. Parse/edit failures mean the config is in a
   // shape we can't safely edit → 'malformed' (graceful skip, never clobber).
   // The actual WRITE is intentionally OUTSIDE this catch so a permission/rename
@@ -184,6 +216,7 @@ export function registerTarget(
       ) {
         ownedKeys?.add(WMUX_SERVER_KEY); // already up to date
         skip = true;
+        resultProfile = profileOf(existing);
       }
       // else: ours but stale path / different profile → update below
     }
@@ -193,6 +226,10 @@ export function registerTarget(
       newText = upsertMcpServer(newText, target.format, WMUX_SERVER_KEY, wmuxScript, profile);
       wrote.push(WMUX_SERVER_KEY);
       ownedKeys?.add(WMUX_SERVER_KEY);
+      resultProfile = profileOf({
+        command: 'node',
+        args: wmuxEntryArgs(wmuxScript, profile, existing),
+      });
     }
 
     // Legacy cleanup only applies to Claude's JSON (old wmux-playwright keys
@@ -201,11 +238,11 @@ export function registerTarget(
       newText = removeMcpServers(newText, 'json', ['wmux-playwright', 'wmux-devtools', 'wmux-a2a']);
     }
   } catch {
-    return { configPath, skipped: 'malformed', wrote: [], foreign };
+    return { configPath, skipped: 'malformed', wrote: [], foreign, profile: null };
   }
 
   if (newText !== text) writeFileAtomic(configPath, newText); // write errors propagate
-  return { configPath, skipped: null, wrote, foreign };
+  return { configPath, skipped: null, wrote, foreign, profile: resultProfile };
 }
 
 export interface UnregisterTargetResult {

--- a/src/shared/mcpRegistration.ts
+++ b/src/shared/mcpRegistration.ts
@@ -27,10 +27,12 @@ import {
   getMcpServerScript,
   isWmuxOwnedEntry,
   upsertMcpServer,
+  wmuxEntryArgs,
   removeMcpServers,
   isWmuxOwnedNotify,
   upsertNotifyToml,
   removeNotifyToml,
+  type WmuxMcpEntryProfile,
 } from './configIO';
 
 export interface ServerRegState {
@@ -105,6 +107,10 @@ export function readAllTargetStatuses(home: string): TargetRegStatus[] {
   return MCP_TARGETS.map((t) => readTargetStatus(t, home));
 }
 
+function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
 export interface RegisterTargetResult {
   configPath: string;
   /** 'absent' = uninstalled (skipped, not created); 'malformed' = corrupt (untouched). */
@@ -119,12 +125,17 @@ export interface RegisterTargetResult {
  * Ensure the `wmux` MCP server points at `wmuxScript` in one target's config.
  * `ownedKeys` (optional) tracks keys written this session so a key wmux already
  * owns is updated even if its on-disk shape looks foreign-adjacent.
+ *
+ * `profile` (optional) is an explicit surface choice — `wmux mcp register
+ * --profile core|full`. Automatic callers (McpRegistrar on boot, lifecycle
+ * refresh) pass nothing, which preserves the profile already on disk.
  */
 export function registerTarget(
   target: McpTarget,
   home: string,
   wmuxScript: string,
   ownedKeys?: Set<string>,
+  profile?: WmuxMcpEntryProfile,
 ): RegisterTargetResult {
   const configPath = target.configPath(home);
   const exists = fs.existsSync(configPath);
@@ -163,16 +174,23 @@ export function registerTarget(
       if (!isWmuxOwnedEntry(existing)) {
         foreign.push(WMUX_SERVER_KEY); // foreign hand-authored entry — never modify
         skip = true;
-      } else if (existing.args[0] === wmuxScript) {
+      } else if (
+        // Compare the WHOLE args array, not just args[0]. The profile flags
+        // live in args too, so a script-path match alone would call an entry
+        // "up to date" while an explicit `--profile core|full` sat unapplied.
+        // With no explicit profile the desired args preserve the on-disk ones,
+        // so this still short-circuits every unchanged boot re-registration.
+        arraysEqual(existing.args, wmuxEntryArgs(wmuxScript, profile, existing))
+      ) {
         ownedKeys?.add(WMUX_SERVER_KEY); // already up to date
         skip = true;
       }
-      // else: ours but stale path → update below
+      // else: ours but stale path / different profile → update below
     }
     if (!skip) {
       // upsert validates its INPUT and OUTPUT, so an inline-table entry the
       // line-based editor can't target (which would duplicate) throws here.
-      newText = upsertMcpServer(newText, target.format, WMUX_SERVER_KEY, wmuxScript);
+      newText = upsertMcpServer(newText, target.format, WMUX_SERVER_KEY, wmuxScript, profile);
       wrote.push(WMUX_SERVER_KEY);
       ownedKeys?.add(WMUX_SERVER_KEY);
     }


### PR DESCRIPTION
## What

Makes the `core` MCP tool profile selectable, and stops automatic re-registration from overwriting the choice. The default stays `full`.

## Why

The `core` profile shipped in #1128 but nothing could select it. The `profile` argument stopped at `wmuxMcpEntry`; `upsertMcpServer` took no profile, so every registration path wrote the `full` entry. The old comment in `configIO.ts` admitted this and named the consequence:

> NOT YET THREADED THROUGH THE WRITERS. […] which also means a hand-added `--core` in a user's config is replaced on the next upsert.

So the profile was both unreachable through any supported surface *and* actively hostile to the workaround (hand-editing the config), because the next app boot reverted it.

## How

**Threading.** `profile` now runs `configIO` → `mcpRegistration` → callers. `DEFAULT_HOST_PROFILE` is the single constant deciding what a fresh registration gets.

It stays **`full`**, deliberately. The browser tools are first-class here — an agent driving the workspace browser is a headline capability, and it works with nothing to wire up precisely *because* the default registration carries `browser_*`. `core` is the opt-in for hosts that do not need that surface and would rather not pay ~27 KB of `tools/list` schema for it.

**Opt-in surface.** `wmux mcp register --profile core|full` (both `--profile core` and `--profile=core`) — one flag on the command that already owns registration. No new settings key (none exists for this today) and no settings UI.

**Preservation (the overwrite fix).** An explicit `--profile` always wins, so `--profile full` walks a config back off `core` — the opt-in is reversible. Omitting the flag means *"no opinion"*, and the entry then **keeps** the profile already on disk. Every automatic caller omits it (`McpRegistrar` on boot, bundle-path refresh after an upgrade), so a routine re-registration can no longer undo a user's `--core`. `--commander` survives the same path, even though no host-config writer ever emits it.

**Only recognised argv is rewritten.** `wmuxEntryArgs` replaces profile flags and passes **every other token through verbatim**. A token wmux did not write — a user's own addition, or a flag from a newer wmux sharing the config — is never dropped. This is what keeps the whole-array comparison below from turning "an arg I don't recognise" into "delete it on every boot".

**Idempotency.** `registerTarget`'s "already up to date" check compares the whole `args` array instead of `args[0]`. With the profile living in `args`, a path-only comparison would report no-op and silently drop a profile change. Combined with pass-through above, a repeat call is a true no-op rather than an oscillation.

**Visibility.** `readTargetStatus` and the register result now carry the profile, so `wmux mcp check` prints `registered (core) → …` (also in `--json`) and register reports which profile it wrote or preserved. Previously nothing could confirm a `--profile core` had landed.

### Behavior matrix

| `--profile` | Existing entry | Written |
|---|---|---|
| *(none)* | *(absent)* | `full` — the default |
| *(none)* | `--core` | `--core` — **preserved** |
| *(none)* | `--commander` | preserved |
| *(none)* | `--core --verbose` | `--core --verbose` — custom token kept |
| `core` | anything | `--core` + any custom tokens |
| `full` | `--core --verbose` | `--verbose` — only the profile flag drops |

## Known limitations

- **Registrar ↔ CLI read-modify-write race.** Two writers can still interleave on one config. Pre-existing (the writes are atomic per file, but not serialized against each other); file locking is out of scope for this PR.
- **`--profile` is `register`-only.** `unregister` and `check` ignore it rather than erroring.
- **`wmuxMcpEntry` remains** alongside `wmuxEntryArgs`. It is the simple "build a fresh entry" helper and has callers/tests; folding the two together is not attempted here.

## How tested

- `npx tsc --noEmit` — clean
- `npm run build:mcp && npm run probe:mcp` — green, unchanged: full 93 / 76,410 B, core 47 / 46,665 B, commander 41 / 43,314 B. This PR touches registration, not the surfaces themselves, so the baseline must not move — and does not.
- `npm test` — 891 files / 13,701 passed, 1 skipped (+26 over base); runtime suites 14 passed / 6 skipped.

Tests added:

`src/shared/__tests__/configIO.test.ts`
- defaults to the one profile constant every writer resolves through
- reads the profile flags back off an existing entry
- an explicit profile wins; omitting one preserves the existing entry
- carries unrecognized argv tokens through instead of dropping them
- de-duplicates a hand-edited repeated profile flag
- writes the default (full) entry when no profile is given
- writes `--core` when the caller opts in (json + toml)
- PRESERVES a hand-edited `--core` across a profile-less rewrite (json)
- PRESERVES a hand-edited `--core` across a profile-less rewrite (toml) — also asserts the surgical-TOML byte guarantee still holds
- PRESERVES `--commander`, which no host writer ever emits itself
- an explicit full profile walks a `--core` entry back

`src/shared/__tests__/mcpRegistration.test.ts`
- registers the full surface by default
- registers `--core` when the caller opts in
- a profile-less re-register PRESERVES an opted-in `--core`
- a profile-less PATH refresh keeps `--core` while updating the script
- switching profile is a WRITE even when the script path is unchanged
- reports the profile in the register result and in readTargetStatus
- PRESERVES a custom argv token across a profile-less re-register, and stays idempotent
- keeps a custom argv token when a PATH refresh rewrites the entry
- an explicit `--profile full` drops only `--core`, never a custom token
- (TOML target) registers `--core` when the caller opts in
- (TOML target) a profile-less PATH refresh PRESERVES `--core` in the surgical TOML rewrite

`src/cli/commands/__tests__/mcp.test.ts`
- is undefined when the flag is absent (= preserve what is on disk)
- parses both valid values, anywhere in the argv
- parses the attached `--profile=<value>` form
- returns null for an unknown or missing value so the caller can error out
