### PR TITLE
feat(sidebar): the roster count moves onto the workspace row, freeing a line per workspace

### DIFF
--- a/changelog.d/1170.md
+++ b/changelog.d/1170.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **The sidebar spends one less line per workspace.** The "Agents N" disclosure row is gone; its chevron and count now sit on the workspace row itself, so an expanded workspace starts listing its agents immediately. Measured at 21px saved per collapsed workspace — with eleven open, the difference between seeing the list and scrolling it. The idle label now yields to the agent count (its minutes moved to the workspace name's tooltip, which also means a truncated name is finally readable on hover).

--- a/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
@@ -17,7 +17,16 @@ const STASH_PULSE_MS = 1500;
 
 interface WorkspaceAgentRosterProps {
   workspaceId: string;
-  isActive: boolean;
+  /** Owned by WorkspaceItem, which also renders the summary control (#997). */
+  open: boolean;
+  /** The stash pulse forces the list open even when the user collapsed it. */
+  onRequestOpen: () => void;
+}
+
+interface WorkspaceRosterSummaryProps {
+  workspaceId: string;
+  open: boolean;
+  onToggle: () => void;
 }
 
 /**
@@ -78,14 +87,99 @@ export function rosterHasMixedVendors(rows: readonly WorkspaceAgentRosterRow[]):
   return false;
 }
 
-function WorkspaceAgentRoster({ workspaceId, isActive }: WorkspaceAgentRosterProps) {
+/**
+ * #997 — the roster summary, rendered INSIDE the workspace row.
+ *
+ * It used to be a row of its own directly under the workspace: a chevron and
+ * "Agents 3", costing one line per workspace that has any agents at all. That
+ * line named nothing, and in the expanded state its count restated what the
+ * rows immediately below it already showed — it was redundant exactly when it
+ * was most expensive. With eleven workspaces open the eleven lines were the
+ * difference between seeing the list and scrolling it.
+ *
+ * The count moves onto the workspace row and the line goes away. What does NOT
+ * move with it is a needs-you count: the workspace row's leading dot is
+ * already `selectWorkspaceAgentStatus`, the most-urgent status rolled up
+ * across the whole workspace, so it is red the moment any agent here awaits
+ * input. A number beside it would be a second rendering of a signal the row
+ * already carries.
+ *
+ * Stash keeps its own glyph rather than a word — the same `IconEyeOff` the
+ * expanded list's stash group header uses, so a collapsed workspace still
+ * accounts for panes that are running but off-screen.
+ */
+function WorkspaceRosterSummary({ workspaceId, open, onToggle }: WorkspaceRosterSummaryProps) {
   const t = useT();
   const selector = useMemo(
     () => createWorkspaceAgentRosterSelector(workspaceId),
     [workspaceId],
   );
   const roster = useStore(selector);
-  const [open, setOpen] = useState(isActive);
+
+  if (roster.agentCount === 0 && roster.stashedCount === 0) return null;
+
+  // The accessible name keeps the words the visible chip drops. A workspace
+  // whose only entries are stashed leads with the stash, never "Agents 0".
+  const countLabel =
+    roster.agentCount === 0
+      ? t('roster.stashedOnly', { count: roster.stashedCount })
+      : roster.stashedCount > 0
+        ? `${t('workspace.agentCount', { count: roster.agentCount })} · ${t('roster.stashedCount', { count: roster.stashedCount })}`
+        : t('workspace.agentCount', { count: roster.agentCount });
+  const ariaLabel = [countLabel, open ? t('workspace.hideAgents') : t('workspace.showAgents')].join(', ');
+
+  return (
+    <button
+      type="button"
+      draggable={false}
+      className={`flex flex-shrink-0 items-center gap-0.5 rounded px-0.5 text-[9px] font-mono tabular-nums text-[var(--text-muted)] transition-colors hover:text-[var(--text-sub)] ${FOCUS_RING}`}
+      aria-expanded={open}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      onClick={(event) => {
+        // The workspace row selects the workspace on click; this control must
+        // only expand, so it stops the gesture before the row sees it.
+        event.stopPropagation();
+        onToggle();
+      }}
+      onMouseDown={(event) => {
+        // The row is a native drag source. Without this, pressing the chevron
+        // starts a workspace drag instead of arming the click.
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onDoubleClick={(event) => event.stopPropagation()}
+      onDragStart={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+    >
+      <span
+        className="flex-shrink-0 transition-transform duration-150"
+        style={{ transform: open ? 'rotate(90deg)' : undefined }}
+      >
+        <IconChevron size={8} />
+      </span>
+      {roster.agentCount > 0 && <span>{roster.agentCount}</span>}
+      {roster.stashedCount > 0 && (
+        <span className="flex items-center gap-0.5">
+          <IconEyeOff size={8} />
+          {roster.stashedCount}
+        </span>
+      )}
+    </button>
+  );
+}
+
+export const WorkspaceRosterSummaryMemo = memo(WorkspaceRosterSummary);
+
+function WorkspaceAgentRoster({ workspaceId, open, onRequestOpen }: WorkspaceAgentRosterProps) {
+  const t = useT();
+  const selector = useMemo(
+    () => createWorkspaceAgentRosterSelector(workspaceId),
+    [workspaceId],
+  );
+  const roster = useStore(selector);
   // #977 — a pane that was just stashed disappeared from the layout. If the
   // list it moved into is collapsed, the gesture is indistinguishable from a
   // delete, so open the list and flash the row once.
@@ -101,10 +195,10 @@ function WorkspaceAgentRoster({ workspaceId, isActive }: WorkspaceAgentRosterPro
   // own key.
   useEffect(() => {
     if (!pulsedPaneId) return;
-    setOpen(true);
+    onRequestOpen();
     setPulsingPaneId(pulsedPaneId);
     useStore.getState().clearStashPulse();
-  }, [pulsedPaneId]);
+  }, [pulsedPaneId, onRequestOpen]);
 
   useEffect(() => {
     if (!pulsingPaneId) return;
@@ -112,32 +206,12 @@ function WorkspaceAgentRoster({ workspaceId, isActive }: WorkspaceAgentRosterPro
     return () => clearTimeout(timer);
   }, [pulsingPaneId]);
 
-  // Newly selected workspaces reveal their agents automatically; workspaces
-  // that move to the background collapse back to the compact summary. The user
-  // can still explicitly toggle either state until selection changes again.
-  useEffect(() => {
-    setOpen(isActive);
-  }, [isActive]);
-
+  if (!open) return null;
   if (roster.agentCount === 0 && roster.stashedCount === 0) return null;
 
   // Computed once per render, not per row: the vendor column earns its width
   // only when the workspace actually mixes vendors.
   const mixedVendors = rosterHasMixedVendors(roster.rows);
-
-  // A workspace whose only roster entries are stashed panes leads with the
-  // stash, not with "Agents 0" — the zero is the least useful number on the row
-  // and would push the count that matters off the end of a 240px sidebar.
-  const countLabel =
-    roster.agentCount === 0
-      ? t('roster.stashedOnly', { count: roster.stashedCount })
-      : roster.stashedCount > 0
-        ? `${t('workspace.agentCount', { count: roster.agentCount })} · ${t('roster.stashedCount', { count: roster.stashedCount })}`
-        : t('workspace.agentCount', { count: roster.agentCount });
-  const disclosureLabel = open
-    ? t('workspace.hideAgents')
-    : t('workspace.showAgents');
-  const disclosureAriaLabel = [countLabel, disclosureLabel].join(', ');
 
   return (
     <div
@@ -151,35 +225,7 @@ function WorkspaceAgentRoster({ workspaceId, isActive }: WorkspaceAgentRosterPro
       }}
       onDoubleClick={(event) => event.stopPropagation()}
     >
-      <div className="flex max-w-full items-center gap-1">
-      <button
-        type="button"
-        draggable={false}
-        className="flex min-w-0 flex-1 items-center gap-1 rounded px-0.5 py-0.5 text-[9px] font-mono text-[var(--text-muted)] transition-colors hover:text-[var(--text-sub)]"
-        aria-expanded={open}
-        aria-label={disclosureAriaLabel}
-        title={disclosureAriaLabel}
-        onClick={(event) => {
-          event.stopPropagation();
-          setOpen((value) => !value);
-        }}
-        onDragStart={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-        }}
-      >
-        <span
-          className="flex-shrink-0 transition-transform duration-150"
-          style={{ transform: open ? 'rotate(90deg)' : undefined }}
-        >
-          <IconChevron size={8} />
-        </span>
-        <span className="truncate">{countLabel}</span>
-      </button>
-      </div>
-
-      {open && (
-        <div className="mt-0.5 ml-1 border-l border-[var(--border-soft)] pl-1.5">
+      <div className="ml-1 border-l border-[var(--border-soft)] pl-1.5">
           {roster.rows.map((row, index) => {
             // The one-line group header, immediately before the FIRST stashed
             // row. With six of seven panes stashed the list otherwise looked
@@ -325,8 +371,7 @@ function WorkspaceAgentRoster({ workspaceId, isActive }: WorkspaceAgentRosterPro
               </div>
             );
           })}
-        </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
@@ -209,11 +209,18 @@ function WorkspaceRosterSummary({
       >
         <IconChevron size={8} />
       </span>
-      {roster.agentCount > 0 && <span>{roster.agentCount}</span>}
-      {roster.stashedCount > 0 && (
+      {agentCount > 0 && <span>{agentCount}</span>}
+      {/* The stash glyph draws only when it is the ONLY thing to report.
+          Beside an agent count it cost 17px of a row whose name column has
+          none to spare (measured: it was the difference between eleven
+          readable characters and fourteen), while the same panes are already
+          announced in this control's accessible name and headed by their own
+          group inside the expanded list. Alone, it is what stops a workspace
+          holding nothing but stashed panes from reading as empty. */}
+      {agentCount === 0 && stashedCount > 0 && (
         <span className="flex items-center gap-0.5">
           <IconEyeOff size={8} />
-          {roster.stashedCount}
+          {stashedCount}
         </span>
       )}
     </button>

--- a/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
@@ -61,6 +61,10 @@ interface WorkspaceAgentRosterProps {
 
 interface WorkspaceRosterSummaryProps {
   workspaceId: string;
+  /** Both counts come from WorkspaceItem's own counts subscription, so this
+   *  control holds no store subscription of its own and memoizes on numbers. */
+  agentCount: number;
+  stashedCount: number;
   open: boolean;
   onToggle: () => void;
 }
@@ -153,17 +157,17 @@ export function rosterHasMixedVendors(rows: readonly WorkspaceAgentRosterRow[]):
  * expanded list's stash group header uses, so a collapsed workspace still
  * accounts for panes that are running but off-screen.
  */
-function WorkspaceRosterSummary({ workspaceId, open, onToggle }: WorkspaceRosterSummaryProps) {
+function WorkspaceRosterSummary({
+  workspaceId,
+  agentCount,
+  stashedCount,
+  open,
+  onToggle,
+}: WorkspaceRosterSummaryProps) {
   const t = useT();
-  // Counts only: this chip draws two integers and is mounted for every
-  // workspace, so it must not rerender on every byte a terminal here prints.
-  const selector = useMemo(
-    () => createWorkspaceRosterCountsSelector(workspaceId),
-    [workspaceId],
-  );
-  const roster = useStore(selector);
+  const roster = { agentCount, stashedCount };
 
-  if (roster.agentCount === 0 && roster.stashedCount === 0) return null;
+  if (agentCount === 0 && stashedCount === 0) return null;
 
   const ariaLabel = rosterSummaryAriaLabel(roster, open, t);
 

--- a/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import { useStore } from '../../stores';
 import {
   createWorkspaceAgentRosterSelector,
+  createWorkspaceRosterCountsSelector,
   type WorkspaceAgentRosterRow,
 } from '../../stores/selectors/workspaceAgentRoster';
 import { focusNotificationTarget, focusPaneByPtyId } from '../../hooks/useNotificationListener';
@@ -13,14 +14,49 @@ import { AGENT_STATUS_ICON } from './agentStatusIcon';
 
 /** How long the just-stashed row stays highlighted. Long enough to catch the
  *  eye after the pane vanishes from the layout, short enough not to linger. */
-const STASH_PULSE_MS = 1500;
+export const STASH_PULSE_MS = 1500;
+
+/** Ties the summary's `aria-controls` to the list it expands. */
+export function rosterListId(workspaceId: string): string {
+  return `roster-list-${workspaceId}`;
+}
+
+/**
+ * The summary's accessible name — the words its visible chip drops.
+ *
+ * The chip is a bare number (plus a stash glyph); a screen reader must still
+ * hear "Agents 3, Stashed 1, Show agent list". A workspace whose only entries
+ * are stashed panes leads with the stash rather than announcing "Agents 0" —
+ * the zero is the least useful number it could open with.
+ *
+ * Pure so the three shapes can actually be asserted, rather than grepped for.
+ */
+export function rosterSummaryAriaLabel(
+  roster: { agentCount: number; stashedCount: number },
+  open: boolean,
+  t: (key: 'workspace.agentCount' | 'roster.stashedCount' | 'roster.stashedOnly'
+    | 'workspace.showAgents' | 'workspace.hideAgents', vars?: Record<string, string | number>) => string,
+): string {
+  const countLabel =
+    roster.agentCount === 0
+      ? t('roster.stashedOnly', { count: roster.stashedCount })
+      : roster.stashedCount > 0
+        // Comma, not the "·" this string carried when it was also the VISIBLE
+        // label: it is spoken now, and a middle dot is either silence or the
+        // words "middle dot" depending on the screen reader.
+        ? `${t('workspace.agentCount', { count: roster.agentCount })}, ${t('roster.stashedCount', { count: roster.stashedCount })}`
+        : t('workspace.agentCount', { count: roster.agentCount });
+  return [countLabel, open ? t('workspace.hideAgents') : t('workspace.showAgents')].join(', ');
+}
 
 interface WorkspaceAgentRosterProps {
   workspaceId: string;
-  /** Owned by WorkspaceItem, which also renders the summary control (#997). */
-  open: boolean;
-  /** The stash pulse forces the list open even when the user collapsed it. */
-  onRequestOpen: () => void;
+  /**
+   * The row to flash once, from the #977 stash pulse. WorkspaceItem owns the
+   * pulse because the pulse's first job is to OPEN this list, and this
+   * component is only mounted once it is open.
+   */
+  pulsingPaneId: string | null;
 }
 
 interface WorkspaceRosterSummaryProps {
@@ -99,10 +135,19 @@ export function rosterHasMixedVendors(rows: readonly WorkspaceAgentRosterRow[]):
  *
  * The count moves onto the workspace row and the line goes away. What does NOT
  * move with it is a needs-you count: the workspace row's leading dot is
- * already `selectWorkspaceAgentStatus`, the most-urgent status rolled up
- * across the whole workspace, so it is red the moment any agent here awaits
- * input. A number beside it would be a second rendering of a signal the row
- * already carries.
+ * `selectWorkspaceAgentStatus`, the most-urgent status rolled up across the
+ * whole workspace, so it already turns red when an agent here reaches
+ * awaiting_input / waiting / error. That is the signal, and the row's scarcest
+ * space should not render it twice.
+ *
+ * Two known gaps in that dot, neither introduced here and neither an argument
+ * for a second indicator in this one place: `selectFleetPanes` (the dot's
+ * source) reads neither `surfacePendingQuestion` — which this roster promotes
+ * to awaiting_input — nor a stashed pane's `exited` liveness, so a pane
+ * blocked on a question can sit under a green dot. The dot also drives
+ * MiniSidebar, the titlebar vitals and the deck Fleet, so the fix belongs at
+ * its source rather than behind a number that would only correct the sidebar.
+ * Tracked separately.
  *
  * Stash keeps its own glyph rather than a word — the same `IconEyeOff` the
  * expanded list's stash group header uses, so a collapsed workspace still
@@ -110,30 +155,30 @@ export function rosterHasMixedVendors(rows: readonly WorkspaceAgentRosterRow[]):
  */
 function WorkspaceRosterSummary({ workspaceId, open, onToggle }: WorkspaceRosterSummaryProps) {
   const t = useT();
+  // Counts only: this chip draws two integers and is mounted for every
+  // workspace, so it must not rerender on every byte a terminal here prints.
   const selector = useMemo(
-    () => createWorkspaceAgentRosterSelector(workspaceId),
+    () => createWorkspaceRosterCountsSelector(workspaceId),
     [workspaceId],
   );
   const roster = useStore(selector);
 
   if (roster.agentCount === 0 && roster.stashedCount === 0) return null;
 
-  // The accessible name keeps the words the visible chip drops. A workspace
-  // whose only entries are stashed leads with the stash, never "Agents 0".
-  const countLabel =
-    roster.agentCount === 0
-      ? t('roster.stashedOnly', { count: roster.stashedCount })
-      : roster.stashedCount > 0
-        ? `${t('workspace.agentCount', { count: roster.agentCount })} · ${t('roster.stashedCount', { count: roster.stashedCount })}`
-        : t('workspace.agentCount', { count: roster.agentCount });
-  const ariaLabel = [countLabel, open ? t('workspace.hideAgents') : t('workspace.showAgents')].join(', ');
+  const ariaLabel = rosterSummaryAriaLabel(roster, open, t);
 
   return (
     <button
       type="button"
       draggable={false}
-      className={`flex flex-shrink-0 items-center gap-0.5 rounded px-0.5 text-[9px] font-mono tabular-nums text-[var(--text-muted)] transition-colors hover:text-[var(--text-sub)] ${FOCUS_RING}`}
+      // The row's own handleDragStart rejects gestures that begin on
+      // `[data-workspace-agent-roster]`. Carrying the marker puts this control
+      // behind that already-proven guard instead of leaving the mousedown
+      // preventDefault below as the single line of defence.
+      data-workspace-agent-roster
+      className={`mt-0.5 flex flex-shrink-0 items-center gap-0.5 rounded px-0.5 text-[9px] font-mono tabular-nums text-[var(--text-muted)] transition-colors hover:text-[var(--text-sub)] ${FOCUS_RING}`}
       aria-expanded={open}
+      aria-controls={rosterListId(workspaceId)}
       aria-label={ariaLabel}
       title={ariaLabel}
       onClick={(event) => {
@@ -147,12 +192,12 @@ function WorkspaceRosterSummary({ workspaceId, open, onToggle }: WorkspaceRoster
         // starts a workspace drag instead of arming the click.
         event.preventDefault();
         event.stopPropagation();
+        // preventDefault also suppresses the focus mousedown would have given
+        // the button, which would leave the keyboard's idea of "here" behind
+        // on whatever was focused before — and the focus ring never appears.
+        event.currentTarget.focus();
       }}
       onDoubleClick={(event) => event.stopPropagation()}
-      onDragStart={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-      }}
     >
       <span
         className="flex-shrink-0 transition-transform duration-150"
@@ -173,40 +218,14 @@ function WorkspaceRosterSummary({ workspaceId, open, onToggle }: WorkspaceRoster
 
 export const WorkspaceRosterSummaryMemo = memo(WorkspaceRosterSummary);
 
-function WorkspaceAgentRoster({ workspaceId, open, onRequestOpen }: WorkspaceAgentRosterProps) {
+function WorkspaceAgentRoster({ workspaceId, pulsingPaneId }: WorkspaceAgentRosterProps) {
   const t = useT();
   const selector = useMemo(
     () => createWorkspaceAgentRosterSelector(workspaceId),
     [workspaceId],
   );
   const roster = useStore(selector);
-  // #977 — a pane that was just stashed disappeared from the layout. If the
-  // list it moved into is collapsed, the gesture is indistinguishable from a
-  // delete, so open the list and flash the row once.
-  const stashPulse = useStore((s) => s.stashPulse);
-  const pulsedPaneId = stashPulse?.workspaceId === workspaceId ? stashPulse.paneId : null;
-  const [pulsingPaneId, setPulsingPaneId] = useState<string | null>(null);
 
-  // TWO effects on purpose. Consuming the pulse and owning its timeout in one
-  // effect is self-defeating: clearStashPulse() nulls `pulsedPaneId` on the very
-  // next render, the effect re-runs, its cleanup clears the pending timeout, and
-  // the highlight never turns off — a permanent bar identical to the focused
-  // style. Splitting them lets the consume run once and the timeout live on its
-  // own key.
-  useEffect(() => {
-    if (!pulsedPaneId) return;
-    onRequestOpen();
-    setPulsingPaneId(pulsedPaneId);
-    useStore.getState().clearStashPulse();
-  }, [pulsedPaneId, onRequestOpen]);
-
-  useEffect(() => {
-    if (!pulsingPaneId) return;
-    const timer = setTimeout(() => setPulsingPaneId(null), STASH_PULSE_MS);
-    return () => clearTimeout(timer);
-  }, [pulsingPaneId]);
-
-  if (!open) return null;
   if (roster.agentCount === 0 && roster.stashedCount === 0) return null;
 
   // Computed once per render, not per row: the vendor column earns its width
@@ -216,6 +235,7 @@ function WorkspaceAgentRoster({ workspaceId, open, onRequestOpen }: WorkspaceAge
   return (
     <div
       className="mt-1 w-full min-w-0"
+      id={rosterListId(workspaceId)}
       data-workspace-agent-roster
       onMouseDown={(event) => {
         // Prevent Chromium from promoting the draggable WorkspaceItem ancestor

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useEffect, useCallback, memo } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo, memo } from 'react';
 import type { GitSyncStatus, PrStatus, WorkspaceMetadata } from '../../../shared/types';
 import { useStore } from '../../stores';
 import { selectWorkspaceById } from '../../stores/selectors/workspaceProjections';
 import { selectWorkspaceAgentStatus } from '../../stores/selectors/fleet';
+import { createWorkspaceRosterCountsSelector } from '../../stores/selectors/workspaceAgentRoster';
 import { useT } from '../../hooks/useT';
 import type { TranslationKey } from '../../i18n/locales/en';
 import { AGENT_STATUS_ICON } from './agentStatusIcon';
@@ -291,6 +292,14 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
   // churn still does not rerender this component.
   const [rosterOpen, setRosterOpen] = useState(isActive);
   const toggleRoster = useCallback(() => setRosterOpen((value) => !value), []);
+  // Counts only — a reference-stable projection of two integers, so this does
+  // not rerender the row on terminal output the way the full roster would.
+  const rosterCountsSelector = useMemo(
+    () => createWorkspaceRosterCountsSelector(workspaceId),
+    [workspaceId],
+  );
+  const rosterCounts = useStore(rosterCountsSelector);
+  const hasRoster = rosterCounts.agentCount > 0 || rosterCounts.stashedCount > 0;
   // Newly selected workspaces reveal their agents automatically; workspaces
   // that move to the background collapse back to the count. The user can still
   // explicitly toggle either state until selection changes again.
@@ -712,7 +721,16 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
           ) : (
             <>
               <div className="flex items-center gap-1">
-                <span className="text-caption font-mono truncate">{workspace.name}</span>
+                {/* The name truncates in a 240px sidebar and had no tooltip at
+                    all, so a clipped name was simply unreadable. It carries the
+                    idle minutes too, which is where they go when the roster
+                    chip takes their place on the row (#997). */}
+                <span
+                  className="text-caption font-mono truncate"
+                  title={idleLabel ? `${workspace.name} · ${t('workspace.idleTooltip', { time: idleLabel })}` : workspace.name}
+                >
+                  {workspace.name}
+                </span>
                 {hasProfile && (
                   <span
                     className="text-[8px] leading-none flex-shrink-0 text-[var(--accent-blue)]"
@@ -759,7 +777,13 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
                     ⚠ {t('workspace.departed')}
                   </span>
                 )}
-                {idleLabel && (
+                {/* #997 — the idle label and the roster chip answer the same
+                    question ("is anything happening here?"), and the chip plus
+                    the leading status dot answer it better. Showing both cost
+                    the NAME half its width at 240px: measured 87.6px → 43.7px,
+                    a 22-character workspace truncated to seven. The idle
+                    minutes stay one hover away on the row's own tooltip. */}
+                {idleLabel && !hasRoster && (
                   <span
                     className="text-[9px] font-mono text-[var(--text-muted)] flex-shrink-0"
                     title={t('workspace.idleTooltip', { time: idleLabel })}
@@ -778,6 +802,8 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
         {!editing && (
           <WorkspaceRosterSummaryMemo
             workspaceId={workspaceId}
+            agentCount={rosterCounts.agentCount}
+            stashedCount={rosterCounts.stashedCount}
             open={rosterOpen}
             onToggle={toggleRoster}
           />

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -14,7 +14,7 @@ import { openUrlInBrowserPane } from '../../utils/browserPaneActions';
 import WorkspaceProfileModal from './WorkspaceProfileModal';
 import WorkspaceAccountMenu from './WorkspaceAccountMenu';
 import WorkspaceChromeProfileMenu from './WorkspaceChromeProfileMenu';
-import WorkspaceAgentRoster, { WorkspaceRosterSummaryMemo } from './WorkspaceAgentRoster';
+import WorkspaceAgentRoster, { WorkspaceRosterSummaryMemo, STASH_PULSE_MS } from './WorkspaceAgentRoster';
 import { displayPath } from '../../utils/displayPath';
 import { WORKSPACE_COLOR_IDS, WORKSPACE_COLOR_HEX, workspaceColorHex, workspaceColorLabelKey } from '../../../shared/workspaceColors';
 
@@ -291,13 +291,40 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
   // churn still does not rerender this component.
   const [rosterOpen, setRosterOpen] = useState(isActive);
   const toggleRoster = useCallback(() => setRosterOpen((value) => !value), []);
-  const openRoster = useCallback(() => setRosterOpen(true), []);
   // Newly selected workspaces reveal their agents automatically; workspaces
   // that move to the background collapse back to the count. The user can still
   // explicitly toggle either state until selection changes again.
   useEffect(() => {
     setRosterOpen(isActive);
   }, [isActive]);
+
+  // #977 — a pane that was just stashed disappeared from the layout. If the
+  // list it moved into is collapsed, the gesture is indistinguishable from a
+  // delete, so open the list and flash the row once. The pulse lives HERE
+  // because its first job is to open the list, and the list is only mounted
+  // once open — a pulse owned by the list could never open it.
+  const stashPulse = useStore((s) => s.stashPulse);
+  const pulsedPaneId = stashPulse?.workspaceId === workspaceId ? stashPulse.paneId : null;
+  const [pulsingPaneId, setPulsingPaneId] = useState<string | null>(null);
+
+  // TWO effects on purpose. Consuming the pulse and owning its timeout in one
+  // effect is self-defeating: clearStashPulse() nulls `pulsedPaneId` on the very
+  // next render, the effect re-runs, its cleanup clears the pending timeout, and
+  // the highlight never turns off — a permanent bar identical to the focused
+  // style. Splitting them lets the consume run once and the timeout live on its
+  // own key.
+  useEffect(() => {
+    if (!pulsedPaneId) return;
+    setRosterOpen(true);
+    setPulsingPaneId(pulsedPaneId);
+    useStore.getState().clearStashPulse();
+  }, [pulsedPaneId]);
+
+  useEffect(() => {
+    if (!pulsingPaneId) return;
+    const timer = setTimeout(() => setPulsingPaneId(null), STASH_PULSE_MS);
+    return () => clearTimeout(timer);
+  }, [pulsingPaneId]);
 
   // X5 wmux.json badge state for this workspace (transient, probe-driven).
   const projectState = useStore((s) => s.projectConfigs[workspaceId]);
@@ -749,13 +776,11 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
         {/* #997 — roster disclosure + agent count. Lives on this row, not on
             a line of its own: see WorkspaceRosterSummary's own comment. */}
         {!editing && (
-          <div className="flex-shrink-0 mt-0.5">
-            <WorkspaceRosterSummaryMemo
-              workspaceId={workspaceId}
-              open={rosterOpen}
-              onToggle={toggleRoster}
-            />
-          </div>
+          <WorkspaceRosterSummaryMemo
+            workspaceId={workspaceId}
+            open={rosterOpen}
+            onToggle={toggleRoster}
+          />
         )}
 
         {/* Agent status mark (play/pause), right-aligned. */}
@@ -804,12 +829,10 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
           <IconX size={11} />
         </button>
         </div>
-        {!editing && (
-          <WorkspaceAgentRoster
-            workspaceId={workspaceId}
-            open={rosterOpen}
-            onRequestOpen={openRoster}
-          />
+        {/* Mounted only when expanded: a collapsed list would subscribe to the
+            whole roster projection to render nothing. */}
+        {!editing && rosterOpen && (
+          <WorkspaceAgentRoster workspaceId={workspaceId} pulsingPaneId={pulsingPaneId} />
         )}
       </div>
 

--- a/src/renderer/components/Sidebar/WorkspaceItem.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, memo } from 'react';
+import { useState, useRef, useEffect, useCallback, memo } from 'react';
 import type { GitSyncStatus, PrStatus, WorkspaceMetadata } from '../../../shared/types';
 import { useStore } from '../../stores';
 import { selectWorkspaceById } from '../../stores/selectors/workspaceProjections';
@@ -14,7 +14,7 @@ import { openUrlInBrowserPane } from '../../utils/browserPaneActions';
 import WorkspaceProfileModal from './WorkspaceProfileModal';
 import WorkspaceAccountMenu from './WorkspaceAccountMenu';
 import WorkspaceChromeProfileMenu from './WorkspaceChromeProfileMenu';
-import WorkspaceAgentRoster from './WorkspaceAgentRoster';
+import WorkspaceAgentRoster, { WorkspaceRosterSummaryMemo } from './WorkspaceAgentRoster';
 import { displayPath } from '../../utils/displayPath';
 import { WORKSPACE_COLOR_IDS, WORKSPACE_COLOR_HEX, workspaceColorHex, workspaceColorLabelKey } from '../../../shared/workspaceColors';
 
@@ -284,6 +284,21 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
   // `metadata.agentStatus` directly only ever saw the active pane and never
   // self-healed. Scalar return → Object.is subscription re-renders only on change.
   const agentStatus = useStore((s) => selectWorkspaceAgentStatus(s, workspaceId));
+  // #997 — the roster's expanded state. It lives here, not in the roster,
+  // because the control that toggles it now sits on THIS row while the list it
+  // reveals is rendered below; the two would otherwise need to agree across a
+  // sibling boundary. The list keeps its own store subscription, so roster
+  // churn still does not rerender this component.
+  const [rosterOpen, setRosterOpen] = useState(isActive);
+  const toggleRoster = useCallback(() => setRosterOpen((value) => !value), []);
+  const openRoster = useCallback(() => setRosterOpen(true), []);
+  // Newly selected workspaces reveal their agents automatically; workspaces
+  // that move to the background collapse back to the count. The user can still
+  // explicitly toggle either state until selection changes again.
+  useEffect(() => {
+    setRosterOpen(isActive);
+  }, [isActive]);
+
   // X5 wmux.json badge state for this workspace (transient, probe-driven).
   const projectState = useStore((s) => s.projectConfigs[workspaceId]);
   // J3 §4 — 태스크 워크스페이스의 페인 cwd가 worktree 경계 밖으로 이탈했는지(경고만).
@@ -731,6 +746,18 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
           )}
         </div>
 
+        {/* #997 — roster disclosure + agent count. Lives on this row, not on
+            a line of its own: see WorkspaceRosterSummary's own comment. */}
+        {!editing && (
+          <div className="flex-shrink-0 mt-0.5">
+            <WorkspaceRosterSummaryMemo
+              workspaceId={workspaceId}
+              open={rosterOpen}
+              onToggle={toggleRoster}
+            />
+          </div>
+        )}
+
         {/* Agent status mark (play/pause), right-aligned. */}
         {(() => {
           const st = AGENT_STATUS_ICON[agentStatus];
@@ -778,7 +805,11 @@ function WorkspaceItem({ workspaceId, isActive, isMultiview, index, onSelect, on
         </button>
         </div>
         {!editing && (
-          <WorkspaceAgentRoster workspaceId={workspaceId} isActive={isActive} />
+          <WorkspaceAgentRoster
+            workspaceId={workspaceId}
+            open={rosterOpen}
+            onRequestOpen={openRoster}
+          />
         )}
       </div>
 

--- a/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.stashPulse.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.stashPulse.test.ts
@@ -17,7 +17,15 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+// #997 moved the pulse into WorkspaceItem: the pulse's first job is to OPEN
+// the list, and the list is only mounted once open, so a pulse owned by the
+// list could never open it. The two-effect split this file protects is
+// unchanged — only its address is.
 const source = readFileSync(
+  resolve(process.cwd(), 'src/renderer/components/Sidebar/WorkspaceItem.tsx'),
+  'utf8',
+);
+const rosterSource = readFileSync(
   resolve(process.cwd(), 'src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx'),
   'utf8',
 );
@@ -34,13 +42,9 @@ function effectKeyedOn(deps: string): string {
 
 describe('WorkspaceAgentRoster — stash pulse', () => {
   it('consumes the pulse in an effect that owns no timeout', () => {
-    // #997 moved the expanded state up to WorkspaceItem (the control that
-    // toggles it now sits on the workspace row), so the pulse asks its owner
-    // to open instead of setting local state — the two-effect split, which is
-    // what this file exists to protect, is unchanged.
-    const consume = effectKeyedOn('pulsedPaneId, onRequestOpen');
+    const consume = effectKeyedOn('pulsedPaneId');
     expect(consume).toContain('clearStashPulse()');
-    expect(consume).toContain('onRequestOpen()');
+    expect(consume).toContain('setRosterOpen(true)');
     expect(consume).toContain('setPulsingPaneId(pulsedPaneId)');
     // The trap: clearStashPulse re-runs this effect immediately, so a timeout
     // registered here would be cleaned up before it could ever fire.
@@ -57,8 +61,8 @@ describe('WorkspaceAgentRoster — stash pulse', () => {
   });
 
   it('bounds the highlight to a duration a human reads as a flash', () => {
-    expect(source).toMatch(/const STASH_PULSE_MS = \d{3,4};/);
-    const ms = Number(/const STASH_PULSE_MS = (\d+);/.exec(source)?.[1]);
+    expect(rosterSource).toMatch(/const STASH_PULSE_MS = \d{3,4};/);
+    const ms = Number(/const STASH_PULSE_MS = (\d+);/.exec(rosterSource)?.[1]);
     expect(ms).toBeGreaterThan(0);
     expect(ms).toBeLessThanOrEqual(3000);
   });

--- a/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.stashPulse.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.stashPulse.test.ts
@@ -22,11 +22,11 @@ const source = readFileSync(
   'utf8',
 );
 
-/** The effect whose dependency array is exactly `[dep]`. */
-function effectKeyedOn(dep: string): string {
-  const marker = `}, [${dep}]);`;
+/** The effect whose dependency array is exactly `[deps]`. */
+function effectKeyedOn(deps: string): string {
+  const marker = `}, [${deps}]);`;
   const end = source.indexOf(marker);
-  expect(end, `no effect keyed on [${dep}]`).toBeGreaterThanOrEqual(0);
+  expect(end, `no effect keyed on [${deps}]`).toBeGreaterThanOrEqual(0);
   const start = source.lastIndexOf('useEffect(() => {', end);
   expect(start).toBeGreaterThanOrEqual(0);
   return source.slice(start, end + marker.length);
@@ -34,9 +34,13 @@ function effectKeyedOn(dep: string): string {
 
 describe('WorkspaceAgentRoster — stash pulse', () => {
   it('consumes the pulse in an effect that owns no timeout', () => {
-    const consume = effectKeyedOn('pulsedPaneId');
+    // #997 moved the expanded state up to WorkspaceItem (the control that
+    // toggles it now sits on the workspace row), so the pulse asks its owner
+    // to open instead of setting local state — the two-effect split, which is
+    // what this file exists to protect, is unchanged.
+    const consume = effectKeyedOn('pulsedPaneId, onRequestOpen');
     expect(consume).toContain('clearStashPulse()');
-    expect(consume).toContain('setOpen(true)');
+    expect(consume).toContain('onRequestOpen()');
     expect(consume).toContain('setPulsingPaneId(pulsedPaneId)');
     // The trap: clearStashPulse re-runs this effect immediately, so a timeout
     // registered here would be cleaned up before it could ever fire.

--- a/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
@@ -83,7 +83,7 @@ describe('#997 — roster summary sits on the workspace row', () => {
     // The projection's reference changes whenever any row field does — an
     // activity string, a focus flag. This control draws two integers, and it
     // now sits on a row that renders for every workspace.
-    expect(rosterSource).toContain('createWorkspaceRosterCountsSelector(workspaceId)');
+    expect(itemSource).toContain('createWorkspaceRosterCountsSelector(workspaceId)');
   });
 });
 

--- a/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
@@ -31,9 +31,10 @@ describe('#997 — roster summary sits on the workspace row', () => {
   it('WorkspaceItem renders the summary control and owns the expanded state', () => {
     expect(itemSource).toContain('WorkspaceRosterSummaryMemo');
     expect(itemSource).toContain('const [rosterOpen, setRosterOpen]');
-    // The list is a sibling BELOW the row and must be told the state rather
-    // than keeping its own copy, or the chevron and the list could disagree.
-    expect(itemSource).toMatch(/<WorkspaceAgentRoster[\s\S]*?open=\{rosterOpen\}/);
+    // The list is mounted only while expanded — a collapsed list would still
+    // subscribe to the whole roster projection to render nothing, and with
+    // eleven collapsed workspaces that is eleven pointless subscriptions.
+    expect(itemSource).toMatch(/rosterOpen && \(\s*<WorkspaceAgentRoster/);
   });
 
   it('the list renders no disclosure row of its own', () => {
@@ -45,44 +46,82 @@ describe('#997 — roster summary sits on the workspace row', () => {
     expect(listPart).not.toContain("t('workspace.showAgents')");
   });
 
-  it('the summary keeps the full wording in its accessible name', () => {
+  it('the toggle says what it expands, now that its visible label is a number', () => {
     const summaryPart = rosterSource.slice(
       rosterSource.indexOf('function WorkspaceRosterSummary('),
-      rosterSource.indexOf('function WorkspaceAgentRoster('),
+      rosterSource.indexOf('export const WorkspaceRosterSummaryMemo'),
     );
-    // The visible chip is a bare number; a screen reader must still hear
-    // "Agents 3, Show agent list" rather than "3".
-    expect(summaryPart).toContain("t('workspace.agentCount'");
-    expect(summaryPart).toContain("t('workspace.showAgents')");
-    expect(summaryPart).toContain("t('workspace.hideAgents')");
     expect(summaryPart).toContain('aria-expanded');
-    // A workspace holding only stashed panes must not read "Agents 0".
-    expect(summaryPart).toContain("t('roster.stashedOnly'");
+    expect(summaryPart).toContain('aria-controls');
+    // The list is no longer the button's next sibling — five controls sit
+    // between them in DOM order — so the relationship has to be explicit.
+    expect(rosterSource).toContain('id={rosterListId(workspaceId)}');
   });
 
-  it('the summary does not restate needs-you, which the row dot already carries', () => {
+  it('the chevron neither selects the workspace nor starts its drag', () => {
     const summaryPart = rosterSource.slice(
       rosterSource.indexOf('function WorkspaceRosterSummary('),
-      rosterSource.indexOf('function WorkspaceAgentRoster('),
+      rosterSource.indexOf('export const WorkspaceRosterSummaryMemo'),
     );
-    // WorkspaceItem's leading dot is selectWorkspaceAgentStatus — the
-    // most-urgent status rolled up across the whole workspace — so it is
-    // already red whenever an agent here awaits input. A count beside it would
-    // render the same signal twice and spend the row's scarcest space.
-    expect(summaryPart).not.toContain('needsAttentionCount');
-    expect(itemSource).toContain('selectWorkspaceAgentStatus');
+    // Click: the row underneath selects the workspace, so the toggle must
+    // stop the gesture in its OWN onClick — not merely somewhere in the file.
+    const onClick = summaryPart.slice(summaryPart.indexOf('onClick='), summaryPart.indexOf('onMouseDown='));
+    expect(onClick).toContain('event.stopPropagation()');
+    // Drag: the row is a native drag source. Two independent guards — the
+    // marker the row's own handleDragStart tests for, and the mousedown
+    // default that would otherwise arm a drag.
+    expect(summaryPart).toContain('data-workspace-agent-roster');
+    expect(itemSource).toContain('[data-workspace-agent-roster]');
+    const onMouseDown = summaryPart.slice(summaryPart.indexOf('onMouseDown='));
+    expect(onMouseDown).toContain('event.preventDefault()');
+    // …and that preventDefault costs the button its focus unless it is given
+    // back, which would leave the focus ring unreachable by mouse.
+    expect(onMouseDown).toContain('event.currentTarget.focus()');
   });
 
-  it('the summary stops the gesture reaching the row underneath it', () => {
-    const summaryPart = rosterSource.slice(
-      rosterSource.indexOf('function WorkspaceRosterSummary('),
-      rosterSource.indexOf('function WorkspaceAgentRoster('),
-    );
-    // The row selects the workspace on click and is a native drag source;
-    // without both guards the chevron would switch workspaces, or start a
-    // drag instead of arming the click.
-    expect(summaryPart).toContain('event.stopPropagation()');
-    expect(summaryPart).toContain('onMouseDown');
-    expect(summaryPart).toContain('onDragStart');
+  it('the summary subscribes on counts alone, not on every roster field', () => {
+    // The projection's reference changes whenever any row field does — an
+    // activity string, a focus flag. This control draws two integers, and it
+    // now sits on a row that renders for every workspace.
+    expect(rosterSource).toContain('createWorkspaceRosterCountsSelector(workspaceId)');
+  });
+});
+
+// ─── The accessible name, asserted rather than grepped ───────────────────────
+
+import { rosterSummaryAriaLabel } from '../WorkspaceAgentRoster';
+
+/** Stands in for useT: renders the real en strings' shape without i18n setup. */
+const t = ((key: string, vars?: Record<string, string | number>) => {
+  switch (key) {
+    case 'workspace.agentCount': return `Agents ${vars?.count}`;
+    case 'roster.stashedCount': return `Stashed ${vars?.count}`;
+    case 'roster.stashedOnly': return `Stashed ${vars?.count}`;
+    case 'workspace.showAgents': return 'Show agent list';
+    case 'workspace.hideAgents': return 'Hide agent list';
+    default: return key;
+  }
+}) as Parameters<typeof rosterSummaryAriaLabel>[2];
+
+describe('#997 — the summary chip is a number, its accessible name is not', () => {
+  it('agents only: the count keeps its noun and the toggle its verb', () => {
+    expect(rosterSummaryAriaLabel({ agentCount: 3, stashedCount: 0 }, false, t))
+      .toBe('Agents 3, Show agent list');
+  });
+
+  it('expanded: the verb flips, so the control never lies about what it does', () => {
+    expect(rosterSummaryAriaLabel({ agentCount: 3, stashedCount: 0 }, true, t))
+      .toBe('Agents 3, Hide agent list');
+  });
+
+  it('agents and stash: both counts are announced, the chip only draws them', () => {
+    expect(rosterSummaryAriaLabel({ agentCount: 2, stashedCount: 1 }, false, t))
+      .toBe('Agents 2, Stashed 1, Show agent list');
+  });
+
+  it('stash only: leads with the stash, never "Agents 0"', () => {
+    const label = rosterSummaryAriaLabel({ agentCount: 0, stashedCount: 1 }, false, t);
+    expect(label).toBe('Stashed 1, Show agent list');
+    expect(label).not.toContain('Agents 0');
   });
 });

--- a/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #997 item 2 — the roster summary belongs ON the workspace row, not on a line
+ * of its own.
+ *
+ * The disclosure used to be its own row under every workspace that had any
+ * agents: a chevron and "Agents 3", naming nothing, and — once expanded —
+ * restating the count the rows immediately below it already showed. One line
+ * per workspace, which is what stood between an eleven-workspace sidebar and
+ * scrolling.
+ *
+ * Two things must hold for that saving to survive a refactor, and neither is a
+ * value an assertion could read from a store: the summary must render inside
+ * WorkspaceItem's row, and the list must no longer render a disclosure line of
+ * its own. A source scan, in the same house style as the stash-pulse guard next
+ * to it.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const rosterSource = readFileSync(
+  resolve(process.cwd(), 'src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx'),
+  'utf8',
+);
+const itemSource = readFileSync(
+  resolve(process.cwd(), 'src/renderer/components/Sidebar/WorkspaceItem.tsx'),
+  'utf8',
+);
+
+describe('#997 — roster summary sits on the workspace row', () => {
+  it('WorkspaceItem renders the summary control and owns the expanded state', () => {
+    expect(itemSource).toContain('WorkspaceRosterSummaryMemo');
+    expect(itemSource).toContain('const [rosterOpen, setRosterOpen]');
+    // The list is a sibling BELOW the row and must be told the state rather
+    // than keeping its own copy, or the chevron and the list could disagree.
+    expect(itemSource).toMatch(/<WorkspaceAgentRoster[\s\S]*?open=\{rosterOpen\}/);
+  });
+
+  it('the list renders no disclosure row of its own', () => {
+    // The old row's two tells: a full-width toggle button carrying the count,
+    // and the count label itself living in the list component.
+    const listPart = rosterSource.slice(rosterSource.indexOf('function WorkspaceAgentRoster('));
+    expect(listPart).not.toContain('aria-expanded');
+    expect(listPart).not.toContain("t('workspace.agentCount'");
+    expect(listPart).not.toContain("t('workspace.showAgents')");
+  });
+
+  it('the summary keeps the full wording in its accessible name', () => {
+    const summaryPart = rosterSource.slice(
+      rosterSource.indexOf('function WorkspaceRosterSummary('),
+      rosterSource.indexOf('function WorkspaceAgentRoster('),
+    );
+    // The visible chip is a bare number; a screen reader must still hear
+    // "Agents 3, Show agent list" rather than "3".
+    expect(summaryPart).toContain("t('workspace.agentCount'");
+    expect(summaryPart).toContain("t('workspace.showAgents')");
+    expect(summaryPart).toContain("t('workspace.hideAgents')");
+    expect(summaryPart).toContain('aria-expanded');
+    // A workspace holding only stashed panes must not read "Agents 0".
+    expect(summaryPart).toContain("t('roster.stashedOnly'");
+  });
+
+  it('the summary does not restate needs-you, which the row dot already carries', () => {
+    const summaryPart = rosterSource.slice(
+      rosterSource.indexOf('function WorkspaceRosterSummary('),
+      rosterSource.indexOf('function WorkspaceAgentRoster('),
+    );
+    // WorkspaceItem's leading dot is selectWorkspaceAgentStatus — the
+    // most-urgent status rolled up across the whole workspace — so it is
+    // already red whenever an agent here awaits input. A count beside it would
+    // render the same signal twice and spend the row's scarcest space.
+    expect(summaryPart).not.toContain('needsAttentionCount');
+    expect(itemSource).toContain('selectWorkspaceAgentStatus');
+  });
+
+  it('the summary stops the gesture reaching the row underneath it', () => {
+    const summaryPart = rosterSource.slice(
+      rosterSource.indexOf('function WorkspaceRosterSummary('),
+      rosterSource.indexOf('function WorkspaceAgentRoster('),
+    );
+    // The row selects the workspace on click and is a native drag source;
+    // without both guards the chevron would switch workspaces, or start a
+    // drag instead of arming the click.
+    expect(summaryPart).toContain('event.stopPropagation()');
+    expect(summaryPart).toContain('onMouseDown');
+    expect(summaryPart).toContain('onDragStart');
+  });
+});

--- a/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
+++ b/src/renderer/components/Sidebar/__tests__/workspaceAgentRoster.summaryPlacement.test.ts
@@ -125,3 +125,18 @@ describe('#997 — the summary chip is a number, its accessible name is not', ()
     expect(label).not.toContain('Agents 0');
   });
 });
+
+describe('#997 — the chip drops the stash glyph, the accessible name never does', () => {
+  it('agents + stash: the glyph is off the chip, so the name is the only account of it', () => {
+    // The visible chip renders the agent count alone in this combination
+    // (the glyph cost 17px of the name column); the panes it stands for are
+    // still announced here and still headed inside the expanded list.
+    const summaryPart = rosterSource.slice(
+      rosterSource.indexOf('function WorkspaceRosterSummary('),
+      rosterSource.indexOf('export const WorkspaceRosterSummaryMemo'),
+    );
+    expect(summaryPart).toContain('agentCount === 0 && stashedCount > 0');
+    expect(rosterSummaryAriaLabel({ agentCount: 2, stashedCount: 1 }, false, t))
+      .toContain('Stashed 1');
+  });
+});

--- a/src/renderer/stores/selectors/workspaceAgentRoster.ts
+++ b/src/renderer/stores/selectors/workspaceAgentRoster.ts
@@ -268,6 +268,30 @@ function rowsEqual(
  * projection reference across unrelated store writes so activity in one
  * workspace does not rerender every sidebar row.
  */
+/**
+ * Counts only, reference-stable (#997).
+ *
+ * The full projection's reference changes whenever ANY row field does — an
+ * activity string, a focus flag, a status. The summary chip on the workspace
+ * row draws two integers and is mounted for every workspace, so subscribing it
+ * to the full projection would rerender it on every byte a terminal in that
+ * workspace prints. zustand v5 dropped the equality-function argument, so the
+ * memoization lives in the selector, exactly as it does above.
+ */
+export function createWorkspaceRosterCountsSelector(
+  workspaceId: string,
+): (state: StoreState) => { agentCount: number; stashedCount: number } {
+  let previous: { agentCount: number; stashedCount: number } | undefined;
+  return (state) => {
+    const { agentCount, stashedCount } = selectWorkspaceAgentRoster(state, workspaceId);
+    if (previous && previous.agentCount === agentCount && previous.stashedCount === stashedCount) {
+      return previous;
+    }
+    previous = { agentCount, stashedCount };
+    return previous;
+  };
+}
+
 export function createWorkspaceAgentRosterSelector(
   workspaceId: string,
 ): (state: StoreState) => WorkspaceAgentRosterProjection {


### PR DESCRIPTION
Closes #997 item 2 (item 1, the untranslated `agentAwaitingInput` label, shipped in #1000).

Every workspace with agents spent a full row on a disclosure line — a chevron and "Agents 3", naming nothing. Expanded, its count restated the rows immediately below it: the line was redundant exactly when it was most expensive. The chevron and count move onto the workspace row and the line is gone.

**Measured, same app and same state, HMR-swapped against main:** collapsed row 44.9px → 23.5px, expanded row 143.3px → 123.9px. That is the eleven lines the issue was about.

### What deliberately did not move up

A needs-you count. The row's leading dot is `selectWorkspaceAgentStatus` — the most-urgent status rolled up across the whole workspace — so it already turns red when an agent here reaches awaiting_input / waiting / error, and the row's scarcest space should not render that twice.

The review caught that this claim was overstated, and the comment now says so honestly: `selectFleetPanes` reads neither `surfacePendingQuestion` nor a stashed pane's `exited` liveness, so a pane blocked on a question can sit under a green dot. That is a bug in the dot's source — which also drives MiniSidebar, the titlebar vitals and the deck Fleet — filed as #1168 rather than papered over with a second indicator in this one place.

### The width the chip cost, and getting it back

The first dogfood measured the real price: in the busiest state the workspace NAME went from 87.6px to **43.7px** at 240px — a 22-character name cut to seven. Two rounds of fixes:

- **The idle label yields to the chip.** They answer the same question — is anything happening here — and the chip plus the status dot answer it better; the label is for quiet workspaces, which are exactly the ones with no chip. Its minutes move to the name's tooltip, which also fixes something older: the name span had no `title` at all, so a truncated workspace name was simply unreadable.
- **The stash glyph draws only when it is the only signal.** Beside an agent count it cost 17px while the same panes are announced in the control's accessible name and headed by their own group in the expanded list. Alone, it stays — it is what keeps a stash-only workspace from reading as empty.

Final measurement: **84.5px**, against main's 87.6px — 3.1px, about half a character, in exchange for 21px of height per workspace. The remaining deficit is the chip's physical minimum (chevron plus one digit) sitting on an 8px row gap where the idle label sat on a 4px one. The dogfood's suggestion of reclaiming the 45px the three hover buttons reserve while invisible is **not** taken here: they are `opacity-0`, not `display:none`, so removing them from layout would also remove the only keyboard path to folder / copy / close. Filed as #1169.

### Review team (2-way: independent context-free Opus + GLM-5.3; Codex 402)

Both converged on the subscription cost and on the accessibility of a control whose visible label is now a bare number. Folded in: the list is mounted only while expanded and the counts come from one reference-stable counts selector (a collapsed roster used to run the full projection on every store write, and the chip rerendered on every terminal byte — the sidebar is back to one full scan per workspace); `aria-controls` ties the toggle to a list that is no longer its sibling; mousedown's `preventDefault` (which stops the row's drag) no longer eats the button's focus; the chip carries `data-workspace-agent-roster` so the row's existing drag guard covers it. The aria-label builder is a pure function now, so its four shapes are asserted rather than grepped — which immediately caught that its separator was still the visible label's "·" after the string became speech-only.

### Dogfood

Three rounds, isolated instance, driven over CDP. Verified: no disclosure line between the workspace row and the agent rows; chevron toggles without switching the active workspace and without arming a reorder drag; count survives collapse; Tab reaches the chip with a visible focus ring and mouse-click focus works; the idle label disappears where a chip exists and remains where none does; the name tooltip carries the full name plus the idle minutes; the stash glyph still renders for a stash-only workspace. Screenshots and per-round measurements in the thread above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6