### PR TITLE
fix(browser): launch the dedicated Chrome with --disable-blink-features=AutomationControlled

### DIFF
--- a/changelog.d/1171.md
+++ b/changelog.d/1171.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **The dedicated browser no longer announces itself as automated.** Every page
+  it opened saw `navigator.webdriver = true` — not because an agent was driving
+  it, but because Chrome sets that flag the moment a debugging port is passed at
+  launch, attached client or not. Sites that check it treated the browser as a
+  robot. It now launches with `--disable-blink-features=AutomationControlled`, so
+  Chrome reports its normal value, with no page scripts injected. (#1171)

--- a/src/main/browser-session/ChromeLauncher.ts
+++ b/src/main/browser-session/ChromeLauncher.ts
@@ -771,6 +771,9 @@ export class ChromeLauncher implements ChromeBackendClient {
         `--remote-debugging-port=${pinned ?? 0}`,
         // connectOverCDP's websocket handshake (Chrome 111+ origin check).
         '--remote-allow-origins=*',
+        // `--remote-debugging-port` alone flips `navigator.webdriver` to true on
+        // every page, even with no client attached; this restores its normal value.
+        '--disable-blink-features=AutomationControlled',
         '--no-first-run',
         '--no-default-browser-check',
       ],

--- a/src/main/browser-session/__tests__/ChromeLauncher.test.ts
+++ b/src/main/browser-session/__tests__/ChromeLauncher.test.ts
@@ -98,6 +98,9 @@ describe('ChromeLauncher', () => {
     // port produces no file (measured on Chrome 151, #1064 dogfood).
     expect(args).toContain('--remote-debugging-port=0');
     expect(args).toContain('--remote-allow-origins=*');
+    // Without this switch the debugging port alone makes every page report
+    // `navigator.webdriver === true` (measured on Chrome 152).
+    expect(args).toContain('--disable-blink-features=AutomationControlled');
   });
 
   it('a stale DevToolsActivePort (dead previous instance) is neither adopted nor mistaken for the fresh write', async () => {


### PR DESCRIPTION
## Problem

Every page loaded in wmux's dedicated Chrome reports `navigator.webdriver === true`.

This is not caused by an automation client attaching. Measured on Chrome 152: passing
`--remote-debugging-port` at launch is by itself enough to flip the flag, so the value is
already `true` on a Chrome that nothing has connected to. Bot-detection pages read that flag
directly, which is why the dedicated browser rated as a robot on public detectors.

## Fix

`ChromeLauncher` now also passes Chrome's own switch:

```
--disable-blink-features=AutomationControlled
```

With it, Blink reports the normal value natively. No page script is injected — a JS
`defineProperty` patch over `navigator.webdriver` is itself a detectable signal, so this
deliberately stays a launch-flag-only change.

## Verification

Two live conditions against a scratch `--user-data-dir`, using exactly the argument set
`ChromeLauncher` now passes.

**Condition A — Chrome launched with the flags, no automation client attached** (URLs opened
via Chrome's CLI; only raw CDP `Page.captureScreenshot` / `DOM.getOuterHTML`, never the
`Runtime` domain):

```
bot-detector.rebrowser.net   🟢 navigatorWebdriver — No webdriver presented.
bot.sannysoft.com            WebDriver (New)      missing (passed)
                             WebDriver Advanced   passed
```

**Condition B — same Chrome + `connectOverCDP`, navigating, a large DOM `evaluate`, a real
mouse click, then reading `navigator.webdriver`**:

```
B-rebrowser.txt    "webdriver": false
B-browserscan.txt  "webdriver": false
B-sannysoft.txt    "webdriver": false

browserscan.net/bot-detection   Bot Detection — Test Results: Normal
                                WebDriver Normal · WebDriver Advance Normal
                                CDP Normal · Dev Tool Normal
                                "No bots detected - the visitor could be a human
                                 using a regular browser."
bot-detector.rebrowser.net      🟢 navigatorWebdriver — No webdriver presented.
bot.sannysoft.com               WebDriver (New) missing (passed)
```

Gates: `tsc --noEmit` clean, `vitest run src/main/browser-session` 17 files / 262 tests green
(one new assertion added to the existing spawn-args test).

## Out of scope

- **Live-attach lane** (`LiveChromeClient`): attaches to a Chrome the user already started.
  Its launch arguments are the user's, not ours, so nothing here changes and nothing should.
- **Electron webview lane** (`src/main/index.ts` `remote-debugging-port` switch): that is the
  wmux app's own renderer CDP port for internal automation, not a browsing surface presented
  to websites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dedicated browser sessions no longer expose `navigator.webdriver = true` when launched with a debugging port.
  * Pages now observe Chrome’s normal browser automation value without requiring injected scripts.

* **Tests**
  * Added coverage to verify the browser launches with the required setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->