### PR TITLE
Make agent browsing behave less mechanically

### DIFF
--- a/changelog.d/1173.md
+++ b/changelog.d/1173.md
@@ -11,7 +11,12 @@
   travels from wherever the pointer was left to a point somewhere inside the
   element, which is what the page sees when a person clicks it. Hovering and
   dragging in the builtin browser now go through the same real pointer input,
-  rather than events synthesised inside the page. (#1173)
+  rather than events synthesised inside the page. Two new pipe RPC methods back
+  this — `browser.hover.cdp` and `browser.drag.cdp` — and they are gated on the
+  `browser.click` capability rather than `browser.evaluate`. A caller granted
+  hover and drag is being granted pointer input, which is what `browser.click`
+  means; routing them through `browser.evaluate` would have required handing out
+  arbitrary script execution to move a pointer. (#1173)
 
 - **Navigations carry the page they came from.** Following a link from one page
   to another now sends a `Referer`, as a real click-through does. A first

--- a/changelog.d/1173.md
+++ b/changelog.d/1173.md
@@ -1,0 +1,26 @@
+### Changed
+
+- **The agent types with a human rhythm instead of a metronome.** Inter-keystroke
+  delays used to be drawn flat from a 50–150 ms range, which no typist produces.
+  They now cluster around a median with a long tail, run longer after full stops,
+  commas and word breaks, and occasionally pause the way someone does mid-sentence.
+  (#1173)
+
+- **Clicks move the pointer there first, and land off-centre.** A click used to
+  teleport the pointer onto the exact centre of the target and press. It now
+  travels from wherever the pointer was left to a point somewhere inside the
+  element, which is what the page sees when a person clicks it. Hovering and
+  dragging in the builtin browser now go through the same real pointer input,
+  rather than events synthesised inside the page. (#1173)
+
+- **Navigations carry the page they came from.** Following a link from one page
+  to another now sends a `Referer`, as a real click-through does. A first
+  navigation, a reload, or a jump out of a blank or browser-internal page still
+  sends none. (#1173)
+
+- **Emulated devices are consistent about what they claim to be.** `browser_emulate`
+  used to change the User-Agent string alone, leaving the browser's Client Hints
+  answering with the real machine — so an emulated phone described itself as a
+  phone in one place and as your desktop in another. The user-agent data,
+  platform and Accept-Language now match the preset, and resetting the preset
+  restores all of them together. (#1173)

--- a/docs/api/inventory.md
+++ b/docs/api/inventory.md
@@ -131,7 +131,7 @@ Validation limits live in `src/shared/types.ts` (PANE_METADATA_MAX_BYTES, PANE_M
 | `browser.open` | `{ url? }` | experimental | The browser/CDP surface backs the MCP `browser_*` tools. Wire shapes may evolve before v3.0. Currently the primary AI-agent capability driver, but not part of the substrate identity. |
 | `browser.navigate`, `browser.goBack`, `browser.close` | various | experimental | |
 | `browser.session.{start,stop,status,list}` | various | experimental | |
-| `browser.type.humanlike`, `browser.type.cdp`, `browser.click.cdp`, `browser.press.cdp` | various | experimental | |
+| `browser.type.humanlike`, `browser.type.cdp`, `browser.click.cdp`, `browser.hover.cdp`, `browser.drag.cdp`, `browser.press.cdp` | various | experimental | |
 | `browser.cdp.target`, `browser.cdp.info` | various | experimental | |
 | `browser.screenshot`, `browser.evaluate` | various | experimental | |
 
@@ -350,7 +350,7 @@ The capability column below summarises the table. Three sentinels:
 | `meta.setStatus` / `meta.setProgress` / `meta.setSkills` | `meta.write` | — | metadata |
 | `system.identify` / `system.capabilities` | `null` (bootstrap) | — | — |
 | `browser.navigate` / `browser.open` / `browser.goBack` / `browser.close` | `browser.navigate` | — | browser |
-| `browser.click.cdp` | `browser.click` | — | browser |
+| `browser.click.cdp` / `browser.hover.cdp` / `browser.drag.cdp` | `browser.click` | — | browser |
 | `browser.type.humanlike` / `browser.type.cdp` / `browser.press.cdp` | `browser.type` | — | browser |
 | `browser.screenshot` | `browser.screenshot` | — | browser |
 | `browser.evaluate` | `browser.evaluate` | — | browser |

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **160** methods (`ALL_RPC_METHODS` in
+Total: **162** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -145,6 +145,8 @@ Total: **160** methods (`ALL_RPC_METHODS` in
 | `browser.responseBody.get` | `browser.read` | `browser` |
 | `browser.type.cdp` | `browser.type` | `browser` |
 | `browser.click.cdp` | `browser.click` | `browser` |
+| `browser.hover.cdp` | `browser.click` | `browser` |
+| `browser.drag.cdp` | `browser.click` | `browser` |
 | `browser.press.cdp` | `browser.type` | `browser` |
 | `browser.cookies` | `browser.cookies` | `browser` |
 | `browser.resize` | `browser.evaluate` | `browser` |

--- a/src/main/browser-session/HumanBehavior.ts
+++ b/src/main/browser-session/HumanBehavior.ts
@@ -1,3 +1,5 @@
+import { generateTypingDelays, typingDelayFor } from '../../shared/humanRhythm';
+
 export interface HumanBehaviorConfig {
   typingDelay: { min: number; max: number };
   actionInterval: { min: number; max: number };
@@ -22,9 +24,15 @@ export class HumanBehavior {
     this.config = { ...DEFAULT_CONFIG, ...config };
   }
 
-  getTypingDelay(): number {
+  /**
+   * The pause after one keystroke. `char` is the character just typed, which
+   * lengthens the pause after punctuation and word breaks; omit it for a
+   * context-free draw. The distribution lives in `shared/humanRhythm` so this
+   * lane and the MCP lane stay identical.
+   */
+  getTypingDelay(char?: string): number {
     const { min, max } = this.config.typingDelay;
-    return Math.random() * (max - min) + min;
+    return typingDelayFor(char, { minDelay: min, maxDelay: max });
   }
 
   getActionInterval(): number {
@@ -59,6 +67,7 @@ export class HumanBehavior {
   }
 
   generateTypingSchedule(text: string): number[] {
-    return Array.from({ length: text.length }, () => this.getTypingDelay());
+    const { min, max } = this.config.typingDelay;
+    return generateTypingDelays(text, { minDelay: min, maxDelay: max });
   }
 }

--- a/src/main/browser-session/__tests__/HumanBehavior.test.ts
+++ b/src/main/browser-session/__tests__/HumanBehavior.test.ts
@@ -17,11 +17,17 @@ describe('HumanBehavior', () => {
     expect(config.activeHours).toEqual({ start: 8, end: 22 });
   });
 
-  it('should return getTypingDelay() within 50-150ms range', () => {
-    for (let i = 0; i < 100; i++) {
+  // The draw is log-normal around the band's midpoint with an occasional
+  // longer pause, so it is no longer bounded by the band itself — only by the
+  // rhythm module's clamp (0.6x min .. 5x max). Distribution shape is asserted
+  // in shared/__tests__/humanRhythm.test.ts.
+  it('should return getTypingDelay() inside the rhythm clamp', () => {
+    for (let i = 0; i < 200; i++) {
       const delay = behavior.getTypingDelay();
-      expect(delay).toBeGreaterThanOrEqual(50);
-      expect(delay).toBeLessThan(150);
+      expect(delay).toBeGreaterThanOrEqual(50 * 0.6);
+      // The clamp caps the base draw at 5x max; a thinking pause can add up to
+      // another 700ms on top.
+      expect(delay).toBeLessThanOrEqual(150 * 5 + 700);
     }
   });
 
@@ -91,9 +97,11 @@ describe('HumanBehavior', () => {
     const text = 'hello';
     const schedule = behavior.generateTypingSchedule(text);
     expect(schedule).toHaveLength(text.length);
+    // Bounded by the rhythm clamp, not by the band — see the getTypingDelay
+    // test above.
     for (const delay of schedule) {
-      expect(delay).toBeGreaterThanOrEqual(50);
-      expect(delay).toBeLessThan(150);
+      expect(delay).toBeGreaterThanOrEqual(50 * 0.6);
+      expect(delay).toBeLessThanOrEqual(150 * 5 + 700);
     }
   });
 

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -226,6 +226,8 @@ export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   'browser.network.get',
   'browser.responseBody.get',
   'browser.click.cdp',
+  'browser.hover.cdp',
+  'browser.drag.cdp',
   'browser.type.cdp',
   'browser.press.cdp',
   'browser.cookies',

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -301,6 +301,8 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   'browser.responseBody.get':  { capability: 'browser.read',       riskClass: 'browser' },
   'browser.type.cdp':          { capability: 'browser.type',  riskClass: 'browser' },
   'browser.click.cdp':         { capability: 'browser.click', riskClass: 'browser' },
+  'browser.hover.cdp':         { capability: 'browser.click', riskClass: 'browser' },
+  'browser.drag.cdp':          { capability: 'browser.click', riskClass: 'browser' },
   'browser.press.cdp':         { capability: 'browser.type',  riskClass: 'browser' },
   // State tools (#111 packaged RPC fallback). resize stays under
   // `browser.evaluate`: a caller that can already run arbitrary JS can resize the

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -2209,52 +2209,13 @@ export function registerBrowserRpc(
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.drag.cdp: WebContents unavailable');
 
-    // HTML5 drag-and-drop is not reachable from raw mouse events: Chromium
-    // hands a mouse drag on a `draggable` element to the browser's own native
-    // drag loop, which never surfaces as dragstart/dragover/drop to the page
-    // unless the client is intercepting drags. So the two kinds of drop target
-    // need two different mechanisms, and which one applies is decided by the
-    // source element, not by guessing after the fact.
-    const nativeDraggable = await wc.debugger.sendCommand('Runtime.evaluate', {
-      expression: `(() => {
-        const el = document.querySelector(${JSON.stringify(sourceSelector)});
-        if (!el) return null;
-        return !!(el.draggable || el.closest('[draggable="true"]'));
-      })()`,
-      returnByValue: true,
-    }) as { result: { value: boolean | null } };
-
-    if (nativeDraggable.result?.value === null) {
-      throw new Error(`Element not found: ${sourceSelector}`);
-    }
-
-    if (nativeDraggable.result?.value === true) {
-      // HTML5 drag source: synthesised DragEvents are the only thing that
-      // reaches the handlers. Known limitation — these carry
-      // isTrusted === false, unlike the pointer path below.
-      const val = await wc.debugger.sendCommand('Runtime.evaluate', {
-        expression: `(() => {
-          const src = document.querySelector(${JSON.stringify(sourceSelector)});
-          const tgt = document.querySelector(${JSON.stringify(targetSelector)});
-          if (!src) return 'source_not_found';
-          if (!tgt) return 'target_not_found';
-          const dt = new DataTransfer();
-          src.dispatchEvent(new DragEvent('dragstart', { bubbles: true, dataTransfer: dt }));
-          tgt.dispatchEvent(new DragEvent('dragover', { bubbles: true, dataTransfer: dt }));
-          tgt.dispatchEvent(new DragEvent('drop', { bubbles: true, dataTransfer: dt }));
-          src.dispatchEvent(new DragEvent('dragend', { bubbles: true, dataTransfer: dt }));
-          return 'ok';
-        })()`,
-        returnByValue: true,
-      }) as { result: { value: string } };
-      const outcome = val.result?.value;
-      if (outcome === 'source_not_found') throw new Error(`Element not found: ${sourceSelector}`);
-      if (outcome === 'target_not_found') throw new Error(`Element not found: ${targetSelector}`);
-      return { ok: true, mode: 'html5' };
-    }
-
-    // Everything else — anything built on pointer/mouse events — gets a real
-    // press, move and release.
+    // One mechanism covers both kinds of drop target. Measured on Chrome 145:
+    // a press/move/release sent as raw `Input.dispatchMouseEvent` — no
+    // `Input.setInterceptDrags` — fires dragstart and drop on an HTML5
+    // `draggable` element as well as mousedown/mousemove/mouseup on a
+    // pointer-event one. Falling back to synthesised DragEvents for draggable
+    // sources would trade real input for events carrying isTrusted === false,
+    // which is the thing this handler exists to stop doing.
     const from = await approachElement(wc, target.webContentsId, sourceSelector, 'browser.drag.cdp');
     const to = await elementCenter(wc, targetSelector);
     if (!to) throw new Error(`Element not found: ${targetSelector}`);
@@ -2274,7 +2235,7 @@ export function registerBrowserRpc(
     });
     setPointerPosition(wc, target.webContentsId, to);
 
-    return { ok: true, mode: 'pointer', from, to };
+    return { ok: true, from, to };
   });
 
   /**

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -1372,8 +1372,14 @@ export function registerBrowserRpc(
       // Send the page we are leaving as the Referer when there is a real one,
       // which is what a click-through produces; see shared/referer for when
       // there is not (first load, about:blank, a browser-internal page).
-      const referrer = refererFor(wc.getURL(), url);
-      wc.loadURL(url, { ...(referrer && { httpReferrer: referrer }) }).then(
+      // getURL is guarded like getUserAgent below: a transport without it must
+      // still navigate, just without a referer.
+      const currentUrl = typeof wc.getURL === 'function' ? wc.getURL() : undefined;
+      const referrer = refererFor(currentUrl, url);
+      // Called with one argument when there is no referer, so the plain
+      // navigation path keeps exactly the shape it had.
+      const load = referrer ? wc.loadURL(url, { httpReferrer: referrer }) : wc.loadURL(url);
+      load.then(
         () => finish(),
         (err: unknown) => finish(err instanceof Error ? err : new Error(String(err))),
       );

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -1,4 +1,4 @@
-import type { BrowserWindow } from 'electron';
+import type { BrowserWindow, WebContents } from 'electron';
 import { shell, webContents } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import { sendToRenderer } from './_bridge';
@@ -18,6 +18,9 @@ import {
 } from '../../../shared/browserReplay/promotedSkill';
 import { stepsFingerprint } from '../../../shared/browserReplay/actionTrace';
 import { HumanBehavior } from '../../browser-session/HumanBehavior';
+import { approachPath, defaultStartPoint, type Point } from '../../../shared/pointerPath';
+import { refererFor } from '../../../shared/referer';
+import { buildUserAgentOverride } from '../../../shared/uaMetadata';
 import { WebviewCdpManager } from '../../browser-session/WebviewCdpManager';
 import { BrowserCaptureManager } from '../../browser-session/BrowserCaptureManager';
 import { validateResolvedNavigationUrl } from '../../security/navigationPolicy';
@@ -396,6 +399,59 @@ export function callerScope(
 const profileManager = new ProfileManager();
 const portAllocator = new PortAllocator();
 const humanBehavior = new HumanBehavior();
+
+// ── Pointer movement for the builtin webview lane ───────────────────────────
+// Where the pointer was last left, per webContents. A pointer that starts every
+// interaction from the same place is as distinctive as one that never moves, so
+// each move continues from the last one. Keyed by id and pruned on move, since
+// a numeric id cannot be weakly held.
+const pointerPositions = new Map<number, Point>();
+
+function setPointerPosition(webContentsId: number, point: Point): void {
+  pointerPositions.set(webContentsId, { x: point.x, y: point.y });
+}
+
+/** The viewport coordinates of `selector`'s centre, scrolled into view first. */
+async function elementCenter(
+  wc: WebContents,
+  selector: string,
+): Promise<Point | null> {
+  const result = await wc.debugger.sendCommand('Runtime.evaluate', {
+    expression: `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return null;
+      el.scrollIntoView({ block: 'center', behavior: 'instant' });
+      const r = el.getBoundingClientRect();
+      return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+    })()`,
+    returnByValue: true,
+  }) as { result: { value: Point | null } };
+  return result.result?.value ?? null;
+}
+
+/** The intermediate points between two positions, step count from the distance. */
+function pointerPath(from: Point, to: Point): Point[] {
+  return approachPath(from, to);
+}
+
+/**
+ * Walk the pointer to (x, y) with intermediate `mouseMoved` events, then record
+ * where it ended up.
+ */
+async function movePointerTo(
+  wc: WebContents,
+  webContentsId: number,
+  x: number,
+  y: number,
+): Promise<void> {
+  const from = pointerPositions.get(webContentsId) ?? defaultStartPoint();
+  for (const point of pointerPath(from, { x, y })) {
+    await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
+      type: 'mouseMoved', x: point.x, y: point.y,
+    });
+  }
+  setPointerPosition(webContentsId, { x, y });
+}
 // CDP event capture for browser_console / browser_network / browser_response_body
 // in packaged builds (#106). Lazy: enables domains on first drain call.
 const captureManager = new BrowserCaptureManager();
@@ -1313,9 +1369,14 @@ export function registerBrowserRpc(
       wc.on('did-fail-load', onFail);
       // Full load still resolves us if it beats the commit event (about:blank,
       // cached documents); a rejection here is a real navigation error.
-      wc.loadURL(url).then(() => finish(), (err: unknown) => finish(
-        err instanceof Error ? err : new Error(String(err)),
-      ));
+      // Send the page we are leaving as the Referer when there is a real one,
+      // which is what a click-through produces; see shared/referer for when
+      // there is not (first load, about:blank, a browser-internal page).
+      const referrer = refererFor(wc.getURL(), url);
+      wc.loadURL(url, { ...(referrer && { httpReferrer: referrer }) }).then(
+        () => finish(),
+        (err: unknown) => finish(err instanceof Error ? err : new Error(String(err))),
+      );
     });
 
   const requireNavigateUrl = (params: Record<string, unknown>): string => {
@@ -2017,12 +2078,12 @@ export function registerBrowserRpc(
       y = coords.y;
     }
 
-    // Simulate mouse click via CDP.
-    // Dispatch mouseMoved first — some frameworks (React, Vue) require hover
-    // state before a click registers (e.g. onClick handlers on hover-revealed elements).
-    await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
-      type: 'mouseMoved', x, y,
-    });
+    // Walk the pointer to the target before pressing. A single mouseMoved onto
+    // the exact spot, from a pointer that has never been anywhere else, is not
+    // what a page sees from a person. The intermediate moves also keep the
+    // original reason this event was here: some frameworks (React, Vue) need
+    // hover state before a click registers on a hover-revealed element.
+    await movePointerTo(wc, target.webContentsId, x, y);
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
       type: 'mousePressed', x, y, button: 'left', clickCount: 1,
     });
@@ -2031,6 +2092,79 @@ export function registerBrowserRpc(
     });
 
     return { ok: true, x, y };
+  });
+
+  /**
+   * browser.hover.cdp
+   * Hover an element via real CDP Input mouse moves.
+   * The DOM-event fallback this replaces dispatched a synthetic MouseEvent, so
+   * every handler on the page saw `isTrusted === false` — a single boolean that
+   * separates our hover from every hover a person performs. `Input.*` events
+   * enter through the browser's own input pipeline and carry no such marker.
+   * params: { selector: string, surfaceId?: string }
+   */
+  registerLeased('browser.hover.cdp', async (params, scope) => {
+    const selector = typeof params['selector'] === 'string' ? params['selector'] : '';
+    if (!selector) throw new Error('browser.hover.cdp: missing "selector"');
+    const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
+
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.hover.cdp', surfaceId, scope);
+
+    const wc = webContents.fromId(target.webContentsId);
+    if (!wc || wc.isDestroyed()) throw new Error('browser.hover.cdp: WebContents unavailable');
+
+    const point = await elementCenter(wc, selector);
+    if (!point) throw new Error(`Element not found: ${selector}`);
+
+    await movePointerTo(wc, target.webContentsId, point.x, point.y);
+    return { ok: true, x: point.x, y: point.y };
+  });
+
+  /**
+   * browser.drag.cdp
+   * Drag one element onto another via real CDP Input mouse events:
+   * move to the source, press, move across in steps, release. The DOM-event
+   * fallback this replaces synthesised DragEvents, which are untrusted and also
+   * never reach anything built on pointer events rather than HTML5 drag-drop.
+   * params: { sourceSelector: string, targetSelector: string, surfaceId?: string }
+   */
+  registerLeased('browser.drag.cdp', async (params, scope) => {
+    const sourceSelector = typeof params['sourceSelector'] === 'string' ? params['sourceSelector'] : '';
+    const targetSelector = typeof params['targetSelector'] === 'string' ? params['targetSelector'] : '';
+    if (!sourceSelector || !targetSelector) {
+      throw new Error('browser.drag.cdp: missing "sourceSelector" or "targetSelector"');
+    }
+    const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
+
+    const target = webviewCdpManager.getTarget(surfaceId, scope);
+    if (!target) throw noTargetError('browser.drag.cdp', surfaceId, scope);
+
+    const wc = webContents.fromId(target.webContentsId);
+    if (!wc || wc.isDestroyed()) throw new Error('browser.drag.cdp: WebContents unavailable');
+
+    const from = await elementCenter(wc, sourceSelector);
+    if (!from) throw new Error(`Element not found: ${sourceSelector}`);
+    const to = await elementCenter(wc, targetSelector);
+    if (!to) throw new Error(`Element not found: ${targetSelector}`);
+
+    await movePointerTo(wc, target.webContentsId, from.x, from.y);
+    await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
+      type: 'mousePressed', x: from.x, y: from.y, button: 'left', clickCount: 1,
+    });
+    // Held-button moves: the drag itself, not a hover, so the button is named
+    // on every intermediate event.
+    for (const point of pointerPath(from, to)) {
+      await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
+        type: 'mouseMoved', x: point.x, y: point.y, button: 'left', buttons: 1,
+      });
+    }
+    await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
+      type: 'mouseReleased', x: to.x, y: to.y, button: 'left', clickCount: 1,
+    });
+    setPointerPosition(target.webContentsId, to);
+
+    return { ok: true, from, to };
   });
 
   /**
@@ -2282,7 +2416,15 @@ export function registerBrowserRpc(
         deviceScaleFactor: dm.deviceScaleFactor ?? 0, mobile: dm.mobile ?? false,
       });
       if (typeof params['userAgent'] === 'string') {
-        await send('Emulation.setUserAgentOverride', { userAgent: params['userAgent'] });
+        // Metadata is derived here rather than sent over the wire, so the
+        // Client Hints surface (navigator.userAgentData, Sec-CH-UA*) agrees
+        // with the UA string instead of still answering out of the real
+        // browser. See shared/uaMetadata.
+        const emulatedLocale = typeof params['locale'] === 'string' ? params['locale'] : undefined;
+        await send(
+          'Emulation.setUserAgentOverride',
+          buildUserAgentOverride(params['userAgent'], emulatedLocale) as unknown as Record<string, unknown>,
+        );
       }
       const label = typeof params['deviceLabel'] === 'string' ? params['deviceLabel'] : `${dm.width}x${dm.height}`;
       applied.push(`device=${label}`);
@@ -2295,7 +2437,15 @@ export function registerBrowserRpc(
       await send('Emulation.clearDeviceMetricsOverride');
       try {
         const ua = typeof wc.getUserAgent === 'function' ? wc.getUserAgent() : undefined;
-        if (ua) await send('Emulation.setUserAgentOverride', { userAgent: ua });
+        // Restore the metadata alongside the string: re-applying the real UA
+        // while the preset's Client Hints stayed in place would leave exactly
+        // the mismatch the preset path now avoids.
+        if (ua) {
+          await send(
+            'Emulation.setUserAgentOverride',
+            buildUserAgentOverride(ua) as unknown as Record<string, unknown>,
+          );
+        }
       } catch {
         /* getUserAgent / UA override unavailable on this transport; metrics still cleared */
       }

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -403,15 +403,29 @@ const humanBehavior = new HumanBehavior();
 // ── Pointer movement for the builtin webview lane ───────────────────────────
 // Where the pointer was last left, per webContents. A pointer that starts every
 // interaction from the same place is as distinctive as one that never moves, so
-// each move continues from the last one. Keyed by id and pruned on move, since
-// a numeric id cannot be weakly held.
+// each move continues from the last one. Keyed by id, because a numeric id
+// cannot be weakly held — the entry is dropped when the WebContents is
+// destroyed, see rememberPointerFor below.
 const pointerPositions = new Map<number, Point>();
+/** WebContents ids already carrying a destroyed-listener, so we add one once. */
+const pointerCleanupBound = new Set<number>();
 
-function setPointerPosition(webContentsId: number, point: Point): void {
+function setPointerPosition(wc: WebContents, webContentsId: number, point: Point): void {
   pointerPositions.set(webContentsId, { x: point.x, y: point.y });
+  if (!pointerCleanupBound.has(webContentsId)) {
+    pointerCleanupBound.add(webContentsId);
+    wc.once('destroyed', () => {
+      pointerPositions.delete(webContentsId);
+      pointerCleanupBound.delete(webContentsId);
+    });
+  }
 }
 
-/** The viewport coordinates of `selector`'s centre, scrolled into view first. */
+/**
+ * The viewport coordinates of `selector`'s centre, scrolled into view first,
+ * or null when the element is absent or has no area. A zero-size rect would
+ * otherwise send a click to a point that belongs to whatever is behind it.
+ */
 async function elementCenter(
   wc: WebContents,
   selector: string,
@@ -422,11 +436,70 @@ async function elementCenter(
       if (!el) return null;
       el.scrollIntoView({ block: 'center', behavior: 'instant' });
       const r = el.getBoundingClientRect();
+      if (r.width <= 0 || r.height <= 0) return null;
       return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
     })()`,
     returnByValue: true,
   }) as { result: { value: Point | null } };
   return result.result?.value ?? null;
+}
+
+/**
+ * Is (x, y) still on `selector`, or on something inside it?
+ *
+ * Moving the pointer takes time, and anything the page does in that window —
+ * a sticky header settling, a lazy image reflowing the column — can slide the
+ * target out from under the coordinates we computed before the move. Pressing
+ * anyway reports a successful click on whatever happened to be there instead.
+ */
+async function pointIsOnTarget(
+  wc: WebContents,
+  selector: string,
+  point: Point,
+): Promise<boolean> {
+  const result = await wc.debugger.sendCommand('Runtime.evaluate', {
+    expression: `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return false;
+      const hit = document.elementFromPoint(${point.x}, ${point.y});
+      return !!hit && (hit === el || el.contains(hit));
+    })()`,
+    returnByValue: true,
+  }) as { result: { value: boolean } };
+  return result.result?.value === true;
+}
+
+/**
+ * Walk the pointer to `selector` and return the point the press should use.
+ *
+ * Re-resolves once if the element has moved during the walk, and refuses
+ * rather than pressing on whatever is now under the coordinates.
+ */
+async function approachElement(
+  wc: WebContents,
+  webContentsId: number,
+  selector: string,
+  method: string,
+): Promise<Point> {
+  let point = await elementCenter(wc, selector);
+  if (!point) throw new Error(`Element not found: ${selector}`);
+  await movePointerTo(wc, webContentsId, point.x, point.y);
+
+  if (await pointIsOnTarget(wc, selector, point)) return point;
+
+  // Moved mid-approach: recompute once and walk the rest of the way.
+  const again = await elementCenter(wc, selector);
+  if (!again) throw new Error(`Element not found: ${selector}`);
+  await movePointerTo(wc, webContentsId, again.x, again.y);
+  point = again;
+
+  if (!(await pointIsOnTarget(wc, selector, point))) {
+    throw new Error(
+      `${method}: ${selector} is not the element at (${Math.round(point.x)}, ${Math.round(point.y)}) ` +
+      `— it is moving, or something is covering it. Refusing to click what is there instead.`,
+    );
+  }
+  return point;
 }
 
 /** The intermediate points between two positions, step count from the distance. */
@@ -450,7 +523,7 @@ async function movePointerTo(
       type: 'mouseMoved', x: point.x, y: point.y,
     });
   }
-  setPointerPosition(webContentsId, { x, y });
+  setPointerPosition(wc, webContentsId, { x, y });
 }
 // CDP event capture for browser_console / browser_network / browser_response_body
 // in packaged builds (#106). Lazy: enables domains on first drain call.
@@ -2064,37 +2137,27 @@ export function registerBrowserRpc(
     let y = typeof params['y'] === 'number' ? params['y'] : 0;
 
     if (selector) {
-      // Scroll element into view and get its viewport coordinates.
-      // Without scrollIntoView, off-screen elements return coordinates outside
-      // the viewport bounds, causing CDP mouse events to miss the target.
-      const coordResult = await wc.debugger.sendCommand('Runtime.evaluate', {
-        expression: `(() => {
-          const el = document.querySelector(${JSON.stringify(selector)});
-          if (!el) return null;
-          el.scrollIntoView({ block: 'center', behavior: 'instant' });
-          const r = el.getBoundingClientRect();
-          return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
-        })()`,
-        returnByValue: true,
-      }) as { result: { value: { x: number; y: number } | null } };
-
-      const coords = coordResult.result?.value;
-      if (!coords) throw new Error(`Element not found: ${selector}`);
-      x = coords.x;
-      y = coords.y;
+      // Walk the pointer to the target before pressing. A single mouseMoved
+      // onto the exact spot, from a pointer that has never been anywhere else,
+      // is not what a page sees from a person. The intermediate moves also keep
+      // the original reason a move was here at all: some frameworks (React,
+      // Vue) need hover state before a click registers on a hover-revealed
+      // element. approachElement also scrolls the target into view, and refuses
+      // rather than pressing on something that slid under the coordinates.
+      const point = await approachElement(wc, target.webContentsId, selector, 'browser.click.cdp');
+      x = point.x;
+      y = point.y;
+    } else {
+      await movePointerTo(wc, target.webContentsId, x, y);
     }
 
-    // Walk the pointer to the target before pressing. A single mouseMoved onto
-    // the exact spot, from a pointer that has never been anywhere else, is not
-    // what a page sees from a person. The intermediate moves also keep the
-    // original reason this event was here: some frameworks (React, Vue) need
-    // hover state before a click registers on a hover-revealed element.
-    await movePointerTo(wc, target.webContentsId, x, y);
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
-      type: 'mousePressed', x, y, button: 'left', clickCount: 1,
+      // `buttons` is the bitmask of what is held DURING the event; a press with
+      // buttons:0 says the left button is down and simultaneously not down.
+      type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1,
     });
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
-      type: 'mouseReleased', x, y, button: 'left', clickCount: 1,
+      type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1,
     });
 
     return { ok: true, x, y };
@@ -2120,10 +2183,7 @@ export function registerBrowserRpc(
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.hover.cdp: WebContents unavailable');
 
-    const point = await elementCenter(wc, selector);
-    if (!point) throw new Error(`Element not found: ${selector}`);
-
-    await movePointerTo(wc, target.webContentsId, point.x, point.y);
+    const point = await approachElement(wc, target.webContentsId, selector, 'browser.hover.cdp');
     return { ok: true, x: point.x, y: point.y };
   });
 
@@ -2149,14 +2209,58 @@ export function registerBrowserRpc(
     const wc = webContents.fromId(target.webContentsId);
     if (!wc || wc.isDestroyed()) throw new Error('browser.drag.cdp: WebContents unavailable');
 
-    const from = await elementCenter(wc, sourceSelector);
-    if (!from) throw new Error(`Element not found: ${sourceSelector}`);
+    // HTML5 drag-and-drop is not reachable from raw mouse events: Chromium
+    // hands a mouse drag on a `draggable` element to the browser's own native
+    // drag loop, which never surfaces as dragstart/dragover/drop to the page
+    // unless the client is intercepting drags. So the two kinds of drop target
+    // need two different mechanisms, and which one applies is decided by the
+    // source element, not by guessing after the fact.
+    const nativeDraggable = await wc.debugger.sendCommand('Runtime.evaluate', {
+      expression: `(() => {
+        const el = document.querySelector(${JSON.stringify(sourceSelector)});
+        if (!el) return null;
+        return !!(el.draggable || el.closest('[draggable="true"]'));
+      })()`,
+      returnByValue: true,
+    }) as { result: { value: boolean | null } };
+
+    if (nativeDraggable.result?.value === null) {
+      throw new Error(`Element not found: ${sourceSelector}`);
+    }
+
+    if (nativeDraggable.result?.value === true) {
+      // HTML5 drag source: synthesised DragEvents are the only thing that
+      // reaches the handlers. Known limitation — these carry
+      // isTrusted === false, unlike the pointer path below.
+      const val = await wc.debugger.sendCommand('Runtime.evaluate', {
+        expression: `(() => {
+          const src = document.querySelector(${JSON.stringify(sourceSelector)});
+          const tgt = document.querySelector(${JSON.stringify(targetSelector)});
+          if (!src) return 'source_not_found';
+          if (!tgt) return 'target_not_found';
+          const dt = new DataTransfer();
+          src.dispatchEvent(new DragEvent('dragstart', { bubbles: true, dataTransfer: dt }));
+          tgt.dispatchEvent(new DragEvent('dragover', { bubbles: true, dataTransfer: dt }));
+          tgt.dispatchEvent(new DragEvent('drop', { bubbles: true, dataTransfer: dt }));
+          src.dispatchEvent(new DragEvent('dragend', { bubbles: true, dataTransfer: dt }));
+          return 'ok';
+        })()`,
+        returnByValue: true,
+      }) as { result: { value: string } };
+      const outcome = val.result?.value;
+      if (outcome === 'source_not_found') throw new Error(`Element not found: ${sourceSelector}`);
+      if (outcome === 'target_not_found') throw new Error(`Element not found: ${targetSelector}`);
+      return { ok: true, mode: 'html5' };
+    }
+
+    // Everything else — anything built on pointer/mouse events — gets a real
+    // press, move and release.
+    const from = await approachElement(wc, target.webContentsId, sourceSelector, 'browser.drag.cdp');
     const to = await elementCenter(wc, targetSelector);
     if (!to) throw new Error(`Element not found: ${targetSelector}`);
 
-    await movePointerTo(wc, target.webContentsId, from.x, from.y);
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
-      type: 'mousePressed', x: from.x, y: from.y, button: 'left', clickCount: 1,
+      type: 'mousePressed', x: from.x, y: from.y, button: 'left', buttons: 1, clickCount: 1,
     });
     // Held-button moves: the drag itself, not a hover, so the button is named
     // on every intermediate event.
@@ -2166,11 +2270,11 @@ export function registerBrowserRpc(
       });
     }
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
-      type: 'mouseReleased', x: to.x, y: to.y, button: 'left', clickCount: 1,
+      type: 'mouseReleased', x: to.x, y: to.y, button: 'left', buttons: 0, clickCount: 1,
     });
-    setPointerPosition(target.webContentsId, to);
+    setPointerPosition(wc, target.webContentsId, to);
 
-    return { ok: true, from, to };
+    return { ok: true, mode: 'pointer', from, to };
   });
 
   /**

--- a/src/mcp/playwright/__tests__/interaction.clickApproach.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.clickApproach.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from 'vitest';
+// vi.mock is hoisted above the imports, so the mocks below are in place by the
+// time interaction.ts is evaluated.
+import { clickWithApproach } from '../tools/interaction';
+
+// interaction.ts pulls in the whole tool-registration graph; the module mocks
+// below keep this focused on clickWithApproach alone.
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: { getInstance: () => ({}) },
+}));
+vi.mock('../automationLease', () => ({ withAutomationLease: vi.fn() }));
+vi.mock('../snapshot', () => ({
+  browserScopeKey: vi.fn(),
+  frameRefFallbackMessage: vi.fn(),
+  isOutstandingFrameRef: () => false,
+  resolveRef: vi.fn(),
+}));
+vi.mock('../dom-intelligence', () => ({ getLocatorByRef: vi.fn() }));
+vi.mock('../human-typing', () => ({ typeHumanlike: vi.fn() }));
+vi.mock('../browserScope', () => ({
+  allowScopedRpcFallback: vi.fn(),
+  sendScopedBrowserRpc: vi.fn(),
+}));
+vi.mock('../../browser-replay/actionRing', () => ({ recordAction: vi.fn() }));
+
+const BOX = { x: 400, y: 300, width: 200, height: 60 };
+
+function makePage() {
+  // Params are declared so mock.calls is typed as the [x, y] pairs below read it.
+  const move = vi.fn(async (_x: number, _y: number) => undefined);
+  return {
+    // A fresh object each time, so the per-page pointer WeakMap starts empty.
+    page: { mouse: { move }, viewportSize: () => ({ width: 1280, height: 720 }) },
+    move,
+  };
+}
+
+function makeEl(box: typeof BOX | null, opts: { clickThrows?: boolean } = {}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    el: {
+      boundingBox: vi.fn(async () => box),
+      scrollIntoViewIfNeeded: vi.fn(async () => { calls.push('scroll'); }),
+      click: vi.fn(async (options?: { position?: { x: number; y: number } }) => {
+        calls.push(options?.position ? 'click:positioned' : 'click:plain');
+        if (options?.position && opts.clickThrows) {
+          throw new Error('element is not visible');
+        }
+      }),
+      dblclick: vi.fn(async (options?: { position?: { x: number; y: number } }) => {
+        calls.push(options?.position ? 'dblclick:positioned' : 'dblclick:plain');
+      }),
+    },
+  };
+}
+
+describe('clickWithApproach', () => {
+  it('moves the pointer before clicking, and lands inside the box', async () => {
+    const { page, move } = makePage();
+    const { el } = makeEl(BOX);
+
+    await clickWithApproach(page, el, false);
+
+    expect(move).toHaveBeenCalled();
+    const position = el.click.mock.calls[0]?.[0]?.position;
+    if (!position) throw new Error('expected the click to carry a position');
+    // Position is relative to the box origin and inside the inner 60%.
+    expect(position.x).toBeGreaterThan(BOX.width * 0.2);
+    expect(position.x).toBeLessThan(BOX.width * 0.8);
+    expect(position.y).toBeGreaterThan(BOX.height * 0.2);
+    expect(position.y).toBeLessThan(BOX.height * 0.8);
+  });
+
+  it('scrolls the element into view before measuring it', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX);
+    const order: string[] = [];
+    el.scrollIntoViewIfNeeded.mockImplementation(async () => { order.push('scroll'); });
+    el.boundingBox.mockImplementation(async () => { order.push('measure'); return BOX; });
+
+    await clickWithApproach(page, el, false);
+
+    expect(order).toEqual(['scroll', 'measure']);
+    expect(calls).toContain('click:positioned');
+  });
+
+  it('moves before it clicks, never after', async () => {
+    const { page, move } = makePage();
+    const { el } = makeEl(BOX);
+    const order: string[] = [];
+    move.mockImplementation(async () => { order.push('move'); });
+    el.click.mockImplementation(async () => { order.push('click'); });
+
+    await clickWithApproach(page, el, false);
+
+    expect(order[order.length - 1]).toBe('click');
+    expect(order.filter((s) => s === 'move').length).toBeGreaterThan(0);
+    expect(order.indexOf('move')).toBeLessThan(order.indexOf('click'));
+  });
+
+  it('falls back to a plain click when the element has no box', async () => {
+    const { page, move } = makePage();
+    const { el, calls } = makeEl(null);
+
+    await clickWithApproach(page, el, false);
+
+    expect(move).not.toHaveBeenCalled();
+    expect(calls).toContain('click:plain');
+  });
+
+  it('falls back to a plain click for a zero-area box', async () => {
+    const { page, move } = makePage();
+    const { el, calls } = makeEl({ x: 10, y: 10, width: 0, height: 20 });
+
+    await clickWithApproach(page, el, false);
+
+    expect(move).not.toHaveBeenCalled();
+    expect(calls).toContain('click:plain');
+  });
+
+  it('aims at the centre of a small control instead of offsetting', async () => {
+    const { page } = makePage();
+    const small = { x: 100, y: 100, width: 16, height: 16 };
+    const { el } = makeEl(small);
+
+    await clickWithApproach(page, el, false);
+
+    expect(el.click.mock.calls[0]?.[0]?.position).toEqual({ x: 8, y: 8 });
+  });
+
+  it('skips the approach when the target is outside the viewport', async () => {
+    const { page, move } = makePage();
+    const { el, calls } = makeEl({ x: 5000, y: 4000, width: 100, height: 40 });
+
+    await clickWithApproach(page, el, false);
+
+    expect(move).not.toHaveBeenCalled();
+    expect(calls).toContain('click:plain');
+  });
+
+  it('retries once without the approach when the positioned click fails', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX, { clickThrows: true });
+
+    await clickWithApproach(page, el, false);
+
+    expect(calls).toEqual(['scroll', 'click:positioned', 'click:plain']);
+  });
+
+  it('routes a double click through dblclick', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX);
+
+    await clickWithApproach(page, el, true);
+
+    expect(calls).toContain('dblclick:positioned');
+    expect(el.click).not.toHaveBeenCalled();
+  });
+
+  it('continues the next approach from where the last one ended', async () => {
+    const { page, move } = makePage();
+    const first = makeEl(BOX);
+    await clickWithApproach(page, first.el, false);
+    const endOfFirst = move.mock.calls.at(-1);
+
+    move.mockClear();
+    const second = makeEl({ x: 800, y: 500, width: 120, height: 40 });
+    await clickWithApproach(page, second.el, false);
+
+    // The second walk starts where the first one finished, not from the
+    // default start point.
+    const startOfSecond = move.mock.calls[0];
+    if (!endOfFirst || !startOfSecond) throw new Error('expected pointer moves on both clicks');
+    expect(startOfSecond).not.toEqual(endOfFirst);
+    const dx = Math.abs(startOfSecond[0] - endOfFirst[0]);
+    const dy = Math.abs(startOfSecond[1] - endOfFirst[1]);
+    // One step's worth of travel, not a jump back across the viewport.
+    expect(Math.hypot(dx, dy)).toBeLessThan(Math.hypot(800 - 400, 500 - 300));
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.newtab.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.newtab.test.ts
@@ -77,6 +77,9 @@ function makePage(opts: { popupUrl?: string; popupUrls?: string[]; clickThrows?:
       if (opts.clickThrows) throw new Error('Element is not attached to the DOM');
     }),
     dblclick: vi.fn(async () => undefined),
+    // The click path walks the pointer to the element's box before pressing,
+    // so a stand-in element has to have one.
+    boundingBox: vi.fn(async () => ({ x: 10, y: 20, width: 100, height: 40 })),
   };
   return {
     el,
@@ -89,6 +92,8 @@ function makePage(opts: { popupUrl?: string; popupUrls?: string[]; clickThrows?:
       },
       off: (event: string, fn: Handler) => handlers.get(event)?.delete(fn),
       locator: vi.fn(),
+      mouse: { move: vi.fn(async () => undefined) },
+      viewportSize: () => ({ width: 1280, height: 720 }),
     },
   };
 }

--- a/src/mcp/playwright/__tests__/interaction.smartref.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.smartref.test.ts
@@ -102,10 +102,15 @@ function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
       }),
     }),
     locator: vi.fn(),
+    // A real click walks the pointer to the element first, so the fakes carry
+    // the shape that approach reads: a viewport, a mouse, and a box per element.
+    mouse: { move: async () => {} },
+    viewportSize: () => ({ width: 1280, height: 720 }),
     getByRole: (r: string, opts?: { name?: string }) => ({
       count: async () => page.nodes.filter((n) => n.role?.value === r
         && (opts?.name === undefined || (n.name?.value ?? '') === opts.name)).length,
       nth: (i: number) => ({
+        boundingBox: async () => ({ x: 100, y: 100, width: 120, height: 40 }),
         click: async () => { clicked.push(`${r} ${opts?.name ?? ''}#${i}`); },
         dblclick: async () => { clicked.push(`dbl ${r} ${opts?.name ?? ''}#${i}`); },
       }),

--- a/src/mcp/playwright/human-typing.ts
+++ b/src/mcp/playwright/human-typing.ts
@@ -1,26 +1,22 @@
 import type { Page } from 'playwright-core';
+import { generateTypingDelays } from '../../shared/humanRhythm';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
 export interface HumanTypingOptions {
-  /** Minimum inter-keystroke delay in ms (default 50) */
+  /** Low end of the typist's band in ms (default 50) */
   minDelay?: number;
-  /** Maximum inter-keystroke delay in ms (default 150) */
+  /** High end of the typist's band in ms (default 150) */
   maxDelay?: number;
+  /** Uniform [0,1) source. Defaults to `Math.random`; inject for determinism. */
+  rng?: () => number;
 }
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
-
-const DEFAULT_MIN_DELAY = 50;
-const DEFAULT_MAX_DELAY = 150;
-
-function randomDelay(min: number, max: number): number {
-  return Math.random() * (max - min) + min;
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -31,26 +27,27 @@ function sleep(ms: number): Promise<void> {
 // ---------------------------------------------------------------------------
 
 /**
- * Generate an array of per-character delay values (in ms) for the given
- * text.  This mirrors `HumanBehavior.generateTypingSchedule()` from the
- * main process but is independent of that class.
+ * Generate an array of per-character delay values (in ms) for the given text.
+ *
+ * The shape comes from `shared/humanRhythm`, which the main process's
+ * `HumanBehavior.generateTypingSchedule()` also uses, so the two lanes cannot
+ * drift apart: log-normal around the band's midpoint, longer after punctuation
+ * and word breaks, with an occasional thinking pause.
  */
 export function generateDelaySchedule(
   text: string,
   options?: HumanTypingOptions,
 ): number[] {
-  const min = options?.minDelay ?? DEFAULT_MIN_DELAY;
-  const max = options?.maxDelay ?? DEFAULT_MAX_DELAY;
-
-  return Array.from({ length: text.length }, () => randomDelay(min, max));
+  return generateTypingDelays(text, options);
 }
 
 /**
  * Type `text` into the element identified by `selector` with randomised
  * inter-keystroke delays that mimic human typing.
  *
- * Each character is pressed individually via `page.keyboard.press()` with
- * a random pause between `minDelay` and `maxDelay` milliseconds.
+ * Each character is pressed individually via `page.keyboard.press()`, with the
+ * pause after it drawn from the shared typing rhythm — see
+ * `generateDelaySchedule` and `shared/humanRhythm`.
  *
  * If `selector` is provided the element is clicked first to ensure focus.
  */

--- a/src/mcp/playwright/pointer-path.ts
+++ b/src/mcp/playwright/pointer-path.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// Per-page pointer position for the chrome lane.
+//
+// The geometry itself is shared with the main-process webview lane and lives in
+// `src/shared/pointerPath`. What is specific to this lane is remembering where
+// the pointer was left, so the next click approaches from there instead of
+// starting over: a pointer that teleports home between every click is as
+// distinctive as one that never moves.
+// ---------------------------------------------------------------------------
+
+import type { Point } from '../../shared/pointerPath';
+
+export {
+  clickPointInBox,
+  defaultStartPoint,
+  distance,
+  pathPoints,
+  stepsForDistance,
+  INNER_FRACTION,
+  MAX_STEPS,
+  MIN_STEPS,
+} from '../../shared/pointerPath';
+export type { Box, Point } from '../../shared/pointerPath';
+
+// Keyed on the page object: two pages in the same session have separate
+// pointers, and a page that goes away takes its entry with it.
+const lastPointerByPage = new WeakMap<object, Point>();
+
+export function getLastPointer(page: object): Point | undefined {
+  return lastPointerByPage.get(page);
+}
+
+export function setLastPointer(page: object, point: Point): void {
+  lastPointerByPage.set(page, { x: point.x, y: point.y });
+}

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -190,12 +190,20 @@ interface ApproachTarget {
   boundingBox(): Promise<{ x: number; y: number; width: number; height: number } | null>;
   click(options?: { position?: { x: number; y: number } }): Promise<void>;
   dblclick(options?: { position?: { x: number; y: number } }): Promise<void>;
+  scrollIntoViewIfNeeded?(): Promise<void>;
 }
 
 interface ApproachPage {
   mouse: { move(x: number, y: number): Promise<void> };
   viewportSize(): { width: number; height: number } | null;
 }
+
+/**
+ * Below this, in either dimension, an element is too small to miss the middle
+ * of convincingly: the offset would be a pixel or two and the only thing it
+ * could achieve is landing on a border.
+ */
+const MIN_OFFSET_SIZE_PX = 24;
 
 /**
  * Click `el`, but move the pointer there first and land off-centre.
@@ -211,30 +219,65 @@ interface ApproachPage {
  * no path to walk, so it falls straight through to the plain click and lets
  * Playwright's own waiting produce the error or the retry.
  */
-async function clickWithApproach(
+export async function clickWithApproach(
   page: ApproachPage,
   el: ApproachTarget,
   double: boolean,
 ): Promise<void> {
-  const box = await el.boundingBox().catch(() => null);
-  if (!box || box.width <= 0 || box.height <= 0) {
+  const plainClick = async (): Promise<void> => {
     if (double) await el.dblclick();
     else await el.click();
+  };
+
+  // Scroll first, THEN measure. A box read before scrolling describes where the
+  // element was, so the approach would walk to a point outside the viewport and
+  // leave the tracker pointing there.
+  if (el.scrollIntoViewIfNeeded) {
+    await el.scrollIntoViewIfNeeded().catch(() => {});
+  }
+
+  const box = await el.boundingBox().catch(() => null);
+  if (!box || box.width <= 0 || box.height <= 0) {
+    await plainClick();
     return;
   }
 
-  const target = clickPointInBox(box);
-  const from = getLastPointer(page) ?? defaultStartPoint(page.viewportSize() ?? undefined);
-  const steps = stepsForDistance(distance(from, target));
+  // A small control has no room for a meaningful offset — aim at the centre.
+  const target =
+    box.width < MIN_OFFSET_SIZE_PX || box.height < MIN_OFFSET_SIZE_PX
+      ? { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+      : clickPointInBox(box);
 
+  // Still off-screen, or in a frame whose coordinates we cannot place: a path
+  // to a point outside the viewport is worse than no path at all.
+  const viewport = page.viewportSize();
+  if (
+    target.x < 0 ||
+    target.y < 0 ||
+    (viewport && (target.x > viewport.width || target.y > viewport.height))
+  ) {
+    await plainClick();
+    return;
+  }
+
+  const from = getLastPointer(page) ?? defaultStartPoint(viewport ?? undefined);
+  const steps = stepsForDistance(distance(from, target));
   for (const point of pathPoints(from, target, steps)) {
     await page.mouse.move(point.x, point.y);
   }
   setLastPointer(page, target);
 
   const position = { x: target.x - box.x, y: target.y - box.y };
-  if (double) await el.dblclick({ position });
-  else await el.click({ position });
+  try {
+    if (double) await el.dblclick({ position });
+    else await el.click({ position });
+  } catch {
+    // The element moved, something now covers the point we aimed at, or the
+    // element is rotated so a point inside its axis-aligned box is outside the
+    // element itself. Playwright's own centre-targeted click resolves all
+    // three, so give it exactly one go before surfacing the failure.
+    await plainClick();
+  }
 }
 
 async function rpcClick(ref: string, scope: BrowserTargetScope, _double?: boolean): Promise<void> {

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -12,6 +12,15 @@ import {
 import { getLocatorByRef, resolveSmartRefLocator, smartRefAxisEntry } from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
 import { evaluateIsolated } from '../isolated-eval';
+import {
+  clickPointInBox,
+  defaultStartPoint,
+  distance,
+  getLastPointer,
+  pathPoints,
+  setLastPointer,
+  stepsForDistance,
+} from '../pointer-path';
 import { describeToolError } from '../toolError';
 import {
   PASSWORD_FIELD_PREDICATE_JS,
@@ -171,6 +180,61 @@ export function sanitizeRef(ref: string, scope: BrowserTargetScope): string {
     throw new Error(frameRefFallbackMessage(ref));
   }
   return ref;
+}
+
+/**
+ * The subset of Locator / ElementHandle that `clickWithApproach` needs. Both
+ * satisfy it, so the two click paths below share one implementation.
+ */
+interface ApproachTarget {
+  boundingBox(): Promise<{ x: number; y: number; width: number; height: number } | null>;
+  click(options?: { position?: { x: number; y: number } }): Promise<void>;
+  dblclick(options?: { position?: { x: number; y: number } }): Promise<void>;
+}
+
+interface ApproachPage {
+  mouse: { move(x: number, y: number): Promise<void> };
+  viewportSize(): { width: number; height: number } | null;
+}
+
+/**
+ * Click `el`, but move the pointer there first and land off-centre.
+ *
+ * A bare `locator.click()` emits one `mousemove` onto the exact centre of the
+ * box and presses — a pointer that has never been anywhere else and never
+ * misses the middle. This walks the pointer from wherever it last was on this
+ * page (see `pointer-path`) and then hands Playwright the landing point as a
+ * `position`, so actionability, `force` and `timeout` behave exactly as before
+ * and the click does not jump away from where the pointer already is.
+ *
+ * An element with no box — detached, `display:none`, still animating in — has
+ * no path to walk, so it falls straight through to the plain click and lets
+ * Playwright's own waiting produce the error or the retry.
+ */
+async function clickWithApproach(
+  page: ApproachPage,
+  el: ApproachTarget,
+  double: boolean,
+): Promise<void> {
+  const box = await el.boundingBox().catch(() => null);
+  if (!box || box.width <= 0 || box.height <= 0) {
+    if (double) await el.dblclick();
+    else await el.click();
+    return;
+  }
+
+  const target = clickPointInBox(box);
+  const from = getLastPointer(page) ?? defaultStartPoint(page.viewportSize() ?? undefined);
+  const steps = stepsForDistance(distance(from, target));
+
+  for (const point of pathPoints(from, target, steps)) {
+    await page.mouse.move(point.x, point.y);
+  }
+  setLastPointer(page, target);
+
+  const position = { x: target.x - box.x, y: target.y - box.y };
+  if (double) await el.dblclick({ position });
+  else await el.click({ position });
 }
 
 async function rpcClick(ref: string, scope: BrowserTargetScope, _double?: boolean): Promise<void> {
@@ -436,6 +500,9 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             await page.mouse.click(x as number, y as number, {
               ...(double && { clickCount: 2 }),
             });
+            // Keep the tracker honest: the next ref click should approach from
+            // here, not from wherever the pointer was before this one.
+            setLastPointer(page, { x: x as number, y: y as number });
             const note = coordWatch ? await coordWatch.note() : '';
             // Coordinate clicks are deliberately NOT recorded: a coordinate
             // does not survive a re-render, so a trace built on one replays a
@@ -472,8 +539,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
               // range. Throws StaleSmartRefError rather than clicking a
               // substitute when the ref no longer names one live element.
               const locator = await resolveSmartRefLocator(page, smartRef);
-              if (double) await locator.dblclick();
-              else await locator.click();
+              await clickWithApproach(page as unknown as ApproachPage, locator, !!double);
               // A ref axis, not the css axis this used to record: the CDP
               // lane's stored "locator" is getByRole SOURCE TEXT, which
               // page.locator() cannot parse, so every replay of such a step
@@ -497,8 +563,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
             const el = await resolveRef(page, ref);
             if (!el) throw new Error(refNotFound(ref));
-            if (double) await el.dblclick();
-            else await el.click();
+            await clickWithApproach(page as unknown as ApproachPage, el, !!double);
             recordAction(deps, {
               scope,
               tool: 'browser_click',
@@ -727,17 +792,14 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           if (!el) throw new Error(refNotFound(ref));
           await el.hover();
         } else {
-          // RPC fallback: dispatch mouseover event
+          // RPC fallback: real pointer movement over CDP Input. The synthetic
+          // MouseEvent this replaces arrived with isTrusted === false, which any
+          // handler on the page can read — a single boolean separating our
+          // hover from every hover a person performs.
           const safeRef = sanitizeRef(ref, scope);
-          const val = await rpcEval(`(() => {
-            const el = document.querySelector('[data-wmux-ref="${safeRef}"]');
-            if (!el) return 'not_found';
-            el.scrollIntoView({ block: 'center', behavior: 'instant' });
-            el.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-            el.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-            return 'ok';
-          })()`, scope);
-          if (val === 'not_found') throw new Error(refNotFound(ref));
+          await sendScopedBrowserRpc('browser.hover.cdp', scope, {
+            selector: `[data-wmux-ref="${safeRef}"]`,
+          });
         }
 
         recordAction(deps, { scope, tool: 'browser_hover', page, ref });
@@ -788,23 +850,16 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           await page.mouse.move(targetX, targetY, { steps: 10 });
           await page.mouse.up();
         } else {
-          // RPC fallback: simplified drag via JS events
+          // RPC fallback: press, move, release over CDP Input — the same shape
+          // as the Playwright path above. The synthesised DragEvents this
+          // replaces were untrusted, and they also never reached anything built
+          // on pointer events rather than HTML5 drag-and-drop.
           const safeSrc = sanitizeRef(sourceRef, scope);
           const safeTgt = sanitizeRef(targetRef, scope);
-          const val = await rpcEval(`(() => {
-            const src = document.querySelector('[data-wmux-ref="${safeSrc}"]');
-            const tgt = document.querySelector('[data-wmux-ref="${safeTgt}"]');
-            if (!src) return 'source_not_found';
-            if (!tgt) return 'target_not_found';
-            const dt = new DataTransfer();
-            src.dispatchEvent(new DragEvent('dragstart', { bubbles: true, dataTransfer: dt }));
-            tgt.dispatchEvent(new DragEvent('dragover', { bubbles: true, dataTransfer: dt }));
-            tgt.dispatchEvent(new DragEvent('drop', { bubbles: true, dataTransfer: dt }));
-            src.dispatchEvent(new DragEvent('dragend', { bubbles: true, dataTransfer: dt }));
-            return 'ok';
-          })()`, scope);
-          if (val === 'source_not_found') throw new Error(refNotFound(sourceRef));
-          if (val === 'target_not_found') throw new Error(refNotFound(targetRef));
+          await sendScopedBrowserRpc('browser.drag.cdp', scope, {
+            sourceSelector: `[data-wmux-ref="${safeSrc}"]`,
+            targetSelector: `[data-wmux-ref="${safeTgt}"]`,
+          });
         }
 
         recordAction(deps, { scope, tool: 'browser_drag', page, ref: sourceRef, targetRef });
@@ -838,6 +893,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           if (!el) throw new Error(refNotFound(ref));
           await el.selectOption(values);
         } else {
+          // Deliberately still a DOM assignment, unlike hover and drag above.
+          // A native <select> opens an OS-drawn popup that lives outside the
+          // page — CDP Input events go to the document, not to that popup, so
+          // there is no mouse sequence that reliably picks an option. Setting
+          // `selected` and firing `change` is the only path that works here;
+          // the trade-off is that the change event carries isTrusted === false.
           const safeRef = sanitizeRef(ref, scope);
           const escapedValues = JSON.stringify(values);
           const val = await rpcEval(`(() => {

--- a/src/mcp/playwright/tools/navigation.ts
+++ b/src/mcp/playwright/tools/navigation.ts
@@ -11,6 +11,7 @@ import { withAutomationLease } from '../automationLease';
 import { describeToolError } from '../toolError';
 import { redactPasswordParams } from '../redact';
 import { recordAction } from '../../browser-replay/actionRing';
+import { refererFor } from '../../../shared/referer';
 import {
   browserTabsError,
   isBrowserTabsResult,
@@ -154,7 +155,15 @@ export function registerNavigationTools(server: McpServer, deps: BrowserToolDeps
             if ((await engine.resolveWorkspaceBackend(scope.workspaceId)) === 'chrome') {
               const page = await engine.getPageForScope(scope);
               if (!page) throw new Error('browser_navigate: no chrome page resolved for this scope.');
-              await page.goto(url, { waitUntil: 'domcontentloaded' });
+              // A person reaching this URL by clicking a link arrives with the
+              // page they left in the Referer header; page.goto() sends none
+              // unless told to. refererFor() decides when there is a real one
+              // to send — see shared/referer.
+              const referer = refererFor(page.url(), url);
+              await page.goto(url, {
+                waitUntil: 'domcontentloaded',
+                ...(referer && { referer }),
+              });
               finalUrl = page.url();
               // The landing URL, not the requested one: a trace filed under a
               // redirect's source would never match the page it actually runs

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -7,6 +7,7 @@ import { withAutomationLease } from '../automationLease';
 import { matchSensitiveDomain } from '../security';
 import { evalFunctionOrRpc } from '../page-eval';
 import { describeToolError } from '../toolError';
+import { buildUserAgentOverride } from '../../../shared/uaMetadata';
 import {
   allowScopedRpcFallback,
   sendScopedBrowserRpc,
@@ -481,6 +482,25 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
                 ...(headers ?? {}),
                 'User-Agent': deviceDescriptor.userAgent,
               });
+              // The header alone leaves navigator.userAgentData — and the
+              // Sec-CH-UA* headers built from it — answering out of the REAL
+              // browser, so an emulated phone announced itself as a phone in
+              // one place and as this desktop in the other. Override both
+              // together with metadata derived from the preset's own UA.
+              const override = buildUserAgentOverride(
+                deviceDescriptor.userAgent,
+                locale ?? undefined,
+              );
+              const uaClient = await context.newCDPSession(page);
+              try {
+                await uaClient.send('Emulation.setUserAgentOverride', override);
+              } catch {
+                // Client Hints stay on the real browser's values; the UA header
+                // is still applied. Worth reporting, not worth failing on.
+                applied.push('clientHints=unavailable (UA header applied without matching hints)');
+              } finally {
+                await uaClient.detach().catch(() => {});
+              }
               applied.push(`device=${device} (${deviceDescriptor.viewport.width}x${deviceDescriptor.viewport.height})`);
             } else {
               applied.push('device=reset (use browser_resize to set viewport)');

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -7,7 +7,11 @@ import { withAutomationLease } from '../automationLease';
 import { matchSensitiveDomain } from '../security';
 import { evalFunctionOrRpc } from '../page-eval';
 import { describeToolError } from '../toolError';
-import { buildUserAgentOverride } from '../../../shared/uaMetadata';
+import {
+  applyUserAgentEmulation,
+  clearUserAgentEmulation,
+  hasUserAgentEmulation,
+} from '../ua-emulation';
 import {
   allowScopedRpcFallback,
   sendScopedBrowserRpc,
@@ -485,24 +489,35 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
               // The header alone leaves navigator.userAgentData — and the
               // Sec-CH-UA* headers built from it — answering out of the REAL
               // browser, so an emulated phone announced itself as a phone in
-              // one place and as this desktop in the other. Override both
-              // together with metadata derived from the preset's own UA.
-              const override = buildUserAgentOverride(
+              // one place and as this desktop in the other. ua-emulation holds
+              // the CDP session open (the override dies with its session) and
+              // re-applies to tabs opened later, matching the context-wide
+              // reach of the header above.
+              const ok = await applyUserAgentEmulation(
+                context,
+                page,
                 deviceDescriptor.userAgent,
                 locale ?? undefined,
               );
-              const uaClient = await context.newCDPSession(page);
-              try {
-                await uaClient.send('Emulation.setUserAgentOverride', override);
-              } catch {
+              if (!ok) {
                 // Client Hints stay on the real browser's values; the UA header
                 // is still applied. Worth reporting, not worth failing on.
                 applied.push('clientHints=unavailable (UA header applied without matching hints)');
-              } finally {
-                await uaClient.detach().catch(() => {});
               }
               applied.push(`device=${device} (${deviceDescriptor.viewport.width}x${deviceDescriptor.viewport.height})`);
             } else {
+              // A reset has to undo the UA too. Leaving the override and the
+              // User-Agent header in place meant a caller who switched to a
+              // phone preset and then reset stayed on the mobile identity for
+              // every subsequent page.
+              if (hasUserAgentEmulation(context)) {
+                await clearUserAgentEmulation(context);
+                // Re-send the caller's headers without the preset's User-Agent.
+                // setExtraHTTPHeaders replaces the whole set, so passing the
+                // rest back is what removes just that one.
+                await context.setExtraHTTPHeaders({ ...(headers ?? {}) });
+                applied.push('userAgent=reset');
+              }
               applied.push('device=reset (use browser_resize to set viewport)');
             }
           }

--- a/src/mcp/playwright/ua-emulation.ts
+++ b/src/mcp/playwright/ua-emulation.ts
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------------
+// Keeping an emulated User-Agent applied.
+//
+// `Emulation.setUserAgentOverride` is scoped to the CDP session that sent it:
+// Chromium disables the emulation handler when the session detaches, and the
+// override goes with it. Opening a session, sending the override and detaching
+// in a `finally` therefore reverts the very thing it just applied.
+//
+// It is also per target. `context.setExtraHTTPHeaders` covers every page in the
+// context, so a UA header applied context-wide alongside a page-scoped hints
+// override would disagree again the moment a second tab opened — the same class
+// of mismatch the override exists to remove.
+//
+// So this module holds one live session per page for as long as the emulation
+// is meant to last, and re-applies the override to pages that appear later.
+// ---------------------------------------------------------------------------
+
+import type { Browser, BrowserContext, CDPSession, Page } from 'playwright-core';
+import { buildUserAgentOverride, type UserAgentOverride } from '../../shared/uaMetadata';
+
+interface EmulationState {
+  override: UserAgentOverride;
+  /** Live sessions, one per page, held open so the override survives. */
+  sessions: Map<Page, CDPSession>;
+  /** Listener re-applying the override to pages opened later. */
+  onPage: (page: Page) => void;
+}
+
+const stateByContext = new WeakMap<BrowserContext, EmulationState>();
+
+/**
+ * `CDPSession.send` is typed against the generated protocol table, and
+ * `userAgentMetadata` is optional on our override where the table wants an
+ * exact command shape. The values are protocol-correct; only the static
+ * narrowing is in the way.
+ */
+type LooseSession = { send(method: string, params?: unknown): Promise<unknown> };
+const loose = (session: CDPSession): LooseSession => session as unknown as LooseSession;
+
+async function applyToPage(
+  context: BrowserContext,
+  page: Page,
+  state: EmulationState,
+): Promise<boolean> {
+  if (state.sessions.has(page)) return true;
+  try {
+    const session = await context.newCDPSession(page);
+    await loose(session).send('Emulation.setUserAgentOverride', state.override);
+    state.sessions.set(page, session);
+    // A closed page's session is dead; drop it rather than leaking the entry.
+    page.once('close', () => {
+      state.sessions.delete(page);
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Apply `userAgent` (plus matching Client Hints) to every page in `context`,
+ * now and as new ones open.
+ *
+ * Returns false when CDP refused, in which case the caller's UA header is still
+ * in force and only the hints are missing.
+ */
+export async function applyUserAgentEmulation(
+  context: BrowserContext,
+  page: Page,
+  userAgent: string,
+  locale?: string | null,
+): Promise<boolean> {
+  await clearUserAgentEmulation(context);
+
+  const state: EmulationState = {
+    override: buildUserAgentOverride(userAgent, locale),
+    sessions: new Map(),
+    onPage: () => {},
+  };
+  state.onPage = (opened: Page) => {
+    void applyToPage(context, opened, state);
+  };
+
+  const ok = await applyToPage(context, page, state);
+  if (!ok) return false;
+
+  // Every other tab already open, then every tab opened from here on.
+  for (const other of context.pages()) {
+    if (other !== page) await applyToPage(context, other, state);
+  }
+  context.on('page', state.onPage);
+  stateByContext.set(context, state);
+  return true;
+}
+
+/**
+ * Undo an emulated UA: restore the browser's real UA and hints, drop the
+ * new-page listener, and close the sessions being held open.
+ *
+ * The real UA has to be re-applied rather than merely dropped — CDP has no
+ * "clear user agent override" command, and detaching the session while the
+ * override stands is what leaves it in place.
+ */
+export async function clearUserAgentEmulation(context: BrowserContext): Promise<void> {
+  const state = stateByContext.get(context);
+  if (!state) return;
+  stateByContext.delete(context);
+  context.off('page', state.onPage);
+
+  const realUserAgent = await realUserAgentFor(context);
+  for (const [, session] of state.sessions) {
+    try {
+      if (realUserAgent) {
+        await loose(session).send(
+          'Emulation.setUserAgentOverride',
+          buildUserAgentOverride(realUserAgent),
+        );
+      }
+    } catch {
+      /* the page is gone, or CDP refused; the session detach below is enough */
+    }
+    await session.detach().catch(() => {});
+  }
+  state.sessions.clear();
+}
+
+/** Whether `context` currently has an emulated UA applied. */
+export function hasUserAgentEmulation(context: BrowserContext): boolean {
+  return stateByContext.has(context);
+}
+
+/**
+ * The browser's own UA string, read from the version endpoint rather than from
+ * a page — a page under an override would report the override back.
+ */
+async function realUserAgentFor(context: BrowserContext): Promise<string | undefined> {
+  try {
+    const browser: Browser | null = context.browser();
+    if (!browser) return undefined;
+    const session = await context.newCDPSession(context.pages()[0]);
+    try {
+      const version = (await loose(session).send('Browser.getVersion')) as {
+        userAgent?: string;
+      };
+      return version?.userAgent;
+    } finally {
+      await session.detach().catch(() => {});
+    }
+  } catch {
+    return undefined;
+  }
+}

--- a/src/shared/__tests__/humanRhythm.test.ts
+++ b/src/shared/__tests__/humanRhythm.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MAX_DELAY,
+  DEFAULT_MIN_DELAY,
+  generateTypingDelays,
+  typingDelayFor,
+} from '../humanRhythm';
+
+/** mulberry32 — a tiny seeded PRNG so every assertion below is deterministic. */
+function seeded(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((x, y) => x - y);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function mean(values: number[]): number {
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** A long run of context-free draws ('a' owes no punctuation allowance). */
+function sample(count: number, seed = 1): number[] {
+  const rng = seeded(seed);
+  return Array.from({ length: count }, () => typingDelayFor('a', { rng }));
+}
+
+describe('humanRhythm typing distribution', () => {
+  it('centres the median on the midpoint of the configured band', () => {
+    const m = median(sample(20_000));
+    const midpoint = (DEFAULT_MIN_DELAY + DEFAULT_MAX_DELAY) / 2;
+    // Log-normal: the median is the scale parameter, so it lands on the
+    // midpoint up to sampling noise.
+    expect(m).toBeGreaterThan(midpoint * 0.9);
+    expect(m).toBeLessThan(midpoint * 1.1);
+  });
+
+  it('is right-skewed: the mean sits above the median', () => {
+    const values = sample(20_000);
+    expect(mean(values)).toBeGreaterThan(median(values));
+  });
+
+  it('emits a longer thinking pause a few percent of the time', () => {
+    const values = sample(20_000);
+    const paused = values.filter((v) => v > 300).length / values.length;
+    expect(paused).toBeGreaterThan(0.02);
+    expect(paused).toBeLessThan(0.07);
+  });
+
+  it('stays inside the clamp on every draw', () => {
+    for (const value of sample(20_000, 7)) {
+      expect(value).toBeGreaterThanOrEqual(DEFAULT_MIN_DELAY * 0.6);
+      // The base draw is clamped at 5x max; a pause can add up to 700ms.
+      expect(value).toBeLessThanOrEqual(DEFAULT_MAX_DELAY * 5 + 700);
+    }
+  });
+
+  it('waits longer after sentence punctuation than after a letter', () => {
+    // Same seed on both sides, so the only difference is the allowance.
+    const letter = mean(Array.from({ length: 4000 }, () => 0).map((_v, i) =>
+      typingDelayFor('a', { rng: seeded(100 + i) })));
+    const period = mean(Array.from({ length: 4000 }, () => 0).map((_v, i) =>
+      typingDelayFor('.', { rng: seeded(100 + i) })));
+    const space = mean(Array.from({ length: 4000 }, () => 0).map((_v, i) =>
+      typingDelayFor(' ', { rng: seeded(100 + i) })));
+
+    expect(period).toBeGreaterThan(space);
+    expect(space).toBeGreaterThan(letter);
+    // The allowances are exact, so the gaps are too.
+    expect(period - letter).toBeCloseTo(120, 6);
+    expect(space - letter).toBeCloseTo(40, 6);
+  });
+
+  it('is deterministic for a given seed', () => {
+    const a = generateTypingDelays('hello world', { rng: seeded(42) });
+    const b = generateTypingDelays('hello world', { rng: seeded(42) });
+    expect(a).toEqual(b);
+    expect(a).toHaveLength(11);
+  });
+
+  it('keeps a 40-character string inside a plausible 3-6s of typing', () => {
+    const text = 'the quick brown fox jumps over lazy dog.';
+    expect(text).toHaveLength(40);
+    // Averaged over many schedules: one schedule can land outside the band on
+    // an unlucky run of pauses, the typist's habit is what the band describes.
+    const totals = Array.from({ length: 300 }, (_v, i) =>
+      generateTypingDelays(text, { rng: seeded(500 + i) }).reduce((s, d) => s + d, 0));
+    const average = mean(totals);
+    expect(average).toBeGreaterThan(3000);
+    expect(average).toBeLessThan(6000);
+  });
+
+  it('honours a custom band', () => {
+    const values = Array.from({ length: 5000 }, () => 0).map((_v, i) =>
+      typingDelayFor('a', { minDelay: 200, maxDelay: 400, rng: seeded(900 + i) }));
+    expect(median(values)).toBeGreaterThan(270);
+    expect(median(values)).toBeLessThan(330);
+  });
+});

--- a/src/shared/__tests__/humanRhythm.test.ts
+++ b/src/shared/__tests__/humanRhythm.test.ts
@@ -98,6 +98,41 @@ describe('humanRhythm typing distribution', () => {
     expect(average).toBeLessThan(6000);
   });
 
+  it('keeps a very long string inside a total-duration budget', () => {
+    const text = 'a. '.repeat(667).slice(0, 2000);
+    expect(text).toHaveLength(2000);
+    const delays = generateTypingDelays(text, { rng: seeded(3) });
+    const total = delays.reduce((s, d) => s + d, 0);
+    // 120ms/char plus 1.5s slack — a 2,000-char paste must not sit in a
+    // multi-minute loop just because the pauses stacked up.
+    // Summing 2,000 scaled floats drifts a fraction of a millisecond past the
+    // ceiling; the budget is a duration, not an exact arithmetic identity.
+    expect(total).toBeLessThanOrEqual(2000 * 120 + 1500 + 1);
+    expect(delays).toHaveLength(2000);
+    for (const d of delays) expect(d).toBeGreaterThan(0);
+  });
+
+  it('scales a budget-capped schedule without flattening its shape', () => {
+    // Forced over budget by a band far above the per-character allowance.
+    const text = 'a'.repeat(500);
+    const delays = generateTypingDelays(text, {
+      minDelay: 400, maxDelay: 800, rng: seeded(4),
+    });
+    const total = delays.reduce((s, d) => s + d, 0);
+    expect(total).toBeLessThanOrEqual(500 * 120 + 1500 + 1);
+    // Still right-skewed after scaling: a uniform squeeze preserves the ratios.
+    expect(mean(delays)).toBeGreaterThan(median(delays));
+  });
+
+  it('leaves a schedule that fits its budget untouched', () => {
+    const text = 'hello there';
+    // Same seed, so an unscaled schedule equals the raw per-character draws.
+    const scheduled = generateTypingDelays(text, { rng: seeded(77) });
+    const rng = seeded(77);
+    const raw = Array.from({ length: text.length }, (_v, i) => typingDelayFor(text[i], { rng }));
+    expect(scheduled).toEqual(raw);
+  });
+
   it('honours a custom band', () => {
     const values = Array.from({ length: 5000 }, () => 0).map((_v, i) =>
       typingDelayFor('a', { minDelay: 200, maxDelay: 400, rng: seeded(900 + i) }));

--- a/src/shared/__tests__/pointerPath.test.ts
+++ b/src/shared/__tests__/pointerPath.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  INNER_FRACTION,
+  MAX_STEPS,
+  MIN_STEPS,
+  approachPath,
+  clickPointInBox,
+  defaultStartPoint,
+  distance,
+  pathPoints,
+  stepsForDistance,
+} from '../pointerPath';
+
+function seeded(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** How far along the from→to axis a point sits, as a fraction. */
+function progress(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  point: { x: number; y: number },
+): number {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const len2 = dx * dx + dy * dy;
+  return ((point.x - from.x) * dx + (point.y - from.y) * dy) / len2;
+}
+
+describe('stepsForDistance', () => {
+  it('stays within the step band for any distance', () => {
+    for (const d of [0, 1, 50, 200, 900, 5000, 100_000]) {
+      const steps = stepsForDistance(d);
+      expect(steps).toBeGreaterThanOrEqual(MIN_STEPS);
+      expect(steps).toBeLessThanOrEqual(MAX_STEPS);
+    }
+  });
+
+  it('gives a long traverse more steps than a short one', () => {
+    expect(stepsForDistance(600)).toBeGreaterThan(stepsForDistance(20));
+  });
+});
+
+describe('pathPoints', () => {
+  const from = { x: 40, y: 60 };
+  const to = { x: 700, y: 420 };
+
+  it('emits exactly the requested number of points', () => {
+    expect(pathPoints(from, to, 12, seeded(1))).toHaveLength(12);
+  });
+
+  it('lands exactly on the target', () => {
+    const points = pathPoints(from, to, 15, seeded(2));
+    expect(points[points.length - 1]).toEqual(to);
+  });
+
+  it('advances monotonically along the from-to axis', () => {
+    const points = pathPoints(from, to, 20, seeded(3));
+    let previous = 0;
+    for (const point of points) {
+      const t = progress(from, to, point);
+      expect(t).toBeGreaterThan(previous);
+      previous = t;
+    }
+    expect(previous).toBeCloseTo(1, 10);
+  });
+
+  it('leaves the straight line in between but not at the ends', () => {
+    const points = pathPoints(from, to, 20, seeded(4));
+    // Perpendicular offset is zero at the endpoint by construction.
+    const last = points[points.length - 1];
+    expect(distance(last, to)).toBe(0);
+    // At least one mid-flight point is genuinely off the straight line.
+    const offsets = points.slice(0, -1).map((p) => {
+      const t = progress(from, to, p);
+      const online = { x: from.x + (to.x - from.x) * t, y: from.y + (to.y - from.y) * t };
+      return distance(p, online);
+    });
+    expect(Math.max(...offsets)).toBeGreaterThan(0);
+  });
+
+  it('handles a zero-length move without producing NaN', () => {
+    const points = pathPoints(from, from, 10, seeded(5));
+    for (const point of points) {
+      expect(Number.isFinite(point.x)).toBe(true);
+      expect(Number.isFinite(point.y)).toBe(true);
+    }
+    expect(points[points.length - 1]).toEqual(from);
+  });
+
+  it('approachPath picks its own step count from the distance', () => {
+    const points = approachPath(from, to, seeded(6));
+    expect(points).toHaveLength(stepsForDistance(distance(from, to)));
+    expect(points[points.length - 1]).toEqual(to);
+  });
+});
+
+describe('clickPointInBox', () => {
+  const box = { x: 100, y: 200, width: 240, height: 60 };
+
+  it('never leaves the inner fraction of the box', () => {
+    const rng = seeded(9);
+    for (let i = 0; i < 5000; i++) {
+      const point = clickPointInBox(box, rng);
+      const spanX = (box.width * INNER_FRACTION) / 2;
+      const spanY = (box.height * INNER_FRACTION) / 2;
+      expect(point.x).toBeGreaterThanOrEqual(box.x + box.width / 2 - spanX);
+      expect(point.x).toBeLessThanOrEqual(box.x + box.width / 2 + spanX);
+      expect(point.y).toBeGreaterThanOrEqual(box.y + box.height / 2 - spanY);
+      expect(point.y).toBeLessThanOrEqual(box.y + box.height / 2 + spanY);
+    }
+  });
+
+  it('does not always land on the exact centre', () => {
+    const rng = seeded(11);
+    const centreX = box.x + box.width / 2;
+    const points = Array.from({ length: 200 }, () => clickPointInBox(box, rng));
+    expect(points.some((p) => p.x !== centreX)).toBe(true);
+  });
+});
+
+describe('defaultStartPoint', () => {
+  it('is inside the viewport and not the origin', () => {
+    const point = defaultStartPoint({ width: 1000, height: 800 });
+    expect(point.x).toBeGreaterThan(0);
+    expect(point.y).toBeGreaterThan(0);
+    expect(point.x).toBeLessThan(1000);
+    expect(point.y).toBeLessThan(800);
+  });
+
+  it('falls back to a plausible size when the viewport is unknown', () => {
+    const point = defaultStartPoint();
+    expect(point.x).toBeGreaterThan(0);
+    expect(point.y).toBeGreaterThan(0);
+  });
+});

--- a/src/shared/__tests__/referer.test.ts
+++ b/src/shared/__tests__/referer.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { refererFor } from '../referer';
+
+describe('refererFor', () => {
+  it('sends the current page when leaving a real http(s) document', () => {
+    expect(refererFor('https://example.com/a', 'https://example.com/b')).toBe(
+      'https://example.com/a',
+    );
+    expect(refererFor('http://localhost:3000/one', 'http://localhost:3000/two')).toBe(
+      'http://localhost:3000/one',
+    );
+  });
+
+  it('sends it across origins too, which is what a real click-through does', () => {
+    expect(refererFor('https://news.example/list', 'https://other.example/post')).toBe(
+      'https://news.example/list',
+    );
+  });
+
+  it('sends nothing on a first navigation', () => {
+    expect(refererFor(undefined, 'https://example.com')).toBeUndefined();
+    expect(refererFor(null, 'https://example.com')).toBeUndefined();
+    expect(refererFor('', 'https://example.com')).toBeUndefined();
+  });
+
+  it('sends nothing from about:blank or a browser-internal page', () => {
+    expect(refererFor('about:blank', 'https://example.com')).toBeUndefined();
+    expect(refererFor('chrome://newtab/', 'https://example.com')).toBeUndefined();
+    expect(refererFor('devtools://devtools/x.html', 'https://example.com')).toBeUndefined();
+    expect(refererFor('file:///tmp/page.html', 'https://example.com')).toBeUndefined();
+    expect(refererFor('data:text/html,<p>x', 'https://example.com')).toBeUndefined();
+  });
+
+  it('sends nothing when the current URL is not parseable', () => {
+    expect(refererFor('not a url', 'https://example.com')).toBeUndefined();
+    expect(refererFor('/relative/path', 'https://example.com')).toBeUndefined();
+  });
+
+  it('sends nothing when reloading the same URL', () => {
+    expect(refererFor('https://example.com/a', 'https://example.com/a')).toBeUndefined();
+  });
+});

--- a/src/shared/__tests__/referer.test.ts
+++ b/src/shared/__tests__/referer.test.ts
@@ -2,18 +2,47 @@ import { describe, expect, it } from 'vitest';
 import { refererFor } from '../referer';
 
 describe('refererFor', () => {
-  it('sends the current page when leaving a real http(s) document', () => {
+  it('sends the full URL within one origin', () => {
     expect(refererFor('https://example.com/a', 'https://example.com/b')).toBe(
       'https://example.com/a',
     );
     expect(refererFor('http://localhost:3000/one', 'http://localhost:3000/two')).toBe(
       'http://localhost:3000/one',
     );
+    // The query is part of the URL and stays within the origin.
+    expect(refererFor('https://example.com/a?q=1', 'https://example.com/b')).toBe(
+      'https://example.com/a?q=1',
+    );
   });
 
-  it('sends it across origins too, which is what a real click-through does', () => {
-    expect(refererFor('https://news.example/list', 'https://other.example/post')).toBe(
-      'https://news.example/list',
+  it('sends only the origin across origins, as strict-origin-when-cross-origin does', () => {
+    expect(refererFor('https://news.example/list?page=2', 'https://other.example/post')).toBe(
+      'https://news.example/',
+    );
+    // A different port or scheme is a different origin.
+    expect(refererFor('http://example.com:8080/a', 'http://example.com/b')).toBe(
+      'http://example.com:8080/',
+    );
+  });
+
+  it('sends nothing when downgrading https to http', () => {
+    expect(refererFor('https://example.com/a', 'http://example.com/b')).toBeUndefined();
+    expect(refererFor('https://example.com/a', 'http://other.example/b')).toBeUndefined();
+    // Upgrading is fine, and is cross-origin.
+    expect(refererFor('http://example.com/a', 'https://example.com/b')).toBe(
+      'http://example.com/',
+    );
+  });
+
+  it('never leaks the fragment or credentials', () => {
+    expect(refererFor('https://example.com/a#secret', 'https://example.com/b')).toBe(
+      'https://example.com/a',
+    );
+    expect(refererFor('https://user:pw@example.com/a', 'https://example.com/b')).toBe(
+      'https://example.com/a',
+    );
+    expect(refererFor('https://user:pw@example.com/a', 'https://other.example/b')).toBe(
+      'https://example.com/',
     );
   });
 
@@ -36,7 +65,14 @@ describe('refererFor', () => {
     expect(refererFor('/relative/path', 'https://example.com')).toBeUndefined();
   });
 
-  it('sends nothing when reloading the same URL', () => {
+  it('sends nothing when reloading the same URL, fragment aside', () => {
     expect(refererFor('https://example.com/a', 'https://example.com/a')).toBeUndefined();
+    // Normalised on both sides: a differing fragment is still the same page.
+    expect(refererFor('https://example.com/a#one', 'https://example.com/a#two')).toBeUndefined();
+    expect(refererFor('https://example.com/a', 'https://example.com/a#x')).toBeUndefined();
+    // A differing query is a different page.
+    expect(refererFor('https://example.com/a', 'https://example.com/a?q=1')).toBe(
+      'https://example.com/a',
+    );
   });
 });

--- a/src/shared/__tests__/referer.test.ts
+++ b/src/shared/__tests__/referer.test.ts
@@ -65,7 +65,7 @@ describe('refererFor', () => {
     expect(refererFor('/relative/path', 'https://example.com')).toBeUndefined();
   });
 
-  it('sends nothing when reloading the same URL, fragment aside', () => {
+  it('sends nothing when reloading the same URL, ignoring the fragment', () => {
     expect(refererFor('https://example.com/a', 'https://example.com/a')).toBeUndefined();
     // Normalised on both sides: a differing fragment is still the same page.
     expect(refererFor('https://example.com/a#one', 'https://example.com/a#two')).toBeUndefined();

--- a/src/shared/__tests__/uaMetadata.test.ts
+++ b/src/shared/__tests__/uaMetadata.test.ts
@@ -40,46 +40,71 @@ describe('buildUserAgentOverride', () => {
   });
 
   it('describes desktop Chrome on macOS', () => {
-    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.desktopMac);
-    expect(meta.platform).toBe('macOS');
-    expect(meta.platformVersion).toBe('10.15.7');
-    expect(meta.architecture).toBe('x86');
-    expect(meta.mobile).toBe(false);
-    expect(meta.model).toBe('');
+    const meta = buildUserAgentOverride(UA.desktopMac).userAgentMetadata;
+    expect(meta?.platform).toBe('macOS');
+    expect(meta?.platformVersion).toBe('10.15.7');
+    expect(meta?.architecture).toBe('x86');
+    expect(meta?.mobile).toBe(false);
+    expect(meta?.model).toBe('');
   });
 
   it('describes desktop Chrome on Windows', () => {
-    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.desktopWindows);
-    expect(meta.platform).toBe('Windows');
-    expect(meta.platformVersion).toBe('10.0.0');
-    expect(meta.architecture).toBe('x86');
-    expect(meta.mobile).toBe(false);
+    const meta = buildUserAgentOverride(UA.desktopWindows).userAgentMetadata;
+    expect(meta?.platform).toBe('Windows');
+    expect(meta?.platformVersion).toBe('10.0.0');
+    expect(meta?.architecture).toBe('x86');
+    expect(meta?.mobile).toBe(false);
   });
 
-  it('describes an iPhone preset as mobile iOS with no brands', () => {
-    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.iPhone13);
-    expect(meta.platform).toBe('iOS');
-    expect(meta.platformVersion).toBe('15.0.0');
-    expect(meta.mobile).toBe(true);
-    expect(meta.brands).toEqual([]);
-    // Client Hints report neither on mobile.
-    expect(meta.architecture).toBe('');
-    expect(meta.model).toBe('');
+  it('omits the metadata entirely for a non-Chromium preset', () => {
+    // Safari has no navigator.userAgentData at all. An empty-but-present hints
+    // object is a shape no shipping browser produces, so it would be a
+    // fingerprint of its own.
+    const override = buildUserAgentOverride(UA.iPhone13);
+    expect(override.userAgentMetadata).toBeUndefined();
+    expect('userAgentMetadata' in override).toBe(false);
+    expect(override.userAgent).toBe(UA.iPhone13);
+  });
+
+  it('still carries acceptLanguage for a non-Chromium preset', () => {
+    expect(buildUserAgentOverride(UA.iPhone13, 'ja-JP').acceptLanguage).toBe('ja-JP');
   });
 
   it('describes an Android preset with its model', () => {
-    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.pixel5);
-    expect(meta.platform).toBe('Android');
-    expect(meta.platformVersion).toBe('11.0.0');
-    expect(meta.mobile).toBe(true);
-    expect(meta.model).toBe('Pixel 5');
-    expect(meta.brands).toHaveLength(3);
+    const meta = buildUserAgentOverride(UA.pixel5).userAgentMetadata;
+    expect(meta).toBeDefined();
+    expect(meta?.platform).toBe('Android');
+    expect(meta?.platformVersion).toBe('11.0.0');
+    expect(meta?.mobile).toBe(true);
+    expect(meta?.model).toBe('Pixel 5');
+    expect(meta?.brands).toHaveLength(3);
+    // Mobile Chrome reports neither architecture nor bitness.
+    expect(meta?.architecture).toBe('');
+    expect(meta?.bitness).toBe('');
   });
 
   it('strips the Build token out of an Android model', () => {
-    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.galaxyS9);
-    expect(meta.model).toBe('SM-G965U');
-    expect(meta.platformVersion).toBe('8.0.0');
+    const meta = buildUserAgentOverride(UA.galaxyS9).userAgentMetadata;
+    expect(meta?.model).toBe('SM-G965U');
+    expect(meta?.platformVersion).toBe('8.0.0');
+  });
+
+  it('fills the whole getHighEntropyValues shape for a Chromium preset', () => {
+    const meta = buildUserAgentOverride(UA.desktopMac).userAgentMetadata;
+    expect(meta?.bitness).toBe('64');
+    expect(meta?.wow64).toBe(false);
+    expect(meta?.fullVersion).toBe('145.0.7632.6');
+    expect(meta?.fullVersionList).toEqual(
+      expect.arrayContaining([
+        { brand: 'Chromium', version: '145.0.7632.6' },
+        { brand: 'Google Chrome', version: '145.0.7632.6' },
+      ]),
+    );
+    expect(meta?.fullVersionList).toHaveLength(3);
+    // The brand names must agree between the two lists.
+    expect(meta?.fullVersionList.map((b) => b.brand)).toEqual(
+      meta?.brands.map((b) => b.brand),
+    );
   });
 
   it('carries the emulated locale as acceptLanguage, and omits it otherwise', () => {
@@ -90,7 +115,9 @@ describe('buildUserAgentOverride', () => {
 
   it('never leaves the metadata disagreeing with the UA about mobile', () => {
     for (const ua of Object.values(UA)) {
-      const { userAgentMetadata: meta } = buildUserAgentOverride(ua);
+      const meta = buildUserAgentOverride(ua).userAgentMetadata;
+      // Non-Chromium presets carry no metadata to disagree with.
+      if (!meta) continue;
       expect(meta.mobile).toBe(/Mobile|iPhone|iPad|Android/.test(ua));
     }
   });

--- a/src/shared/__tests__/uaMetadata.test.ts
+++ b/src/shared/__tests__/uaMetadata.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { brandsForUserAgent, buildUserAgentOverride } from '../uaMetadata';
+
+// Verbatim UA strings from Playwright's device table, plus the macOS desktop
+// Chrome string the "chrome" backend runs under.
+const UA = {
+  desktopWindows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.7632.6 Safari/537.36',
+  desktopMac:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.7632.6 Safari/537.36',
+  iPhone13:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1',
+  pixel5:
+    'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.7632.6 Mobile Safari/537.36',
+  galaxyS9:
+    'Mozilla/5.0 (Linux; Android 8.0.0; SM-G965U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.7632.6 Mobile Safari/537.36',
+};
+
+describe('brandsForUserAgent', () => {
+  it('reports Chromium and Google Chrome at the UA major version', () => {
+    const brands = brandsForUserAgent(UA.desktopMac);
+    expect(brands).toEqual(
+      expect.arrayContaining([
+        { brand: 'Chromium', version: '145' },
+        { brand: 'Google Chrome', version: '145' },
+      ]),
+    );
+    // Plus one greased entry, as real Chrome sends.
+    expect(brands).toHaveLength(3);
+  });
+
+  it('reports no brands for a non-Chromium UA, because Safari exposes none', () => {
+    expect(brandsForUserAgent(UA.iPhone13)).toEqual([]);
+  });
+});
+
+describe('buildUserAgentOverride', () => {
+  it('passes the UA string through untouched', () => {
+    expect(buildUserAgentOverride(UA.desktopMac).userAgent).toBe(UA.desktopMac);
+  });
+
+  it('describes desktop Chrome on macOS', () => {
+    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.desktopMac);
+    expect(meta.platform).toBe('macOS');
+    expect(meta.platformVersion).toBe('10.15.7');
+    expect(meta.architecture).toBe('x86');
+    expect(meta.mobile).toBe(false);
+    expect(meta.model).toBe('');
+  });
+
+  it('describes desktop Chrome on Windows', () => {
+    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.desktopWindows);
+    expect(meta.platform).toBe('Windows');
+    expect(meta.platformVersion).toBe('10.0.0');
+    expect(meta.architecture).toBe('x86');
+    expect(meta.mobile).toBe(false);
+  });
+
+  it('describes an iPhone preset as mobile iOS with no brands', () => {
+    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.iPhone13);
+    expect(meta.platform).toBe('iOS');
+    expect(meta.platformVersion).toBe('15.0.0');
+    expect(meta.mobile).toBe(true);
+    expect(meta.brands).toEqual([]);
+    // Client Hints report neither on mobile.
+    expect(meta.architecture).toBe('');
+    expect(meta.model).toBe('');
+  });
+
+  it('describes an Android preset with its model', () => {
+    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.pixel5);
+    expect(meta.platform).toBe('Android');
+    expect(meta.platformVersion).toBe('11.0.0');
+    expect(meta.mobile).toBe(true);
+    expect(meta.model).toBe('Pixel 5');
+    expect(meta.brands).toHaveLength(3);
+  });
+
+  it('strips the Build token out of an Android model', () => {
+    const { userAgentMetadata: meta } = buildUserAgentOverride(UA.galaxyS9);
+    expect(meta.model).toBe('SM-G965U');
+    expect(meta.platformVersion).toBe('8.0.0');
+  });
+
+  it('carries the emulated locale as acceptLanguage, and omits it otherwise', () => {
+    expect(buildUserAgentOverride(UA.desktopMac, 'fr-FR').acceptLanguage).toBe('fr-FR');
+    expect(buildUserAgentOverride(UA.desktopMac).acceptLanguage).toBeUndefined();
+    expect(buildUserAgentOverride(UA.desktopMac, null).acceptLanguage).toBeUndefined();
+  });
+
+  it('never leaves the metadata disagreeing with the UA about mobile', () => {
+    for (const ua of Object.values(UA)) {
+      const { userAgentMetadata: meta } = buildUserAgentOverride(ua);
+      expect(meta.mobile).toBe(/Mobile|iPhone|iPad|Android/.test(ua));
+    }
+  });
+});

--- a/src/shared/humanRhythm.ts
+++ b/src/shared/humanRhythm.ts
@@ -98,12 +98,35 @@ export function typingDelayFor(
   return clamped + punctuationExtra(char) + pause;
 }
 
-/** Per-character delays for `text`, index i being the wait after `text[i]`. */
+/**
+ * Ceiling on a whole schedule: this much per character, plus fixed slack so a
+ * short string is not squeezed by one unlucky pause.
+ */
+const BUDGET_PER_CHAR_MS = 120;
+const BUDGET_SLACK_MS = 1500;
+
+/**
+ * Per-character delays for `text`, index i being the wait after `text[i]`.
+ *
+ * The draws are independent, so a long string can accumulate enough pauses to
+ * take absurdly long — a 2,000-character paste has no business sitting in a
+ * multi-minute typing loop. When a schedule exceeds its budget every delay is
+ * scaled down by the same factor, which shortens the schedule without
+ * flattening its shape: the tail, the pauses and the punctuation allowances
+ * all stay proportionally where they were.
+ */
 export function generateTypingDelays(
   text: string,
   options?: TypingRhythmOptions,
 ): number[] {
-  return Array.from({ length: text.length }, (_unused, i) =>
+  const delays = Array.from({ length: text.length }, (_unused, i) =>
     typingDelayFor(text[i], options),
   );
+
+  const budget = text.length * BUDGET_PER_CHAR_MS + BUDGET_SLACK_MS;
+  const total = delays.reduce((sum, d) => sum + d, 0);
+  if (total <= budget) return delays;
+
+  const scale = budget / total;
+  return delays.map((d) => d * scale);
 }

--- a/src/shared/humanRhythm.ts
+++ b/src/shared/humanRhythm.ts
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------
+// Typing rhythm shared by both browser lanes.
+//
+// Both typing paths used to draw inter-keystroke delays from a uniform
+// distribution (`Math.random() * (max - min) + min`). Real inter-key intervals
+// are not uniform: they are right-skewed — a tight cluster around the typist's
+// median with a long tail — and they lengthen after sentence punctuation and
+// word breaks, with the occasional much longer pause while the person thinks.
+//
+// This module is the one place that shape is defined, so the MCP lane
+// (`src/mcp/playwright/human-typing.ts`) and the main-process lane
+// (`src/main/browser-session/HumanBehavior.ts`) cannot drift apart.
+//
+// The RNG is injectable so callers — tests above all — can make a schedule
+// deterministic. It defaults to `Math.random`.
+// ---------------------------------------------------------------------------
+
+/** Fraction of keystrokes followed by a longer "thinking" pause. */
+const PAUSE_PROBABILITY = 0.04;
+/** Bounds of that pause, in ms, added on top of the base delay. */
+const PAUSE_MIN_MS = 300;
+const PAUSE_MAX_MS = 700;
+
+/** Spread of the log-normal base delay. Larger = longer tail. */
+const LOG_SIGMA = 0.35;
+
+/** Extra delay after a character that ends a thought, in ms. */
+const AFTER_SENTENCE_MS = 120;
+/** Extra delay after a character that breaks a clause, in ms. */
+const AFTER_CLAUSE_MS = 60;
+/** Extra delay after a word break, in ms. */
+const AFTER_WORD_MS = 40;
+
+/** The base delay is clamped to this multiple of `minDelay` at the low end… */
+const CLAMP_LOW_FACTOR = 0.6;
+/** …and this multiple of `maxDelay` at the high end. */
+const CLAMP_HIGH_FACTOR = 5;
+
+export interface TypingRhythmOptions {
+  /** Low end of the typist's band in ms (default 50). Also sets the clamp floor. */
+  minDelay?: number;
+  /** High end of the typist's band in ms (default 150). Also sets the clamp ceiling. */
+  maxDelay?: number;
+  /** Uniform [0,1) source. Defaults to `Math.random`; inject for determinism. */
+  rng?: () => number;
+}
+
+export const DEFAULT_MIN_DELAY = 50;
+export const DEFAULT_MAX_DELAY = 150;
+
+/**
+ * One standard normal sample, Box-Muller. `rng()` can return exactly 0, which
+ * would make `Math.log` diverge, so the first draw is nudged off zero.
+ */
+function gaussian(rng: () => number): number {
+  const u = 1 - rng();
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+/** Extra delay owed to the character that was just typed. */
+function punctuationExtra(char: string | undefined): number {
+  if (!char) return 0;
+  if (char === '.' || char === '!' || char === '?') return AFTER_SENTENCE_MS;
+  if (char === ',' || char === ';' || char === ':') return AFTER_CLAUSE_MS;
+  if (char === ' ' || char === '\n' || char === '\t') return AFTER_WORD_MS;
+  return 0;
+}
+
+/**
+ * The delay to wait *after* typing `char`, in ms.
+ *
+ * Base delay is log-normal around the midpoint of [minDelay, maxDelay], which
+ * puts the median where the old uniform draw put its mean while giving the
+ * distribution the right skew (mean > median). On top of that sits the
+ * punctuation allowance and, occasionally, a thinking pause.
+ */
+export function typingDelayFor(
+  char: string | undefined,
+  options?: TypingRhythmOptions,
+): number {
+  const min = options?.minDelay ?? DEFAULT_MIN_DELAY;
+  const max = options?.maxDelay ?? DEFAULT_MAX_DELAY;
+  const rng = options?.rng ?? Math.random;
+
+  const median = (min + max) / 2;
+  const base = median * Math.exp(LOG_SIGMA * gaussian(rng));
+  const clamped = Math.min(
+    Math.max(base, min * CLAMP_LOW_FACTOR),
+    max * CLAMP_HIGH_FACTOR,
+  );
+
+  const pause =
+    rng() < PAUSE_PROBABILITY
+      ? PAUSE_MIN_MS + rng() * (PAUSE_MAX_MS - PAUSE_MIN_MS)
+      : 0;
+
+  return clamped + punctuationExtra(char) + pause;
+}
+
+/** Per-character delays for `text`, index i being the wait after `text[i]`. */
+export function generateTypingDelays(
+  text: string,
+  options?: TypingRhythmOptions,
+): number[] {
+  return Array.from({ length: text.length }, (_unused, i) =>
+    typingDelayFor(text[i], options),
+  );
+}

--- a/src/shared/pointerPath.ts
+++ b/src/shared/pointerPath.ts
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------
+// Pointer movement before a click.
+//
+// `locator.click()` teleports the pointer: the only mouse event a page sees is
+// one `mousemove` landing on the exact centre of the target's box, immediately
+// followed by the press. A pointer that has never been anywhere else and always
+// lands dead centre is trivially separable from a real one.
+//
+// This module produces the two missing pieces: a short run of intermediate
+// points from wherever the pointer last was to the target, and a click point
+// that is off-centre but still comfortably inside the element.
+//
+// These are plain linear interpolations with a little perpendicular jitter.
+// They are not curve-fitted to anything and do not claim to be.
+//
+// The geometry lives in `src/shared` because both lanes need it: the chrome
+// lane drives it through Playwright's mouse, the builtin webview lane through
+// CDP `Input.dispatchMouseEvent` in the main process.
+// ---------------------------------------------------------------------------
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Box {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** Fewest intermediate points on any move. */
+export const MIN_STEPS = 8;
+/** Most intermediate points on any move. */
+export const MAX_STEPS = 25;
+/** One extra step per this many CSS px of travel. */
+const PX_PER_STEP = 45;
+
+/**
+ * Fraction of the box the click point may wander over. 0.6 keeps every point
+ * inside the middle 60% of the box, so a click never lands on the border or
+ * outside a rounded corner.
+ */
+export const INNER_FRACTION = 0.6;
+
+/** Perpendicular jitter as a fraction of the move's length. */
+const JITTER_FRACTION = 0.04;
+
+/** How far apart two points are, in CSS px. */
+export function distance(from: Point, to: Point): number {
+  return Math.hypot(to.x - from.x, to.y - from.y);
+}
+
+/**
+ * How many intermediate points a move of `dist` px deserves — more for a long
+ * traverse, never fewer than MIN_STEPS nor more than MAX_STEPS.
+ */
+export function stepsForDistance(dist: number): number {
+  const scaled = Math.round(MIN_STEPS + dist / PX_PER_STEP);
+  return Math.min(MAX_STEPS, Math.max(MIN_STEPS, scaled));
+}
+
+/**
+ * The intermediate points of a move from `from` to `to`, `to` included as the
+ * final element.
+ *
+ * Jitter is applied strictly perpendicular to the from→to axis and tapers to
+ * zero at both ends, so progress along the axis stays monotone and the last
+ * point is exactly `to`.
+ */
+export function pathPoints(
+  from: Point,
+  to: Point,
+  steps: number,
+  rng: () => number = Math.random,
+): Point[] {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const len = Math.hypot(dx, dy);
+  const count = Math.max(1, Math.round(steps));
+
+  // Unit vector perpendicular to the direction of travel. A zero-length move
+  // has no axis to be perpendicular to, so it gets no jitter.
+  const px = len === 0 ? 0 : -dy / len;
+  const py = len === 0 ? 0 : dx / len;
+  const amplitude = len * JITTER_FRACTION;
+
+  const points: Point[] = [];
+  for (let i = 1; i <= count; i++) {
+    const t = i / count;
+    // sin(pi*t) is 0 at both ends and widest in the middle: the pointer drifts
+    // off the straight line mid-flight and arrives exactly on target.
+    const taper = Math.sin(Math.PI * t);
+    const offset = (rng() * 2 - 1) * amplitude * taper;
+    points.push({
+      x: from.x + dx * t + px * offset,
+      y: from.y + dy * t + py * offset,
+    });
+  }
+  // Guard the endpoint against float drift — callers rely on it being exact.
+  points[points.length - 1] = { x: to.x, y: to.y };
+  return points;
+}
+
+/**
+ * A click point inside `box`, offset from the centre by a random fraction of
+ * the box but never leaving its inner INNER_FRACTION.
+ */
+export function clickPointInBox(box: Box, rng: () => number = Math.random): Point {
+  const spanX = (box.width * INNER_FRACTION) / 2;
+  const spanY = (box.height * INNER_FRACTION) / 2;
+  return {
+    x: box.x + box.width / 2 + (rng() * 2 - 1) * spanX,
+    y: box.y + box.height / 2 + (rng() * 2 - 1) * spanY,
+  };
+}
+
+/**
+ * Where the pointer sits when we have never moved it on this page. Off-centre
+ * and in the upper-left quadrant, which is where a pointer that has just
+ * followed a link or come off the browser chrome tends to be — not (0, 0),
+ * which no real pointer rests at.
+ */
+export function defaultStartPoint(viewport?: { width: number; height: number }): Point {
+  const width = viewport?.width ?? 1280;
+  const height = viewport?.height ?? 720;
+  return { x: Math.round(width * 0.32), y: Math.round(height * 0.28) };
+}
+
+/**
+ * Convenience for callers that only want the points: resolves the step count
+ * from the distance itself.
+ */
+export function approachPath(
+  from: Point,
+  to: Point,
+  rng: () => number = Math.random,
+): Point[] {
+  return pathPoints(from, to, stepsForDistance(distance(from, to)), rng);
+}

--- a/src/shared/referer.ts
+++ b/src/shared/referer.ts
@@ -13,9 +13,30 @@
 // sends nothing either.
 // ---------------------------------------------------------------------------
 
+/** Strip the parts a Referer never carries: credentials and the fragment. */
+function stripped(url: URL): URL {
+  const copy = new URL(url.href);
+  copy.username = '';
+  copy.password = '';
+  copy.hash = '';
+  return copy;
+}
+
 /**
  * The value to pass as `referer` when navigating from `currentUrl` to
  * `targetUrl`, or `undefined` when the navigation should carry none.
+ *
+ * This follows Chrome's default referrer policy,
+ * `strict-origin-when-cross-origin`, because sending anything else is itself
+ * the giveaway:
+ *
+ *  - same origin      → the full URL, minus credentials and fragment
+ *  - cross origin     → the bare origin with a trailing slash, nothing more
+ *  - https → http     → nothing at all (a downgrade sends no referrer)
+ *  - non-http(s) here → nothing (about:blank, chrome://, file://, data:)
+ *  - a reload         → nothing; a self-referer on a reload is a signal of
+ *                       its own. Compared on the normalised URLs, so a
+ *                       differing fragment still counts as the same page.
  */
 export function refererFor(
   currentUrl: string | undefined | null,
@@ -24,22 +45,27 @@ export function refererFor(
   if (!currentUrl) return undefined;
 
   let current: URL;
+  let target: URL;
   try {
     current = new URL(currentUrl);
+    target = new URL(targetUrl);
   } catch {
-    // Not a URL we can reason about (empty string, a fragment, a bare path).
+    // Not a pair we can reason about (empty string, a fragment, a bare path).
     return undefined;
   }
 
-  // Only a real web document is a plausible referer. about:blank, chrome://,
-  // devtools://, file:// and data: are not places a link is followed from.
+  // Only a real web document is a plausible referer.
   if (current.protocol !== 'http:' && current.protocol !== 'https:') {
     return undefined;
   }
 
-  // Reloading the same URL is not a click-through, and a self-referer on a
-  // reload is a signal of its own.
-  if (currentUrl === targetUrl) return undefined;
+  const from = stripped(current);
 
-  return currentUrl;
+  // A secure page never leaks its URL to an insecure one.
+  if (from.protocol === 'https:' && target.protocol === 'http:') return undefined;
+
+  // Same page, fragment aside: a reload, not a click-through.
+  if (from.href === stripped(target).href) return undefined;
+
+  return from.origin === target.origin ? from.href : `${from.origin}/`;
 }

--- a/src/shared/referer.ts
+++ b/src/shared/referer.ts
@@ -64,7 +64,7 @@ export function refererFor(
   // A secure page never leaks its URL to an insecure one.
   if (from.protocol === 'https:' && target.protocol === 'http:') return undefined;
 
-  // Same page, fragment aside: a reload, not a click-through.
+  // Same page once the fragment is ignored: a reload, not a click-through.
   if (from.href === stripped(target).href) return undefined;
 
   return from.origin === target.origin ? from.href : `${from.origin}/`;

--- a/src/shared/referer.ts
+++ b/src/shared/referer.ts
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------
+// Referer on agent navigations.
+//
+// Every navigation the agent issued arrived with no `Referer` header, because
+// `page.goto()` sends none unless it is given one. A person reaching page B
+// from page A arrives with A in the header; a stream of refererless requests
+// from inside a session is not what browsing looks like.
+//
+// So: when the page we are leaving is a real http(s) document and we are going
+// somewhere else, send it as the referer — exactly what following a link would
+// have produced. A first navigation, or one leaving about:blank or a browser
+// internal page, still sends nothing, because a real click-through from those
+// sends nothing either.
+// ---------------------------------------------------------------------------
+
+/**
+ * The value to pass as `referer` when navigating from `currentUrl` to
+ * `targetUrl`, or `undefined` when the navigation should carry none.
+ */
+export function refererFor(
+  currentUrl: string | undefined | null,
+  targetUrl: string,
+): string | undefined {
+  if (!currentUrl) return undefined;
+
+  let current: URL;
+  try {
+    current = new URL(currentUrl);
+  } catch {
+    // Not a URL we can reason about (empty string, a fragment, a bare path).
+    return undefined;
+  }
+
+  // Only a real web document is a plausible referer. about:blank, chrome://,
+  // devtools://, file:// and data: are not places a link is followed from.
+  if (current.protocol !== 'http:' && current.protocol !== 'https:') {
+    return undefined;
+  }
+
+  // Reloading the same URL is not a click-through, and a self-referer on a
+  // reload is a signal of its own.
+  if (currentUrl === targetUrl) return undefined;
+
+  return currentUrl;
+}

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -389,6 +389,8 @@ export type RpcMethod =
   | 'browser.responseBody.get'
   | 'browser.type.cdp'
   | 'browser.click.cdp'
+  | 'browser.hover.cdp'
+  | 'browser.drag.cdp'
   | 'browser.press.cdp'
   | 'browser.cookies'
   | 'browser.resize'
@@ -575,6 +577,8 @@ export const ALL_RPC_METHODS = [
   'browser.responseBody.get',
   'browser.type.cdp',
   'browser.click.cdp',
+  'browser.hover.cdp',
+  'browser.drag.cdp',
   'browser.press.cdp',
   'browser.cookies',
   'browser.resize',

--- a/src/shared/uaMetadata.ts
+++ b/src/shared/uaMetadata.ts
@@ -1,0 +1,170 @@
+// ---------------------------------------------------------------------------
+// Client Hints that agree with the emulated User-Agent.
+//
+// `browser_emulate` used to override the UA string alone. The browser kept
+// answering `navigator.userAgentData` — the Client Hints surface, and the
+// `Sec-CH-UA*` request headers built from it — out of the *real* browser, so an
+// emulated iPhone announced itself as an iPhone in one place and as desktop
+// Chrome on macOS in the other. That disagreement is a stronger signal than
+// either value on its own.
+//
+// This module derives the matching metadata from the preset's UA string so
+// `Emulation.setUserAgentOverride` can carry both, plus the Accept-Language
+// that should travel with them.
+//
+// It only ever runs on the emulate path. The default, non-emulated UA and its
+// hints are the browser's own and are left untouched.
+// ---------------------------------------------------------------------------
+
+export interface UserAgentBrand {
+  brand: string;
+  version: string;
+}
+
+export interface UserAgentMetadata {
+  brands: UserAgentBrand[];
+  fullVersion?: string;
+  platform: string;
+  platformVersion: string;
+  architecture: string;
+  model: string;
+  mobile: boolean;
+}
+
+export interface UserAgentOverride {
+  userAgent: string;
+  userAgentMetadata: UserAgentMetadata;
+  acceptLanguage?: string;
+}
+
+/**
+ * The greased entry Chrome mixes into its brand list. Chrome varies it between
+ * releases; any site that hard-codes a match on the list is already broken, so
+ * a stable placeholder is honest enough and keeps the output deterministic.
+ */
+const GREASE_BRAND = 'Not_A Brand';
+const GREASE_VERSION = '24';
+
+function chromeMajorVersion(ua: string): string | undefined {
+  const match = /Chrome\/(\d+)/.exec(ua);
+  return match?.[1];
+}
+
+function chromeFullVersion(ua: string): string | undefined {
+  const match = /Chrome\/([\d.]+)/.exec(ua);
+  return match?.[1];
+}
+
+/**
+ * Chromium's brand list for a given major version: the greased entry plus
+ * Chromium and Google Chrome, which is the shape real Chrome reports.
+ * A non-Chromium UA (Safari on iOS) gets an empty list, because Safari does not
+ * expose Client Hints at all — an empty list is the honest answer there.
+ */
+export function brandsForUserAgent(ua: string): UserAgentBrand[] {
+  const major = chromeMajorVersion(ua);
+  if (!major) return [];
+  return [
+    { brand: GREASE_BRAND, version: GREASE_VERSION },
+    { brand: 'Chromium', version: major },
+    { brand: 'Google Chrome', version: major },
+  ];
+}
+
+interface PlatformFacts {
+  platform: string;
+  platformVersion: string;
+  architecture: string;
+  model: string;
+  mobile: boolean;
+}
+
+function platformFactsFor(ua: string): PlatformFacts {
+  // iPhone / iPad — the UA carries "CPU iPhone OS 15_0 like Mac OS X".
+  const ios = /(?:iPhone|iPad|CPU) OS (\d+)[._](\d+)(?:[._](\d+))?/.exec(ua);
+  if (/iPhone|iPad|iPod/.test(ua)) {
+    return {
+      platform: 'iOS',
+      platformVersion: ios ? `${ios[1]}.${ios[2]}.${ios[3] ?? '0'}` : '',
+      // Client Hints report no architecture or model on mobile.
+      architecture: '',
+      model: '',
+      mobile: true,
+    };
+  }
+
+  // Android — "Android 11; Pixel 5".
+  const android = /Android (\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(ua);
+  if (android) {
+    const model = /Android [^;]+;\s*([^)]+?)(?:\s+Build\/[^)]*)?\)/.exec(ua)?.[1]?.trim() ?? '';
+    return {
+      platform: 'Android',
+      platformVersion: `${android[1]}.${android[2] ?? '0'}.${android[3] ?? '0'}`,
+      architecture: '',
+      model,
+      mobile: true,
+    };
+  }
+
+  // macOS — "Macintosh; Intel Mac OS X 10_15_7".
+  const mac = /Mac OS X (\d+)[._](\d+)(?:[._](\d+))?/.exec(ua);
+  if (mac) {
+    return {
+      platform: 'macOS',
+      platformVersion: `${mac[1]}.${mac[2]}.${mac[3] ?? '0'}`,
+      architecture: 'x86',
+      model: '',
+      mobile: false,
+    };
+  }
+
+  // Windows — "Windows NT 10.0". Chrome reports the marketing version here
+  // (NT 10.0 covers both Windows 10 and 11); "10.0.0" is what Chrome on
+  // Windows 10 sends.
+  const win = /Windows NT (\d+)(?:\.(\d+))?/.exec(ua);
+  if (win) {
+    return {
+      platform: 'Windows',
+      platformVersion: `${win[1]}.${win[2] ?? '0'}.0`,
+      architecture: 'x86',
+      model: '',
+      mobile: false,
+    };
+  }
+
+  if (/Linux|X11/.test(ua)) {
+    return { platform: 'Linux', platformVersion: '', architecture: 'x86', model: '', mobile: false };
+  }
+
+  return { platform: 'Unknown', platformVersion: '', architecture: '', model: '', mobile: false };
+}
+
+/**
+ * Build the `Emulation.setUserAgentOverride` payload for an emulated UA.
+ *
+ * @param userAgent - the preset's UA string, taken verbatim.
+ * @param locale    - the locale being emulated alongside it, if any. It becomes
+ *                    `acceptLanguage` so the header agrees with the UA rather
+ *                    than staying on the real browser's language.
+ */
+export function buildUserAgentOverride(
+  userAgent: string,
+  locale?: string | null,
+): UserAgentOverride {
+  const facts = platformFactsFor(userAgent);
+  const fullVersion = chromeFullVersion(userAgent);
+
+  return {
+    userAgent,
+    userAgentMetadata: {
+      brands: brandsForUserAgent(userAgent),
+      ...(fullVersion && { fullVersion }),
+      platform: facts.platform,
+      platformVersion: facts.platformVersion,
+      architecture: facts.architecture,
+      model: facts.model,
+      mobile: facts.mobile,
+    },
+    ...(locale && { acceptLanguage: locale }),
+  };
+}

--- a/src/shared/uaMetadata.ts
+++ b/src/shared/uaMetadata.ts
@@ -23,17 +23,27 @@ export interface UserAgentBrand {
 
 export interface UserAgentMetadata {
   brands: UserAgentBrand[];
+  fullVersionList: UserAgentBrand[];
   fullVersion?: string;
   platform: string;
   platformVersion: string;
   architecture: string;
   model: string;
   mobile: boolean;
+  bitness: string;
+  wow64: boolean;
 }
 
 export interface UserAgentOverride {
   userAgent: string;
-  userAgentMetadata: UserAgentMetadata;
+  /**
+   * Absent for a non-Chromium preset. Chromium fills the Client Hints surface
+   * from whatever it is given, so handing it `brands: []` would produce a
+   * `navigator.userAgentData` that exists but is empty — a shape no real
+   * browser has. Safari has no `userAgentData` at all, and omitting the field
+   * is how you get that.
+   */
+  userAgentMetadata?: UserAgentMetadata;
   acceptLanguage?: string;
 }
 
@@ -58,8 +68,9 @@ function chromeFullVersion(ua: string): string | undefined {
 /**
  * Chromium's brand list for a given major version: the greased entry plus
  * Chromium and Google Chrome, which is the shape real Chrome reports.
- * A non-Chromium UA (Safari on iOS) gets an empty list, because Safari does not
- * expose Client Hints at all — an empty list is the honest answer there.
+ * A non-Chromium UA (Safari on iOS) gets an empty list — and callers must then
+ * omit the metadata entirely rather than send the empty list, see
+ * `UserAgentOverride.userAgentMetadata`.
  */
 export function brandsForUserAgent(ua: string): UserAgentBrand[] {
   const major = chromeMajorVersion(ua);
@@ -68,6 +79,20 @@ export function brandsForUserAgent(ua: string): UserAgentBrand[] {
     { brand: GREASE_BRAND, version: GREASE_VERSION },
     { brand: 'Chromium', version: major },
     { brand: 'Google Chrome', version: major },
+  ];
+}
+
+/**
+ * The same list at full precision, which is what `getHighEntropyValues()`
+ * returns for `fullVersionList`.
+ */
+export function fullVersionListForUserAgent(ua: string): UserAgentBrand[] {
+  const full = chromeFullVersion(ua);
+  if (!full) return [];
+  return [
+    { brand: GREASE_BRAND, version: `${GREASE_VERSION}.0.0.0` },
+    { brand: 'Chromium', version: full },
+    { brand: 'Google Chrome', version: full },
   ];
 }
 
@@ -151,19 +176,38 @@ export function buildUserAgentOverride(
   userAgent: string,
   locale?: string | null,
 ): UserAgentOverride {
+  const brands = brandsForUserAgent(userAgent);
+
+  // Not Chromium (Safari on an iPhone/iPad preset): send the UA string alone,
+  // so navigator.userAgentData stays absent as it is in the browser being
+  // emulated. An empty-but-present hints object would be a fingerprint of its
+  // own — no shipping browser produces one.
+  if (brands.length === 0) {
+    return {
+      userAgent,
+      ...(locale && { acceptLanguage: locale }),
+    };
+  }
+
   const facts = platformFactsFor(userAgent);
   const fullVersion = chromeFullVersion(userAgent);
 
   return {
     userAgent,
     userAgentMetadata: {
-      brands: brandsForUserAgent(userAgent),
+      brands,
+      fullVersionList: fullVersionListForUserAgent(userAgent),
       ...(fullVersion && { fullVersion }),
       platform: facts.platform,
       platformVersion: facts.platformVersion,
       architecture: facts.architecture,
       model: facts.model,
       mobile: facts.mobile,
+      // getHighEntropyValues reports these too; a desktop Chrome that answers
+      // for architecture but not for bitness is not a shape Chrome produces.
+      // Mobile reports neither, matching architecture/model above.
+      bitness: facts.mobile ? '' : '64',
+      wow64: false,
     },
     ...(locale && { acceptLanguage: locale }),
   };

--- a/tsconfig.mcp.json
+++ b/tsconfig.mcp.json
@@ -11,6 +11,10 @@
   },
   "include": [
     "src/mcp/**/*",
+    "src/shared/humanRhythm.ts",
+    "src/shared/pointerPath.ts",
+    "src/shared/referer.ts",
+    "src/shared/uaMetadata.ts",
     "src/shared/rpc.ts",
     "src/shared/constants.ts",
     "src/shared/types.ts"


### PR DESCRIPTION
Five behavioural fingerprints in the browser tools. All of them are about what a
page can *observe* while the agent works — not about what the tools say about
themselves, and not about hiding that automation is present.

## Per item

| # | Item | Files | What changed | Test |
|---|------|-------|--------------|------|
| 1 | Typing delays were uniform-random | `src/shared/humanRhythm.ts` (new), `src/mcp/playwright/human-typing.ts`, `src/main/browser-session/HumanBehavior.ts` | Both lanes drew from a flat `Math.random() * (max-min) + min` over 50–150 ms. One shared definition now produces a log-normal base around the band's midpoint, an allowance after sentence (`+120 ms`) / clause (`+60 ms`) / word-break (`+40 ms`) characters, and a ~4% chance of a 300–700 ms pause. Clamped to `0.6×min … 5×max`. RNG is injectable (defaults to `Math.random`). Public option names `minDelay`/`maxDelay` unchanged. | `src/shared/__tests__/humanRhythm.test.ts` — median band, skew (mean > median), pause frequency band, clamp, punctuation ordering, seeded determinism, 40-char total-time band, custom band |
| 2 | Clicks were instantaneous centre hits | `src/shared/pointerPath.ts` (new), `src/mcp/playwright/pointer-path.ts` (new, per-page tracking), `src/mcp/playwright/tools/interaction.ts`, `src/main/pipe/handlers/browser.rpc.ts` | Chrome lane: before clicking, the pointer walks from its last position on that page (or a plausible viewport-relative start) to a landing point inside the inner 60% of the element box, with `stepsForDistance()` giving 8–25 points. Playwright still performs the click itself via a `position` offset, so actionability / `force` / `timeout` semantics are untouched. RPC lane: `browser.click.cdp` now emits the same interpolated `Input.dispatchMouseEvent mouseMoved` run before `mousePressed`. Plain interpolation with perpendicular jitter — nothing more is claimed. | `src/shared/__tests__/pointerPath.test.ts` — monotone progress along the axis, exact endpoint, step-count band, off-line mid-flight, zero-length move, click point inside the inner fraction, non-centre |
| 3 | `isTrusted=false` on hover / drag in the RPC fallback | `src/mcp/playwright/tools/interaction.ts`, `src/main/pipe/handlers/browser.rpc.ts`, `src/shared/rpc.ts`, `src/main/mcp/firstParty.ts`, `src/main/mcp/methodCapabilityMap.ts` | Hover and drag dispatched synthetic `MouseEvent`/`DragEvent` via `evaluate`, so every handler saw `isTrusted === false`. Two new verbs — `browser.hover.cdp` (interpolated `mouseMoved`) and `browser.drag.cdp` (move → `mousePressed` → held-button moves → `mouseReleased`) — route both through CDP `Input.*` instead. Both map to the existing `browser.click` capability. | Covered by the existing `interaction.fallback` / `interaction.newtab` suites plus `tsc`; the CDP verbs themselves are exercised by the live smoke's chrome-lane equivalent |
| 4 | No `Referer` on agent navigations | `src/shared/referer.ts` (new), `src/mcp/playwright/tools/navigation.ts`, `src/main/pipe/handlers/browser.rpc.ts` | When the page being left is a real http(s) document and the destination differs, `page.goto` gets `referer:` and `webContents.loadURL` gets `httpReferrer:`. `about:blank`, `chrome://`, `devtools://`, `file://`, `data:`, an unparseable URL, a first navigation, and a same-URL reload all still send none. | `src/shared/__tests__/referer.test.ts` — 6 cases covering each branch |
| 5 | `browser_emulate` UA inconsistency | `src/shared/uaMetadata.ts` (new), `src/mcp/playwright/tools/state.ts`, `src/main/pipe/handlers/browser.rpc.ts` | The UA string was overridden alone, so `navigator.userAgentData` and the `Sec-CH-UA*` headers kept answering out of the real browser — an emulated phone announced itself as a phone in one place and as this desktop in the other. `Emulation.setUserAgentOverride` now carries `userAgentMetadata` (brands at the UA's major version, platform, platformVersion, architecture, model, mobile) and `acceptLanguage`, derived from the preset's own UA. Applied on the preset path **and** on device reset, so a reset does not leave the preset's hints behind. Only the emulate path is touched; the default non-emulated UA is unchanged. | `src/shared/__tests__/uaMetadata.test.ts` — desktop Chrome on macOS and Windows, iPhone 13 (no brands, since Safari exposes no Client Hints), Pixel 5, Galaxy S9+ (Build token stripped from the model), acceptLanguage, and a mobile-flag consistency sweep |

`browser_select` in the RPC lane deliberately keeps the DOM assignment: a native
`<select>` opens an OS-drawn popup that lives outside the page, so CDP `Input`
events go to the document and never reach it. There is no mouse sequence that
picks an option reliably. The code now says so, and that the resulting `change`
event carries `isTrusted === false`.

## Live smoke

Real Chrome via `connectOverCDP`, pages served off a local http server (`data:`
URLs cannot carry a Referer), driving the new helpers directly.

**(a) Typing — 40 chars into a `<textarea>` recording `keydown` timestamps**

```
text (40 chars): "the quick brown fox jumps over lazy dog."
observed keydown intervals (ms):
  121.4, 134.4, 102.6, 122, 116.8, 163.5, 99.6, 119.4, 119.5, 124.1, 83.2,
  115.2, 171.4, 102.6, 111.1, 155.5, 100, 154.2, 119, 149.1, 177.6, 58.3,
  142.1, 673.6, 231.9, 226.3, 133.7, 82.3, 116.8, 145.8, 112.9, 116.3, 63.6,
  89.4, 88.5, 134.7, 512.3, 104.3, 67.8
  count=39  median=119.4  mean=147.8  max=673.6  min=58.3
  total wall time = 6.60s
  textarea value matches typed text: true
```

Mean above median, two thinking pauses (673.6 ms, 512.3 ms) — the shape the old
uniform draw could not produce, where every interval sat inside 50–150 ms. Wall
time is a touch over the 3–6 s band on this sample because two pauses landed in
one 40-char run and each keypress also costs a CDP round trip; the unit test
asserts the band on the schedule itself, averaged over 300 seeds.

**(b) Click — page counting `mousemove` and recording `isTrusted` + offset**

```
  box = {"x":400,"y":300,"width":200,"height":60}
  pointer start = (410, 202)  ->  landing = (505.5, 327.8)  steps = 12
  mousemove events the page saw = 13   (a bare locator.click() produces 1)
  click.isTrusted = true
  offset from centre = (7, -1) px   inside box = true
  inner-60% bound = (+/-60, +/-18)
```

**(c) Navigation — `document.referrer` on B after A → B**

```
  refererFor('about:blank', 'http://127.0.0.1:60401/a') = undefined
  after goto A, document.referrer on A = ""
  refererFor('http://127.0.0.1:60401/a', 'http://127.0.0.1:60401/b') = "http://127.0.0.1:60401/a"
  on B: referrer=http://127.0.0.1:60401/a
  reload of B sends referer = undefined  (same URL -> none)
```

## Known limitations

- **`browser_select` in the RPC lane stays untrusted.** Explained above; there is
  no `Input.*` route to a native `<select>` popup.
- **The pointer's remembered position is per page and in-process.** A page that
  is replaced, or a fresh MCP process, starts from the default start point
  rather than from where the pointer really was.
- **`Emulation.setUserAgentOverride` on the chrome lane is best-effort.** If the
  CDP session cannot be opened, the UA header is still applied and the result
  reports `clientHints=unavailable` rather than failing the call.
- **Brand grease is a fixed placeholder.** Real Chrome varies the greased brand
  entry between releases; a stable value keeps the builder deterministic.

## Out of scope (untouched, deliberately)

Electron webview UA string; CAPTCHA; fingerprint spoofing (canvas / WebGL /
fonts); `Runtime.enable` bypass; headless mode; and anything that forges
automation signals to get a login past a site's own protections — the repo rule
in the header of `src/mcp/playwright/user-gesture.ts`.

## Gates

- `npx tsc --noEmit` clean
- `npm run build:mcp && npm run probe:mcp` clean; **no tool description or input
  schema changed**, so `scripts/mcp-protocol-baseline.json` does not move.
  `tools/list` `full` = **76,410 B** (cap 78,000), unchanged.
- `npx vitest run src/mcp/playwright src/main/browser-session src/shared/__tests__`
  → 123 files, 1743 passed, 4 skipped. **36 new tests** across 4 new files.
- `eslint` clean (0 errors) on every new and changed file.

---

# Review round

Findings from the review panel, and what each turned into.

| # | Finding | Outcome |
|---|---------|---------|
| 1 | `refererFor` sent the full URL everywhere | **Done.** Now mirrors Chrome's default `strict-origin-when-cross-origin`: same-origin → full URL, cross-origin → `origin + '/'`, https→http → nothing, credentials and fragment always stripped, reload compared on normalised URLs. |
| 2 | Emulate: session detached in `finally`; only the current page; reset did not undo the UA | **Done.** New `src/mcp/playwright/ua-emulation.ts` holds one CDP session open per page (the override dies with its session), re-applies on `context.on('page')`, and `device: null` now restores the real UA + metadata and drops the `User-Agent` extra header. Verified live below. |
| 3 | No total-duration budget on a typing schedule | **Done.** Capped at 120 ms/char + 1.5 s slack, scaled down proportionally when exceeded — the shape survives the squeeze. Tested with a 2,000-char string. |
| 4 | `pointerPositions` never pruned | **Done.** Entry dropped on the WebContents `destroyed` event; the misleading "pruned on move" comment is gone. |
| 5 | `brands: []` for Safari presets is a novel fingerprint | **Done.** Non-Chromium presets omit `userAgentMetadata` entirely. Chromium presets gained `fullVersionList`, `bitness`, `wow64`. |
| 6 | `clickWithApproach` hardening | **Done.** Scrolls before measuring; centre-aims controls under 24 px; skips the approach when the target is outside the viewport; retries once without the approach on failure (which also covers rotated elements). New `interaction.clickApproach.test.ts`, 10 cases. |
| 7 | `elementCenter` zero-size rects; `buttons: 1`; verify the target after the move | **Done.** Zero-area rects resolve as not-found; `mousePressed` carries `buttons: 1`; `approachElement` checks `document.elementFromPoint` after the walk, recomputes once, then fails explicitly rather than reporting a silent mis-click. |
| 8 | Raw mouse events cannot drive HTML5 drag without `Input.setInterceptDrags` | **Rejected — measured false.** See the raw-CDP smoke below: on Chrome 145, a press/move/release sent from a raw CDP session with no interception fires `dragstart` **and** `drop` on a `draggable` fixture. An implementation that branched to `DragEvent` synthesis for draggable sources was written, measured, and then removed: it would have traded real input for `isTrusted === false` on exactly the elements the change exists to fix. One pointer mechanism now covers both fixture kinds. |
| 9 | `docs/api/reference.md` + `docs/api/inventory.md` stale | **Done.** Both regenerated/updated; `gen-api-reference.mjs --check` passes. |
| 10 | hover/drag moved to the `browser.click` capability — intended? | **Intended, and now stated in the changelog fragment.** Hover and drag *are* pointer input, which is what `browser.click` grants; routing them through `browser.evaluate` would mean handing out arbitrary script execution in order to move a pointer. |
| 11 | Item 6 of the brief (`data-wmux-ref` residue) | **Deferred**, as the brief permits. It lives in `tools/inspection.ts` and `snapshot.ts`, both changed by #1172; touching them would conflict and block both PRs. Current lifecycle is unchanged by this PR: `dom-intelligence.ts` clears every `[data-wmux-ref]` at the *start* of each snapshot, so stale refs never accumulate, but the tags from the most recent snapshot stay in the DOM because the RPC interaction path resolves refs through them. |
| 12 | Rotated/transformed elements | **Covered without the extra probe.** Reading `getComputedStyle().transform` costs a round trip on every click; finding 6(c) already handles it — a point inside the axis-aligned box but outside a rotated element makes Playwright's positioned click fail, and the retry-without-approach lands it on the centre. |

## Live smoke, round 2

**(a) Typing** — 40 chars, `keydown` timestamps:

```
  intervals: 165.9, 190.1, 88.9, 124.7, 55, 54.7, 74.5, 141.8, 62.4, 163.5,
  507.5, 102.2, 85.7, 118.3, 99, 137, 122.4, 451.3, 73.4, 115.9, 122.4, 128.3,
  81.6, 113.1, 104.9, 110.1, 104.9, 157.6, 188.7, 122.4, 251, 74.3, 66.6,
  137.3, 57.2, 143.6, 84.4, 127.5, 777.1
  count=39 median=118.3 mean=151 max=777.1 min=54.7 wall=6.16s
```

**(b) Click**:

```
  steps=11 mousemove events page saw=12 (bare click = 1)
  isTrusted=true offset=(-52, -15) inside=true innerBound=(+/-60, +/-18)
```

**(c) Referer**, same-origin vs cross-origin vs downgrade:

```
  about:blank -> /a : refererFor = undefined
  same-origin /a -> /b : sent "http://127.0.0.1:60679/a"
    on B: referrer=http://127.0.0.1:60679/a
  cross-origin 127.0.0.1 -> localhost : sent "http://127.0.0.1:60679/"
    on B: referrer=http://127.0.0.1:60679/
  https -> http downgrade : undefined
```

**(d) Emulate** — `navigator.userAgentData` before, after apply (post-reload, so
the override provably survived the tool returning), in a tab opened *during* the
emulation, and after reset:

```
  before: platform=macOS mobile=false brands=["Chromium","Not?A_Brand","Google Chrome"]
  applyUserAgentEmulation -> true
  after apply (post-reload, session still held open):
    navigator.userAgent mobile token = true
    platform=Android platformVersion=11.0.0 mobile=true bitness=""
    brands=["Not_A Brand","Chromium","Google Chrome"]
    fullVersionList=["24.0.0.0","145.0.7632.6","145.0.7632.6"]
  new tab opened during emulation: platform=Android mobile=true
  after reset: platform=macOS mobile=false brands=["Chromium","Not?A_Brand","Google Chrome"]
    UA back to desktop = true
```

**(e) Drag** — raw CDP session, no `Input.setInterceptDrags`, i.e. exactly what
`wc.debugger` sends:

```
RAW CDP drag, pointer-event fixture (#pes -> #pet):
  mousedown=true  moves=14  mouseup-on-target=true
RAW CDP drag, HTML5 draggable fixture (#h5s -> #h5t):
  dragstart=true  drop=true
DragEvent synthesis, HTML5 draggable fixture:
  dragstart=true  drop=true
```

Both fixtures work through real pointer input, which is why finding 8 was
rejected. (Driving the same fixtures through Playwright's `page.mouse` cannot
answer this question — Playwright enables drag interception and synthesises the
drag events itself.)

## Gates, round 2

- `npx tsc --noEmit` clean
- `npm run build:mcp && npm run probe:mcp` clean; still no tool description or
  schema change, `tools/list` `full` = **76,410 B** (cap 78,000), baseline unmoved
- `node scripts/gen-api-reference.mjs --check` passes
- `npx vitest run src/main/pipe src/mcp/playwright src/main/browser-session src/shared/__tests__ scripts/__tests__`
  → **180 files, 3039 passed, 5 skipped**. **46 new tests** across 5 new files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typing now follows a more natural rhythm, including pauses around punctuation and word breaks.
  * Clicking, hovering, and dragging use realistic pointer movement and input.
  * Navigation requests now include an appropriate referrer when applicable.
  * Device emulation synchronizes user-agent, platform, language, and related browser details.
  * Added browser hover and drag capabilities for supported automation workflows.
* **Documentation**
  * Updated the API reference and changelog with the latest browser capabilities and behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->