### PR TITLE
Browser tools run their own page scripts in an isolated world

### DIFF
--- a/changelog.d/1172.md
+++ b/changelog.d/1172.md
@@ -1,0 +1,9 @@
+### Changed
+
+- **Browser tools now run their own page scripts in an isolated world.** A
+  website can no longer see the scripts the agent injects to read the page, nor
+  hand them doctored results by redefining the DOM methods they call — the
+  snapshot, extraction, wait and scroll scripts share the page's DOM but not
+  its JavaScript, so they are invisible to it. `browser_evaluate` runs there
+  too by default and gained a `mainWorld` option for the expressions that
+  genuinely need the page's own globals. (#1172)

--- a/changelog.d/1172.md
+++ b/changelog.d/1172.md
@@ -6,4 +6,5 @@
   snapshot, extraction, wait and scroll scripts share the page's DOM but not
   its JavaScript, so they are invisible to it. `browser_evaluate` runs there
   too by default and gained a `mainWorld` option for the expressions that
-  genuinely need the page's own globals. (#1172)
+  genuinely need the page's own globals — as does the backend that has no
+  isolated world to offer, which now says so in its answer. (#1172)

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "d65b9f3f8bf957dd1095d1358bd3628911640c8c4595c6079669a68788811661",
+      "wireResultSha256": "db19fc959c10612d3c8dc1a00e9e46c319b22e9db4dfaaba7397264c666919ef",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/mcp/playwright/__tests__/inspection.evaluate.world.test.ts
+++ b/src/mcp/playwright/__tests__/inspection.evaluate.world.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Which world browser_evaluate runs the caller's expression in. The default is
+// the isolated one — the page must not be able to watch or doctor an agent
+// script — and `mainWorld:true` is the deliberate opt-out for expressions that
+// need the page's own globals (window.__NEXT_DATA__ and friends).
+
+const { getPage, resolveWorkspaceBackend, isolated, gesture } = vi.hoisted(() => ({
+  getPage: vi.fn(),
+  resolveWorkspaceBackend: vi.fn(),
+  isolated: vi.fn(async () => 'from-isolated'),
+  gesture: vi.fn(async () => 'from-main'),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string) =>
+    method.startsWith('browser.lease.') || method === 'browser.lifecycle.get'
+      ? Promise.resolve({ token: null })
+      : Promise.resolve({}),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({ getPageForScope: getPage, resolveWorkspaceBackend }),
+  },
+}));
+
+vi.mock('../snapshot', () => ({
+  resolveRef: vi.fn(),
+  generateSnapshot: vi.fn(),
+  generateScopedSnapshot: vi.fn(),
+  markDomRefsActive: vi.fn(),
+}));
+
+vi.mock('../isolated-eval', () => ({ evaluateIsolated: isolated }));
+vi.mock('../user-gesture', () => ({ evaluateWithGesture: gesture }));
+
+import { registerInspectionTools } from '../tools/inspection';
+
+type ToolResult = { content: Array<{ type: string; text?: string }>; isError?: boolean };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+const deps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+const tools = new Map<string, ToolHandler>();
+registerInspectionTools(
+  { tool: (name: string, _d: string, _s: unknown, handler: ToolHandler) => tools.set(name, handler) } as never,
+  deps as never,
+);
+const evaluate = tools.get('browser_evaluate');
+if (!evaluate) throw new Error('browser_evaluate failed to register');
+
+const page = { evaluate: vi.fn() };
+
+describe('browser_evaluate world selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPage.mockResolvedValue(page);
+  });
+
+  it('runs in the isolated world by default', async () => {
+    const out = await evaluate({ expression: 'document.title' });
+
+    expect(isolated).toHaveBeenCalledWith(page, 'document.title');
+    expect(gesture).not.toHaveBeenCalled();
+    expect(out.content[0]?.text).toBe('from-isolated');
+  });
+
+  it('runs in the page\'s own world when mainWorld is true', async () => {
+    const out = await evaluate({ expression: 'window.__NEXT_DATA__', mainWorld: true });
+
+    expect(gesture).toHaveBeenCalledWith(page, 'window.__NEXT_DATA__');
+    expect(isolated).not.toHaveBeenCalled();
+    expect(out.content[0]?.text).toBe('from-main');
+  });
+});

--- a/src/mcp/playwright/__tests__/isolated-eval.test.ts
+++ b/src/mcp/playwright/__tests__/isolated-eval.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Page } from 'playwright-core';
+import { evaluateIsolated, resetIsolatedEval, waitForIsolated } from '../isolated-eval';
+
+type Handler = (payload: any) => void;
+
+interface FakeOptions {
+  /** Value the isolated call resolves to, or a function of the sent params. */
+  result?: unknown | ((params: any) => unknown);
+  /** Return null from Page.createIsolatedWorld (no isolated world available). */
+  noWorld?: boolean;
+}
+
+/** Fake Page + CDP session recording exactly what the helper sends. */
+function makePage(options: FakeOptions = {}) {
+  const sent: Array<{ method: string; params: any }> = [];
+  const handlers = new Map<string, Handler[]>();
+  let worldId = 100;
+
+  const client = {
+    send: vi.fn(async (method: string, params?: any) => {
+      sent.push({ method, params });
+      if (method === 'Page.getFrameTree') return { frameTree: { frame: { id: 'FRAME-1' } } };
+      if (method === 'Page.createIsolatedWorld') {
+        if (options.noWorld) return {};
+        worldId += 1;
+        return { executionContextId: worldId };
+      }
+      if (method === 'Runtime.callFunctionOn') {
+        const value =
+          typeof options.result === 'function'
+            ? (options.result as (p: any) => unknown)(params)
+            : options.result;
+        return { result: { value } };
+      }
+      return {};
+    }),
+    on: (event: string, handler: Handler) => {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+  };
+
+  const page = {
+    context: () => ({ newCDPSession: async () => client }),
+    evaluate: vi.fn(async () => 'main-world'),
+    on: vi.fn(),
+  };
+
+  const emit = (event: string, payload?: unknown): void => {
+    for (const handler of handlers.get(event) ?? []) handler(payload);
+  };
+
+  return { page: page as unknown as Page, client, sent, emit, rawPage: page };
+}
+
+const callsTo = (sent: Array<{ method: string }>, method: string): number =>
+  sent.filter((entry) => entry.method === method).length;
+
+describe('evaluateIsolated', () => {
+  beforeEach(() => {
+    resetIsolatedEval();
+  });
+
+  it('runs the script in a created isolated world and returns its value', async () => {
+    const { page, sent } = makePage({ result: 42 });
+
+    expect(await evaluateIsolated(page, '1 + 41')).toBe(42);
+
+    const world = sent.find((entry) => entry.method === 'Page.createIsolatedWorld');
+    expect(world?.params.frameId).toBe('FRAME-1');
+    expect(world?.params.grantUniveralAccess).toBe(true);
+    // The world name must not name the product — it is the one string about us
+    // that reaches the browser at all.
+    expect(String(world?.params.worldName)).not.toMatch(/wmux|automation|playwright/i);
+
+    const call = sent.find((entry) => entry.method === 'Runtime.callFunctionOn');
+    expect(call?.params.executionContextId).toBe(101);
+    expect(call?.params.returnByValue).toBe(true);
+    expect(call?.params.awaitPromise).toBe(true);
+  });
+
+  it('passes arg as the function\'s single parameter, like page.evaluate(fn, arg)', async () => {
+    const { page, sent } = makePage({ result: 'ok' });
+
+    await evaluateIsolated(page, (n: number) => n * 2, 21);
+
+    const call = sent.find((entry) => entry.method === 'Runtime.callFunctionOn');
+    expect(call?.params.arguments).toEqual([{ value: 21 }]);
+    expect(String(call?.params.functionDeclaration)).toContain('n * 2');
+  });
+
+  it('creates the world once and reuses the cached context', async () => {
+    const { page, sent } = makePage({ result: 1 });
+
+    await evaluateIsolated(page, 'a');
+    await evaluateIsolated(page, 'b');
+    await evaluateIsolated(page, 'c');
+
+    expect(callsTo(sent, 'Page.createIsolatedWorld')).toBe(1);
+    expect(callsTo(sent, 'Runtime.callFunctionOn')).toBe(3);
+  });
+
+  it('drops the cached context when the page clears its execution contexts', async () => {
+    const { page, sent, emit } = makePage({ result: 1 });
+
+    await evaluateIsolated(page, 'a');
+    emit('Runtime.executionContextsCleared');
+    await evaluateIsolated(page, 'b');
+
+    expect(callsTo(sent, 'Page.createIsolatedWorld')).toBe(2);
+    const calls = sent.filter((entry) => entry.method === 'Runtime.callFunctionOn');
+    expect(calls.map((entry) => entry.params.executionContextId)).toEqual([101, 102]);
+  });
+
+  it('re-throws a page exception with the page\'s own message', async () => {
+    const { page } = makePage({});
+    (page as any).context = () => ({
+      newCDPSession: async () => ({
+        on: () => undefined,
+        send: async (method: string) => {
+          if (method === 'Page.getFrameTree') return { frameTree: { frame: { id: 'F' } } };
+          if (method === 'Page.createIsolatedWorld') return { executionContextId: 7 };
+          if (method === 'Runtime.callFunctionOn') {
+            return {
+              exceptionDetails: {
+                text: 'Uncaught',
+                exception: { description: 'TypeError: nope is not a function' },
+              },
+            };
+          }
+          return {};
+        },
+      }),
+    });
+
+    await expect(evaluateIsolated(page, 'nope()')).rejects.toThrow(
+      'TypeError: nope is not a function',
+    );
+  });
+
+  it('falls back to the main world when no isolated world can be created', async () => {
+    const { page, rawPage, sent } = makePage({ noWorld: true });
+
+    expect(await evaluateIsolated(page, 'x')).toBe('main-world');
+    expect(rawPage.evaluate).toHaveBeenCalledTimes(1);
+    // One argument, exactly as the pre-existing page.evaluate(expression) call.
+    expect(rawPage.evaluate.mock.calls[0]).toHaveLength(1);
+    expect(callsTo(sent, 'Runtime.callFunctionOn')).toBe(0);
+  });
+});
+
+describe('waitForIsolated', () => {
+  beforeEach(() => {
+    resetIsolatedEval();
+  });
+
+  it('resolves once the predicate turns truthy', async () => {
+    let polls = 0;
+    const { page } = makePage({
+      result: () => {
+        polls += 1;
+        return polls >= 3;
+      },
+    });
+
+    await waitForIsolated(page, 'ready', undefined, 5000);
+    expect(polls).toBe(3);
+  });
+
+  it('throws a timeout error when the predicate never satisfies', async () => {
+    const { page } = makePage({ result: false });
+
+    await expect(waitForIsolated(page, 'never', undefined, 30)).rejects.toThrow(
+      'Timeout 30ms exceeded',
+    );
+  });
+});

--- a/src/mcp/playwright/__tests__/isolated-eval.test.ts
+++ b/src/mcp/playwright/__tests__/isolated-eval.test.ts
@@ -26,15 +26,18 @@ function makePage(options: FakeOptions = {}) {
         worldId += 1;
         return { executionContextId: worldId };
       }
-      if (method === 'Runtime.callFunctionOn') {
-        const value =
+      if (method === 'Runtime.callFunctionOn' || method === 'Runtime.evaluate') {
+        const produced =
           typeof options.result === 'function'
             ? (options.result as (p: any) => unknown)(params)
             : options.result;
-        return { result: { value } };
+        return typeof produced === 'string' && produced.startsWith('@unserializable:')
+          ? { result: { unserializableValue: produced.slice('@unserializable:'.length) } }
+          : { result: { value: produced } };
       }
       return {};
     }),
+    detach: vi.fn(async () => undefined),
     on: (event: string, handler: Handler) => {
       const list = handlers.get(event) ?? [];
       list.push(handler);
@@ -46,6 +49,7 @@ function makePage(options: FakeOptions = {}) {
     context: () => ({ newCDPSession: async () => client }),
     evaluate: vi.fn(async () => 'main-world'),
     on: vi.fn(),
+    isClosed: () => false,
   };
 
   const emit = (event: string, payload?: unknown): void => {
@@ -70,13 +74,14 @@ describe('evaluateIsolated', () => {
 
     const world = sent.find((entry) => entry.method === 'Page.createIsolatedWorld');
     expect(world?.params.frameId).toBe('FRAME-1');
-    expect(world?.params.grantUniveralAccess).toBe(true);
     // The world name must not name the product — it is the one string about us
     // that reaches the browser at all.
     expect(String(world?.params.worldName)).not.toMatch(/wmux|automation|playwright/i);
+    // Parity with the main world, not extra privilege.
+    expect(world?.params.grantUniveralAccess).toBe(false);
 
-    const call = sent.find((entry) => entry.method === 'Runtime.callFunctionOn');
-    expect(call?.params.executionContextId).toBe(101);
+    const call = sent.find((entry) => entry.method === 'Runtime.evaluate');
+    expect(call?.params.contextId).toBe(101);
     expect(call?.params.returnByValue).toBe(true);
     expect(call?.params.awaitPromise).toBe(true);
   });
@@ -99,7 +104,7 @@ describe('evaluateIsolated', () => {
     await evaluateIsolated(page, 'c');
 
     expect(callsTo(sent, 'Page.createIsolatedWorld')).toBe(1);
-    expect(callsTo(sent, 'Runtime.callFunctionOn')).toBe(3);
+    expect(callsTo(sent, 'Runtime.evaluate')).toBe(3);
   });
 
   it('drops the cached context when the page clears its execution contexts', async () => {
@@ -110,19 +115,21 @@ describe('evaluateIsolated', () => {
     await evaluateIsolated(page, 'b');
 
     expect(callsTo(sent, 'Page.createIsolatedWorld')).toBe(2);
-    const calls = sent.filter((entry) => entry.method === 'Runtime.callFunctionOn');
-    expect(calls.map((entry) => entry.params.executionContextId)).toEqual([101, 102]);
+    const calls = sent.filter((entry) => entry.method === 'Runtime.evaluate');
+    expect(calls.map((entry) => entry.params.contextId)).toEqual([101, 102]);
   });
 
   it('re-throws a page exception with the page\'s own message', async () => {
     const { page } = makePage({});
+    (page as any).isClosed = () => false;
     (page as any).context = () => ({
       newCDPSession: async () => ({
         on: () => undefined,
+        detach: async () => undefined,
         send: async (method: string) => {
           if (method === 'Page.getFrameTree') return { frameTree: { frame: { id: 'F' } } };
           if (method === 'Page.createIsolatedWorld') return { executionContextId: 7 };
-          if (method === 'Runtime.callFunctionOn') {
+          if (method === 'Runtime.evaluate') {
             return {
               exceptionDetails: {
                 text: 'Uncaught',
@@ -147,7 +154,88 @@ describe('evaluateIsolated', () => {
     expect(rawPage.evaluate).toHaveBeenCalledTimes(1);
     // One argument, exactly as the pre-existing page.evaluate(expression) call.
     expect(rawPage.evaluate.mock.calls[0]).toHaveLength(1);
+    expect(callsTo(sent, 'Runtime.evaluate')).toBe(0);
+  });
+
+  it('sends a multi-statement string as an expression, not a return-wrapped body', async () => {
+    const { page, sent } = makePage({ result: 5 });
+    const script = 'const a = document.title;\na.length';
+
+    expect(await evaluateIsolated(page, script)).toBe(5);
+
+    const call = sent.find((entry) => entry.method === 'Runtime.evaluate');
+    // Wrapping this in `function () { return (...) }` would be a SyntaxError,
+    // and page.evaluate(string) always accepted it.
+    expect(call?.params.expression).toBe(script);
     expect(callsTo(sent, 'Runtime.callFunctionOn')).toBe(0);
+  });
+
+  it('restores the values JSON cannot carry (NaN, Infinity, -0)', async () => {
+    for (const [wire, expected] of [
+      ['NaN', NaN],
+      ['Infinity', Infinity],
+      ['-Infinity', -Infinity],
+    ] as Array<[string, number]>) {
+      resetIsolatedEval();
+      const { page } = makePage({ result: `@unserializable:${wire}` });
+      expect(await evaluateIsolated(page, 'x')).toBe(expected);
+    }
+    resetIsolatedEval();
+    const { page } = makePage({ result: '@unserializable:-0' });
+    expect(Object.is(await evaluateIsolated(page, 'x'), -0)).toBe(true);
+  });
+
+  it('retries once on a stale context instead of surfacing the race', async () => {
+    let calls = 0;
+    const { page, sent } = makePage({
+      result: () => {
+        calls += 1;
+        if (calls === 1) throw new Error('Cannot find context with specified id');
+        return 'second';
+      },
+    });
+
+    expect(await evaluateIsolated(page, 'x')).toBe('second');
+    expect(callsTo(sent, 'Page.createIsolatedWorld')).toBe(2);
+  });
+
+  it('retries the world after a failure instead of writing the page off', async () => {
+    let allowWorld = false;
+    const sent: Array<{ method: string }> = [];
+    const handlers = new Map<string, Handler[]>();
+    const client = {
+      send: vi.fn(async (method: string) => {
+        sent.push({ method });
+        if (method === 'Page.getFrameTree') {
+          // First attempt loses a race with a navigation.
+          if (!allowWorld) throw new Error('Session closed');
+          return { frameTree: { frame: { id: 'F' } } };
+        }
+        if (method === 'Page.createIsolatedWorld') return { executionContextId: 9 };
+        if (method === 'Runtime.evaluate') return { result: { value: 'isolated' } };
+        return {};
+      }),
+      on: (event: string, handler: Handler) => {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      },
+      detach: vi.fn(async () => undefined),
+    };
+    const page = {
+      context: () => ({ newCDPSession: async () => client }),
+      evaluate: vi.fn(async () => 'main-world'),
+      on: vi.fn(),
+      isClosed: () => false,
+    } as unknown as Page;
+
+    expect(await evaluateIsolated(page, 'x')).toBe('main-world');
+
+    // The page navigates; the next call must try the isolated world again
+    // rather than stay downgraded for the page's whole life.
+    allowWorld = true;
+    for (const handler of handlers.get('Page.frameNavigated') ?? []) handler({ frame: {} });
+    expect(await evaluateIsolated(page, 'x')).toBe('isolated');
   });
 });
 
@@ -167,6 +255,30 @@ describe('waitForIsolated', () => {
 
     await waitForIsolated(page, 'ready', undefined, 5000);
     expect(polls).toBe(3);
+  });
+
+  it('waits out a stale context on the first poll instead of failing', async () => {
+    let calls = 0;
+    const { page } = makePage({
+      result: () => {
+        calls += 1;
+        if (calls === 1) throw new Error('Execution context was destroyed');
+        return calls >= 2;
+      },
+    });
+
+    await waitForIsolated(page, 'ready', undefined, 5000);
+    expect(calls).toBe(2);
+  });
+
+  it('still fails fast on a malformed predicate', async () => {
+    const { page } = makePage({
+      result: () => {
+        throw new Error('SyntaxError: Unexpected token');
+      },
+    });
+
+    await expect(waitForIsolated(page, 'nope(', undefined, 5000)).rejects.toThrow('SyntaxError');
   });
 
   it('throws a timeout error when the predicate never satisfies', async () => {

--- a/src/mcp/playwright/isolated-eval.ts
+++ b/src/mcp/playwright/isolated-eval.ts
@@ -60,8 +60,21 @@ interface PageState {
   contextId: number | null;
   /** In-flight creation, so concurrent callers share one round trip. */
   creating: Promise<number | null> | null;
-  /** Set when the world could not be created — stop retrying every call. */
-  unavailable: boolean;
+  /**
+   * Bumped every time the document underneath us changes. A creation that was
+   * already in flight when that happened describes the OLD document, so its
+   * result is discarded rather than cached.
+   */
+  epoch: number;
+  /**
+   * True only when this Page can never give us an isolated world: no CDP
+   * session, or a session we could not subscribe to. A world that merely
+   * FAILED to be created is retried — a getFrameTree that lost a race with a
+   * navigation must not downgrade the page to the main world for its lifetime.
+   */
+  sessionUnusable: boolean;
+  /** One main-world warning per page is diagnosable; one per call is noise. */
+  warned: boolean;
 }
 
 /**
@@ -108,10 +121,10 @@ export async function createIsolatedContext(
     const world = (await client.send('Page.createIsolatedWorld', {
       frameId: targetFrameId,
       worldName: WORLD_NAME,
-      // The DOM is shared regardless; universal access additionally lets the
-      // script reach same-page cross-origin objects the way main-world code
-      // reaching them would, so behaviour does not change under our feet.
-      grantUniveralAccess: true,
+      // Parity with the main world is the goal, not extra privilege: universal
+      // access would let an agent-supplied browser_evaluate script reach into
+      // cross-origin frames that main-world code cannot touch.
+      grantUniveralAccess: false,
     })) as { executionContextId?: number };
     return typeof world?.executionContextId === 'number' ? world.executionContextId : null;
   } catch {
@@ -132,9 +145,17 @@ async function openState(page: Page): Promise<PageState> {
     client,
     contextId: null,
     creating: null,
-    unavailable: client === null,
+    epoch: 0,
+    sessionUnusable: client === null,
+    warned: false,
   };
   if (!client) return state;
+
+  /** The document changed: retire the context AND any creation in flight. */
+  const invalidate = (): void => {
+    state.contextId = null;
+    state.epoch += 1;
+  };
 
   // Cache invalidation is not optional: a context id that outlives its
   // document silently evaluates nothing. If the subscriptions below cannot be
@@ -146,26 +167,31 @@ async function openState(page: Page): Promise<PageState> {
     await client.send('Runtime.enable').catch(() => undefined);
     await client.send('Page.enable').catch(() => undefined);
 
-    client.on('Runtime.executionContextsCleared', () => {
-      state.contextId = null;
-    });
+    client.on('Runtime.executionContextsCleared', invalidate);
     client.on('Runtime.executionContextDestroyed', (payload: { executionContextId?: number }) => {
-      if (payload?.executionContextId === state.contextId) state.contextId = null;
+      if (payload?.executionContextId === state.contextId) invalidate();
     });
     client.on('Page.frameNavigated', (payload: { frame?: { parentId?: string } }) => {
       // Only the main frame's navigation retires our world; a subframe moving
-      // is none of our business.
-      if (!payload?.frame?.parentId) state.contextId = null;
+      // is none of our business. (Same-document navigation arrives as
+      // navigatedWithinDocument and keeps the context, correctly.)
+      if (!payload?.frame?.parentId) invalidate();
     });
 
     const drop = (): void => {
       states.delete(page);
+      void Promise.resolve()
+        .then(() => (client as unknown as { detach?: () => Promise<void> }).detach?.())
+        .catch(() => undefined);
     };
     page.on('close', drop);
     page.on('crash', drop);
+    // A page that was ALREADY closed never fires 'close', so the entry (and
+    // its session) would sit in the map for the rest of the process.
+    if (page.isClosed()) drop();
   } catch {
     state.client = null;
-    state.unavailable = true;
+    state.sessionUnusable = true;
   }
 
   return state;
@@ -182,37 +208,69 @@ async function stateFor(page: Page): Promise<PageState> {
   return created;
 }
 
-/** Resolve the page's isolated context id, creating the world on demand. */
+/**
+ * Resolve the page's isolated context id, creating the world on demand.
+ *
+ * A failure is transient by default — a getFrameTree that lost a race with a
+ * navigation says nothing about the next call — so nothing is latched here.
+ * Only a Page that could never give us a session is written off, in openState.
+ */
 async function contextIdFor(state: PageState): Promise<number | null> {
-  if (state.contextId !== null) return state.contextId;
-  if (state.unavailable) return null;
-  if (!state.creating) {
+  // Two attempts: one for the ordinary case, one for a document that changed
+  // WHILE the world was being created (the id we got describes the old one).
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    if (state.contextId !== null) return state.contextId;
     const client = state.client;
-    if (!client) return null;
-    state.creating = createIsolatedContext(client)
-      .then((id) => {
-        state.contextId = id;
-        if (id === null) state.unavailable = true;
-        return id;
-      })
-      .finally(() => {
-        state.creating = null;
-      });
+    if (!client || state.sessionUnusable) return null;
+    if (!state.creating) {
+      const epoch = state.epoch;
+      state.creating = createIsolatedContext(client)
+        .then((id) => {
+          if (id !== null && state.epoch === epoch) state.contextId = id;
+          return id;
+        })
+        .finally(() => {
+          state.creating = null;
+        });
+    }
+    const created = await state.creating;
+    if (created === null) return null;
+    if (state.contextId !== null) return state.contextId;
   }
-  return state.creating;
+  return null;
 }
 
 /**
- * Wrap a script for `Runtime.callFunctionOn`.
- *
- * A function is sent as-is and receives `arg` as its single parameter, exactly
- * like `page.evaluate(fn, arg)`. A string is treated as an expression, exactly
- * like `page.evaluate(expression)` — the newlines matter, so a trailing line
- * comment in the source cannot swallow the closing parenthesis.
+ * CDP hands NaN, +/-Infinity and -0 back as `unserializableValue` instead of
+ * `value`, because JSON has no spelling for them. `page.evaluate` restores
+ * them, so this does too — otherwise they would silently arrive as undefined.
  */
-function functionDeclarationFor<A, R>(script: IsolatedScript<A, R>): string {
-  if (typeof script === 'function') return script.toString();
-  return `function () { return (\n${script}\n); }`;
+function decodeResult(result?: { value?: unknown; unserializableValue?: string }): unknown {
+  if (!result) return undefined;
+  if (result.unserializableValue === undefined) return result.value;
+  switch (result.unserializableValue) {
+    case 'NaN':
+      return NaN;
+    case 'Infinity':
+      return Infinity;
+    case '-Infinity':
+      return -Infinity;
+    case '-0':
+      return -0;
+    default:
+      // Anything else (BigInt literals) has no JSON form either way.
+      return undefined;
+  }
+}
+
+function throwPageException(details?: {
+  text?: string;
+  exception?: { description?: string };
+}): void {
+  if (!details) return;
+  throw new Error(
+    details.exception?.description ?? details.text ?? 'Isolated evaluation threw an exception',
+  );
 }
 
 /**
@@ -235,38 +293,51 @@ export async function evaluateIsolated<R = unknown, A = unknown>(
   options?: IsolatedEvalOptions,
 ): Promise<R> {
   const state = await stateFor(page);
-  const declaration = functionDeclarationFor(script);
 
   // Main-world fallback, used only when no isolated world can be had. Called
   // with the SAME arity as before this module existed, so a one-argument
   // page.evaluate stays a one-argument call.
   const mainWorld = (): Promise<R> => {
+    if (!state.warned) {
+      state.warned = true;
+      console.warn(
+        '[isolated-eval] no isolated world on this page; page scripts run in the main world',
+      );
+    }
     const evaluatable = script as unknown as (a: unknown) => R;
     return (arg === undefined
       ? page.evaluate(evaluatable)
       : page.evaluate(evaluatable, arg)) as Promise<R>;
   };
 
+  type EvalReply = {
+    result?: { value?: unknown; unserializableValue?: string };
+    exceptionDetails?: { text?: string; exception?: { description?: string } };
+  };
+
   const call = async (contextId: number, client: IsolatedCdpSession): Promise<R> => {
-    const result = (await client.send('Runtime.callFunctionOn', {
-      functionDeclaration: declaration,
-      executionContextId: contextId,
-      arguments: [{ value: arg }],
-      returnByValue: true,
-      awaitPromise: true,
-      userGesture: options?.userGesture ?? false,
-    })) as {
-      result?: { value?: unknown };
-      exceptionDetails?: { text?: string; exception?: { description?: string } };
-    };
-    if (result?.exceptionDetails) {
-      throw new Error(
-        result.exceptionDetails.exception?.description ??
-          result.exceptionDetails.text ??
-          'Isolated evaluation threw an exception',
-      );
-    }
-    return result?.result?.value as R;
+    // A STRING goes through Runtime.evaluate, not callFunctionOn: the old
+    // page.evaluate(string) / Runtime.evaluate({expression}) path accepted
+    // whole scripts ("const a = document.title; a.length"), and wrapping those
+    // in `return (...)` would turn them into a SyntaxError.
+    const reply = (await (typeof script === 'string'
+      ? client.send('Runtime.evaluate', {
+          expression: script,
+          contextId,
+          returnByValue: true,
+          awaitPromise: true,
+          userGesture: options?.userGesture ?? false,
+        })
+      : client.send('Runtime.callFunctionOn', {
+          functionDeclaration: script.toString(),
+          executionContextId: contextId,
+          arguments: [{ value: arg }],
+          returnByValue: true,
+          awaitPromise: true,
+          userGesture: options?.userGesture ?? false,
+        }))) as EvalReply;
+    throwPageException(reply?.exceptionDetails);
+    return decodeResult(reply?.result) as R;
   };
 
   let contextId = await contextIdFor(state);
@@ -287,6 +358,26 @@ export async function evaluateIsolated<R = unknown, A = unknown>(
     if (contextId === null) return await mainWorld();
     return await call(contextId, client);
   }
+}
+
+/**
+ * The cached session and isolated context for `page`, for callers that must
+ * send raw CDP themselves (the occlusion probe needs remote handles, not
+ * values). Reusing this session is what keeps Chromium from minting a fresh
+ * isolated world per snapshot: worlds are cached per (session, frame, name),
+ * so a new session per snapshot would accumulate them in the renderer.
+ *
+ * Null when the page has no isolated world; the caller then does what it did
+ * before, in the main world.
+ */
+export async function isolatedProbeTarget(
+  page: Page,
+): Promise<{ client: IsolatedCdpSession; contextId: number } | null> {
+  const state = await stateFor(page).catch(() => null);
+  if (!state) return null;
+  const contextId = await contextIdFor(state);
+  if (contextId === null || !state.client) return null;
+  return { client: state.client, contextId };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -315,7 +406,11 @@ export async function waitForIsolated<A = unknown>(
     try {
       if (await evaluateIsolated<unknown, A>(page, script, arg)) return;
     } catch (error) {
-      if (first) throw error;
+      // A malformed predicate must fail fast rather than expire as a timeout,
+      // so the first evaluation re-throws — except for the context error a
+      // wait started right after a click or a navigation routinely hits, which
+      // page.waitForFunction simply waited out.
+      if (first && !isStaleContextError(errorMessage(error))) throw error;
     }
     first = false;
     if (hasDeadline && Date.now() >= deadline) {

--- a/src/mcp/playwright/isolated-eval.ts
+++ b/src/mcp/playwright/isolated-eval.ts
@@ -1,0 +1,334 @@
+import type { Page } from 'playwright-core';
+
+// ---------------------------------------------------------------------------
+// Run our own page scripts in an isolated world.
+// ---------------------------------------------------------------------------
+//
+// Everything wmux injected used to run in the page's MAIN world: the same
+// JavaScript realm the site's own code lives in. Measured against a
+// bot-detector page, `window.dummyFn()` defined by the page was callable from
+// browser_evaluate, and the detector's "main world execution" probe — it hooks
+// `document.getElementsByClassName` and friends and watches for calls that do
+// not come from page code — went red the moment our snapshot scan ran.
+//
+// That is not only a fingerprint. A page can redefine the DOM methods our
+// scripts call and hand back whatever it likes, so a hostile site can both
+// SEE and TAMPER WITH the agent's view of itself.
+//
+// An isolated world fixes both: it shares the DOM (same document, same
+// elements, same attributes) but not the JavaScript globals, so page code
+// cannot see our scripts, and page-installed hooks on built-ins do not run for
+// us. Playwright's own locator/click/fill internals already work this way —
+// this module brings OUR scripts up to the same footing.
+//
+// Not in scope: the main-process RPC lane (page-eval.ts's rpcEvaluator), which
+// has no Playwright Page to attach a session to, and the `Runtime.enable`
+// fingerprint, which measured clean on current Chrome.
+
+/**
+ * Name of the world we create. It never reaches the page — only CDP traffic —
+ * but it stays bland anyway so that nothing product-specific is written down
+ * anywhere a devtools listener could read it.
+ */
+const WORLD_NAME = 'util';
+
+/** How often a wait predicate is re-evaluated. */
+const POLL_INTERVAL_MS = 100;
+
+/** Just enough of a CDP session to create a world on it. */
+export interface IsolatedCdpSender {
+  send: (method: string, params?: unknown) => Promise<unknown>;
+}
+
+/** The slice of a CDP session this module needs (also what fakes implement). */
+export interface IsolatedCdpSession extends IsolatedCdpSender {
+  on: (event: string, handler: (payload: any) => void) => void;
+}
+
+/** A page function, or a bare JavaScript expression to evaluate. */
+export type IsolatedScript<A, R> = string | ((arg: A) => R | Promise<R>);
+
+export interface IsolatedEvalOptions {
+  /** Treat the call as user-initiated (transient activation). Default false. */
+  userGesture?: boolean;
+}
+
+interface PageState {
+  /** null when this Page cannot give us a CDP session at all. */
+  client: IsolatedCdpSession | null;
+  /** Cached context id for the main frame; null once it is known to be stale. */
+  contextId: number | null;
+  /** In-flight creation, so concurrent callers share one round trip. */
+  creating: Promise<number | null> | null;
+  /** Set when the world could not be created — stop retrying every call. */
+  unavailable: boolean;
+}
+
+/**
+ * One state per live Page. Entries are dropped when the page closes or
+ * crashes, which is also what detaches the session — a plain Map is therefore
+ * enough (and tsconfig.mcp.json targets ES2020, where WeakRef does not exist).
+ */
+const states = new Map<Page, Promise<PageState>>();
+
+/** Errors that mean "the context you had is gone", not "the script failed". */
+function isStaleContextError(message: string): boolean {
+  return /Cannot find context|Execution context was destroyed|Inspected target navigated|Target closed|Session closed/i.test(
+    message,
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Create an isolated world on `client` and return its execution context id.
+ *
+ * Exported for callers that already hold their own short-lived session and
+ * pass the id straight into a raw `Runtime.evaluate` (snapshot's occlusion
+ * probe, which needs remote handles rather than values). Returns null when the
+ * world cannot be created, and every caller treats that as "use the main
+ * world" rather than failing the whole operation.
+ */
+export async function createIsolatedContext(
+  client: IsolatedCdpSender,
+  frameId?: string,
+): Promise<number | null> {
+  try {
+    await client.send('Page.enable');
+    let targetFrameId = frameId;
+    if (!targetFrameId) {
+      const tree = (await client.send('Page.getFrameTree')) as {
+        frameTree?: { frame?: { id?: string } };
+      };
+      targetFrameId = tree?.frameTree?.frame?.id;
+    }
+    if (!targetFrameId) return null;
+    const world = (await client.send('Page.createIsolatedWorld', {
+      frameId: targetFrameId,
+      worldName: WORLD_NAME,
+      // The DOM is shared regardless; universal access additionally lets the
+      // script reach same-page cross-origin objects the way main-world code
+      // reaching them would, so behaviour does not change under our feet.
+      grantUniveralAccess: true,
+    })) as { executionContextId?: number };
+    return typeof world?.executionContextId === 'number' ? world.executionContextId : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Open (once) the long-lived session this module drives a page through. */
+async function openState(page: Page): Promise<PageState> {
+  // A Page that cannot give us a CDP session (a backend Playwright reached
+  // some other way) is not a failure: the caller still gets its script run,
+  // in the main world, exactly as before this module existed.
+  const client = (await Promise.resolve()
+    .then(() => page.context().newCDPSession(page))
+    .catch(() => null)) as unknown as IsolatedCdpSession | null;
+
+  const state: PageState = {
+    client,
+    contextId: null,
+    creating: null,
+    unavailable: client === null,
+  };
+  if (!client) return state;
+
+  // Cache invalidation is not optional: a context id that outlives its
+  // document silently evaluates nothing. If the subscriptions below cannot be
+  // set up, the honest answer is to not use an isolated world on this page at
+  // all rather than to serve a stale context.
+  try {
+    // Runtime must be enabled for the lifecycle events. Playwright already
+    // enables it on its own session, so this adds no new observable signal.
+    await client.send('Runtime.enable').catch(() => undefined);
+    await client.send('Page.enable').catch(() => undefined);
+
+    client.on('Runtime.executionContextsCleared', () => {
+      state.contextId = null;
+    });
+    client.on('Runtime.executionContextDestroyed', (payload: { executionContextId?: number }) => {
+      if (payload?.executionContextId === state.contextId) state.contextId = null;
+    });
+    client.on('Page.frameNavigated', (payload: { frame?: { parentId?: string } }) => {
+      // Only the main frame's navigation retires our world; a subframe moving
+      // is none of our business.
+      if (!payload?.frame?.parentId) state.contextId = null;
+    });
+
+    const drop = (): void => {
+      states.delete(page);
+    };
+    page.on('close', drop);
+    page.on('crash', drop);
+  } catch {
+    state.client = null;
+    state.unavailable = true;
+  }
+
+  return state;
+}
+
+async function stateFor(page: Page): Promise<PageState> {
+  const existing = states.get(page);
+  if (existing) return existing;
+  const created = openState(page).catch((error) => {
+    states.delete(page);
+    throw error;
+  });
+  states.set(page, created);
+  return created;
+}
+
+/** Resolve the page's isolated context id, creating the world on demand. */
+async function contextIdFor(state: PageState): Promise<number | null> {
+  if (state.contextId !== null) return state.contextId;
+  if (state.unavailable) return null;
+  if (!state.creating) {
+    const client = state.client;
+    if (!client) return null;
+    state.creating = createIsolatedContext(client)
+      .then((id) => {
+        state.contextId = id;
+        if (id === null) state.unavailable = true;
+        return id;
+      })
+      .finally(() => {
+        state.creating = null;
+      });
+  }
+  return state.creating;
+}
+
+/**
+ * Wrap a script for `Runtime.callFunctionOn`.
+ *
+ * A function is sent as-is and receives `arg` as its single parameter, exactly
+ * like `page.evaluate(fn, arg)`. A string is treated as an expression, exactly
+ * like `page.evaluate(expression)` — the newlines matter, so a trailing line
+ * comment in the source cannot swallow the closing parenthesis.
+ */
+function functionDeclarationFor<A, R>(script: IsolatedScript<A, R>): string {
+  if (typeof script === 'function') return script.toString();
+  return `function () { return (\n${script}\n); }`;
+}
+
+/**
+ * Evaluate one of OUR scripts in the page's isolated world.
+ *
+ * Same call shape and same return shape as `page.evaluate(fn, arg)` /
+ * `page.evaluate(expression)`: the value comes back JSON-serialised, a
+ * returned promise is awaited, and an exception inside the page is re-thrown
+ * here with the page's own message.
+ *
+ * If the isolated world cannot be created at all (a target that refuses
+ * Page.createIsolatedWorld), this falls back to `page.evaluate` rather than
+ * failing the tool: losing the privacy property is bad, losing every browser
+ * tool is worse.
+ */
+export async function evaluateIsolated<R = unknown, A = unknown>(
+  page: Page,
+  script: IsolatedScript<A, R>,
+  arg?: A,
+  options?: IsolatedEvalOptions,
+): Promise<R> {
+  const state = await stateFor(page);
+  const declaration = functionDeclarationFor(script);
+
+  // Main-world fallback, used only when no isolated world can be had. Called
+  // with the SAME arity as before this module existed, so a one-argument
+  // page.evaluate stays a one-argument call.
+  const mainWorld = (): Promise<R> => {
+    const evaluatable = script as unknown as (a: unknown) => R;
+    return (arg === undefined
+      ? page.evaluate(evaluatable)
+      : page.evaluate(evaluatable, arg)) as Promise<R>;
+  };
+
+  const call = async (contextId: number, client: IsolatedCdpSession): Promise<R> => {
+    const result = (await client.send('Runtime.callFunctionOn', {
+      functionDeclaration: declaration,
+      executionContextId: contextId,
+      arguments: [{ value: arg }],
+      returnByValue: true,
+      awaitPromise: true,
+      userGesture: options?.userGesture ?? false,
+    })) as {
+      result?: { value?: unknown };
+      exceptionDetails?: { text?: string; exception?: { description?: string } };
+    };
+    if (result?.exceptionDetails) {
+      throw new Error(
+        result.exceptionDetails.exception?.description ??
+          result.exceptionDetails.text ??
+          'Isolated evaluation threw an exception',
+      );
+    }
+    return result?.result?.value as R;
+  };
+
+  let contextId = await contextIdFor(state);
+  const client = state.client;
+  if (contextId === null || !client) {
+    // No isolated world available — keep the tool working in the main world.
+    return await mainWorld();
+  }
+
+  try {
+    return await call(contextId, client);
+  } catch (error) {
+    // A navigation between "read the cached id" and "use it" is ordinary, and
+    // the retry costs one round trip.
+    if (!isStaleContextError(errorMessage(error))) throw error;
+    state.contextId = null;
+    contextId = await contextIdFor(state);
+    if (contextId === null) return await mainWorld();
+    return await call(contextId, client);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Poll an isolated-world predicate until it is truthy — the isolated-world
+ * stand-in for `page.waitForFunction`.
+ *
+ * `timeoutMs` of 0 means "wait forever", matching Playwright. The first
+ * evaluation is allowed to throw straight through, so a malformed predicate
+ * still fails fast instead of expiring as a timeout; later failures are the
+ * ordinary mid-navigation ones and keep polling.
+ */
+export async function waitForIsolated<A = unknown>(
+  page: Page,
+  script: IsolatedScript<A, unknown>,
+  arg: A | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  const hasDeadline = timeoutMs > 0;
+  const deadline = Date.now() + timeoutMs;
+  let first = true;
+  for (;;) {
+    try {
+      if (await evaluateIsolated<unknown, A>(page, script, arg)) return;
+    } catch (error) {
+      if (first) throw error;
+    }
+    first = false;
+    if (hasDeadline && Date.now() >= deadline) {
+      throw new Error(`Timeout ${timeoutMs}ms exceeded`);
+    }
+    await sleep(
+      hasDeadline ? Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())) : POLL_INTERVAL_MS,
+    );
+  }
+}
+
+/** Forget a page's cached session — tests, and anything that reuses a Page. */
+export function resetIsolatedEval(page?: Page): void {
+  if (page) states.delete(page);
+  else states.clear();
+}

--- a/src/mcp/playwright/occlusion.ts
+++ b/src/mcp/playwright/occlusion.ts
@@ -215,7 +215,11 @@ function propOf(props: RemoteProp[], name: string): RemoteProp['value'] {
  * failure. Fail-open is deliberate: this is an annotation on top of a
  * snapshot, and a snapshot without it is exactly today's snapshot.
  */
-export async function collectOcclusion(client: CdpSender): Promise<OcclusionInfo | null> {
+export async function collectOcclusion(
+  client: CdpSender,
+  /** Isolated-world context to probe in; omitted (or null) means main world. */
+  contextId?: number | null,
+): Promise<OcclusionInfo | null> {
   const objectGroup = 'wmux-occlusion';
   const deadline = Date.now() + TOTAL_BUDGET_MS;
 
@@ -241,6 +245,10 @@ export async function collectOcclusion(client: CdpSender): Promise<OcclusionInfo
         returnByValue: false,
         objectGroup,
         timeout: TOTAL_BUDGET_MS,
+        // The probe walks the DOM, which the isolated world shares, so the page
+        // cannot see the walk or hook the methods it uses. The handles it
+        // returns still resolve through DOM.describeNode either way.
+        ...(typeof contextId === 'number' ? { contextId } : {}),
       }),
     )) as { result?: { objectId?: string } } | null;
 

--- a/src/mcp/playwright/page-eval.ts
+++ b/src/mcp/playwright/page-eval.ts
@@ -1,5 +1,6 @@
 import type { Page } from 'playwright-core';
 import type { PlaywrightEngine } from './PlaywrightEngine';
+import { evaluateIsolated } from './isolated-eval';
 import {
   allowScopedRpcFallback,
   sendScopedBrowserRpc,
@@ -23,9 +24,15 @@ import {
 /** Evaluate a JS expression string and resolve its JSON-serialisable value. */
 export type JsonEvaluator = (expression: string) => Promise<unknown>;
 
-/** Evaluator backed by a live Playwright Page (dev / when getPage succeeds). */
+/**
+ * Evaluator backed by a live Playwright Page (dev / when getPage succeeds).
+ *
+ * Runs in the page's isolated world: these scripts only read the DOM, which is
+ * shared, and keeping them out of the main world stops the site from watching
+ * or rewriting the extraction (see isolated-eval.ts).
+ */
 export function pageEvaluator(page: Page): JsonEvaluator {
-  return (expression) => page.evaluate(expression);
+  return (expression) => evaluateIsolated(page, expression);
 }
 
 /**
@@ -83,10 +90,10 @@ export async function evalFunctionOrRpc<A, R>(
   scope: BrowserTargetScope,
 ): Promise<R> {
   if (page) {
-    // Playwright types page.evaluate's function param as PageFunction<Unboxed<A>, R>,
-    // which a free generic A cannot satisfy. The function is correct at runtime
-    // (it ran identically before #105 via the same call), so cast at this boundary.
-    return (await page.evaluate(fn as (a: unknown) => R, arg)) as R;
+    // Isolated world (same DOM, no shared globals) so the site cannot observe
+    // or rewrite the extraction; `arg` is passed as the single parameter,
+    // exactly as page.evaluate(fn, arg) did.
+    return await evaluateIsolated<R, A>(page, fn, arg);
   }
   const expression = `(${fn.toString()})(${JSON.stringify(arg)})`;
   const result = await sendScopedBrowserRpc<{ value: R }>('browser.evaluate', scope, {

--- a/src/mcp/playwright/pageFacts.ts
+++ b/src/mcp/playwright/pageFacts.ts
@@ -1,4 +1,5 @@
 import type { Page } from 'playwright-core';
+import { evaluateIsolated } from './isolated-eval';
 
 // ---------------------------------------------------------------------------
 // One-round-trip page facts for snapshot annotation.
@@ -180,7 +181,8 @@ export async function collectPageFacts(
     // The evaluation keeps running in the page after a timeout — there is no
     // way to cancel it — but its promise is deliberately dropped, so attach a
     // catch to it here or an eventual rejection becomes an unhandled one.
-    const evaluation = page.evaluate(buildPageFactsExpression());
+    // Isolated world: reads only DOM/layout, which the isolated world shares.
+    const evaluation = evaluateIsolated(page, buildPageFactsExpression());
     evaluation.catch(() => undefined);
     const raw = (await Promise.race([
       evaluation,

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -8,7 +8,7 @@ import {
 import { collectOcclusion, occlusionNote, type OcclusionInfo } from './occlusion';
 import { collectPageFacts, formatPageFactsFooter } from './pageFacts';
 import { peekRecentPendingRequests } from './pageCapture';
-import { createIsolatedContext, evaluateIsolated } from './isolated-eval';
+import { evaluateIsolated, isolatedProbeTarget } from './isolated-eval';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1622,6 +1622,19 @@ async function withCdpSession<T>(
   }
 }
 
+/**
+ * Run the overlay probe in the page's isolated world when there is one, on the
+ * session that owns it; otherwise on `fallback`, in the main world, which is
+ * what this did before isolated worlds existed.
+ */
+async function occlusionFor(page: Page, fallback: CdpClient): Promise<OcclusionInfo | null> {
+  const probe = await isolatedProbeTarget(page).catch(() => null);
+  return await collectOcclusion(
+    probe?.client ?? fallback,
+    probe?.contextId,
+  ).catch(() => null);
+}
+
 /** The a11y tree plus the annotations that only a live CDP session can supply. */
 interface SnapshotSource {
   tree: AXNode | null;
@@ -1640,10 +1653,12 @@ async function getAccessibilityTree(page: Page): Promise<SnapshotSource> {
       // After the tree, never instead of it: a thrown occlusion probe must not
       // cost the caller its snapshot (collectOcclusion swallows its own
       // failures, and this ordering keeps the tree even if that ever changes).
-        occlusion: await collectOcclusion(
-          client,
-          await createIsolatedContext(client),
-        ).catch(() => null),
+        // The probe runs on the module's CACHED per-page session, not on this
+        // short-lived one: Chromium caches an isolated world per (session,
+        // frame, name), so minting one per snapshot would pile them up in the
+        // renderer of a long-lived SPA. Falls back to this session, main
+        // world, exactly as before, when there is no isolated world.
+        occlusion: await occlusionFor(page, client),
       }),
       { tree: null, occlusion: null },
     );
@@ -1853,10 +1868,7 @@ export async function generateScopedSnapshot(
         // Occlusion is a whole-page fact, so it is worth just as much inside a
         // scope — a selector aimed at the page behind an overlay is exactly the
         // case where the agent is about to click something inert.
-        occlusion: await collectOcclusion(
-          client,
-          await createIsolatedContext(client),
-        ).catch(() => null),
+        occlusion: await occlusionFor(page, client),
       };
     },
     { forest: null, occlusion: null },

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -8,6 +8,7 @@ import {
 import { collectOcclusion, occlusionNote, type OcclusionInfo } from './occlusion';
 import { collectPageFacts, formatPageFactsFooter } from './pageFacts';
 import { peekRecentPendingRequests } from './pageCapture';
+import { createIsolatedContext, evaluateIsolated } from './isolated-eval';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1639,7 +1640,10 @@ async function getAccessibilityTree(page: Page): Promise<SnapshotSource> {
       // After the tree, never instead of it: a thrown occlusion probe must not
       // cost the caller its snapshot (collectOcclusion swallows its own
       // failures, and this ordering keeps the tree even if that ever changes).
-        occlusion: await collectOcclusion(client).catch(() => null),
+        occlusion: await collectOcclusion(
+          client,
+          await createIsolatedContext(client),
+        ).catch(() => null),
       }),
       { tree: null, occlusion: null },
     );
@@ -1693,9 +1697,10 @@ export async function generateSnapshot(
       // gets the same URL redaction the network listing does (inspection.ts
       // applies it to its own two DOM-listing branches).
       let domSnapshot = redactPasswordParams(
-        (await page.evaluate(
+        (await evaluateIsolated<string>(
+          page,
           buildDomSnapshotExpression(undefined, { filter: options?.filter }),
-        )) as string,
+        )),
       );
       // aria has no DOM-listing equivalent — say so instead of silently
       // returning the ai-style listing (same honesty rule as the selector
@@ -1848,7 +1853,10 @@ export async function generateScopedSnapshot(
         // Occlusion is a whole-page fact, so it is worth just as much inside a
         // scope — a selector aimed at the page behind an overlay is exactly the
         // case where the agent is about to click something inert.
-        occlusion: await collectOcclusion(client).catch(() => null),
+        occlusion: await collectOcclusion(
+          client,
+          await createIsolatedContext(client),
+        ).catch(() => null),
       };
     },
     { forest: null, occlusion: null },

--- a/src/mcp/playwright/tools/file.ts
+++ b/src/mcp/playwright/tools/file.ts
@@ -525,6 +525,8 @@ async function resolveFileInputFromRef(
   // caller named is used exactly as it was before this search existed.
   let isFileInput: boolean | null = null;
   try {
+    // Main world, deliberately: element-scoped, and an ElementHandle cannot be
+    // adopted into an isolated context (see isolated-eval.ts).
     isFileInput = await el.evaluate((node: unknown) => {
       const n = node as { tagName?: string; getAttribute?: (a: string) => unknown } | null;
       return (
@@ -540,6 +542,9 @@ async function resolveFileInputFromRef(
 
   let handle: { asElement?: () => unknown; dispose?: () => Promise<void> } | null | undefined;
   try {
+    // Main world, deliberately: the RESULT is a handle Playwright then passes
+    // to setInputFiles, so it has to live in the world Playwright resolved the
+    // element in.
     handle = await el.evaluateHandle(findFileInputNearElement);
   } catch {
     return el; // probe unavailable — keep the pre-existing behaviour

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -530,7 +530,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
   // -----------------------------------------------------------------------
   server.tool(
     'browser_evaluate',
-    'Evaluate a JavaScript expression in the page. Patterns that enable prompt-injection exfiltration (fetch, XHR, cookies, storage, eval, Function) are BLOCKED unless allowDangerous:true. Blocking is a case-sensitive whole-word text scan that reads strings and comments too: the call forms (fetch/eval/require/import) need a "(" next, whitespace allowed — retrieval, evaluateScore(), prefetch() and myFetch() all pass, while both window.fetch(url) and fetch (url) are blocked — while the rest (localStorage, WebSocket, document.cookie) match the bare word anywhere, even in a comment. Strings return verbatim, everything else as JSON (DOM nodes/Map/functions become {}); a returned Promise is awaited, top-level await is a SyntaxError. Runs in an isolated world that shares the DOM but not the page\'s JS globals, so pass mainWorld:true to read those.',
+    'Evaluate a JavaScript expression in the page. Patterns that enable prompt-injection exfiltration (fetch, XHR, cookies, storage, eval, Function) are BLOCKED unless allowDangerous:true. Blocking is a case-sensitive whole-word text scan that reads strings and comments too: the call forms (fetch/eval/require/import) need a "(" next, whitespace allowed — retrieval, evaluateScore(), prefetch() and myFetch() all pass, while both window.fetch(url) and fetch (url) are blocked — while the rest (localStorage, WebSocket, document.cookie) match the bare word anywhere, even in a comment. Strings return verbatim, everything else as JSON (DOM nodes/Map/functions become {}); a returned Promise is awaited, top-level await is a SyntaxError. On the Chrome backend it runs in an isolated world that shares the DOM but not the page\'s JS globals; pass mainWorld:true to read those.',
     BROWSER_EVALUATE_SHAPE,
     async ({ expression, allowDangerous, mainWorld, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
@@ -549,6 +549,9 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
         }
 
         let result: unknown;
+        // Set when the isolated world was asked for and could not be had, so
+        // the answer says which world it actually came from.
+        let worldNote = '';
 
         // Try Playwright first for gesture-aware evaluation
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
@@ -560,18 +563,23 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
             ? await evaluateWithGesture(page, expression)
             : await evaluateIsolated(page, expression);
         } else {
-          // Fallback: RPC evaluation via main process webContents
+          // Fallback: RPC evaluation via main process webContents. This lane
+          // drives a guest webContents and has no isolated world at all, so
+          // say so rather than let the tool description imply one.
           const rpcResult = await sendScopedBrowserRpc<{ value: unknown }>('browser.evaluate', scope, {
             expression,
           });
           result = rpcResult.value;
+          if (!mainWorld) {
+            worldNote = "\n(ran in the page's main world: this backend has no isolated world)";
+          }
         }
 
         const text =
           typeof result === 'string' ? result : (JSON.stringify(result, null, 2) ?? 'undefined');
 
         return {
-          content: [{ type: 'text' as const, text: text ?? 'undefined' }],
+          content: [{ type: 'text' as const, text: (text ?? 'undefined') + worldNote }],
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -16,6 +16,7 @@ import { pageEvaluator, rpcEvaluator } from '../page-eval';
 import { formatSnapshotResult } from '../snapshotDiff';
 import { getSnapshotBaseline, setSnapshotBaseline, snapshotSurfaceKey } from '../snapshotCache';
 import { evaluateWithGesture } from '../user-gesture';
+import { evaluateIsolated } from '../isolated-eval';
 import { detectDangerousPatterns } from '../security';
 import { redactPasswordParams } from '../redact';
 import { sanitizeRef } from './interaction';
@@ -80,6 +81,10 @@ const BROWSER_EVALUATE_SHAPE = {
     .boolean()
     .optional()
     .describe('Run a blocked pattern anyway. Default false; trusted input only.'),
+  mainWorld: z
+    .boolean()
+    .optional()
+    .describe("Run in the page's own JS world to reach its globals (e.g. window.__NEXT_DATA__). Default false."),
   surfaceId: optionalSurfaceId,
 };
 
@@ -438,11 +443,11 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
   };
 
   /** Read the ratio at capture time, so the note describes THIS image. */
-  const readDpr = async (
-    page: { evaluate: (expr: string) => Promise<unknown> } | null,
-  ): Promise<number | null> => {
+  const readDpr = async (page: Page | null): Promise<number | null> => {
     if (!page) return null;
-    const value = await page.evaluate('window.devicePixelRatio').catch(() => null);
+    // devicePixelRatio is a property of the frame, not of the main world's
+    // globals, so the isolated world reads the same number.
+    const value = await evaluateIsolated(page, 'window.devicePixelRatio').catch(() => null);
     return typeof value === 'number' && value > 0 ? value : null;
   };
 
@@ -525,9 +530,9 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
   // -----------------------------------------------------------------------
   server.tool(
     'browser_evaluate',
-    'Evaluate a JavaScript expression in the page. Patterns that enable prompt-injection exfiltration (fetch, XHR, cookies, storage, eval, Function) are BLOCKED unless allowDangerous:true. Blocking is a case-sensitive whole-word text scan that reads strings and comments too: the call forms (fetch/eval/require/import) need a "(" next, whitespace allowed — retrieval, evaluateScore(), prefetch() and myFetch() all pass, while both window.fetch(url) and fetch (url) are blocked — while the rest (localStorage, WebSocket, document.cookie) match the bare word anywhere, even in a comment. Strings return verbatim, everything else as JSON (DOM nodes/Map/functions become {}); a returned Promise is awaited, top-level await is a SyntaxError.',
+    'Evaluate a JavaScript expression in the page. Patterns that enable prompt-injection exfiltration (fetch, XHR, cookies, storage, eval, Function) are BLOCKED unless allowDangerous:true. Blocking is a case-sensitive whole-word text scan that reads strings and comments too: the call forms (fetch/eval/require/import) need a "(" next, whitespace allowed — retrieval, evaluateScore(), prefetch() and myFetch() all pass, while both window.fetch(url) and fetch (url) are blocked — while the rest (localStorage, WebSocket, document.cookie) match the bare word anywhere, even in a comment. Strings return verbatim, everything else as JSON (DOM nodes/Map/functions become {}); a returned Promise is awaited, top-level await is a SyntaxError. Runs in an isolated world that shares the DOM but not the page\'s JS globals, so pass mainWorld:true to read those.',
     BROWSER_EVALUATE_SHAPE,
-    async ({ expression, allowDangerous, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ expression, allowDangerous, mainWorld, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         const warnings = detectDangerousPatterns(expression);
         if (warnings.length > 0 && !allowDangerous) {
@@ -548,7 +553,12 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
         // Try Playwright first for gesture-aware evaluation
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
         if (page) {
-          result = await evaluateWithGesture(page, expression);
+          // Isolated world by default: the page can neither see the script nor
+          // hand it doctored built-ins. mainWorld:true opts back into the
+          // page's own realm for scripts that need its globals.
+          result = mainWorld
+            ? await evaluateWithGesture(page, expression)
+            : await evaluateIsolated(page, expression);
         } else {
           // Fallback: RPC evaluation via main process webContents
           const rpcResult = await sendScopedBrowserRpc<{ value: unknown }>('browser.evaluate', scope, {
@@ -761,6 +771,10 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
             throw new Error(`Could not resolve ref="${ref}" to an element.`);
           }
 
+          // Main world, deliberately: element-scoped, and an ElementHandle
+          // cannot be adopted into an isolated context (see isolated-eval.ts).
+          // It writes two inline styles, which the page can see in the DOM
+          // regardless of which world wrote them.
           await el.evaluate(
             (element: Element) => {
               (element as HTMLElement).style.outline = '3px solid red';

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -11,6 +11,7 @@ import {
 } from '../snapshot';
 import { getLocatorByRef, resolveSmartRefLocator, smartRefAxisEntry } from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
+import { evaluateIsolated } from '../isolated-eval';
 import { describeToolError } from '../toolError';
 import {
   PASSWORD_FIELD_PREDICATE_JS,
@@ -210,6 +211,11 @@ async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): P
  */
 async function isPasswordElement(el: ElementHandle): Promise<boolean> {
   try {
+    // Main world, deliberately: the predicate is scoped to an ElementHandle,
+    // and a handle belongs to the world it was resolved in — there is no way
+    // to hand it to an isolated context. It reads two properties off the node
+    // it was given and touches no page global, so the exposure is a property
+    // read a page could equally observe from its own input listener.
     return await el.evaluate(isPasswordFieldNode);
   } catch {
     return false;
@@ -405,9 +411,10 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             // bounds check was dead exactly where it matters (live dogfood:
             // x=99999 reported success). The page's own innerWidth/innerHeight
             // is the same CSS-pixel space x/y are defined in.
-            const size = await page
-              .evaluate('[window.innerWidth, window.innerHeight]')
-              .catch(() => null);
+            const size = await evaluateIsolated(
+              page,
+              '[window.innerWidth, window.innerHeight]',
+            ).catch(() => null);
             if (Array.isArray(size) && typeof size[0] === 'number' && typeof size[1] === 'number') {
               viewport = { width: size[0], height: size[1] };
             }
@@ -924,14 +931,17 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           if (ref) {
             const el = await resolveRef(page, ref);
             if (!el) throw new Error(refNotFound(ref));
+            // Main world, deliberately: element-scoped, and an ElementHandle
+            // cannot be adopted into an isolated context (see isolated-eval.ts).
             await el.evaluate(
               (node, [dx, dy]) => { (node as Element).scrollBy(dx, dy); },
               [deltaX, deltaY] as [number, number],
             );
           } else {
-            await page.evaluate(
+            await evaluateIsolated<void, [number, number]>(
+              page,
               ([dx, dy]) => { window.scrollBy(dx, dy); },
-              [deltaX, deltaY] as [number, number],
+              [deltaX, deltaY],
             );
           }
         } else {

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -4,6 +4,7 @@ import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
 import { detectDangerousPatterns } from '../security';
 import { rpcEvaluator } from '../page-eval';
+import { waitForIsolated } from '../isolated-eval';
 import { allowScopedRpcFallback, type BrowserToolDeps } from '../browserScope';
 import { describeToolError } from '../toolError';
 import {
@@ -252,10 +253,15 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
         }
 
         if (text) {
-          await page.waitForFunction(
-            (t: string) => document.body.innerText.includes(t),
+          // waitForIsolated rather than page.waitForFunction: the predicate
+          // reads document.body, and a page that hooks innerText should not be
+          // able to watch (or answer) the poll. Same timeout semantics,
+          // timeout:0 included.
+          await waitForIsolated(
+            page,
+            (t: string) => !!(document.body && document.body.innerText.includes(t)),
             text,
-            { timeout: resolvedTimeout },
+            resolvedTimeout,
           );
           return {
             content: [{ type: 'text' as const, text: `Wait completed: text "${text}" found` }],
@@ -267,7 +273,12 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
           if (warnings.length > 0) {
             console.warn(`[browser_wait] Dangerous patterns in fn: ${warnings.join(', ')}`);
           }
-          await page.waitForFunction(fn, undefined, { timeout: resolvedTimeout });
+          // Mirrors page.waitForFunction(string): a function-looking string is
+          // CALLED each poll, a bare expression is evaluated, and the result is
+          // coerced to a boolean in the page so a non-serialisable truthy value
+          // (a DOM node) still satisfies the wait.
+          const expression = isFunctionExpression(fn) ? `!!((${fn})())` : `!!(${fn})`;
+          await waitForIsolated(page, expression, undefined, resolvedTimeout);
           const warningPrefix = warnings.length > 0
             ? `⚠ Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`
             : '';


### PR DESCRIPTION
## Problem (measured)

Every script the browser tools inject ran in the page's **main world** — the
same JavaScript realm the site's own code lives in. Measured live against
`bot-detector.rebrowser.net` on Chrome 152 / playwright-core 1.58.2, driving
the exact snapshot-style DOM scan the tools perform:

```
🔴 sourceUrlLeak       Error stack contains UtilityScript.. You're using unpatched Playwright.
🔴 mainWorldExecution  You've called document.getElementsByClassName() in the main world.
typeof dummyFn = "function"     ← the page's own global, callable from our script
```

`dummyFn` is defined by the page. Being able to call it is the same fact from
the other side: the page can equally see and redefine everything our scripts
touch, so a hostile site can both observe the agent and hand it a doctored DOM.

## Design

`src/mcp/playwright/isolated-eval.ts`:

- **World.** One isolated world per page via CDP `Page.createIsolatedWorld`
  (`grantUniveralAccess: false` — parity with the main world, not extra
  privilege) on the page's main frame. The world name is
  `util` — bland on purpose; it never reaches the page, and nothing
  product-specific is written anywhere a devtools listener could read it.
- **Caching.** One long-lived `newCDPSession` per `Page`, plus the world's
  `executionContextId`, both cached in a `Map<Page, …>` and dropped on
  `page.on('close' | 'crash')`. Concurrent first calls share one creation
  round trip.
- **Invalidation.** The cached context id is cleared on
  `Runtime.executionContextsCleared`, `Runtime.executionContextDestroyed` for
  our id, and `Page.frameNavigated` for the **main** frame only. A call that
  still races a navigation retries once on a stale-context error.
- **Evaluation.** A function goes through `Runtime.callFunctionOn`; a string
  goes through `Runtime.evaluate({expression, contextId})`, because wrapping a
  string in `return (…)` would reject the multi-statement scripts
  `page.evaluate(string)` always accepted. Both with `returnByValue` and
  `awaitPromise`, and `NaN` / `±Infinity` / `-0` decoded back out of
  `unserializableValue`. `evaluateIsolated(page, fn|expression, arg?)` keeps the
  `page.evaluate(fn, arg)` / `page.evaluate(expression)` call and return shape,
  and re-throws a page exception with the page's own message.
- **Degradation.** If no isolated world can be had — no CDP session, or a
  target that refuses `createIsolatedWorld` — the call falls back to
  `page.evaluate` with the same arity. Losing the privacy property is bad;
  losing every browser tool is worse.
- `waitForIsolated` is the isolated-world stand-in for `page.waitForFunction`:
  a 100 ms poll, `timeout: 0` meaning "forever" as Playwright does, and the
  first evaluation allowed to throw straight through so a malformed predicate
  still fails fast instead of expiring as a timeout.

## Per-site migration

| Site | World | Reason |
| --- | --- | --- |
| `snapshot.ts` DOM fallback | isolated | DOM read + `data-wmux-ref` tagging; the DOM is shared |
| `pageFacts.ts` `collectPageFacts` | isolated | DOM/layout reads only |
| `page-eval.ts` `pageEvaluator` | isolated | `browser_extract_text` / smart-snapshot serialiser |
| `page-eval.ts` `evalFunctionOrRpc` | isolated | `browser_extract_data`; `arg` still the single parameter |
| `occlusion.ts` overlay probe | isolated | `Runtime.evaluate` now takes the world's `contextId`; the handles it returns still resolve through `DOM.describeNode` |
| `inspection.ts` `readDpr` | isolated | `devicePixelRatio` is a frame property, same value in either world |
| `inspection.ts` `browser_evaluate` | isolated (default) | new `mainWorld` opt-out, below |
| `interaction.ts` viewport bounds | isolated | `window.innerWidth/innerHeight` are per-frame |
| `interaction.ts` page scroll | isolated | `window.scrollBy` acts on the shared frame |
| `wait.ts` text predicate | isolated | reads `document.body.innerText`; a page that hooks it must not get to answer the poll |
| `wait.ts` custom `fn` predicate | isolated | same, with `page.waitForFunction(string)` semantics preserved |
| `interaction.ts` password-field check | **main** | element-scoped: an `ElementHandle` belongs to the world it was resolved in and cannot be adopted into an isolated context. Reads two properties off the given node, no page global |
| `interaction.ts` element scroll | **main** | element-scoped, same reason |
| `inspection.ts` `browser_highlight` | **main** | element-scoped; writes two inline styles the page sees in the DOM either way |
| `file.ts` file-input detection / proximity handle | **main** | element-scoped, and the *result* is a handle Playwright then passes to `setInputFiles`, so it has to live in Playwright's world |

## `browser_evaluate`

Runs in the isolated world by default. New optional `mainWorld: boolean`
(default `false`) routes back through the existing `evaluateWithGesture` path
for expressions that need the page's own globals (`window.__NEXT_DATA__` and
friends). One sentence added to the tool description.

`tools/list` after the change: **full 76,690 B** against a 78,000 B budget
(93 tools). `core` and `commander` are byte-identical — `browser_evaluate` is
full-only — so only the `full` `wireResultSha256` moved in
`scripts/mcp-protocol-baseline.json`.

## Verification (live)

Same launcher, same Chrome flags, same page, same script — once through
`evaluateIsolated`, once through `page.evaluate` as a control:

```
mode "isolated":  { "seesDummy": "undefined", "scanned": 94,  "gotNode": true }
⚪️ mainWorldExecution   Call document.getElementsByClassName('div') to trigger this test.
                        If you did and the test wasn't triggered, then you're running it
                        in an isolated world, which is safe and not detectable.
⚪️ sourceUrlLeak        Call document.getElementById('detections-json') to test sourceUrl leak.
🟢 runtimeEnableLeak     No leak detected.
🟢 pwInitScripts         No window.__pwInitScripts detected.

mode "main" (control):  { "seesDummy": "function", "scanned": 103, "gotNode": true }
🔴 mainWorldExecution   You've called document.getElementsByClassName() in the main world.
🔴 sourceUrlLeak        Error stack contains UtilityScript..
🟢 runtimeEnableLeak     No leak detected.
```

Both runs really made the calls the detector hooks (`getElementsByClassName`,
`getElementById('detections-json')`) and both got real answers back — the
isolated run simply was not seen. `runtimeEnableLeak` stays green in both.

## Out of scope

- **The RPC lane.** `page-eval.ts`'s `rpcEvaluator` (packaged builds, the
  Electron webview guest) has no Playwright `Page` to attach a session to, so
  it is untouched.
- **Bypassing `Runtime.enable`.** It measured green on Chrome 152 with stock
  playwright-core, so no patched fork and no bypass. Our session enables
  `Runtime` exactly as Playwright's own session already does.
- **Playwright's internals.** Its locator/click/fill machinery already runs in
  its utility world and is deliberately left alone.

## Tests

16 added: 14 in `__tests__/isolated-eval.test.ts` (world creation and its
parameters, the non-branded world name and `grantUniveralAccess: false`,
`arg` passing, context caching, invalidation on `executionContextsCleared`,
page-exception surfacing, main-world fallback arity, the four
`waitForIsolated` outcomes) (plus a multi-statement string, `unserializableValue` decoding, the
stale-context retry, that a failed world is retried after a navigation rather
than latched, and that a stale first poll is waited out) and 2 in
`__tests__/inspection.evaluate.world.test.ts` (`browser_evaluate` routing with
and without `mainWorld`). The 556 existing `src/mcp/playwright` tests stay
green unchanged.


## Review follow-ups (second commit)

- String scripts run through `Runtime.evaluate`, so multi-statement scripts
  keep working.
- A failed world creation is retried rather than latching the page into the
  main world for its lifetime; a fallback warns once per page.
- The occlusion probe reuses the module's cached per-page session — a session
  per snapshot minted an isolated world per snapshot, which accumulates in a
  long-lived SPA's renderer. Measured: three consecutive probe requests return
  the same `contextId` (5, 5, 5). The probe's `Runtime.evaluate` carries
  exactly one execution-context field (`contextId`).
- `unserializableValue` (`NaN`, `±Infinity`, `-0`) decoded instead of dropped.
- `waitForIsolated` waits out a stale context on its first poll; a malformed
  predicate still fails fast.
- Close/crash detaches the session, and an already-closed page is dropped at
  open time.
- An invalidation during an in-flight creation no longer caches the old
  document's context id (epoch check).
- `grantUniveralAccess: false`.
- The RPC lane (no Page) appends "ran in the page's main world: this backend
  has no isolated world" and the tool description now says "On the Chrome
  backend it runs in an isolated world…".
