### PR TITLE
fix(fleet): the workspace dot sees pending questions and dead stashed panes (#1168)

### DIFF
--- a/changelog.d/1175.md
+++ b/changelog.d/1175.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **The workspace dot no longer reads green while an agent is blocked.** When a
+  Claude turn ends on a question, the same signal carries "turn complete" and
+  the question itself — and the sidebar dot only ever read the first half, so it
+  went green while the row directly beneath it said "Needs input" and printed
+  the question. It now turns red, and so do the mini sidebar, the titlebar
+  vitals chip and the deck roster, which all read from the same place. A
+  workspace whose only pane is a stashed session that has since died now shows
+  red too, instead of the grey dot that meant "nothing here". (#1175)

--- a/src/renderer/components/Deck/DeckFleet.tsx
+++ b/src/renderer/components/Deck/DeckFleet.tsx
@@ -73,11 +73,12 @@ export default function DeckFleet({
   const surfaceActivity = useStore((s) => s.surfaceActivity);
   const paneLabel = useStore((s) => s.paneLabel);
   const surfaceAgent = useStore((s) => s.surfaceAgent);
+  const surfacePendingQuestion = useStore((s) => s.surfacePendingQuestion);
   const paneRole = useStore((s) => s.paneRole);
   const roleBindings = useStore((s) => s.orchestratorRoleBindings);
 
   const panes = useMemo(() => {
-    const all = selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, surfaceAgent });
+    const all = selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, surfaceAgent, surfacePendingQuestion });
     // Roster = live terminal panes of the ACTIVE workspace only (M1.5: the
     // deck is this workspace's orchestrator, so its roster is this
     // workspace's agents — the fleet-wide view lives in the titlebar vitals).
@@ -89,7 +90,7 @@ export default function DeckFleet({
       ),
       'attention',
     );
-  }, [workspaces, activeWorkspaceId, surfaceAgentStatus, surfaceActivity, paneLabel, surfaceAgent]);
+  }, [workspaces, activeWorkspaceId, surfaceAgentStatus, surfaceActivity, paneLabel, surfaceAgent, surfacePendingQuestion]);
 
   if (panes.length === 0) return null;
 

--- a/src/renderer/components/FleetView/FleetView.tsx
+++ b/src/renderer/components/FleetView/FleetView.tsx
@@ -54,6 +54,7 @@ export default function FleetView() {
   // #850: per-PTY agent identity — gates workspace metadata inheritance so a
   // non-agent active pane never borrows the real agent's name/status.
   const surfaceAgent = useStore((s) => s.surfaceAgent);
+  const surfacePendingQuestion = useStore((s) => s.surfacePendingQuestion);
   // X8 supervision mirror — subscribed here so the selector re-runs when a
   // supervised pane arms/stops or its restart count changes.
   const supervisionByPtyId = useStore((s) => s.supervisionByPtyId);
@@ -89,8 +90,8 @@ export default function FleetView() {
   // trees or the per-pty attention map change (the two inputs the selector
   // reads), not on every unrelated store mutation.
   const panes = useMemo(
-    () => sortFleetPanes(selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, surfaceAgent }), fleetSortMode),
-    [workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, surfaceAgent, fleetSortMode],
+    () => sortFleetPanes(selectFleetPanes({ workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, surfaceAgent, surfacePendingQuestion }), fleetSortMode),
+    [workspaces, surfaceAgentStatus, surfaceActivity, paneLabel, supervisionByPtyId, surfaceAgent, surfacePendingQuestion, fleetSortMode],
   );
   const needsCount = useMemo(() => countNeedsAttention(panes), [panes]);
   // Stable identity key of the terminal ptyIds to poll for RAM. `panes`

--- a/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceAgentRoster.tsx
@@ -144,14 +144,14 @@ export function rosterHasMixedVendors(rows: readonly WorkspaceAgentRosterRow[]):
  * awaiting_input / waiting / error. That is the signal, and the row's scarcest
  * space should not render it twice.
  *
- * Two known gaps in that dot, neither introduced here and neither an argument
- * for a second indicator in this one place: `selectFleetPanes` (the dot's
- * source) reads neither `surfacePendingQuestion` — which this roster promotes
- * to awaiting_input — nor a stashed pane's `exited` liveness, so a pane
- * blocked on a question can sit under a green dot. The dot also drives
- * MiniSidebar, the titlebar vitals and the deck Fleet, so the fix belongs at
- * its source rather than behind a number that would only correct the sidebar.
- * Tracked separately.
+ * That reading was only true once #1168 closed. The dot's source,
+ * `selectFleetPanes`, used to read neither `surfacePendingQuestion` — which
+ * this roster promotes to awaiting_input — nor a stashed pane's `exited`
+ * liveness, so a pane blocked on a question sat under a green dot while the
+ * row right below it printed the question. Because the same roll-up drives
+ * MiniSidebar, the titlebar vitals and the deck Fleet, the fix went in at the
+ * source rather than behind a number that would only have corrected the
+ * sidebar; that is still the reason not to add a second indicator here.
  *
  * Stash keeps its own glyph rather than a word — the same `IconEyeOff` the
  * expanded list's stash group header uses, so a collapsed workspace still

--- a/src/renderer/components/StatusBar/StatusBar.tsx
+++ b/src/renderer/components/StatusBar/StatusBar.tsx
@@ -112,6 +112,7 @@ export default function StatusBar() {
         surfaceAgentStatus: s.surfaceAgentStatus,
         surfaceActivity: s.surfaceActivity,
         surfaceAgent: s.surfaceAgent,
+        surfacePendingQuestion: s.surfacePendingQuestion,
       }).filter((p) => p.ptyId !== '' && p.surfaceType === 'terminal');
       return {
         running: panes.filter((p) => p.agentStatus === 'running').length,
@@ -128,6 +129,7 @@ export default function StatusBar() {
         surfaceAgentStatus: s.surfaceAgentStatus,
         surfaceActivity: s.surfaceActivity,
         surfaceAgent: s.surfaceAgent,
+        surfacePendingQuestion: s.surfacePendingQuestion,
       }).filter((p) => p.ptyId !== '' && p.surfaceType === 'terminal'),
       'attention',
     );

--- a/src/renderer/hooks/__tests__/workspaceMirrorSnapshot.test.ts
+++ b/src/renderer/hooks/__tests__/workspaceMirrorSnapshot.test.ts
@@ -314,3 +314,49 @@ describe('buildFleetSnapshots — stashed panes (#977)', () => {
     ).toBe('running');
   });
 });
+
+// ─── #1168 — a pane blocked on a question must reach the mirror too ───────────
+//
+// The deck heartbeat and the completion gate read this payload. A stop that
+// asks a question writes `complete` AND the question in one broadcast, so
+// before this the row said `complete` and the gate could finish over an agent
+// that was waiting on an answer.
+describe('buildFleetSnapshots — pending question (#1168)', () => {
+  const ws = workspace('ws-1', 'alpha', leaf('p1', [surface('s1', 'pty-1')]), 'p1');
+
+  it('reports awaiting_input for a question the stop delivered alongside complete', () => {
+    const st = {
+      workspaces: [ws],
+      surfaceAgentStatus: { 'pty-1': 'complete' as AgentStatus },
+      surfaceActivity: {},
+      surfacePendingQuestion: { 'pty-1': 'Which branch should I target?' },
+    } satisfies FleetSelectorState;
+    const [fleet] = buildFleetSnapshots(st, 42);
+    expect(fleet.panes).toHaveLength(1);
+    expect(fleet.panes[0]).toMatchObject({ ptyId: 'pty-1', agentStatus: 'awaiting_input' });
+  });
+
+  it('reports a question that outlived its retained status', () => {
+    // Focusing the pane clears `surfaceAgentStatus`; nothing clears the
+    // question. The pane is still blocked, so the row still has to say so.
+    const st = {
+      workspaces: [ws],
+      surfaceAgentStatus: {},
+      surfaceActivity: {},
+      surfacePendingQuestion: { 'pty-1': 'Which branch should I target?' },
+    } satisfies FleetSelectorState;
+    const [fleet] = buildFleetSnapshots(st, 42);
+    expect(fleet.panes[0]).toMatchObject({ ptyId: 'pty-1', agentStatus: 'awaiting_input' });
+  });
+
+  it('leaves the base derivation alone when there is no question', () => {
+    const st = {
+      workspaces: [ws],
+      surfaceAgentStatus: { 'pty-1': 'complete' as AgentStatus },
+      surfaceActivity: {},
+      surfacePendingQuestion: { 'pty-1': '   ' },
+    } satisfies FleetSelectorState;
+    const [fleet] = buildFleetSnapshots(st, 42);
+    expect(fleet.panes[0]).toMatchObject({ ptyId: 'pty-1', agentStatus: 'complete' });
+  });
+});

--- a/src/renderer/hooks/workspaceMirrorSnapshot.ts
+++ b/src/renderer/hooks/workspaceMirrorSnapshot.ts
@@ -171,7 +171,20 @@ export function buildFleetSnapshots(state: FleetSelectorState, ts: number): Flee
       // (1) One row per surface holding its OWN retained attention status.
       for (const s of leaf.surfaces) {
         if (!s.ptyId) continue;
-        const att = state.surfaceAgentStatus[s.ptyId];
+        // #1168 — a pending question is an attention source in its own right,
+        // promoted here for the same reason selectFleetPanes promotes it. The
+        // stripped base pass below cannot carry it (that pass exists to produce
+        // the NON-attention status), so without this the mirror is the one
+        // consumer the fix misses — and it is the expensive one to miss: a stop
+        // that asks a question writes `complete` and the question in ONE
+        // broadcast, so the row read `complete` and `reasonFor` never called the
+        // pane blocked. The deck heartbeat and the completion gate then treat a
+        // workspace waiting on an answer as quiescent, which is the same class
+        // of error the #977 note below describes. It also emits a row for a
+        // question that OUTLIVED its retained status — focusing the pane clears
+        // `surfaceAgentStatus` but not the question.
+        const blocked = !!state.surfacePendingQuestion?.[s.ptyId]?.trim();
+        const att = blocked ? 'awaiting_input' : state.surfaceAgentStatus[s.ptyId];
         if (att === undefined) continue;
         const isActiveSurface = s.id === leaf.activeSurfaceId;
         const row: FleetSnapshotPane = {

--- a/src/renderer/hooks/workspaceMirrorSnapshot.ts
+++ b/src/renderer/hooks/workspaceMirrorSnapshot.ts
@@ -145,7 +145,10 @@ export function buildFleetSnapshots(state: FleetSelectorState, ts: number): Flee
   // derivation). This is what the active surface carries when the attention
   // actually belongs to a background surface.
   const baseByPane = new Map<string, AgentStatus>();
-  for (const p of selectFleetPanes({ ...state, surfaceAgentStatus: {} })) {
+  // #1168 — the pending-question map is a SECOND attention source inside the
+  // selector, so stripping only `surfaceAgentStatus` would leave a blocked pane
+  // reporting `awaiting_input` as its non-attention base status. Both go.
+  for (const p of selectFleetPanes({ ...state, surfaceAgentStatus: {}, surfacePendingQuestion: {} })) {
     baseByPane.set(p.paneId, p.agentStatus);
   }
 

--- a/src/renderer/stores/selectors/__tests__/dotRosterParity.test.ts
+++ b/src/renderer/stores/selectors/__tests__/dotRosterParity.test.ts
@@ -170,31 +170,6 @@ describe('#1168 — workspace dot vs. roster', () => {
     expectDotCoversRoster(s, 'ws-1');
   });
 
-  it('settles a dead stash on error even when a browser tab of it still has a status', () => {
-    // The one case where liveness and the attention scan genuinely disagree, so
-    // the order they are applied in matters. `stashedPaneLiveness` weighs only
-    // TERMINAL surfaces — a stash whose shell died but whose browser tab still
-    // holds a ptyId reads 'exited' while the per-surface scan can still find
-    // that tab's retained status. The roster picks a terminal representative for
-    // the same pane and reports error; the dot has to land in the same place.
-    const dead = leaf('p-st', [
-      surface('s-term', ''),
-      surface('s-web', 'pty-web', { surfaceType: 'browser' }),
-    ]);
-    const ws: Workspace = {
-      ...workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1'),
-      stashedPanes: [{ pane: dead, stashedAt: NOW - 60_000 }],
-    };
-    const s = state({
-      workspaces: [ws],
-      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'idle' } },
-      surfaceAgentStatus: { 'pty-web': 'complete' },
-    });
-
-    expect(selectWorkspaceAgentRoster(s, 'ws-1').rows.find((r) => r.stashed)?.status).toBe('error');
-    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('error');
-  });
-
   it('leaves a live stashed pane alone', () => {
     // The guard on the fix above: only an EXITED stash is promoted. A stashed
     // pane that is still running keeps deriving its status normally, or every

--- a/src/renderer/stores/selectors/__tests__/dotRosterParity.test.ts
+++ b/src/renderer/stores/selectors/__tests__/dotRosterParity.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { selectWorkspaceAgentStatus, selectAllWorkspaceAgentStatus } from '../fleet';
+import { selectWorkspaceAgentRoster } from '../workspaceAgentRoster';
+import type { StoreState } from '../../index';
+import type { Workspace, Pane, PaneLeaf, Surface, AgentStatus } from '../../../../shared/types';
+
+// ─── #1168 — the sidebar dot and the roster underneath it must agree ─────────
+//
+// `selectWorkspaceAgentStatus` (the dot, and via selectAllWorkspaceAgentStatus
+// the MiniSidebar, the titlebar vitals and the deck Fleet) rolls up
+// `selectFleetPanes`; the row list under the same workspace comes from
+// `selectWorkspaceAgentRoster`. They are separate derivations on purpose — the
+// roster is per-surface and agent-gated, the fleet pass is per-leaf and gates on
+// nothing — so this file does NOT assert they are equal.
+//
+// It asserts the one direction that is a real contract: when the roster says a
+// row needs the user, the dot above it must say so too. The reverse does not
+// hold (a non-agent pane can carry an attention status the roster excludes), and
+// pinning it would be pinning a coincidence.
+//
+// Both selectors are fed the SAME state object in every case here. Deriving the
+// expectation from a second, hand-written fixture is how the two drifted apart
+// in the first place.
+
+// Statuses the roster counts as needsAttention (workspaceAgentRoster's
+// `needsAttention`). Spelled out rather than imported so a change to that
+// predicate has to be made deliberately in both places.
+const NEEDS_YOU: ReadonlySet<AgentStatus> = new Set<AgentStatus>([
+  'awaiting_input',
+  'waiting',
+  'error',
+]);
+
+function surface(id: string, ptyId: string, extra: Partial<Surface> = {}): Surface {
+  return { id, ptyId, title: id, shell: 'pwsh', cwd: `C:\\repo\\${id}`, surfaceType: 'terminal', ...extra };
+}
+function leaf(id: string, surfaces: Surface[], activeSurfaceId?: string): PaneLeaf {
+  return { id, type: 'leaf', surfaces, activeSurfaceId: activeSurfaceId ?? surfaces[0]?.id ?? '' };
+}
+function workspace(id: string, rootPane: Pane, activePaneId: string): Workspace {
+  return { id, name: id, rootPane, activePaneId };
+}
+
+const NOW = 1_000_000;
+
+interface StateOverrides {
+  workspaces?: Workspace[];
+  activeWorkspaceId?: string;
+  surfaceAgent?: Record<string, { name?: string; status: AgentStatus }>;
+  surfaceAgentStatus?: Record<string, AgentStatus>;
+  surfacePendingQuestion?: Record<string, string>;
+  surfaceActivity?: Record<string, string>;
+  surfaceActivityAt?: Record<string, number>;
+  paneLabel?: Record<string, string>;
+  agentClockMs?: number;
+}
+
+function state(overrides: StateOverrides = {}): StoreState {
+  return {
+    workspaces: [],
+    activeWorkspaceId: '',
+    surfaceAgent: {},
+    surfaceAgentStatus: {},
+    surfacePendingQuestion: {},
+    surfaceActivity: {},
+    surfaceActivityAt: {},
+    paneLabel: {},
+    agentClockMs: NOW,
+    ...overrides,
+  } as unknown as StoreState;
+}
+
+/**
+ * The contract, asserted against every consumer of the roll-up at once: if any
+ * roster row wants the user, the single-workspace dot AND the all-workspaces map
+ * (MiniSidebar's source) must both report a needs-you status.
+ */
+function expectDotCoversRoster(s: StoreState, workspaceId: string): void {
+  const roster = selectWorkspaceAgentRoster(s, workspaceId);
+  if (!roster.rows.some((row) => row.needsAttention)) return;
+  const dot = selectWorkspaceAgentStatus(s, workspaceId);
+  expect(NEEDS_YOU.has(dot)).toBe(true);
+  const all = selectAllWorkspaceAgentStatus(s)[workspaceId] ?? 'idle';
+  expect(NEEDS_YOU.has(all)).toBe(true);
+}
+
+describe('#1168 — workspace dot vs. roster', () => {
+  it('reports the pane as awaiting input when a transcript-derived question is pending', () => {
+    // The failure this pins: the stop payload settled the pane to 'complete'
+    // (a green dot) while the transcript scan found an unanswered question. The
+    // roster promotes that to awaiting_input and prints the question; the dot
+    // read green over the top of it.
+    const s = state({
+      workspaces: [workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1')],
+      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'complete' } },
+      surfaceAgentStatus: { 'pty-1': 'complete' },
+      surfacePendingQuestion: { 'pty-1': 'Which branch should I target?' },
+    });
+
+    expect(selectWorkspaceAgentRoster(s, 'ws-1').rows[0]).toMatchObject({
+      status: 'awaiting_input',
+      needsAttention: true,
+    });
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('awaiting_input');
+    expectDotCoversRoster(s, 'ws-1');
+  });
+
+  it('finds a pending question on a BACKGROUND tab of the active pane', () => {
+    // The dot's whole reason to exist is the pane the user is not looking at.
+    const s = state({
+      workspaces: [
+        workspace(
+          'ws-1',
+          leaf('p1', [surface('s-bg', 'pty-bg'), surface('s-fg', 'pty-fg')], 's-fg'),
+          'p1',
+        ),
+      ],
+      surfaceAgent: {
+        'pty-bg': { name: 'Claude Code', status: 'complete' },
+        'pty-fg': { name: 'Codex', status: 'idle' },
+      },
+      surfacePendingQuestion: { 'pty-bg': 'Overwrite the existing file?' },
+    });
+
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('awaiting_input');
+    expectDotCoversRoster(s, 'ws-1');
+  });
+
+  it('reports a stashed pane whose session died as an error, not a neutral dot', () => {
+    // Reconcile clears ptyId when the daemon confirms the session is gone, so
+    // every terminal surface here is dead — `stashedPaneLiveness` → 'exited'.
+    // The roster calls that error/needsAttention; the dot showed grey.
+    const dead = leaf('p-st', [surface('s-st', '')]);
+    const ws: Workspace = {
+      ...workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1'),
+      stashedPanes: [{ pane: dead, stashedAt: NOW - 60_000 }],
+    };
+    const s = state({
+      workspaces: [ws],
+      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'idle' } },
+    });
+
+    const stashedRow = selectWorkspaceAgentRoster(s, 'ws-1').rows.find((r) => r.stashed);
+    expect(stashedRow).toMatchObject({ stashedLiveness: 'exited', status: 'error', needsAttention: true });
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('error');
+    expectDotCoversRoster(s, 'ws-1');
+  });
+
+  it('lights the dot for a question asked by a pane that is stashed, not on screen', () => {
+    // #977's rule ("a stashed agent is off-screen, not off-duty") meets #1168:
+    // the stash is the one place where the dot is the ONLY thing that can carry
+    // the signal, since the pane is on no other surface in the app.
+    const stashed = leaf('p-st', [surface('s-st', 'pty-st')]);
+    const ws: Workspace = {
+      ...workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1'),
+      stashedPanes: [{ pane: stashed, stashedAt: NOW - 60_000 }],
+    };
+    const s = state({
+      workspaces: [ws],
+      surfaceAgent: {
+        'pty-1': { name: 'Claude Code', status: 'idle' },
+        'pty-st': { name: 'Claude Code', status: 'complete' },
+      },
+      surfacePendingQuestion: { 'pty-st': 'Run the migration?' },
+    });
+
+    const stashedRow = selectWorkspaceAgentRoster(s, 'ws-1').rows.find((r) => r.stashed);
+    expect(stashedRow).toMatchObject({ status: 'awaiting_input', needsAttention: true });
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('awaiting_input');
+    expectDotCoversRoster(s, 'ws-1');
+  });
+
+  it('leaves a live stashed pane alone', () => {
+    // The guard on the fix above: only an EXITED stash is promoted. A stashed
+    // pane that is still running keeps deriving its status normally, or every
+    // stash gesture would light the workspace red.
+    const alive = leaf('p-st', [surface('s-st', 'pty-st')]);
+    const ws: Workspace = {
+      ...workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1'),
+      stashedPanes: [{ pane: alive, stashedAt: NOW - 60_000 }],
+    };
+    const s = state({
+      workspaces: [ws],
+      surfaceAgent: {
+        'pty-1': { name: 'Claude Code', status: 'idle' },
+        'pty-st': { name: 'Claude Code', status: 'idle' },
+      },
+    });
+
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('idle');
+  });
+
+  it('leaves a quiet workspace neutral', () => {
+    const s = state({
+      workspaces: [workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1')],
+      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'idle' } },
+    });
+
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('idle');
+    expect(selectAllWorkspaceAgentStatus(s)['ws-1']).toBeUndefined();
+  });
+
+  it('ignores a question left on a pty no surface holds any more', () => {
+    // paneSlice deletes the entry when a surface closes, but the map is keyed by
+    // ptyId and outlives a single render. A stale key must not light a dot for a
+    // workspace that has nothing to answer.
+    const s = state({
+      workspaces: [workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1')],
+      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'idle' } },
+      surfacePendingQuestion: { 'pty-gone': 'Anybody?' },
+    });
+
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('idle');
+  });
+
+  it('ignores a whitespace-only question the way the roster does', () => {
+    const s = state({
+      workspaces: [workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1')],
+      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'idle' } },
+      surfacePendingQuestion: { 'pty-1': '   ' },
+    });
+
+    expect(selectWorkspaceAgentRoster(s, 'ws-1').rows[0]?.status).toBe('idle');
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('idle');
+  });
+});

--- a/src/renderer/stores/selectors/__tests__/dotRosterParity.test.ts
+++ b/src/renderer/stores/selectors/__tests__/dotRosterParity.test.ts
@@ -170,6 +170,31 @@ describe('#1168 — workspace dot vs. roster', () => {
     expectDotCoversRoster(s, 'ws-1');
   });
 
+  it('settles a dead stash on error even when a browser tab of it still has a status', () => {
+    // The one case where liveness and the attention scan genuinely disagree, so
+    // the order they are applied in matters. `stashedPaneLiveness` weighs only
+    // TERMINAL surfaces — a stash whose shell died but whose browser tab still
+    // holds a ptyId reads 'exited' while the per-surface scan can still find
+    // that tab's retained status. The roster picks a terminal representative for
+    // the same pane and reports error; the dot has to land in the same place.
+    const dead = leaf('p-st', [
+      surface('s-term', ''),
+      surface('s-web', 'pty-web', { surfaceType: 'browser' }),
+    ]);
+    const ws: Workspace = {
+      ...workspace('ws-1', leaf('p1', [surface('s1', 'pty-1')]), 'p1'),
+      stashedPanes: [{ pane: dead, stashedAt: NOW - 60_000 }],
+    };
+    const s = state({
+      workspaces: [ws],
+      surfaceAgent: { 'pty-1': { name: 'Claude Code', status: 'idle' } },
+      surfaceAgentStatus: { 'pty-web': 'complete' },
+    });
+
+    expect(selectWorkspaceAgentRoster(s, 'ws-1').rows.find((r) => r.stashed)?.status).toBe('error');
+    expect(selectWorkspaceAgentStatus(s, 'ws-1')).toBe('error');
+  });
+
   it('leaves a live stashed pane alone', () => {
     // The guard on the fix above: only an EXITED stash is promoted. A stashed
     // pane that is still running keeps deriving its status normally, or every

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -1,5 +1,6 @@
 import type { AgentStatus, Task, PaneLeaf, Surface } from '../../../shared/types';
 import { getLeafPanes, getWorkspaceLeafPanes } from '../../../shared/paneUtils';
+import { stashedPaneLiveness } from '../../../shared/paneStash';
 import { isBrainPtyId } from '../../../shared/constants';
 import type { StoreState } from '../index';
 
@@ -78,6 +79,11 @@ export type FleetSelectorState = Pick<StoreState, 'workspaces' | 'surfaceAgentSt
    *  non-agent active pane (e.g. btop) never borrows the agent's name/status.
    *  Optional so existing fixtures stay terse. */
   surfaceAgent?: StoreState['surfaceAgent'];
+  /** #1168 — per-PTY transcript-derived pending question. The roster promotes
+   *  this straight to `awaiting_input` ("the strongest evidence that this agent
+   *  needs input"); this pass has to read the same signal or the dot above the
+   *  roster contradicts it. Optional so existing fixtures stay terse. */
+  surfacePendingQuestion?: StoreState['surfacePendingQuestion'];
 };
 
 /**
@@ -238,7 +244,15 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
       // shown as idle. The card otherwise stays keyed on the active surface.
       let attention: AgentStatus | undefined;
       for (const s of leaf.surfaces) {
-        const st = s.ptyId ? state.surfaceAgentStatus[s.ptyId] : undefined;
+        if (!s.ptyId) continue;
+        // #1168 — a transcript-derived pending question outranks whatever the
+        // stop payload settled this surface to, exactly as it does in
+        // workspaceAgentRoster. Without it a payload carrying `complete`
+        // alongside an unanswered question painted a green "nothing to see"
+        // dot over a red roster row that was printing the question.
+        const st = state.surfacePendingQuestion?.[s.ptyId]?.trim()
+          ? 'awaiting_input'
+          : state.surfaceAgentStatus[s.ptyId];
         if (st && (attention === undefined || STATUS_RANK[st] < STATUS_RANK[attention])) {
           attention = st;
         }
@@ -283,11 +297,21 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
         activityAt !== undefined &&
         state.agentClockMs !== undefined &&
         state.agentClockMs - activityAt <= HOOK_RUNNING_TTL_MS;
-      const status: AgentStatus =
-        attention
-        ?? (metaStatus && metaStatus !== 'idle' ? metaStatus : undefined)
-        ?? (hookRunning ? 'running' : undefined)
-        ?? 'idle';
+      // #1168 — a stashed pane whose every terminal surface has lost its pty is
+      // a session the daemon has confirmed gone. The roster reports that as
+      // `error` / needs-you and offers recovery; this pass had no liveness
+      // handling at all, so the workspace's only entry being a dead stash left
+      // the dot neutral grey — "nothing here" for the one state that most wants
+      // the user. It cannot collide with the attention scan above: `exited`
+      // means no terminal surface still holds a ptyId, and every attention
+      // source is keyed by one.
+      const stashedExited = stashed && stashedPaneLiveness(leaf) === 'exited';
+      const status: AgentStatus = stashedExited
+        ? 'error'
+        : (attention
+          ?? (metaStatus && metaStatus !== 'idle' ? metaStatus : undefined)
+          ?? (hookRunning ? 'running' : undefined)
+          ?? 'idle');
       result.push({
         workspaceId: ws.id,
         workspaceName: ws.name,

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -302,15 +302,14 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
       // `error` / needs-you and offers recovery; this pass had no liveness
       // handling at all, so the workspace's only entry being a dead stash left
       // the dot neutral grey — "nothing here" for the one state that most wants
-      // the user. It is tested BEFORE the attention scan's result, matching the
-      // roster, which also settles liveness first: once the daemon has confirmed
-      // the session gone, a status or question left behind on the pane is not
-      // something the user can still act on. That ordering is load-bearing and
-      // not merely defensive — `stashedPaneLiveness` weighs only TERMINAL
-      // surfaces, so a stash whose lone browser tab still holds a ptyId reads
-      // `exited` while the scan above can still find that tab's retained status.
-      // The roster's representative-surface picker is terminal-only for the same
-      // reason, so both land on 'error' for that pane.
+      // the user. It cannot contradict the attention scan above, which is why it
+      // can sit in front of it: `stashedPaneLiveness` weighs only TERMINAL
+      // surfaces, but the only other type a pane may hold and still be stashable
+      // is `browser` (STASHABLE_SURFACE_TYPES), and a browser surface is created
+      // with `ptyId: ''` and never assigned one — `updateSurfacePtyId` is
+      // reached only from the terminal spawn callback and from reconcile. So
+      // `exited` really does mean no surface in this leaf holds a ptyId, and
+      // every attention source is keyed by one.
       const stashedExited = stashed && stashedPaneLiveness(leaf) === 'exited';
       const status: AgentStatus = stashedExited
         ? 'error'

--- a/src/renderer/stores/selectors/fleet.ts
+++ b/src/renderer/stores/selectors/fleet.ts
@@ -302,9 +302,15 @@ export function selectFleetPanes(state: FleetSelectorState): FleetPane[] {
       // `error` / needs-you and offers recovery; this pass had no liveness
       // handling at all, so the workspace's only entry being a dead stash left
       // the dot neutral grey — "nothing here" for the one state that most wants
-      // the user. It cannot collide with the attention scan above: `exited`
-      // means no terminal surface still holds a ptyId, and every attention
-      // source is keyed by one.
+      // the user. It is tested BEFORE the attention scan's result, matching the
+      // roster, which also settles liveness first: once the daemon has confirmed
+      // the session gone, a status or question left behind on the pane is not
+      // something the user can still act on. That ordering is load-bearing and
+      // not merely defensive — `stashedPaneLiveness` weighs only TERMINAL
+      // surfaces, so a stash whose lone browser tab still holds a ptyId reads
+      // `exited` while the scan above can still find that tab's retained status.
+      // The roster's representative-surface picker is terminal-only for the same
+      // reason, so both land on 'error' for that pane.
       const stashedExited = stashed && stashedPaneLiveness(leaf) === 'exited';
       const status: AgentStatus = stashedExited
         ? 'error'


### PR DESCRIPTION
Closes #1168.

## The bug

A Claude Code turn that ends on a question fires one Stop hook, and
`buildTurnBoundaryMetadata` puts **both** `agentStatus: 'complete'` and the
transcript-derived `pendingQuestion` into a **single** broadcast. The roster
selector promotes that question to `awaiting_input` and prints it; the
roll-up that paints the dot above it never read the field at all, so it took
the `complete` and painted the row **green**.

The same roll-up had no stashed-pane liveness handling either, so a workspace
whose only entry was a stashed pane the daemon had confirmed dead showed a
neutral grey dot while the roster called it `error` and offered recovery.

Both are the dot saying "nothing to see" about a workspace that wants the
user — the one failure the dot exists to prevent.

## The fix

At the source, `selectFleetPanes`, so the sidebar dot, MiniSidebar, the
titlebar vitals chip and the deck Fleet all correct together:

- A non-empty `surfacePendingQuestion` folds into the existing **per-surface**
  attention scan, so a question asked by a background tab lights the dot the
  same way that tab's retained status already did.
- A stashed leaf whose `stashedPaneLiveness` is `exited` resolves to `error`
  ahead of the other derivations, matching the roster's own precedence.

Two consequences the fix drags along:

- Three consumers hand the selector a hand-built narrowed state instead of the
  store, so each had to start passing `surfacePendingQuestion` — otherwise the
  fix would have reached only the two that pass full state.
- `buildFleetSnapshots` (the deck/orchestrator mirror) is a **fifth** consumer,
  and it needed the promotion in its own per-surface row loop, not just the
  stripped base pass. Its rows were gated on `surfaceAgentStatus` alone, so the
  mirror described a blocked pane as `complete` — and that payload feeds the
  deck heartbeat and the completion gate, which would otherwise finish over an
  agent that is waiting on an answer.

## Evidence

**Unit.** `dotRosterParity.test.ts` feeds **one state object** to both the
roster and the dot and asserts the direction that is actually a contract:
when a roster row needs the user, the roll-up above it must say so too. It
deliberately does not assert the two are equal — the roster is per-surface and
agent-gated, the fleet pass is per-leaf and gates on nothing, so equality would
be pinning a coincidence. All four substantive cases fail on `main`; two of the
three new mirror cases fail without the `buildFleetSnapshots` change.

**Dogfood.** An isolated instance (`WMUX_DATA_SUFFIX=-dog1168`) driven over
CDP, with a realistic turn pushed through the **real** hook bridge
(`SessionStart → UserPromptSubmit → PostToolUse → Stop`, the Stop carrying a
transcript whose last assistant message ends in a question). A/B on the same
instance, same sequence:

| moment | before | after |
|---|---|---|
| turn ends on a question | dot `--accent-green`, no glow | dot `--accent-red` + waiting glow |
| the roster row underneath | "Needs input" + the question | unchanged |
| turn ends with a statement | `--accent-green` | `--accent-green` |

So the dot now tracks the signal rather than contradicting the row below it,
and it still returns to green when the question is answered.

Worth recording for the next dogfood: a bare `Stop` hook is **dropped** — the
completion alarm's turn gate needs evidence the agent worked, so the sequence
above is the minimum that reproduces anything.

## Known consequences, deliberately not fixed here

Surfaced by review; each is a separate decision, not part of "stop the dot
lying":

- **The dot loses its dismiss gesture for question-blocked panes.** Focusing a
  pane clears `surfaceAgentStatus` (that is the app's dismiss gesture); nothing
  clears `surfacePendingQuestion` on focus. A user who reads the question and
  declines to answer now has a red dot with no way to dismiss it until the
  agent emits bytes. Making the question dismissible on focus would change the
  roster too, so it wants its own issue.
- **`countNeedsAttention` still counts only `awaiting_input`/`waiting`**, while
  the roster's `needsAttention` also counts `error`. A dead stashed pane
  therefore renders a red error card in FleetView under a header that says
  "0 need you". The divergence predates this change (it applies to every error
  pane); this makes it easier to hit.
- **The new attention source is less gated than the roster's** — no
  `surfaceAgent` identity gate, no per-surface brain-pty filter. It inherits
  that from the retained-status scan it sits in rather than introducing it.

## Gates

Review team (this session + two independent reviewers) and a dogfood, per the
working agreement. The review caught, among other things, an over-correction I
had already committed: I had replaced a true comment with a false one on an
unverified claim and pinned it with a test of a state the data model forbids
(a browser surface holding a ptyId). Commit 3 reverts that and carries the real
argument instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRxH4qJUX5pkr2DpoHTAX6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pending questions now mark affected sessions as awaiting input across fleet views, sidebars, status indicators, and navigation.
  - Exited stashed sessions now appear as errors with red status indicators instead of neutral grey.
  - Status indicators and roster entries now stay consistent across active, background, and stashed sessions.
  - Whitespace-only or stale pending questions no longer trigger attention states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->