### PR TITLE
feat(mcp): browser_repl — drive many browser steps in one tool call

### DIFF
--- a/changelog.d/1177.md
+++ b/changelog.d/1177.md
@@ -1,0 +1,23 @@
+### Added
+
+- **`browser_repl`: drive the browser through many steps in one tool call.**
+  A snapshot, a `refs.find`, a click, a wait and a text extraction used to cost an
+  agent five round trips, each one re-reading a page of tool output. The new
+  full-profile tool runs a JavaScript snippet instead, where every allowed
+  `browser_X` tool is `await browser.X(args)` with its usual arguments. Snapshot
+  results come back with the refs already parsed, a failed step throws a
+  catchable error, `console.log` is captured, and the run's call ledger (tool,
+  redacted arguments, timing, browser events) is printed with the result so the
+  agent still sees what happened. State survives between calls; a snippet that
+  overruns its timeout has its runtime terminated and the next call starts fresh.
+
+  The snippet runs in a worker thread and every browser step goes through the
+  existing tool handler, so automation leases, password redaction, ref maps and
+  the action trace behind `browser_replay` all behave exactly as they do for
+  direct calls. One thing does change: approving a single `browser_repl` call
+  covers the 21 tools it exposes (navigate, navigate_back, tabs, click, type,
+  fill, press_key, hover, drag, select, scroll, scroll_into_view, snapshot,
+  smart_snapshot, extract_text, extract_data, wait, console, highlight, resize,
+  dialog). Tools with a heavier footprint — `evaluate`, `screenshot`, cookies,
+  storage, downloads, uploads, PDF, tracing, replay and surface lifecycle — stay
+  separate calls. (#1177)

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "db19fc959c10612d3c8dc1a00e9e46c319b22e9db4dfaaba7397264c666919ef",
+      "wireResultSha256": "c52e49c7e4af2c2f98830232b675274da4a77d753a21842da69ead106d40e42d",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",
@@ -42,6 +42,7 @@
         "browser_extract_text",
         "browser_extract_data",
         "browser_replay",
+        "browser_repl",
         "browser_session_start",
         "browser_session_stop",
         "browser_session_status",

--- a/src/mcp/__tests__/workspaceRouting.test.ts
+++ b/src/mcp/__tests__/workspaceRouting.test.ts
@@ -215,6 +215,16 @@ describe('MCP workspace routing (source-level invariants)', () => {
     // inside createWmuxServer — one per broker connection. A module-level ring
     // would let one agent's actions be cut into another agent's saved flow.
     expect(src).toMatch(/const browserToolDeps\s*=[\s\S]{0,200}?actionRing:\s*new ActionRing\(\)/);
+    // Browser tools register through a collecting VIEW of the server so
+    // browser_repl can reach the same handlers; the view must wrap the real
+    // server and nothing else, and browser_repl itself registers on the real
+    // server (it is not a browser handler and must not collect itself).
+    expect(src).toMatch(
+      /const browserServer\s*=\s*collectingServer\(\s*server\s*,\s*browserTools\s*\)/,
+    );
+    expect(src).toMatch(
+      /registerBrowserReplTool\(\s*server\s*,\s*browserTools\s*,\s*MCP_CATALOG_OPTIONS\s*\)/,
+    );
     for (const name of [
       'Navigation',
       'Interaction',
@@ -229,7 +239,7 @@ describe('MCP workspace routing (source-level invariants)', () => {
       expect(allCalls, `${name} tools must be registered exactly once`).toHaveLength(1);
       const strictCalls = src.match(
         new RegExp(
-          `register${name}Tools\\(\\s*server\\s*,\\s*browserToolDeps\\s*(?:,|\\))`,
+          `register${name}Tools\\(\\s*browserServer\\s*,\\s*browserToolDeps\\s*(?:,|\\))`,
           'g',
         ),
       ) ?? [];
@@ -300,7 +310,7 @@ describe('MCP workspace routing (source-level invariants)', () => {
 
   it('browser_wait is wired through the same immutable catalog profile', () => {
     expect(src).toMatch(
-      /registerWaitTools\(\s*server\s*,\s*browserToolDeps\s*,\s*MCP_CATALOG_OPTIONS\s*\)/,
+      /registerWaitTools\(\s*browserServer\s*,\s*browserToolDeps\s*,\s*MCP_CATALOG_OPTIONS\s*\)/,
     );
   });
 });

--- a/src/mcp/broker.ts
+++ b/src/mcp/broker.ts
@@ -34,6 +34,7 @@ import {
 } from './connectionScope';
 import type { PlaywrightEngine } from './playwright/PlaywrightEngine';
 import { disposeReplRegistry, setReplBrokerMode } from './repl/replRegistry';
+import { disposeBrowserRepl } from './browser-repl/tool';
 
 interface ShimHandshake {
   wmuxShim: number;
@@ -143,6 +144,9 @@ async function hostConnection(socket: net.Socket, handshake: ShimHandshake): Pro
         // self-exit when their IPC channel closes, which is what covers the case
         // this handler cannot — the broker being killed outright.
         disposeReplRegistry();
+        // And this caller's browser_repl worker, which holds script globals
+        // the same way a REPL child does.
+        disposeBrowserRepl();
         // Close the per-connection McpServer too — without this, repeated shim
         // reconnects accumulate server instances in the broker process.
         void server.close().catch(() => { /* best-effort */ });

--- a/src/mcp/broker.ts
+++ b/src/mcp/broker.ts
@@ -34,7 +34,7 @@ import {
 } from './connectionScope';
 import type { PlaywrightEngine } from './playwright/PlaywrightEngine';
 import { disposeReplRegistry, setReplBrokerMode } from './repl/replRegistry';
-import { disposeBrowserRepl } from './browser-repl/tool';
+import { disposeBrowserRepl, setBrowserReplBrokerMode } from './browser-repl/tool';
 
 interface ShimHandshake {
   wmuxShim: number;
@@ -174,6 +174,7 @@ function main(): void {
   // This process hosts many agents at once, so a REPL call that arrives without
   // a connection scope must fail rather than fall back to a shared registry.
   setReplBrokerMode();
+  setBrowserReplBrokerMode();
   const expectedToken = readAuthToken();
   if (!expectedToken) {
     console.error('[wmux-mcp-broker] auth token not found; refusing to serve. Is wmux running?');

--- a/src/mcp/browser-repl/BrowserReplSession.ts
+++ b/src/mcp/browser-repl/BrowserReplSession.ts
@@ -11,7 +11,9 @@
  * loop, and it costs the script's state; the outcome says so and the next run
  * starts a fresh worker. Handler calls still in flight when the worker dies
  * run to completion (a half-finished click is worse than a finished one) and
- * their results are dropped.
+ * their results are dropped — but the next run waits for them to land first,
+ * or the dead run's late click would slip between the new run's snapshot and
+ * its own click, which is exactly the interleaving the queue exists to stop.
  */
 import { Worker } from 'worker_threads';
 import { OutputBuffer, truncateText, type TruncatedText } from '../repl/truncate';
@@ -20,6 +22,8 @@ import { BROWSER_REPL_WORKER_SOURCE } from './workerSource';
 
 export const CONSOLE_CAP_BYTES = 32 * 1024;
 export const RESULT_CAP_BYTES = 16 * 1024;
+/** Ledger lines kept per run; a snapshot loop must not turn the result into megabytes. */
+export const LEDGER_MAX_LINES = 200;
 /** Worker startup is local and fast; anything slower is a broken runtime. */
 const READY_TIMEOUT_MS = 10_000;
 
@@ -60,6 +64,10 @@ export class BrowserReplSession {
   private disposed = false;
   private lastUsedAt = Date.now();
   private runsInFlight = 0;
+  /** Handler calls started by a run that is over (timed out or crashed). */
+  private readonly straggling = new Set<Promise<unknown>>();
+  /** Id of the run currently executing, if any; stray calls outside it are refused. */
+  private activeRunId: number | null = null;
 
   constructor(private readonly tools: readonly string[]) {}
 
@@ -83,7 +91,13 @@ export class BrowserReplSession {
       () => this.execute(code, timeoutMs, bridge),
       () => this.execute(code, timeoutMs, bridge),
     );
-    this.tail = next.finally(() => {
+    // The caller gets `next` with its rejection intact; the chain itself must
+    // swallow it, or a rejected last run is an unhandled rejection that takes
+    // the whole server process down.
+    this.tail = next.then(
+      () => undefined,
+      () => undefined,
+    ).finally(() => {
       this.runsInFlight--;
       this.lastUsedAt = Date.now();
     });
@@ -116,6 +130,18 @@ export class BrowserReplSession {
       stderr: true,
     });
     this.worker = worker;
+    // Nothing reads these; an unconsumed pipe just buffers whatever a snippet
+    // writes to process.stdout directly.
+    worker.stdout.resume();
+    worker.stderr.resume();
+    // Between runs no run-scoped listener is attached, so a worker that dies
+    // then would be found only by the next run's timeout. Notice it now and
+    // let that run start a fresh worker instead.
+    const onIdleDeath = (reason: string) => {
+      if (this.activeRunId === null && this.worker === worker) this.killWorker(reason);
+    };
+    worker.on('error', (err) => onIdleDeath(`crashed between runs: ${err.message}`));
+    worker.on('exit', (code) => onIdleDeath(`exited between runs (code ${code})`));
     this.ready = new Promise<void>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error('browser_repl worker did not start')), READY_TIMEOUT_MS);
       const onMessage = (msg: WorkerMessage) => {
@@ -132,6 +158,20 @@ export class BrowserReplSession {
       });
       worker.postMessage({ type: 'init', tools: this.tools });
     });
+    // A `browser.*` call that arrives with no run active — a setTimeout or an
+    // un-awaited promise left behind by the previous run — gets an immediate
+    // refusal instead of silence: no listener would otherwise answer it, the
+    // worker-side promise would hang forever, and the browser must not be
+    // driven by code whose run already reported back.
+    worker.on('message', (msg: WorkerMessage) => {
+      if (this.activeRunId !== null || msg?.type !== 'call' || this.worker !== worker) return;
+      worker.postMessage({
+        type: 'callResult',
+        callId: msg.callId,
+        ok: false,
+        error: `browser.${typeof msg.name === 'string' ? msg.name : '?'}: called after its browser_repl run finished — await every browser call inside the run`,
+      });
+    });
     return { worker, ready: this.ready, fresh: true };
   }
 
@@ -139,6 +179,11 @@ export class BrowserReplSession {
     if (this.disposed) throw new Error('browser_repl session is disposed');
     const started = Date.now();
     const ledger: string[] = [];
+    let elidedCalls = 0;
+    const record = (line: string) => {
+      if (ledger.length < LEDGER_MAX_LINES) ledger.push(line);
+      else elidedCalls++;
+    };
     const consoleBuf = new OutputBuffer(CONSOLE_CAP_BYTES);
     const previousDeath = this.previousDeath;
     this.previousDeath = undefined;
@@ -159,17 +204,28 @@ export class BrowserReplSession {
       };
     }
 
+    // Let a dead run's in-flight handler calls land before this run touches
+    // the page. They cannot be cancelled, only waited for.
+    if (this.straggling.size > 0) await Promise.allSettled([...this.straggling]);
+
     const id = this.nextRunId++;
+    const inFlight = new Set<Promise<unknown>>();
 
     return new Promise<BrowserReplRunOutcome>((resolve) => {
       let settled = false;
       const finish = (outcome: Omit<BrowserReplRunOutcome, 'ledger' | 'freshRuntime' | 'previousDeath' | 'elapsedMs' | 'console'>) => {
         if (settled) return;
         settled = true;
+        this.activeRunId = null;
         clearTimeout(timer);
         worker.off('message', onMessage);
         worker.off('error', onError);
         worker.off('exit', onExit);
+        for (const pending of inFlight) {
+          this.straggling.add(pending);
+          void pending.finally(() => this.straggling.delete(pending));
+        }
+        if (elidedCalls > 0) ledger.push(`(${elidedCalls} more call(s) not shown)`);
         resolve({ ...base, ...outcome, elapsedMs: Date.now() - started, console: consoleBuf.render() });
       };
 
@@ -192,17 +248,27 @@ export class BrowserReplSession {
             const callId = msg.callId;
             const name = typeof msg.name === 'string' ? msg.name : '';
             const args = msg.args && typeof msg.args === 'object' ? msg.args : {};
-            void bridge(name, args).then((outcome) => {
-              ledger.push(outcome.ledger);
+            const reply = (message: Record<string, unknown>) => {
               // After a timeout the worker is gone; the handler ran to
               // completion for the page's sake and the reply has nowhere to go.
               if (settled || this.worker !== worker) return;
-              worker.postMessage(
-                outcome.ok
-                  ? { type: 'callResult', callId, ok: true, value: outcome.value }
-                  : { type: 'callResult', callId, ok: false, error: outcome.error },
-              );
-            });
+              worker.postMessage({ type: 'callResult', callId, ...message });
+            };
+            const pending = bridge(name, args).then(
+              (outcome) => {
+                record(outcome.ledger);
+                reply(outcome.ok ? { ok: true, value: outcome.value } : { ok: false, error: outcome.error });
+              },
+              // The bridge reports handler failures as outcomes; a rejection here
+              // is a bug in the bridge itself. Still answer, or the script hangs.
+              (error: unknown) => {
+                const message = error instanceof Error ? error.message : String(error);
+                record(`${name}(…) THREW ${message}`);
+                reply({ ok: false, error: `browser.${name}: bridge failure: ${message}` });
+              },
+            );
+            inFlight.add(pending);
+            void pending.finally(() => inFlight.delete(pending));
             return;
           }
           case 'result':
@@ -234,6 +300,7 @@ export class BrowserReplSession {
       worker.on('message', onMessage);
       worker.on('error', onError);
       worker.on('exit', onExit);
+      this.activeRunId = id;
       worker.postMessage({ type: 'run', id, code });
     });
   }

--- a/src/mcp/browser-repl/BrowserReplSession.ts
+++ b/src/mcp/browser-repl/BrowserReplSession.ts
@@ -30,8 +30,10 @@ const READY_TIMEOUT_MS = 10_000;
 export interface BrowserReplRunOutcome {
   readonly ok: boolean;
   readonly elapsedMs: number;
-  /** One line per `browser.*` call, in order, including refused/failed ones. */
+  /** One line per `browser.*` call, in order, including refused/failed ones; capped at LEDGER_MAX_LINES. */
   readonly ledger: readonly string[];
+  /** Every `browser.*` call the run made, including the ones the ledger elided. */
+  readonly callCount: number;
   readonly console: TruncatedText;
   readonly result?: TruncatedText;
   readonly error?: string;
@@ -179,41 +181,62 @@ export class BrowserReplSession {
     if (this.disposed) throw new Error('browser_repl session is disposed');
     const started = Date.now();
     const ledger: string[] = [];
-    let elidedCalls = 0;
+    let callCount = 0;
     const record = (line: string) => {
+      callCount++;
       if (ledger.length < LEDGER_MAX_LINES) ledger.push(line);
-      else elidedCalls++;
     };
     const consoleBuf = new OutputBuffer(CONSOLE_CAP_BYTES);
     const previousDeath = this.previousDeath;
     this.previousDeath = undefined;
     const { worker, ready, fresh } = this.ensureWorker();
     const base = { ledger, freshRuntime: fresh, previousDeath: fresh ? previousDeath : undefined };
+    const abort = (error: string) => ({
+      ...base,
+      callCount,
+      ok: false,
+      elapsedMs: Date.now() - started,
+      console: consoleBuf.render(),
+      error,
+      timedOut: false,
+    });
 
     try {
       await ready;
     } catch (error) {
       this.killWorker('failed to start');
-      return {
-        ...base,
-        ok: false,
-        elapsedMs: Date.now() - started,
-        console: consoleBuf.render(),
-        error: `browser_repl runtime failed to start: ${error instanceof Error ? error.message : String(error)}`,
-        timedOut: false,
-      };
+      return abort(`browser_repl runtime failed to start: ${error instanceof Error ? error.message : String(error)}`);
     }
 
     // Let a dead run's in-flight handler calls land before this run touches
-    // the page. They cannot be cancelled, only waited for.
-    if (this.straggling.size > 0) await Promise.allSettled([...this.straggling]);
+    // the page. They cannot be cancelled, only waited for — but not past this
+    // run's own deadline, or a handler that never settles pins every later
+    // run on this connection.
+    if (this.straggling.size > 0) {
+      let waitTimer: NodeJS.Timeout | undefined;
+      const landed = await Promise.race([
+        Promise.allSettled([...this.straggling]).then(() => true),
+        new Promise<boolean>((resolve) => {
+          waitTimer = setTimeout(() => resolve(false), timeoutMs);
+        }),
+      ]);
+      clearTimeout(waitTimer);
+      if (!landed) {
+        return abort(
+          `a browser call started by the previous (killed) run is still running after ${timeoutMs}ms; ` +
+            'this run did not start — retry once it finishes',
+        );
+      }
+    }
 
     const id = this.nextRunId++;
     const inFlight = new Set<Promise<unknown>>();
 
     return new Promise<BrowserReplRunOutcome>((resolve) => {
       let settled = false;
-      const finish = (outcome: Omit<BrowserReplRunOutcome, 'ledger' | 'freshRuntime' | 'previousDeath' | 'elapsedMs' | 'console'>) => {
+      const finish = (
+        outcome: Omit<BrowserReplRunOutcome, 'ledger' | 'callCount' | 'freshRuntime' | 'previousDeath' | 'elapsedMs' | 'console'>,
+      ) => {
         if (settled) return;
         settled = true;
         this.activeRunId = null;
@@ -225,8 +248,7 @@ export class BrowserReplSession {
           this.straggling.add(pending);
           void pending.finally(() => this.straggling.delete(pending));
         }
-        if (elidedCalls > 0) ledger.push(`(${elidedCalls} more call(s) not shown)`);
-        resolve({ ...base, ...outcome, elapsedMs: Date.now() - started, console: consoleBuf.render() });
+        resolve({ ...base, ...outcome, callCount, elapsedMs: Date.now() - started, console: consoleBuf.render() });
       };
 
       const timer = setTimeout(() => {

--- a/src/mcp/browser-repl/BrowserReplSession.ts
+++ b/src/mcp/browser-repl/BrowserReplSession.ts
@@ -1,0 +1,240 @@
+/**
+ * One `browser_repl` runtime per MCP connection: a worker thread that holds
+ * the script's globals between calls, plus the run queue in front of it.
+ *
+ * Runs are serialized. Two concurrent `browser_repl` calls on one connection
+ * would otherwise interleave their `browser.*` calls on the same page — each
+ * script's snapshot invalidated by the other's clicks — with nothing in either
+ * result to show it happened.
+ *
+ * A timeout terminates the worker. That is the only way to stop a synchronous
+ * loop, and it costs the script's state; the outcome says so and the next run
+ * starts a fresh worker. Handler calls still in flight when the worker dies
+ * run to completion (a half-finished click is worse than a finished one) and
+ * their results are dropped.
+ */
+import { Worker } from 'worker_threads';
+import { OutputBuffer, truncateText, type TruncatedText } from '../repl/truncate';
+import type { BridgeCall } from './bridge';
+import { BROWSER_REPL_WORKER_SOURCE } from './workerSource';
+
+export const CONSOLE_CAP_BYTES = 32 * 1024;
+export const RESULT_CAP_BYTES = 16 * 1024;
+/** Worker startup is local and fast; anything slower is a broken runtime. */
+const READY_TIMEOUT_MS = 10_000;
+
+export interface BrowserReplRunOutcome {
+  readonly ok: boolean;
+  readonly elapsedMs: number;
+  /** One line per `browser.*` call, in order, including refused/failed ones. */
+  readonly ledger: readonly string[];
+  readonly console: TruncatedText;
+  readonly result?: TruncatedText;
+  readonly error?: string;
+  /** True when the run was killed by the deadline; the worker is gone. */
+  readonly timedOut: boolean;
+  /** True when this run started a new worker (first run, or after a timeout/crash). */
+  readonly freshRuntime: boolean;
+  /** Why the previous worker was gone, when this run had to start a new one. */
+  readonly previousDeath?: string;
+}
+
+interface WorkerMessage {
+  type: string;
+  id?: number;
+  callId?: number;
+  name?: string;
+  args?: Record<string, unknown>;
+  ok?: boolean;
+  result?: string;
+  error?: string;
+  text?: string;
+}
+
+export class BrowserReplSession {
+  private worker: Worker | null = null;
+  private ready: Promise<void> | null = null;
+  private previousDeath: string | undefined;
+  private tail: Promise<unknown> = Promise.resolve();
+  private nextRunId = 1;
+  private disposed = false;
+  private lastUsedAt = Date.now();
+  private runsInFlight = 0;
+
+  constructor(private readonly tools: readonly string[]) {}
+
+  get lastUsed(): number {
+    return this.lastUsedAt;
+  }
+
+  get busy(): boolean {
+    return this.runsInFlight > 0;
+  }
+
+  /**
+   * Queue a run; resolves when it and every run queued before it are done.
+   * `bridge` is per run because the call's surfaceId default and captured
+   * connection scope belong to that call, not to the session.
+   */
+  run(code: string, timeoutMs: number, bridge: BridgeCall): Promise<BrowserReplRunOutcome> {
+    if (this.disposed) return Promise.reject(new Error('browser_repl session is disposed'));
+    this.runsInFlight++;
+    const next = this.tail.then(
+      () => this.execute(code, timeoutMs, bridge),
+      () => this.execute(code, timeoutMs, bridge),
+    );
+    this.tail = next.finally(() => {
+      this.runsInFlight--;
+      this.lastUsedAt = Date.now();
+    });
+    return next;
+  }
+
+  /** Kill the worker; queued runs reject. Idempotent. */
+  dispose(): void {
+    this.disposed = true;
+    this.killWorker('disposed');
+  }
+
+  private killWorker(reason: string): void {
+    const worker = this.worker;
+    this.worker = null;
+    this.ready = null;
+    if (worker) {
+      this.previousDeath = reason;
+      worker.removeAllListeners();
+      void worker.terminate().catch(() => { /* already gone */ });
+    }
+  }
+
+  private ensureWorker(): { worker: Worker; ready: Promise<void>; fresh: boolean } {
+    if (this.worker && this.ready) return { worker: this.worker, ready: this.ready, fresh: false };
+    const worker = new Worker(BROWSER_REPL_WORKER_SOURCE, {
+      eval: true,
+      // The worker never touches stdio; captured console travels as messages.
+      stdout: true,
+      stderr: true,
+    });
+    this.worker = worker;
+    this.ready = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('browser_repl worker did not start')), READY_TIMEOUT_MS);
+      const onMessage = (msg: WorkerMessage) => {
+        if (msg?.type === 'ready') {
+          clearTimeout(timer);
+          worker.off('message', onMessage);
+          resolve();
+        }
+      };
+      worker.on('message', onMessage);
+      worker.once('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      worker.postMessage({ type: 'init', tools: this.tools });
+    });
+    return { worker, ready: this.ready, fresh: true };
+  }
+
+  private async execute(code: string, timeoutMs: number, bridge: BridgeCall): Promise<BrowserReplRunOutcome> {
+    if (this.disposed) throw new Error('browser_repl session is disposed');
+    const started = Date.now();
+    const ledger: string[] = [];
+    const consoleBuf = new OutputBuffer(CONSOLE_CAP_BYTES);
+    const previousDeath = this.previousDeath;
+    this.previousDeath = undefined;
+    const { worker, ready, fresh } = this.ensureWorker();
+    const base = { ledger, freshRuntime: fresh, previousDeath: fresh ? previousDeath : undefined };
+
+    try {
+      await ready;
+    } catch (error) {
+      this.killWorker('failed to start');
+      return {
+        ...base,
+        ok: false,
+        elapsedMs: Date.now() - started,
+        console: consoleBuf.render(),
+        error: `browser_repl runtime failed to start: ${error instanceof Error ? error.message : String(error)}`,
+        timedOut: false,
+      };
+    }
+
+    const id = this.nextRunId++;
+
+    return new Promise<BrowserReplRunOutcome>((resolve) => {
+      let settled = false;
+      const finish = (outcome: Omit<BrowserReplRunOutcome, 'ledger' | 'freshRuntime' | 'previousDeath' | 'elapsedMs' | 'console'>) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        worker.off('message', onMessage);
+        worker.off('error', onError);
+        worker.off('exit', onExit);
+        resolve({ ...base, ...outcome, elapsedMs: Date.now() - started, console: consoleBuf.render() });
+      };
+
+      const timer = setTimeout(() => {
+        this.killWorker(`stopped by the ${timeoutMs}ms timeout`);
+        finish({
+          ok: false,
+          error: `the code was stopped by the ${timeoutMs}ms timeout`,
+          timedOut: true,
+        });
+      }, timeoutMs);
+
+      const onMessage = (msg: WorkerMessage) => {
+        if (!msg || typeof msg !== 'object') return;
+        switch (msg.type) {
+          case 'console':
+            if (typeof msg.text === 'string') consoleBuf.append(Buffer.from(msg.text, 'utf8'));
+            return;
+          case 'call': {
+            const callId = msg.callId;
+            const name = typeof msg.name === 'string' ? msg.name : '';
+            const args = msg.args && typeof msg.args === 'object' ? msg.args : {};
+            void bridge(name, args).then((outcome) => {
+              ledger.push(outcome.ledger);
+              // After a timeout the worker is gone; the handler ran to
+              // completion for the page's sake and the reply has nowhere to go.
+              if (settled || this.worker !== worker) return;
+              worker.postMessage(
+                outcome.ok
+                  ? { type: 'callResult', callId, ok: true, value: outcome.value }
+                  : { type: 'callResult', callId, ok: false, error: outcome.error },
+              );
+            });
+            return;
+          }
+          case 'result':
+            if (msg.id !== id) return;
+            if (msg.ok) {
+              finish({
+                ok: true,
+                result: truncateText(typeof msg.result === 'string' ? msg.result : '', RESULT_CAP_BYTES),
+                timedOut: false,
+              });
+            } else {
+              finish({ ok: false, error: typeof msg.error === 'string' ? msg.error : 'unknown error', timedOut: false });
+            }
+            return;
+          default:
+            return;
+        }
+      };
+      const onError = (err: Error) => {
+        this.killWorker(`crashed: ${err.message}`);
+        finish({ ok: false, error: `browser_repl runtime crashed: ${err.message}`, timedOut: false });
+      };
+      const onExit = (exitCode: number) => {
+        if (settled) return;
+        this.killWorker(`exited with code ${exitCode}`);
+        finish({ ok: false, error: `browser_repl runtime exited (code ${exitCode})`, timedOut: false });
+      };
+
+      worker.on('message', onMessage);
+      worker.on('error', onError);
+      worker.on('exit', onExit);
+      worker.postMessage({ type: 'run', id, code });
+    });
+  }
+}

--- a/src/mcp/browser-repl/__tests__/browserRepl.catalog.test.ts
+++ b/src/mcp/browser-repl/__tests__/browserRepl.catalog.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  expectCommanderCatalogLockstep,
+  expectCoreCatalogLockstep,
+  expectFrozenCatalog,
+} from '../../__tests__/catalogAssertions';
+import { BROWSER_REPL_TOOLS } from '../bridge';
+import { createBrowserReplCatalog } from '../tool';
+
+describe('browser_repl catalog', () => {
+  const catalog = createBrowserReplCatalog(new Map());
+
+  it('registers exactly browser_repl, full profile only, frozen', () => {
+    expect(catalog.map((spec) => spec.name)).toEqual(['browser_repl']);
+    expectFrozenCatalog(catalog);
+    expectCommanderCatalogLockstep(catalog);
+    expectCoreCatalogLockstep(catalog);
+    // The browser_ prefix is excluded from core by derivation; the commander
+    // has no browser hands. Saying so in the spec keeps the probe honest.
+    expect(catalog[0].profiles).toEqual(['full']);
+  });
+
+  it('names the permission boundary it moves: every allowed tool, and that the rest stay separate', () => {
+    const description = catalog[0].description;
+    for (const name of BROWSER_REPL_TOOLS) expect(description).toContain(name);
+    expect(description).toContain('Other browser_* tools stay separate calls');
+    // Evaluate is the one an agent would most expect; it must be absent.
+    expect(BROWSER_REPL_TOOLS).not.toContain('evaluate');
+    expect(BROWSER_REPL_TOOLS).not.toContain('screenshot');
+    expect(BROWSER_REPL_TOOLS).not.toContain('replay');
+  });
+
+  it('stays under the tools/list budget it was squeezed into', () => {
+    // The full profile has ~3.3KB of headroom; the spec's description plus
+    // schema text is what tools/list serializes.
+    const bytes = Buffer.byteLength(JSON.stringify(catalog[0].description), 'utf8');
+    expect(bytes).toBeLessThan(1200);
+  });
+});

--- a/src/mcp/browser-repl/__tests__/browserRepl.test.ts
+++ b/src/mcp/browser-repl/__tests__/browserRepl.test.ts
@@ -200,8 +200,22 @@ describe('browser_repl bridge', () => {
   });
 
   it('never shows typed text in the ledger and masks password query params', () => {
-    expect(summarizeArgs({ ref: '3', text: 'hunter2', value: 'x' })).toBe('ref:"3", text:"…"(7), value:"…"(1)');
+    expect(summarizeArgs({ ref: '3', text: 'hunter2', value: 'x' })).toBe('ref:"3", text:"…(7)", value:"…(1)"');
     expect(summarizeArgs({ url: 'https://h/?password=abc' })).not.toContain('abc');
+    // browser_fill nests the typed values one level down.
+    const fill = summarizeArgs({ fields: [{ ref: '1', value: 'hunter2' }, { ref: '2', value: 'me@x' }] });
+    expect(fill).toBe('fields:[{"ref":"1","value":"…(7)"},{"ref":"2","value":"…(4)"}]');
+  });
+
+  it('does not mistake page text for a lease block', () => {
+    const decoy = '[browser events]\n- this is prose, not an event line';
+    expect(shapeResult(ok(decoy), 'extract_text')).toEqual({ text: decoy, events: [] });
+    // Hints only ever precede the body; the same prefix inside the body stays body.
+    const shaped = shapeResult(
+      { content: [{ type: 'text', text: 'Body' }, { type: 'text', text: '[replay] literal in page' }] },
+      'extract_text',
+    );
+    expect(shaped.text).toBe('Body\n[replay] literal in page');
   });
 });
 
@@ -321,6 +335,81 @@ describe('browser_repl session', () => {
     expect(out.result?.text).toBe('7');
     session.dispose();
     await expect(session.run('1', 1000, bridge)).rejects.toThrow('disposed');
+  });
+
+  it('refuses browser calls that arrive after their run finished', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    // The un-awaited call fires after this run has reported back.
+    await session.run(
+      'globalThis.late = new Promise((r) => setTimeout(() => browser.click({ ref: "x" }).then(() => r("ran"), (e) => r(e.message)), 20)); 0',
+      10_000,
+      bridge,
+    );
+    await new Promise((r) => setTimeout(r, 80));
+    const out = await session.run('await globalThis.late', 10_000, bridge);
+    expect(out.result?.text).toContain('called after its browser_repl run finished');
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('lets a killed run\'s in-flight handler land before the next run touches the page', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run('await browser.wait({ ms: 400 }); await browser.click({ ref: "dead" });', 100, bridge);
+    expect(out.timedOut).toBe(true);
+    const next = await session.run('await browser.click({ ref: "next" }); 1', 10_000, bridge);
+    expect(next.ok).toBe(true);
+    // wait finished (and its late click never happened: the worker is gone), then the new run's click.
+    expect(h.calls.map((c) => `${c.name}:${String(c.args.ref ?? '')}`)).toEqual(['wait:', 'click:next']);
+  });
+
+  it('answers a bridge rejection as a tool error instead of hanging the script', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const broken = async (name: string, args: Record<string, unknown>) => {
+      if (name === 'click') throw new Error('bridge exploded');
+      return bridge(name, args);
+    };
+    const session = newSession();
+    const out = await session.run('let why;\ntry { await browser.click({ ref: "1" }) } catch (e) { why = e.message }\nwhy', 10_000, broken);
+    expect(out.ok).toBe(true);
+    expect(out.result?.text).toContain('bridge failure: bridge exploded');
+    expect(out.ledger[0]).toBe('click(…) THREW bridge exploded');
+  });
+
+  it('caps the ledger and says how many calls were elided', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run('for (let i = 0; i < 205; i++) await browser.extract_text(); 1', 10_000, bridge);
+    expect(out.ok).toBe(true);
+    expect(out.ledger).toHaveLength(201);
+    expect(out.ledger[200]).toBe('(5 more call(s) not shown)');
+  });
+
+  it('explains a redeclared top-level binding instead of a bare SyntaxError', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    await session.run('let twice = 1;', 10_000, bridge);
+    const out = await session.run('let twice = 2;', 10_000, bridge);
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain('has already been declared');
+    expect(out.error).toContain('assign to globalThis');
+  });
+
+  it('recovers from a worker that died between runs', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    await session.run('setTimeout(() => process.exit(3), 10); 1', 10_000, bridge);
+    await new Promise((r) => setTimeout(r, 150));
+    const out = await session.run('1', 10_000, bridge);
+    expect(out.ok).toBe(true);
+    expect(out.freshRuntime).toBe(true);
+    expect(out.previousDeath).toContain('between runs');
   });
 });
 

--- a/src/mcp/browser-repl/__tests__/browserRepl.test.ts
+++ b/src/mcp/browser-repl/__tests__/browserRepl.test.ts
@@ -1,0 +1,355 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CollectedTool } from '../../playwright/toolCollector';
+import {
+  createConnectionScope,
+  getConnectionScope,
+  runInConnectionScope,
+  type ConnectionScope,
+} from '../../connectionScope';
+import {
+  BROWSER_REPL_TOOLS,
+  createBrowserBridge,
+  parseSnapshotRefs,
+  shapeResult,
+  summarizeArgs,
+} from '../bridge';
+import { BrowserReplSession } from '../BrowserReplSession';
+import { formatBrowserReplOutcome } from '../tool';
+
+function ok(text: string, extraBlocks: string[] = []): CallToolResult {
+  return {
+    content: [
+      ...extraBlocks.map((t) => ({ type: 'text' as const, text: t })),
+      { type: 'text' as const, text },
+    ],
+  };
+}
+
+function fail(text: string): CallToolResult {
+  return { content: [{ type: 'text' as const, text }], isError: true };
+}
+
+const SNAPSHOT_TEXT = [
+  '[snapshot: full]',
+  '- document "Home"',
+  '  - link "Log in" ref="3"',
+  '  - button "Search" focused ref="7"',
+  '  - textbox "Email" ref="9" value="a@b"',
+  '  - StaticText "no ref here"',
+].join('\n');
+
+const SMART_TEXT = [
+  'Interactive elements (2):',
+  '  [1] link "Log in"',
+  '  [2] button "Search" - primary action',
+  '',
+  'Page text:',
+  'Welcome',
+].join('\n');
+
+const SMART_DOM_TEXT = ['  [ref=4] a "Log in"', '  [ref=5] input[type=submit] "Go"'].join('\n');
+
+interface Harness {
+  tools: Map<string, CollectedTool>;
+  calls: Array<{ name: string; args: Record<string, unknown>; scope: ConnectionScope | undefined }>;
+}
+
+function harness(overrides: Partial<Record<string, (args: Record<string, unknown>) => Promise<CallToolResult>>> = {}): Harness {
+  const calls: Harness['calls'] = [];
+  const tools = new Map<string, CollectedTool>();
+  const add = (
+    short: string,
+    shape: z.ZodRawShape,
+    impl: (args: Record<string, unknown>) => Promise<CallToolResult>,
+  ) => {
+    tools.set(`browser_${short}`, {
+      name: `browser_${short}`,
+      shape,
+      handler: async (args) => {
+        calls.push({ name: short, args, scope: getConnectionScope() });
+        return (overrides[short] ?? impl)(args);
+      },
+    });
+  };
+  add('navigate', { url: z.string().url(), surfaceId: z.string().optional() }, async (a) => ok(`Navigated to ${String(a.url)}`));
+  add('click', { ref: z.string().optional(), smartRef: z.number().optional(), surfaceId: z.string().optional() }, async (a) =>
+    ok(`Clicked ${String(a.ref ?? a.smartRef)}`),
+  );
+  add('type', { ref: z.string(), text: z.string() }, async () => ok('Typed'));
+  add('snapshot', { full: z.boolean().optional(), surfaceId: z.string().optional() }, async () => ok(SNAPSHOT_TEXT));
+  add('smart_snapshot', { full: z.boolean().optional() }, async () => ok(SMART_TEXT));
+  add('extract_text', { surfaceId: z.string().optional() }, async () => ok('Hello world'));
+  add('wait', { ms: z.number().optional() }, async (a) => {
+    await new Promise((r) => setTimeout(r, Number(a.ms ?? 0)));
+    return ok('waited');
+  });
+  add('cookies', { action: z.string() }, async () => ok('cookies'));
+  return { tools, calls };
+}
+
+const sessions: BrowserReplSession[] = [];
+function newSession(): BrowserReplSession {
+  const s = new BrowserReplSession(BROWSER_REPL_TOOLS);
+  sessions.push(s);
+  return s;
+}
+afterEach(() => {
+  for (const s of sessions.splice(0)) s.dispose();
+});
+
+describe('browser_repl bridge', () => {
+  it('refuses tools outside the whitelist, naming the direct tool when it exists', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const cookies = await bridge('cookies', { action: 'get' });
+    expect(cookies.ok).toBe(false);
+    if (!cookies.ok) expect(cookies.error).toContain('call the browser_cookies tool directly');
+    const bogus = await bridge('teleport', {});
+    expect(bogus.ok).toBe(false);
+    if (!bogus.ok) expect(bogus.error).toContain('not a browser tool');
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('re-validates arguments with the tool schema before calling the handler', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const out = await bridge('navigate', { url: 'not a url' });
+    expect(out.ok).toBe(false);
+    if (!out.ok) expect(out.error).toMatch(/browser\.navigate: invalid arguments — url:/);
+    expect(out.ledger).toContain('INVALID');
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('injects the surfaceId default only where the schema accepts it and the call omits it', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, { surfaceId: 'surf-1' });
+    await bridge('navigate', { url: 'https://example.com' });
+    await bridge('navigate', { url: 'https://example.com', surfaceId: 'surf-2' });
+    await bridge('type', { ref: '3', text: 'hi' });
+    expect(h.calls.map((c) => c.args.surfaceId)).toEqual(['surf-1', 'surf-2', undefined]);
+  });
+
+  it('defaults snapshot tools to full:true and parses refs for both listing formats', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const snap = await bridge('snapshot', {});
+    expect(h.calls[0].args.full).toBe(true);
+    expect(snap.ok && snap.value.refs).toEqual([
+      { ref: 3, param: 'ref', role: 'link', name: 'Log in' },
+      { ref: 7, param: 'ref', role: 'button', name: 'Search' },
+      { ref: 9, param: 'ref', role: 'textbox', name: 'Email' },
+    ]);
+    const smart = await bridge('smart_snapshot', { full: false });
+    expect(h.calls[1].args.full).toBe(false);
+    expect(smart.ok && smart.value.refs).toEqual([
+      { ref: 1, param: 'smartRef', role: 'link', name: 'Log in' },
+      { ref: 2, param: 'smartRef', role: 'button', name: 'Search' },
+    ]);
+    expect(parseSnapshotRefs(SMART_DOM_TEXT, 'smart_snapshot')).toEqual([
+      { ref: 4, param: 'smartRef', role: 'a', name: 'Log in' },
+      { ref: 5, param: 'smartRef', role: 'input', name: 'Go' },
+    ]);
+    expect(parseSnapshotRefs('garbage', 'snapshot')).toEqual([]);
+  });
+
+  it('splits lease event blocks into events, drops replay hints, keeps the body', () => {
+    const shaped = shapeResult(
+      ok('Navigated to https://x', [
+        '[browser events]\n- navigated: https://x (2s ago)\n- dialog: closed (1s ago)\n',
+        '[skill] login — 3 steps — browser_replay {action:"run", name:"login"}\n[replay] 1 recorded flow(s) for this page: login — x',
+      ]),
+      'navigate',
+    );
+    expect(shaped).toEqual({
+      text: 'Navigated to https://x',
+      events: ['navigated: https://x (2s ago)', 'dialog: closed (1s ago)'],
+    });
+    // An image block is noted, never handed to the script.
+    const img = shapeResult({ content: [{ type: 'image', data: 'AAAA', mimeType: 'image/png' }] }, 'click');
+    expect(img.text).toBe('[image content omitted]');
+  });
+
+  it('turns an isError result into a failed outcome carrying the tool text, not the event block', async () => {
+    const h = harness({
+      click: async () => ({
+        content: [
+          { type: 'text', text: '[browser events]\n- navigated: x (1s ago)\n' },
+          { type: 'text', text: 'ref=3 is stale' },
+        ],
+        isError: true,
+      }),
+    });
+    const bridge = createBrowserBridge(h.tools, {});
+    const out = await bridge('click', { ref: '3' });
+    expect(out).toMatchObject({ ok: false, error: 'browser.click: ref=3 is stale' });
+    expect(out.ledger).toMatch(/^click\(ref:"3"\) FAILED \d+ms$/);
+  });
+
+  it('re-enters the captured connection scope for every handler call', async () => {
+    const h = harness();
+    const scope = createConnectionScope();
+    const bridge = createBrowserBridge(h.tools, { scope });
+    await bridge('extract_text', {});
+    expect(h.calls[0].scope).toBe(scope);
+    // Without a captured scope, the handler runs in whatever is ambient.
+    const ambient = createBrowserBridge(h.tools, {});
+    await runInConnectionScope(scope, () => ambient('extract_text', {}));
+    expect(h.calls[1].scope).toBe(scope);
+  });
+
+  it('never shows typed text in the ledger and masks password query params', () => {
+    expect(summarizeArgs({ ref: '3', text: 'hunter2', value: 'x' })).toBe('ref:"3", text:"…"(7), value:"…"(1)');
+    expect(summarizeArgs({ url: 'https://h/?password=abc' })).not.toContain('abc');
+  });
+});
+
+describe('browser_repl session', () => {
+  it('folds several browser steps into one run and keeps a ledger', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run(
+      [
+        'const snap = await browser.snapshot();',
+        'const login = snap.refs.find((r) => r.name === "Log in");',
+        'await browser.click({ [login.param]: String(login.ref) });',
+        'console.log("clicked", login.ref);',
+        'const t = await browser.extract_text();',
+        't.text',
+      ].join('\n'),
+      10_000,
+      bridge,
+    );
+    expect(out.ok).toBe(true);
+    expect(out.result?.text).toBe('Hello world');
+    expect(out.console.text).toBe('clicked 3\n');
+    expect(out.ledger).toHaveLength(3);
+    expect(out.ledger[0]).toMatch(/^snapshot\(full:true\) ok \d+ms$/);
+    expect(out.ledger[1]).toMatch(/^click\(ref:"3"\) ok/);
+    expect(h.calls.map((c) => c.name)).toEqual(['snapshot', 'click', 'extract_text']);
+    expect(out.freshRuntime).toBe(true);
+  });
+
+  it('throws into the script on a failed step, so later steps do not run — unless caught', async () => {
+    const h = harness({ click: async () => fail('nothing at ref=3') });
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run('await browser.click({ ref: "3" }); await browser.extract_text(); 1', 10_000, bridge);
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain('BrowserToolError: browser.click: nothing at ref=3');
+    expect(h.calls.map((c) => c.name)).toEqual(['click']);
+    expect(out.ledger[0]).toContain('FAILED');
+
+    const caught = await session.run(
+      'let msg;\ntry { await browser.click({ ref: "3" }) } catch (e) { msg = e.name + ":" + e.tool }\nmsg',
+      10_000,
+      bridge,
+    );
+    expect(caught.ok).toBe(true);
+    expect(caught.result?.text).toBe('BrowserToolError:click');
+  });
+
+  it('exposes only whitelisted tools on the browser object', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run('typeof browser.cookies + " " + typeof browser.evaluate + " " + typeof browser.click', 10_000, bridge);
+    expect(out.result?.text).toBe('undefined undefined function');
+  });
+
+  it('keeps top-level state between runs', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    await session.run('let counter = 41;', 10_000, bridge);
+    const out = await session.run('counter += 1; counter', 10_000, bridge);
+    expect(out.ok).toBe(true);
+    expect(out.result?.text).toBe('42');
+    expect(out.freshRuntime).toBe(false);
+  });
+
+  it('terminates a synchronous infinite loop on timeout and starts fresh next run', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    await session.run('let survivor = 1;', 10_000, bridge);
+    const out = await session.run('while (true) {}', 300, bridge);
+    expect(out.ok).toBe(false);
+    expect(out.timedOut).toBe(true);
+    expect(out.error).toContain('300ms timeout');
+
+    const next = await session.run('typeof survivor', 10_000, bridge);
+    expect(next.freshRuntime).toBe(true);
+    expect(next.previousDeath).toContain('300ms timeout');
+    expect(next.result?.text).toBe('undefined');
+    const rendered = formatBrowserReplOutcome(next);
+    expect(rendered).toContain('the previous runtime is gone');
+  }, 15_000);
+
+  it('serializes concurrent runs on one connection', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const a = session.run('await browser.wait({ ms: 150 }); await browser.click({ ref: "a" }); "a"', 10_000, bridge);
+    const b = session.run('await browser.click({ ref: "b" }); "b"', 10_000, bridge);
+    const [outA, outB] = await Promise.all([a, b]);
+    expect(outA.result?.text).toBe('a');
+    expect(outB.result?.text).toBe('b');
+    expect(h.calls.map((c) => `${c.name}:${String(c.args.ref ?? '')}`)).toEqual(['wait:', 'click:a', 'click:b']);
+    expect(outA.ledger).toHaveLength(2);
+    expect(outB.ledger).toHaveLength(1);
+  });
+
+  it('rejects malformed calls inside the worker without reaching the bridge', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run('await browser.click([1])', 10_000, bridge);
+    expect(out.ok).toBe(false);
+    expect(out.error).toContain('args must be a plain object');
+    expect(h.calls).toHaveLength(0);
+  });
+
+  it('captures background console output and rejects runs after dispose', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const out = await session.run('console.warn("w", { a: 1 }); await sleep(5); 7', 10_000, bridge);
+    expect(out.console.text).toBe('w { a: 1 }\n');
+    expect(out.result?.text).toBe('7');
+    session.dispose();
+    await expect(session.run('1', 1000, bridge)).rejects.toThrow('disposed');
+  });
+});
+
+describe('formatBrowserReplOutcome', () => {
+  it('renders the header, calls, console, and result blocks', () => {
+    const text = formatBrowserReplOutcome({
+      ok: true,
+      elapsedMs: 12,
+      ledger: ['snapshot(full:true) ok 5ms', 'click(ref:"3") ok 4ms · 1 event(s)'],
+      console: { text: 'hi\n', truncated: false, totalBytes: 3, elidedBytes: 0 },
+      result: { text: "'done'", truncated: false, totalBytes: 6, elidedBytes: 0 },
+      timedOut: false,
+      freshRuntime: true,
+    });
+    expect(text).toBe(
+      [
+        'browser_repl · ok · 12ms · 2 browser call(s)',
+        'note: started a new runtime',
+        '',
+        '--- calls ---',
+        '1. snapshot(full:true) ok 5ms',
+        '2. click(ref:"3") ok 4ms · 1 event(s)',
+        '',
+        '--- console ---',
+        'hi',
+        '',
+        '--- result ---',
+        "'done'",
+      ].join('\n'),
+    );
+  });
+});

--- a/src/mcp/browser-repl/__tests__/browserRepl.test.ts
+++ b/src/mcp/browser-repl/__tests__/browserRepl.test.ts
@@ -385,8 +385,24 @@ describe('browser_repl session', () => {
     const session = newSession();
     const out = await session.run('for (let i = 0; i < 205; i++) await browser.extract_text(); 1', 10_000, bridge);
     expect(out.ok).toBe(true);
-    expect(out.ledger).toHaveLength(201);
-    expect(out.ledger[200]).toBe('(5 more call(s) not shown)');
+    expect(out.ledger).toHaveLength(200);
+    expect(out.callCount).toBe(205);
+    const rendered = formatBrowserReplOutcome(out);
+    expect(rendered).toContain('205 browser call(s)');
+    expect(rendered).toContain('(5 more call(s) not shown)');
+  });
+
+  it('does not wait past its own deadline for a killed run\'s handler that never settles', async () => {
+    const h = harness({ wait: () => new Promise(() => { /* never settles */ }) });
+    const bridge = createBrowserBridge(h.tools, {});
+    const session = newSession();
+    const dead = await session.run('await browser.wait({ ms: 1 });', 100, bridge);
+    expect(dead.timedOut).toBe(true);
+    const started = Date.now();
+    const next = await session.run('1', 200, bridge);
+    expect(next.ok).toBe(false);
+    expect(next.error).toContain('still running after 200ms');
+    expect(Date.now() - started).toBeLessThan(2000);
   });
 
   it('explains a redeclared top-level binding instead of a bare SyntaxError', async () => {
@@ -419,6 +435,7 @@ describe('formatBrowserReplOutcome', () => {
       ok: true,
       elapsedMs: 12,
       ledger: ['snapshot(full:true) ok 5ms', 'click(ref:"3") ok 4ms · 1 event(s)'],
+      callCount: 2,
       console: { text: 'hi\n', truncated: false, totalBytes: 3, elidedBytes: 0 },
       result: { text: "'done'", truncated: false, totalBytes: 6, elidedBytes: 0 },
       timedOut: false,

--- a/src/mcp/browser-repl/__tests__/toolCollector.test.ts
+++ b/src/mcp/browser-repl/__tests__/toolCollector.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { collectingServer, type CollectedTool } from '../../playwright/toolCollector';
+
+function fakeServer() {
+  const calls: Array<{ method: string; name: string }> = [];
+  const server = {
+    tool: (name: string) => {
+      calls.push({ method: 'tool', name });
+      return { name };
+    },
+    registerTool: (name: string) => {
+      calls.push({ method: 'registerTool', name });
+      return { name };
+    },
+    isConnected: () => true,
+  };
+  return { server: server as unknown as McpServer, calls };
+}
+
+describe('collectingServer', () => {
+  it('records the 4-arg tool() form and delegates to the real server', () => {
+    const { server, calls } = fakeServer();
+    const sink = new Map<string, CollectedTool>();
+    const view = collectingServer(server, sink);
+    const shape = { url: z.string() };
+    const handler = async () => ({ content: [] });
+
+    const returned = view.tool('browser_navigate', 'desc', shape, handler);
+
+    expect(returned).toEqual({ name: 'browser_navigate' });
+    expect(calls).toEqual([{ method: 'tool', name: 'browser_navigate' }]);
+    expect(sink.get('browser_navigate')).toEqual({ name: 'browser_navigate', shape, handler });
+  });
+
+  it('records registerTool() by its inputSchema', () => {
+    const { server } = fakeServer();
+    const sink = new Map<string, CollectedTool>();
+    const view = collectingServer(server, sink);
+    const shape = { ms: z.number() };
+    const handler = async () => ({ content: [] });
+
+    view.registerTool('browser_wait', { description: 'd', inputSchema: shape }, handler);
+
+    expect(sink.get('browser_wait')?.shape).toBe(shape);
+    expect(sink.get('browser_wait')?.handler).toBe(handler);
+  });
+
+  it('delegates other arities without recording, and exposes the real server otherwise', () => {
+    const { server, calls } = fakeServer();
+    const sink = new Map<string, CollectedTool>();
+    const view = collectingServer(server, sink);
+
+    (view.tool as unknown as (...a: unknown[]) => unknown)('bare', async () => ({ content: [] }));
+
+    expect(calls).toEqual([{ method: 'tool', name: 'bare' }]);
+    expect(sink.size).toBe(0);
+    expect(view.isConnected()).toBe(true);
+  });
+});

--- a/src/mcp/browser-repl/bridge.ts
+++ b/src/mcp/browser-repl/bridge.ts
@@ -1,0 +1,268 @@
+/**
+ * The main-thread half of `browser_repl`: turns a worker's `browser.X(args)`
+ * into a call through the real `browser_X` handler and shapes the handler's
+ * MCP result into a plain value the script can use.
+ *
+ * Everything the browser tools guarantee — automation lease, password
+ * redaction, action-trace recording, frame-aware refs — lives inside the
+ * handler bodies, so calling the collected handler IS keeping those
+ * guarantees. The bridge adds only what direct calls skip: the SDK's Zod
+ * validation, and the connection scope that MCP dispatch would have set.
+ */
+import { z } from 'zod';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CollectedTool } from '../playwright/toolCollector';
+import { redactPasswordParams } from '../playwright/redact';
+import {
+  getConnectionScope,
+  runInConnectionScope,
+  type ConnectionScope,
+} from '../connectionScope';
+
+/**
+ * The tools a script may call, by short name (`browser.click` → `browser_click`).
+ *
+ * This is the permission boundary the feature moves: one approval of
+ * `browser_repl` covers all of these, so the list holds only the observe/act
+ * tools whose round trips a script is meant to fold together. Everything
+ * that reads or writes state outside the page (cookies, storage, files,
+ * downloads, PDFs, traces), returns non-text (screenshot), runs page scripts
+ * (evaluate), or manages sessions/replay stays a separate, separately
+ * approved tool call.
+ */
+export const BROWSER_REPL_TOOLS: readonly string[] = Object.freeze([
+  'navigate',
+  'navigate_back',
+  'tabs',
+  'click',
+  'type',
+  'fill',
+  'press_key',
+  'hover',
+  'drag',
+  'select',
+  'scroll',
+  'scroll_into_view',
+  'snapshot',
+  'smart_snapshot',
+  'extract_text',
+  'extract_data',
+  'wait',
+  'console',
+  'highlight',
+  'resize',
+  'dialog',
+]);
+
+/** Snapshot tools default to `full:true` inside a script — see `shapeResult`. */
+const SNAPSHOT_TOOLS = new Set(['snapshot', 'smart_snapshot']);
+
+/** Argument keys whose values are typed into the page and never shown in the ledger. */
+const TYPED_TEXT_KEYS = new Set(['text', 'value']);
+
+const LEDGER_ARGS_MAX = 160;
+
+export interface SnapshotRef {
+  /** Numeric ref from the snapshot listing. */
+  readonly ref: number;
+  /** Which browser_click argument takes it: `ref` (snapshot) or `smartRef` (smart_snapshot). */
+  readonly param: 'ref' | 'smartRef';
+  readonly role: string;
+  readonly name: string;
+}
+
+/** What `browser.X(args)` resolves to inside the script. */
+export interface BridgeValue {
+  /** The tool's own text, without the event/hint blocks the lease prepends. */
+  readonly text: string;
+  /** `[browser events]` lines the lease reported alongside this call. */
+  readonly events: readonly string[];
+  /** Snapshot tools only: refs parsed from the listing. Empty when the format is not recognized. */
+  readonly refs?: readonly SnapshotRef[];
+}
+
+export type BridgeOutcome =
+  | { readonly ok: true; readonly value: BridgeValue; readonly ledger: string }
+  | { readonly ok: false; readonly error: string; readonly ledger: string };
+
+export interface BrowserBridgeOptions {
+  /** Injected into every call whose schema accepts `surfaceId` and whose args omit it. */
+  readonly surfaceId?: string;
+  /**
+   * The MCP connection scope captured when the run started. Worker messages
+   * arrive outside the dispatch's AsyncLocalStorage, so without re-entering
+   * it the handlers would fall back to process globals — another agent's
+   * engine and refs under the broker.
+   */
+  readonly scope?: ConnectionScope;
+}
+
+export type BridgeCall = (name: string, args: Record<string, unknown>) => Promise<BridgeOutcome>;
+
+/** Compact, redacted rendering of a call's arguments for the ledger line. */
+export function summarizeArgs(args: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [key, raw] of Object.entries(args)) {
+    if (raw === undefined) continue;
+    if (TYPED_TEXT_KEYS.has(key) && typeof raw === 'string') {
+      // Typed text can be a password; the handler decides what to record in
+      // the trace, the ledger only says how much was typed.
+      parts.push(`${key}:"…"(${raw.length})`);
+      continue;
+    }
+    let rendered: string;
+    try {
+      rendered = JSON.stringify(raw) ?? String(raw);
+    } catch {
+      rendered = String(raw);
+    }
+    parts.push(`${key}:${redactPasswordParams(rendered)}`);
+  }
+  const joined = parts.join(', ');
+  return joined.length > LEDGER_ARGS_MAX ? `${joined.slice(0, LEDGER_ARGS_MAX - 1)}…` : joined;
+}
+
+/** `  - button "Log in" ref="12"` (browser_snapshot, ai format). */
+const SNAPSHOT_LINE = /^\s*-\s+(\S+)(?:\s+"((?:[^"\\]|\\.)*)")?[^\n]*?\sref="(\d+)"/;
+/** `  [12] button "Log in"` (browser_smart_snapshot, Playwright lane). */
+const SMART_LINE = /^\s*\[(\d+)\]\s+(\S+)\s+"((?:[^"\\]|\\.)*)"/;
+/** `  [ref=12] button[type=submit] "Log in"` (browser_smart_snapshot, DOM lane). */
+const SMART_DOM_LINE = /^\s*\[ref=(\d+)\]\s+(\S+?)(?:\[[^\]]*\])?\s+"((?:[^"\\]|\\.)*)"/;
+
+/** Parse refs out of a snapshot listing. Unknown formats yield []. */
+export function parseSnapshotRefs(text: string, tool: string): SnapshotRef[] {
+  const refs: SnapshotRef[] = [];
+  for (const line of text.split('\n')) {
+    if (tool === 'snapshot') {
+      const m = SNAPSHOT_LINE.exec(line);
+      if (m) refs.push({ ref: Number(m[3]), param: 'ref', role: m[1], name: m[2] ?? '' });
+      continue;
+    }
+    const m = SMART_LINE.exec(line);
+    if (m) {
+      refs.push({ ref: Number(m[1]), param: 'smartRef', role: m[2], name: m[3] });
+      continue;
+    }
+    const d = SMART_DOM_LINE.exec(line);
+    if (d) refs.push({ ref: Number(d[1]), param: 'smartRef', role: d[2], name: d[3] });
+  }
+  return refs;
+}
+
+/**
+ * Split a handler result into the script-facing text and the lease's event
+ * lines. The lease prepends up to two extra text blocks — `[browser events]`
+ * and the `[replay]`/`[skill]` hints — which are addressed to the model, not
+ * to code: events are surfaced as data, hints are dropped. Any block that
+ * matches neither is body. Non-text blocks are noted, never returned.
+ */
+export function shapeResult(result: CallToolResult, tool: string): BridgeValue {
+  const events: string[] = [];
+  const body: string[] = [];
+  for (const block of result.content ?? []) {
+    if (block.type !== 'text') {
+      body.push(`[${block.type} content omitted]`);
+      continue;
+    }
+    const text = block.text;
+    if (text.startsWith('[browser events]\n')) {
+      for (const line of text.slice('[browser events]\n'.length).split('\n')) {
+        const trimmed = line.replace(/^-\s*/, '').trim();
+        if (trimmed) events.push(trimmed);
+      }
+      continue;
+    }
+    if (text.startsWith('[replay] ') || text.startsWith('[skill] ')) continue;
+    body.push(text);
+  }
+  const text = body.join('\n');
+  if (SNAPSHOT_TOOLS.has(tool)) {
+    return { text, events, refs: parseSnapshotRefs(text, tool) };
+  }
+  return { text, events };
+}
+
+function errorText(result: CallToolResult): string {
+  const texts = (result.content ?? [])
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    // The lease still prepends events to error results; the script wants the reason.
+    .filter((t) => !t.startsWith('[browser events]\n') && !t.startsWith('[replay] ') && !t.startsWith('[skill] '));
+  return texts.join('\n').trim() || 'tool returned an error without a message';
+}
+
+/**
+ * Build the bridge over the collected handlers. `tools` is the collector sink
+ * (full `browser_*` names); only whitelisted entries are reachable.
+ */
+export function createBrowserBridge(
+  tools: ReadonlyMap<string, CollectedTool>,
+  options: BrowserBridgeOptions,
+): BridgeCall {
+  const validators = new Map<string, z.ZodObject<z.ZodRawShape>>();
+  const allowed = new Set(BROWSER_REPL_TOOLS);
+
+  return async (name, rawArgs) => {
+    const started = Date.now();
+    const ledgerFor = (args: Record<string, unknown>, status: string) =>
+      `${name}(${summarizeArgs(args)}) ${status} ${Date.now() - started}ms`;
+
+    if (!allowed.has(name)) {
+      const reason = tools.has(`browser_${name}`)
+        ? `browser.${name} is not available inside browser_repl — call the browser_${name} tool directly`
+        : `browser.${name} is not a browser tool`;
+      return { ok: false, error: reason, ledger: ledgerFor(rawArgs, 'REFUSED') };
+    }
+    const collected = tools.get(`browser_${name}`);
+    if (!collected) {
+      return {
+        ok: false,
+        error: `browser_${name} is not registered on this server`,
+        ledger: ledgerFor(rawArgs, 'REFUSED'),
+      };
+    }
+
+    const args: Record<string, unknown> = { ...rawArgs };
+    if (options.surfaceId !== undefined && 'surfaceId' in collected.shape && args.surfaceId === undefined) {
+      args.surfaceId = options.surfaceId;
+    }
+    // A diff is a saving for the model reading it; for code parsing refs it is
+    // a listing with most of the elements missing.
+    if (SNAPSHOT_TOOLS.has(name) && 'full' in collected.shape && args.full === undefined) {
+      args.full = true;
+    }
+
+    let validator = validators.get(name);
+    if (!validator) {
+      validator = z.object(collected.shape);
+      validators.set(name, validator);
+    }
+    const parsed = validator.safeParse(args);
+    if (!parsed.success) {
+      const issues = parsed.error.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ');
+      return {
+        ok: false,
+        error: `browser.${name}: invalid arguments — ${issues}`,
+        ledger: ledgerFor(args, 'INVALID'),
+      };
+    }
+
+    const invoke = () => collected.handler(parsed.data as Record<string, unknown>);
+    let result: CallToolResult;
+    try {
+      const scope = options.scope ?? getConnectionScope();
+      result = scope ? await runInConnectionScope(scope, invoke) : await invoke();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { ok: false, error: `browser.${name}: ${message}`, ledger: ledgerFor(args, 'THREW') };
+    }
+    if (result.isError) {
+      return { ok: false, error: `browser.${name}: ${errorText(result)}`, ledger: ledgerFor(args, 'FAILED') };
+    }
+    const value = shapeResult(result, name);
+    const eventNote = value.events.length > 0 ? ` · ${value.events.length} event(s)` : '';
+    return { ok: true, value, ledger: `${ledgerFor(args, 'ok')}${eventNote}` };
+  };
+}

--- a/src/mcp/browser-repl/bridge.ts
+++ b/src/mcp/browser-repl/bridge.ts
@@ -62,6 +62,23 @@ const TYPED_TEXT_KEYS = new Set(['text', 'value']);
 
 const LEDGER_ARGS_MAX = 160;
 
+/**
+ * Typed text can be a password; the handler decides what to record in the
+ * trace, the ledger only says how much was typed. Applied at every depth so
+ * `browser_fill({fields:[{ref, value}]})` is masked the same way as
+ * `browser_type({text})`.
+ */
+function maskTypedText(key: string, raw: unknown): unknown {
+  if (TYPED_TEXT_KEYS.has(key) && typeof raw === 'string') return `…(${raw.length})`;
+  if (Array.isArray(raw)) return raw.map((item) => maskTypedText('', item));
+  if (raw && typeof raw === 'object') {
+    return Object.fromEntries(
+      Object.entries(raw as Record<string, unknown>).map(([k, v]) => [k, maskTypedText(k, v)]),
+    );
+  }
+  return raw;
+}
+
 export interface SnapshotRef {
   /** Numeric ref from the snapshot listing. */
   readonly ref: number;
@@ -104,15 +121,9 @@ export function summarizeArgs(args: Record<string, unknown>): string {
   const parts: string[] = [];
   for (const [key, raw] of Object.entries(args)) {
     if (raw === undefined) continue;
-    if (TYPED_TEXT_KEYS.has(key) && typeof raw === 'string') {
-      // Typed text can be a password; the handler decides what to record in
-      // the trace, the ledger only says how much was typed.
-      parts.push(`${key}:"…"(${raw.length})`);
-      continue;
-    }
     let rendered: string;
     try {
-      rendered = JSON.stringify(raw) ?? String(raw);
+      rendered = JSON.stringify(maskTypedText(key, raw)) ?? String(raw);
     } catch {
       rendered = String(raw);
     }
@@ -155,7 +166,21 @@ export function parseSnapshotRefs(text: string, tool: string): SnapshotRef[] {
  * and the `[replay]`/`[skill]` hints — which are addressed to the model, not
  * to code: events are surfaced as data, hints are dropped. Any block that
  * matches neither is body. Non-text blocks are noted, never returned.
+ *
+ * The lease blocks are recognized by prefix, and page text can start with
+ * anything — so the match is kept tight: lease blocks only ever precede the
+ * handler's own content, and an events block is every line in the lease's
+ * `- type[: url] (N ago)` form. Once a body block is seen, the rest is body.
  */
+const EVENT_LINE = /^- [\w-]+(?::.*)? \([^()]* ago\)$/;
+
+function parseEventsBlock(text: string): string[] | null {
+  if (!text.startsWith('[browser events]\n')) return null;
+  const lines = text.slice('[browser events]\n'.length).split('\n').filter((line) => line.trim() !== '');
+  if (lines.length === 0 || !lines.every((line) => EVENT_LINE.test(line))) return null;
+  return lines.map((line) => line.slice(2));
+}
+
 export function shapeResult(result: CallToolResult, tool: string): BridgeValue {
   const events: string[] = [];
   const body: string[] = [];
@@ -165,14 +190,14 @@ export function shapeResult(result: CallToolResult, tool: string): BridgeValue {
       continue;
     }
     const text = block.text;
-    if (text.startsWith('[browser events]\n')) {
-      for (const line of text.slice('[browser events]\n'.length).split('\n')) {
-        const trimmed = line.replace(/^-\s*/, '').trim();
-        if (trimmed) events.push(trimmed);
+    if (body.length === 0) {
+      const eventLines = parseEventsBlock(text);
+      if (eventLines) {
+        events.push(...eventLines);
+        continue;
       }
-      continue;
+      if (text.startsWith('[replay] ') || text.startsWith('[skill] ')) continue;
     }
-    if (text.startsWith('[replay] ') || text.startsWith('[skill] ')) continue;
     body.push(text);
   }
   const text = body.join('\n');
@@ -187,7 +212,7 @@ function errorText(result: CallToolResult): string {
     .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
     .map((b) => b.text)
     // The lease still prepends events to error results; the script wants the reason.
-    .filter((t) => !t.startsWith('[browser events]\n') && !t.startsWith('[replay] ') && !t.startsWith('[skill] '));
+    .filter((t) => parseEventsBlock(t) === null && !t.startsWith('[replay] ') && !t.startsWith('[skill] '));
   return texts.join('\n').trim() || 'tool returned an error without a message';
 }
 

--- a/src/mcp/browser-repl/tool.ts
+++ b/src/mcp/browser-repl/tool.ts
@@ -133,7 +133,7 @@ export function disposeBrowserRepl(): void {
 export function formatBrowserReplOutcome(outcome: BrowserReplRunOutcome): string {
   const lines: string[] = [];
   lines.push(
-    `browser_repl · ${outcome.ok ? 'ok' : 'error'} · ${outcome.elapsedMs}ms · ${outcome.ledger.length} browser call(s)`,
+    `browser_repl · ${outcome.ok ? 'ok' : 'error'} · ${outcome.elapsedMs}ms · ${outcome.callCount} browser call(s)`,
   );
   if (outcome.freshRuntime) {
     lines.push(
@@ -145,14 +145,16 @@ export function formatBrowserReplOutcome(outcome: BrowserReplRunOutcome): string
   if (outcome.timedOut) {
     lines.push('note: the runtime was terminated. Variables are cleared; the next call starts fresh.');
   }
-  if (outcome.ledger.length > ACTION_RING_CAPACITY) {
+  if (outcome.callCount > ACTION_RING_CAPACITY) {
     lines.push(
-      `note: ${outcome.ledger.length} calls exceed the ${ACTION_RING_CAPACITY}-step action ring; ` +
+      `note: ${outcome.callCount} calls exceed the ${ACTION_RING_CAPACITY}-step action ring; ` +
         'only the last steps are available to browser_replay save.',
     );
   }
   if (outcome.ledger.length > 0) {
     lines.push('', '--- calls ---', ...outcome.ledger.map((l, i) => `${i + 1}. ${l}`));
+    const elided = outcome.callCount - outcome.ledger.length;
+    if (elided > 0) lines.push(`(${elided} more call(s) not shown)`);
   }
   if (outcome.console.text) {
     lines.push('', '--- console ---', outcome.console.text.replace(/\n$/, ''));

--- a/src/mcp/browser-repl/tool.ts
+++ b/src/mcp/browser-repl/tool.ts
@@ -1,0 +1,215 @@
+/**
+ * The `browser_repl` MCP tool: one call runs a JavaScript snippet whose
+ * `browser.*` calls go through this server's own `browser_*` handlers.
+ *
+ * Profile: `full` only, like the rest of the browser surface (the `browser_`
+ * prefix is excluded from core by derivation, and the commander has no hands
+ * in the browser at all).
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { ACTION_RING_CAPACITY } from '../../shared/browserReplay/actionTrace';
+import { getConnectionScope } from '../connectionScope';
+import { IDLE_SWEEP_INTERVAL_MS, IDLE_TIMEOUT_MS } from '../repl/replRegistry';
+import { MAX_TIMEOUT_MS } from '../repl/tools';
+import type { CollectedTool } from '../playwright/toolCollector';
+import {
+  defineWmuxTool,
+  registerWmuxTools,
+  type RegisterWmuxToolsOptions,
+  type WmuxToolSpec,
+} from '../toolCatalog';
+import { BROWSER_REPL_TOOLS, createBrowserBridge } from './bridge';
+import { BrowserReplSession, type BrowserReplRunOutcome } from './BrowserReplSession';
+
+/** Longer than repl_run's 30s: a script here waits on real pages. */
+export const DEFAULT_TIMEOUT_MS = 60_000;
+const MIN_TIMEOUT_MS = 100;
+
+function clampTimeout(requested: number | undefined): number {
+  if (requested === undefined || !Number.isFinite(requested)) return DEFAULT_TIMEOUT_MS;
+  return Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, Math.floor(requested)));
+}
+
+function text(body: string, isError = false): CallToolResult {
+  return { content: [{ type: 'text' as const, text: body }], isError: isError || undefined };
+}
+
+// ── per-connection session registry ───────────────────────────────────────
+
+/**
+ * Sessions live on the connection scope under the broker (one agent's globals
+ * must not become another's) and in this module global for the single-child
+ * server, which belongs to exactly one agent already.
+ */
+let processSession: BrowserReplSession | null = null;
+const liveSessions = new Set<BrowserReplSession>();
+let sweepTimer: NodeJS.Timeout | null = null;
+
+function forgetSession(session: BrowserReplSession): void {
+  liveSessions.delete(session);
+  if (processSession === session) processSession = null;
+  if (liveSessions.size === 0 && sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
+
+/** Terminate every session idle past the REPL threshold; returns how many. */
+export function reclaimIdleBrowserRepls(now: number = Date.now()): number {
+  let reclaimed = 0;
+  for (const session of [...liveSessions]) {
+    if (session.busy || now - session.lastUsed < IDLE_TIMEOUT_MS) continue;
+    session.dispose();
+    forgetSession(session);
+    reclaimed++;
+  }
+  return reclaimed;
+}
+
+function trackSession(session: BrowserReplSession): void {
+  liveSessions.add(session);
+  if (!sweepTimer) {
+    sweepTimer = setInterval(() => reclaimIdleBrowserRepls(), IDLE_SWEEP_INTERVAL_MS);
+    // An idle worker waiting to be reaped must not keep the server alive.
+    sweepTimer.unref?.();
+  }
+}
+
+function getSession(create: () => BrowserReplSession): BrowserReplSession {
+  const scope = getConnectionScope();
+  if (scope) {
+    let session = scope.browserRepl as BrowserReplSession | undefined;
+    if (!session || !liveSessions.has(session)) {
+      session = create();
+      scope.browserRepl = session;
+      trackSession(session);
+    }
+    return session;
+  }
+  if (!processSession || !liveSessions.has(processSession)) {
+    processSession = create();
+    trackSession(processSession);
+  }
+  return processSession;
+}
+
+/**
+ * Tear down the calling connection's session. Tolerant on purpose: this runs
+ * on the connection-close path beside `disposeReplRegistry`, where throwing
+ * would abandon the rest of the teardown.
+ */
+export function disposeBrowserRepl(): void {
+  const scope = getConnectionScope();
+  const session = scope
+    ? (scope.browserRepl as BrowserReplSession | undefined)
+    : processSession ?? undefined;
+  if (scope) scope.browserRepl = undefined;
+  if (!session) return;
+  session.dispose();
+  forgetSession(session);
+}
+
+// ── output ────────────────────────────────────────────────────────────────
+
+export function formatBrowserReplOutcome(outcome: BrowserReplRunOutcome): string {
+  const lines: string[] = [];
+  lines.push(
+    `browser_repl · ${outcome.ok ? 'ok' : 'error'} · ${outcome.elapsedMs}ms · ${outcome.ledger.length} browser call(s)`,
+  );
+  if (outcome.freshRuntime) {
+    lines.push(
+      outcome.previousDeath
+        ? `note: the previous runtime is gone (${outcome.previousDeath}); this run started a fresh one with no variables`
+        : 'note: started a new runtime',
+    );
+  }
+  if (outcome.timedOut) {
+    lines.push('note: the runtime was terminated. Variables are cleared; the next call starts fresh.');
+  }
+  if (outcome.ledger.length > ACTION_RING_CAPACITY) {
+    lines.push(
+      `note: ${outcome.ledger.length} calls exceed the ${ACTION_RING_CAPACITY}-step action ring; ` +
+        'only the last steps are available to browser_replay save.',
+    );
+  }
+  if (outcome.ledger.length > 0) {
+    lines.push('', '--- calls ---', ...outcome.ledger.map((l, i) => `${i + 1}. ${l}`));
+  }
+  if (outcome.console.text) {
+    lines.push('', '--- console ---', outcome.console.text.replace(/\n$/, ''));
+    if (outcome.console.truncated) {
+      lines.push(`(console truncated: ${outcome.console.totalBytes} bytes total)`);
+    }
+  }
+  if (outcome.ok && outcome.result && outcome.result.text !== 'undefined') {
+    lines.push('', '--- result ---', outcome.result.text);
+    if (outcome.result.truncated) {
+      lines.push(`(result truncated: ${outcome.result.totalBytes} bytes total)`);
+    }
+  }
+  if (!outcome.ok && outcome.error) {
+    lines.push('', '--- error ---', outcome.error);
+  }
+  return lines.join('\n');
+}
+
+// ── catalog ───────────────────────────────────────────────────────────────
+
+// Tight on purpose: this rides in tools/list for every full-profile session,
+// and the probe's byte budget is nearly spent. The whitelist is the one list
+// worth its bytes — it is the permission boundary this tool moves.
+const BROWSER_REPL_DESCRIPTION =
+  'Run a JavaScript snippet that drives the browser through many steps in ONE call. ' +
+  'Each allowed browser_X tool is `await browser.X(args)` with the same args, resolving to ' +
+  '{text, events} (+ refs:[{ref,param,role,name}] for snapshot/smart_snapshot, full listing by default; ' +
+  'pass refs[i].ref as the arg named refs[i].param). A failed step throws (catchable). ' +
+  `Allowed: ${BROWSER_REPL_TOOLS.join(', ')}. ` +
+  'Other browser_* tools stay separate calls. Top-level await works; state persists between calls ' +
+  'until a timeout kills the runtime, but let/const inside an awaiting snippet do not — assign to ' +
+  'globalThis to keep a value. console.log is captured; sleep(ms) is available. ' +
+  'Every step still records to the action trace for browser_replay.';
+
+export function createBrowserReplCatalog(
+  tools: ReadonlyMap<string, CollectedTool>,
+): readonly WmuxToolSpec[] {
+  const browserRepl = defineWmuxTool({
+    name: 'browser_repl',
+    description: BROWSER_REPL_DESCRIPTION,
+    inputSchema: {
+      code: z.string().describe('JavaScript. The last expression is the return value.'),
+      timeout: z
+        .number()
+        .optional()
+        .describe(`Milliseconds before the runtime is killed; default ${DEFAULT_TIMEOUT_MS}, max ${MAX_TIMEOUT_MS}.`),
+      surfaceId: z
+        .string()
+        .optional()
+        .describe('Default surfaceId for every browser.* call in this snippet.'),
+    },
+    profiles: ['full'],
+    invoke: async ({ code, timeout, surfaceId }) => {
+      // Captured HERE, inside the MCP dispatch, and re-entered per call: the
+      // worker's messages arrive outside this AsyncLocalStorage context.
+      const scope = getConnectionScope();
+      const bridge = createBrowserBridge(tools, { surfaceId, scope });
+      const session = getSession(() => new BrowserReplSession(BROWSER_REPL_TOOLS));
+      try {
+        const outcome = await session.run(code, clampTimeout(timeout), bridge);
+        return text(formatBrowserReplOutcome(outcome), !outcome.ok);
+      } catch (error) {
+        return text(`browser_repl: ${error instanceof Error ? error.message : String(error)}`, true);
+      }
+    },
+  });
+  return Object.freeze([browserRepl]);
+}
+
+export function registerBrowserReplTool(
+  server: McpServer,
+  tools: ReadonlyMap<string, CollectedTool>,
+  options: RegisterWmuxToolsOptions,
+): void {
+  registerWmuxTools(server, createBrowserReplCatalog(tools), options);
+}

--- a/src/mcp/browser-repl/tool.ts
+++ b/src/mcp/browser-repl/tool.ts
@@ -46,6 +46,17 @@ function text(body: string, isError = false): CallToolResult {
 let processSession: BrowserReplSession | null = null;
 const liveSessions = new Set<BrowserReplSession>();
 let sweepTimer: NodeJS.Timeout | null = null;
+/**
+ * True once this process hosts several agents' connections (set by the broker).
+ * The process-wide fallback below is only right when the process belongs to
+ * one agent; under the broker a call that lost its scope must fail rather than
+ * land on a worker shared with everyone else — same rule as `getReplRegistry`.
+ */
+let brokerMode = false;
+
+export function setBrowserReplBrokerMode(): void {
+  brokerMode = true;
+}
 
 function forgetSession(session: BrowserReplSession): void {
   liveSessions.delete(session);
@@ -87,6 +98,12 @@ function getSession(create: () => BrowserReplSession): BrowserReplSession {
       trackSession(session);
     }
     return session;
+  }
+  if (brokerMode) {
+    throw new Error(
+      'internal: no MCP connection scope is active, so this browser_repl call cannot be attributed ' +
+        "to a caller. Refusing rather than risking another agent's runtime.",
+    );
   }
   if (!processSession || !liveSessions.has(processSession)) {
     processSession = create();

--- a/src/mcp/browser-repl/workerSource.ts
+++ b/src/mcp/browser-repl/workerSource.ts
@@ -1,0 +1,162 @@
+/**
+ * Source of the `browser_repl` worker thread, kept as a string for the same
+ * reason `replRunnerSource.ts` is: the MCP server ships as one bundled file
+ * (`tsconfig.mcp.json`) with nothing on disk beside it for a Worker to load.
+ * `new Worker(source, { eval: true })` runs it as a CommonJS module, so
+ * `require` is module-scoped and invisible to the evaluated snippet — the
+ * snippet sees exactly `browser`, `console`, `sleep`, and its own globals.
+ *
+ * Why a worker and not a vm context: every browser handler lives in the main
+ * thread, so the snippet must call back into it. A vm context bridged with
+ * host functions hands the snippet host-realm Promises and Errors, and any of
+ * those reaches `process` through `.constructor.constructor`. A thread boundary
+ * is structured clone — functions, Promises, and Errors cannot cross it at all,
+ * and `worker.terminate()` stops a `while (true)` that no flag could.
+ *
+ * Not a sandbox claim. `repl_run` already gives the same caller an unrestricted
+ * Node process; the worker exists for robustness (kill on timeout, no leaked
+ * host objects), not for confinement.
+ *
+ * Protocol (main ⇄ worker, structured clone):
+ *   main → worker  { type: 'init', tools: string[] }
+ *   main → worker  { type: 'run', id, code }
+ *   worker → main  { type: 'ready' }
+ *   worker → main  { type: 'console', text }            captured console.*
+ *   worker → main  { type: 'call', callId, name, args }  browser.<name>(args)
+ *   main → worker  { type: 'callResult', callId, ok, value | error }
+ *   worker → main  { type: 'result', id, ok, result | error }
+ */
+export const BROWSER_REPL_WORKER_SOURCE = String.raw`
+'use strict';
+const { parentPort } = require('worker_threads');
+const vm = require('vm');
+const util = require('util');
+
+const RESULT_CAP = 64 * 1024;
+
+function describe(value) {
+  if (typeof value === 'string') return value;
+  let rendered;
+  try {
+    rendered = util.inspect(value, { depth: 4, maxArrayLength: 200, maxStringLength: 8192, breakLength: 100, getters: false });
+  } catch (err) {
+    return '<value could not be inspected: ' + String(err && err.message || err) + '>';
+  }
+  if (rendered.length > RESULT_CAP) {
+    return rendered.slice(0, RESULT_CAP) + '\n… value truncated in the worker (' + rendered.length + ' chars rendered) …';
+  }
+  return rendered;
+}
+
+// Same last-expression rewrite as the Node REPL runner: an async IIFE with a
+// block body has no completion value, so the trailing expression statement is
+// turned into a return when — and only when — the rewrite still compiles.
+function wrapAsync(code) {
+  const trimmed = code.replace(/\s+$/, '').replace(/;+$/, '');
+  const splits = [];
+  for (let i = trimmed.length - 1; i >= 0 && splits.length < 40; i--) {
+    const ch = trimmed[i];
+    if (ch === '\n' || ch === ';') splits.push(i);
+  }
+  for (let s = 0; s < splits.length; s++) {
+    const at = splits[s];
+    const tail = trimmed.slice(at + 1).trim();
+    if (tail === '') continue;
+    if (trimmed[at] !== ';' && ('[(+-*/,.?:=<>&|'.indexOf(tail[0]) !== -1 || tail.charCodeAt(0) === 96)) continue;
+    if (/^(function|class|async|let|const|var|return|if|for|while|do|switch|try|throw|import|export)\b/.test(tail)) continue;
+    const rewritten = '(async () => {\n' + trimmed.slice(0, at + 1) + '\nreturn (' + tail + ');\n})()';
+    try { new vm.Script(rewritten); return rewritten; } catch (_) { /* try an earlier split */ }
+  }
+  const whole = '(async () => {\nreturn (' + trimmed + ');\n})()';
+  try { new vm.Script(whole); return whole; } catch (_) { /* statements, not an expression */ }
+  return '(async () => {\n' + code + '\n})()';
+}
+
+const INTERNAL_FRAME = /^\s+at (Script\.runInThisContext|Object\.runInThisContext|MessagePort\.|process\.processTicksAndRejections|\[kOnMessage\]|node:internal)/;
+function trimStack(error) {
+  const raw = String(error && error.stack || error);
+  const lines = raw.split('\n');
+  const cut = lines.findIndex((line) => INTERNAL_FRAME.test(line));
+  return cut === -1 ? raw : lines.slice(0, cut).join('\n').replace(/\s+$/, '');
+}
+
+// ── browser.* bridge ──────────────────────────────────────────────────────
+let nextCallId = 1;
+const pending = new Map();
+
+function callTool(name, args) {
+  if (args !== undefined && (typeof args !== 'object' || args === null || Array.isArray(args))) {
+    return Promise.reject(new TypeError('browser.' + name + '(args): args must be a plain object'));
+  }
+  const callId = nextCallId++;
+  return new Promise((resolve, reject) => {
+    pending.set(callId, { resolve, reject, name });
+    parentPort.postMessage({ type: 'call', callId, name, args: args || {} });
+  });
+}
+
+function installBrowser(tools) {
+  const browser = {};
+  for (const name of tools) {
+    Object.defineProperty(browser, name, { value: (args) => callTool(name, args), enumerable: true });
+  }
+  Object.freeze(browser);
+  Object.defineProperty(globalThis, 'browser', { value: browser, enumerable: true });
+}
+
+function emit(text) {
+  parentPort.postMessage({ type: 'console', text: text + '\n' });
+}
+const captured = {};
+for (const level of ['log', 'info', 'debug', 'warn', 'error', 'trace', 'dir']) {
+  captured[level] = (...args) => emit(util.format(...args));
+}
+captured.table = captured.log;
+globalThis.console = captured;
+globalThis.sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+process.on('uncaughtException', (err) => emit('[browser_repl] uncaught exception in background code: ' + trimStack(err)));
+process.on('unhandledRejection', (reason) => emit('[browser_repl] unhandled rejection in background code: ' + trimStack(reason)));
+
+parentPort.on('message', (msg) => {
+  if (!msg || typeof msg !== 'object') return;
+  if (msg.type === 'init') {
+    installBrowser(Array.isArray(msg.tools) ? msg.tools : []);
+    parentPort.postMessage({ type: 'ready' });
+    return;
+  }
+  if (msg.type === 'callResult') {
+    const entry = pending.get(msg.callId);
+    if (!entry) return;
+    pending.delete(msg.callId);
+    if (msg.ok) {
+      entry.resolve(msg.value);
+    } else {
+      // Rebuilt in THIS realm from a string; the main thread's Error never crosses.
+      const error = new Error(String(msg.error));
+      error.name = 'BrowserToolError';
+      error.tool = entry.name;
+      entry.reject(error);
+    }
+    return;
+  }
+  if (msg.type === 'run' && typeof msg.code === 'string') {
+    const id = msg.id;
+    const options = { displayErrors: true, filename: 'browser_repl' };
+    const fail = (error) => parentPort.postMessage({ type: 'result', id, ok: false, error: trimStack(error) });
+    let value;
+    try {
+      value = vm.runInThisContext(msg.code, options);
+    } catch (err) {
+      const text = String(err && err.message || err);
+      if (err instanceof SyntaxError && text.indexOf('await is only valid in') !== -1) {
+        try { value = vm.runInThisContext(wrapAsync(msg.code), options); } catch (retryErr) { fail(retryErr); return; }
+      } else { fail(err); return; }
+    }
+    Promise.resolve(value).then(
+      (resolved) => parentPort.postMessage({ type: 'result', id, ok: true, result: describe(resolved) }),
+      fail,
+    );
+  }
+});
+`;

--- a/src/mcp/browser-repl/workerSource.ts
+++ b/src/mcp/browser-repl/workerSource.ts
@@ -143,7 +143,16 @@ parentPort.on('message', (msg) => {
   if (msg.type === 'run' && typeof msg.code === 'string') {
     const id = msg.id;
     const options = { displayErrors: true, filename: 'browser_repl' };
-    const fail = (error) => parentPort.postMessage({ type: 'result', id, ok: false, error: trimStack(error) });
+    const fail = (error) => {
+      let rendered = trimStack(error);
+      // Top-level let/const survive between runs, so re-running a snippet that
+      // declares one is a SyntaxError here — a surprise the agent would otherwise
+      // read as a bug in its own code.
+      if (error instanceof SyntaxError && /has already been declared/.test(String(error.message))) {
+        rendered += '\n(hint: this runtime keeps top-level declarations between browser_repl calls — reuse the name without let/const, pick another, or assign to globalThis)';
+      }
+      parentPort.postMessage({ type: 'result', id, ok: false, error: rendered });
+    };
     let value;
     try {
       value = vm.runInThisContext(msg.code, options);

--- a/src/mcp/connectionScope.ts
+++ b/src/mcp/connectionScope.ts
@@ -72,6 +72,12 @@ export interface ConnectionScope {
    * module); it owns the cast.
    */
   repl?: unknown;
+  /**
+   * Per-connection `browser_repl` worker session, for the same reason as
+   * `repl`. Typed as unknown to avoid an import cycle; browser-repl/tool owns
+   * the cast.
+   */
+  browserRepl?: unknown;
 }
 
 const storage = new AsyncLocalStorage<ConnectionScope>();

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -21,6 +21,8 @@ import { registerStateTools } from './playwright/tools/state';
 import { registerWaitTools } from './playwright/tools/wait';
 import { registerReplayTools } from './browser-replay/tool';
 import { ActionRing } from './browser-replay/actionRing';
+import { collectingServer, type CollectedTool } from './playwright/toolCollector';
+import { registerBrowserReplTool } from './browser-repl/tool';
 import { registerFileTools } from './playwright/tools/file';
 import { registerUtilityTools } from './playwright/tools/utility';
 import { registerExtractionTools } from './playwright/tools/extraction';
@@ -949,15 +951,22 @@ const browserToolDeps = {
   resolveWorkspaceId: requireWorkspaceId,
   actionRing: new ActionRing(),
 };
-registerNavigationTools(server, browserToolDeps);
-registerInteractionTools(server, browserToolDeps);
-registerInspectionTools(server, browserToolDeps);
-registerStateTools(server, browserToolDeps);
-registerWaitTools(server, browserToolDeps, MCP_CATALOG_OPTIONS);
-registerFileTools(server, browserToolDeps);
-registerUtilityTools(server, browserToolDeps);
-registerExtractionTools(server, browserToolDeps);
-registerReplayTools(server, browserToolDeps, MCP_CATALOG_OPTIONS);
+// Registration goes through a collecting view of the server so browser_repl
+// can call the same handlers (lease, redaction, trace recording included)
+// that the MCP dispatcher does. The real server sees every registration
+// unchanged.
+const browserTools = new Map<string, CollectedTool>();
+const browserServer = collectingServer(server, browserTools);
+registerNavigationTools(browserServer, browserToolDeps);
+registerInteractionTools(browserServer, browserToolDeps);
+registerInspectionTools(browserServer, browserToolDeps);
+registerStateTools(browserServer, browserToolDeps);
+registerWaitTools(browserServer, browserToolDeps, MCP_CATALOG_OPTIONS);
+registerFileTools(browserServer, browserToolDeps);
+registerUtilityTools(browserServer, browserToolDeps);
+registerExtractionTools(browserServer, browserToolDeps);
+registerReplayTools(browserServer, browserToolDeps, MCP_CATALOG_OPTIONS);
+registerBrowserReplTool(server, browserTools, MCP_CATALOG_OPTIONS);
 
 // The engine's auto-open (getPage Strategy 4) issues browser.open outside any
 // tool handler, so it cannot rely on the per-tool requireWorkspaceId() guard

--- a/src/mcp/playwright/toolCollector.ts
+++ b/src/mcp/playwright/toolCollector.ts
@@ -1,0 +1,80 @@
+/**
+ * Handler collector for the browser tool registration sites.
+ *
+ * The eight `registerXTools(server, deps)` modules hand their handlers to
+ * `server.tool(...)` / `server.registerTool(...)` and discard the returned
+ * handles, so nothing in the process can call a browser tool except the MCP
+ * dispatcher. `browser_repl` needs exactly that: it runs an agent's script
+ * whose `browser.click(...)` must go THROUGH the real `browser_click` handler
+ * (automation lease, password redaction, action-trace recording, frame-aware
+ * refs all live inside the handler bodies), not around it.
+ *
+ * `collectingServer` wraps the server so registration still reaches the real
+ * instance unchanged while a copy of `{name, shape, handler}` lands in the
+ * sink. The tool modules stay untouched — the same shape the replay-recording
+ * tests already use to reach handlers directly.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { z } from 'zod';
+
+export type CollectedToolHandler = (
+  args: Record<string, unknown>,
+) => CallToolResult | Promise<CallToolResult>;
+
+export interface CollectedTool {
+  readonly name: string;
+  /** The raw Zod shape the SDK validates against before dispatch. */
+  readonly shape: z.ZodRawShape;
+  readonly handler: CollectedToolHandler;
+}
+
+type ToolFn = McpServer['tool'];
+type RegisterToolFn = McpServer['registerTool'];
+
+function isShape(value: unknown): value is z.ZodRawShape {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Return a server whose `tool` and `registerTool` record every registration
+ * into `sink` and then delegate to `server`. Only the 4-argument
+ * `tool(name, description, shape, handler)` form and the
+ * `registerTool(name, {inputSchema}, handler)` form are recorded; the browser
+ * modules use nothing else. Any other arity is delegated without recording.
+ */
+export function collectingServer(
+  server: McpServer,
+  sink: Map<string, CollectedTool>,
+): McpServer {
+  const tool = ((name: string, ...rest: unknown[]) => {
+    if (rest.length === 3 && isShape(rest[1]) && typeof rest[2] === 'function') {
+      sink.set(name, {
+        name,
+        shape: rest[1],
+        handler: rest[2] as CollectedToolHandler,
+      });
+    }
+    return (server.tool as unknown as (...a: unknown[]) => ReturnType<ToolFn>)(name, ...rest);
+  }) as ToolFn;
+
+  const registerTool = ((name: string, config: unknown, handler: unknown) => {
+    const inputSchema = (config as { inputSchema?: unknown } | undefined)?.inputSchema;
+    if (isShape(inputSchema) && typeof handler === 'function') {
+      sink.set(name, { name, shape: inputSchema, handler: handler as CollectedToolHandler });
+    }
+    return (server.registerTool as unknown as (...a: unknown[]) => ReturnType<RegisterToolFn>)(
+      name,
+      config,
+      handler,
+    );
+  }) as RegisterToolFn;
+
+  // A prototype-chained view: every other member (connect, close, server,
+  // isConnected…) resolves to the real instance, so callers that only need
+  // registration cannot tell the difference.
+  return Object.create(server, {
+    tool: { value: tool, enumerable: true },
+    registerTool: { value: registerTool, enumerable: true },
+  }) as McpServer;
+}


### PR DESCRIPTION
## Summary

Adds `browser_repl`: one MCP tool call runs a JavaScript snippet that drives the browser through many steps — `await browser.snapshot()`, `refs.find(...)`, `await browser.click(...)`, `await browser.wait(...)`, `await browser.extract_text()` — where each of those used to be its own round trip.

Every `browser.X(args)` goes through this server's own `browser_X` handler, so automation leases, password redaction, frame-aware refs, snapshot diffing, and action-trace recording for `browser_replay` all apply unchanged. The bridge adds only what direct handler calls would skip: the SDK's Zod validation and the MCP connection scope.

### Design

- **Worker thread, not a vm context.** The snippet runs in a per-connection `worker_threads` Worker; handlers stay on the main thread and calls cross via `postMessage` (structured clone — no host Promises/Errors/functions leak into the snippet). A timeout calls `worker.terminate()`, which stops even a synchronous `while (true)`; the next run starts a fresh worker and says so. Not a sandbox claim: `repl_run` already gives the same caller an unrestricted Node process.
- **Serialized per connection.** Concurrent `browser_repl` calls on one connection run in order; a killed run's in-flight handler calls land before the next run touches the page.
- **Handler collector.** `collectingServer()` wraps `server.tool`/`registerTool` so the eight browser tool modules register unchanged while the bridge gets `{name, shape, handler}`.
- **Permission boundary.** One approval of `browser_repl` covers the observe/act whitelist (navigate, navigate_back, tabs, click, type, fill, press_key, hover, drag, select, scroll, scroll_into_view, snapshot, smart_snapshot, extract_text, extract_data, wait, console, highlight, resize, dialog). Cookies, storage, files, downloads, PDF, trace, screenshot, evaluate, session management, and replay stay separate calls.
- **Profile `full` only**; `browser_` prefix is excluded from core by derivation. tools/list stays within budget; `scripts/mcp-protocol-baseline.json` updated.

### Robustness (from code review)

Stray `browser.*` calls after a run finished are refused instead of hanging; bridge rejections are answered as tool errors; the run chain swallows rejections so a failing run cannot become an unhandled rejection in the server; a worker that dies between runs is detected immediately; the ledger is capped (200 lines) and masks typed text at every depth (`browser_fill` field values included); lease blocks are only classified before the handler's own body; under the broker a scope-less call is refused rather than landing on a shared session.

## Dogfood

Live against a fresh tab through the daemon: wait → snapshot → refs.find → click → wait → extract_text took **1 `browser_repl` call vs 6 direct tool calls**. `browser_replay save` afterwards found the steps in the action trace, confirming the handler path was used.

## Tests

- `src/mcp/browser-repl/__tests__/browserRepl.test.ts` — bridge (whitelist, re-validation, `full:true` default, scope re-entry, ref parsing for three snapshot formats, event/hint separation, ledger masking), session (multi-step run, throw-on-failure and catch, state across runs, timeout → terminate → fresh worker, serialization, stray-call refusal, straggler ordering, bridge rejection, ledger cap, redeclare hint, idle worker death), output formatting.
- `src/mcp/playwright/__tests__/toolCollector.test.ts`, catalog lockstep test, routing test updated.
- `npx tsc --noEmit` clean, full vitest suite green (14052 tests), `npm run build:mcp && npm run probe:mcp` exit 0.

## Notes

- No version bump; changelog fragment at `changelog.d/1177.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `browser_repl` tool for multi-step browser automation using JavaScript in a single call.
  - Supports persistent sessions, console output, browser-call traces, parsed snapshot references, error handling, and configurable timeouts.
  - Preserves existing browser permissions and automation behavior while protecting sensitive arguments.
  - Available for supported browser actions; resource-intensive operations remain separate calls.

- **Bug Fixes**
  - Improved cleanup and recovery when automation sessions time out, crash, or lose their connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->