### PR TITLE
fix(browser-replay): stop a replay when the same-name element population changed

### DIFF
--- a/changelog.d/1179.md
+++ b/changelog.d/1179.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **A replay no longer clicks a look-alike element and calls it a success.** A
+  step recorded against the *first* `button "Submit order"` on a page used to
+  replay against whatever sat at that position later, on the reasoning that the
+  first element cannot have been displaced. It can: a decoy button with the same
+  accessible name inserted above the real one takes over position one, and the
+  run clicked the decoy, never fired the real submit, and still reported the step
+  as `ok`. A same-name population whose size differs from the recording now stops
+  the run at that step — at every position, the first included — naming both
+  counts. The page is left where it stopped, so the recovery is unchanged: take a
+  snapshot, finish the flow live, and `save` under the same name to re-record the
+  healed path. (#1179)

--- a/changelog.d/1179.md
+++ b/changelog.d/1179.md
@@ -1,13 +1,20 @@
 ### Fixed
 
-- **A replay no longer clicks a look-alike element and calls it a success.** A
-  step recorded against the *first* `button "Submit order"` on a page used to
-  replay against whatever sat at that position later, on the reasoning that the
-  first element cannot have been displaced. It can: a decoy button with the same
-  accessible name inserted above the real one takes over position one, and the
-  run clicked the decoy, never fired the real submit, and still reported the step
-  as `ok`. A same-name population whose size differs from the recording now stops
-  the run at that step — at every position, the first included — naming both
-  counts. The page is left where it stopped, so the recovery is unchanged: take a
-  snapshot, finish the flow live, and `save` under the same name to re-record the
-  healed path. (#1179)
+- **A replay stops when the number of same-name elements changed, instead of
+  clicking by position anyway.** A step recorded against the *first*
+  `button "Submit order"` on a page used to replay against whatever sat at that
+  position later, on the reasoning that the first element cannot have been
+  displaced. It can: a look-alike with the same accessible name inserted above
+  the real one takes over position one, and the run clicked the look-alike,
+  never fired the real submit, and still reported the step as `ok`. A live
+  population whose size differs from the recorded one now stops the run at that
+  step — at every position, the first included — saying which way the count
+  moved. The count is also re-checked against the live page at the moment of
+  acting, so an element that appears between the internal snapshot and the click
+  is caught too. A stop of this kind no longer counts toward the failure streak
+  that retires a flow, since a page growing a banner says nothing about whether
+  the recording is still good. The page is left where it stopped, so the
+  recovery is unchanged: take a snapshot, finish the flow live, and `save` under
+  the same name to re-record the healed path. A change that leaves the count
+  unchanged — one look-alike added above, one element removed below — is still
+  not detectable from what a recording stores. (#1179)

--- a/docs/how-to/replay-browser-flows.md
+++ b/docs/how-to/replay-browser-flows.md
@@ -61,11 +61,18 @@ left exactly where the replay stopped, so the cheapest recovery is to take a
 snapshot, finish the flow by hand from there, and `save` under the same name.
 That re-records the healed path.
 
-A changed count of same-named elements also stops the run, at every position
-including the first. Position N names the recorded element only while that
-population is the one that was counted: an element inserted anywhere — above
-the first one included — moves something else into that slot, and the replay
-would act on it. Take a snapshot and finish the flow live instead.
+When the *number* of same-named elements changed, the run also stops, at every
+position including the first. Position N names the recorded element only while
+that population is the one that was counted: an element added anywhere — above
+the first one included — moves something else into that slot, and one removed
+means the position no longer counts the same population. Take a snapshot and
+finish the flow live instead. A stop like this is not held against the flow;
+it does not count toward the failure streak that retires a recording.
+
+A change that leaves the count the *same* is not detected — one look-alike
+added above and one element removed below still measures N, the position still
+resolves, and the element it lands on is a different one. Telling those apart
+needs something the recording does not store.
 
 ## Variables
 

--- a/docs/how-to/replay-browser-flows.md
+++ b/docs/how-to/replay-browser-flows.md
@@ -61,11 +61,11 @@ left exactly where the replay stopped, so the cheapest recovery is to take a
 snapshot, finish the flow by hand from there, and `save` under the same name.
 That re-records the healed path.
 
-If the page's count of same-named elements changed, what happens depends on
-where the recorded element sat: the *first* "Delete" is still the first one
-however many rows were added, so that is a warning; any later position is
-refused, because a row inserted above shifts everything below it and the
-replay would act on whatever moved into that slot.
+A changed count of same-named elements also stops the run, at every position
+including the first. Position N names the recorded element only while that
+population is the one that was counted: an element inserted anywhere — above
+the first one included — moves something else into that slot, and the replay
+would act on it. Take a snapshot and finish the flow live instead.
 
 ## Variables
 

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -955,6 +955,7 @@ export function registerBrowserRpc(
     const trace = await actionCache.stats(workspaceId, name, {
       ok: params['ok'] === true,
       ...(failedStep !== undefined && { failedStep }),
+      ...(params['inconclusive'] === true && { inconclusive: true }),
     });
     // Usage for the promoted store rides on the stats call because it is the
     // one point EVERY replay passes through, whether the trace came from the

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -14,11 +14,17 @@ let refEntries: FakeRefEntry[] = [];
 let snapshotText = 'button "Sign in" [ref=1]';
 const resolved = new Set<string>();
 
+/** The runner narrows on this class, so the mock has to hand out the same one. */
+const { StaleRefError } = vi.hoisted(() => ({
+  StaleRefError: class StaleRefError extends Error {},
+}));
+
 vi.mock('../../playwright/snapshot', () => ({
   generateSnapshot: async () => snapshotText,
   listRefEntries: () => refEntries,
   resolveRef: async (_page: unknown, ref: string) =>
     resolved.has(ref) ? ({ click: async () => undefined, fill: async () => undefined } as never) : null,
+  StaleRefError,
 }));
 
 import { replayBlockedReason, replayTrace } from '../replayRunner';
@@ -129,7 +135,7 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     const spy = vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('sign-in'));
 
     await replayTrace(page, trace([refStep()]), undefined);
-    expect(spy).toHaveBeenCalledWith(page, '904');
+    expect(spy).toHaveBeenCalledWith(page, '904', { strictCount: true });
   });
 
   it('stops at the step whose element is gone and says which and why', async () => {
@@ -168,6 +174,8 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     expect(result.failedStep).toBe(1);
     expect(result.steps[0].detail).toContain('can no longer be identified');
     expect(result.steps[0].detail).toContain('the recording had 1');
+    expect(result.steps[0].detail).toContain('were added');
+    expect(result.inconclusive).toBe(true);
     expect(clicks).toEqual([]);
   });
 
@@ -201,6 +209,8 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     expect(result.ok).toBe(false);
     expect(result.failedStep).toBe(1);
     expect(result.steps[0].detail).toContain('no button "Sign in" on the page any more');
+    // A vanished element IS evidence about the flow — it must still quarantine.
+    expect(result.inconclusive).toBeUndefined();
     expect(clicks).toEqual([]);
   });
 
@@ -241,7 +251,10 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     expect(clicks).toEqual(['second-delete']);
   });
 
-  it('refuses when the recorded position no longer exists in the population', async () => {
+  it('reports the COUNT when the population shrank past the recorded position', async () => {
+    // The count comparison runs before the index lookup (panel ④). Ordered the
+    // other way, this reported only "nothing at position 3" and never said that
+    // the population is what changed.
     refEntries = [
       { role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 1 },
     ];
@@ -250,7 +263,46 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     });
     const result = await replayTrace(page, trace([step]), undefined);
     expect(result.ok).toBe(false);
-    expect(result.steps[0].detail).toContain('none at position 3');
+    expect(result.steps[0].detail).toContain('the recording had 3');
+    expect(result.steps[0].detail).toContain('were removed');
+    expect(result.inconclusive).toBe(true);
+  });
+
+  it('stops when the population grew AFTER the internal snapshot was taken', async () => {
+    // The population compared in matchRefAxis was counted before the step ran.
+    // A decoy that appears in the window between that snapshot and the click is
+    // invisible to it, and is caught by resolveRef's strict count instead.
+    const mod = await import('../../playwright/snapshot');
+    const spy = vi
+      .spyOn(mod, 'resolveRef')
+      .mockRejectedValue(new StaleRefError('ref=1 is stale — the page now has 2 button element(s) named "Sign in"'));
+
+    const result = await replayTrace(page, trace([refStep()]), undefined);
+    expect(spy).toHaveBeenCalledWith(page, '1', { strictCount: true });
+    expect(result.ok).toBe(false);
+    expect(result.failedStep).toBe(1);
+    expect(result.steps[0].detail).toContain('the page now has 2');
+    expect(result.inconclusive).toBe(true);
+    expect(clicks).toEqual([]);
+  });
+
+  it('does not count-check an UNNAMED axis, whose stored total is a role count', async () => {
+    // smartRefAxisEntry stores roleIndex/roleTotal in the sameName fields for an
+    // element with no accessible name, measured over a different walk from the
+    // snapshot ref map counted here. Demanding equality would stop flows on
+    // pages that never changed.
+    refEntries = [
+      { role: 'button', name: '', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 7 },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('unnamed'));
+
+    const step = refStep({
+      axis: { kind: 'ref', role: 'button', name: '', sameNameIndex: 0, sameNameTotal: 4, frameKey: '' },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['unnamed']);
   });
 
   it('does not match an entry in a different frame', async () => {

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -151,18 +151,57 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     expect(result.steps[0].ok).toBe(true);
   });
 
-  it('warns but continues when the population grew AROUND the recorded first element', async () => {
-    // Index 0: nothing can have been inserted above it, so it is still itself.
+  it('REFUSES when a decoy was inserted BEFORE the recorded first element', async () => {
+    // The dogfood defect: one `button "Submit order"` was recorded at index 0,
+    // then a decoy with the same name was inserted above it. Index 0 now names
+    // the decoy. The run used to warn "the first one cannot have been
+    // displaced" and click it, reporting the step ok.
     refEntries = [
       { role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
       { role: 'button', name: 'Sign in', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
     ];
     const mod = await import('../../playwright/snapshot');
-    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('a'));
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('decoy'));
 
     const result = await replayTrace(page, trace([refStep()]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.failedStep).toBe(1);
+    expect(result.steps[0].detail).toContain('can no longer be identified');
+    expect(result.steps[0].detail).toContain('the recording had 1');
+    expect(clicks).toEqual([]);
+  });
+
+  it('runs the recorded first element while its population is unchanged', async () => {
+    refEntries = [
+      { role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
+      { role: 'button', name: 'Sign in', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('first-sign-in'));
+
+    const step = refStep({
+      axis: { kind: 'ref', role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 2, frameKey: '' },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
     expect(result.ok).toBe(true);
-    expect(result.warnings.join(' ')).toContain('the recording had 1');
+    expect(result.warnings).toEqual([]);
+    expect(clicks).toEqual(['first-sign-in']);
+  });
+
+  it('stops when the element was renamed out of the population', async () => {
+    // The name changed, so the recorded axis matches nothing at all — the
+    // oldest stop, still the right one.
+    refEntries = [
+      { role: 'button', name: 'Log in', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 1 },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('log-in'));
+
+    const result = await replayTrace(page, trace([refStep()]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.failedStep).toBe(1);
+    expect(result.steps[0].detail).toContain('no button "Sign in" on the page any more');
+    expect(clicks).toEqual([]);
   });
 
   it('REFUSES when the population changed and the recorded element was not first', async () => {

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -1,5 +1,5 @@
 import type { ElementHandle, Page } from 'playwright-core';
-import { generateSnapshot, listRefEntries, resolveRef } from '../playwright/snapshot';
+import { generateSnapshot, listRefEntries, resolveRef, StaleRefError } from '../playwright/snapshot';
 import { describeToolError } from '../playwright/toolError';
 import { validateNavigationUrl } from '../../shared/types';
 import {
@@ -46,6 +46,11 @@ export interface ReplayResult {
   failedStep?: number;
   /** Set when the run ended early on purpose rather than on a failure. */
   stoppedEarly?: string;
+  /**
+   * The run stopped because the PAGE changed shape, not because the flow is
+   * broken. Kept out of the trace's failure streak (see StepFailure).
+   */
+  inconclusive?: boolean;
   recordedShape: string;
   liveShape: string;
 }
@@ -93,10 +98,16 @@ function shapeWarning(recorded: string, live: string): string | null {
  * no cheaper fallback than stopping: the agent takes one snapshot and finishes
  * the flow live, which is also the next recording.
  *
+ * What this does NOT catch, and cannot with what is recorded: a change that
+ * leaves the COUNT the same — one look-alike added above, one element removed
+ * below. The population still measures N, the index still resolves, and the
+ * element it lands on is a different one. Closing that needs a disambiguator
+ * the recording does not carry.
+ *
  * A missing element is always a refusal — that is the other case where
  * continuing would act on something else.
  */
-function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | { error: string } {
+function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure {
   const population = listRefEntries(page).filter(
     (entry) =>
       entry.role === axis.role &&
@@ -106,23 +117,48 @@ function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | { error: str
   if (population.length === 0) {
     return { error: `no ${describeAxis(axis)} on the page any more` };
   }
+  // Before the index lookup, not after: a population that shrank past the
+  // recorded index would otherwise report only "no element at that position"
+  // and never say that the count is what changed.
+  //
+  // Unnamed axes are exempt, exactly as resolveRef's own count check is, and
+  // for a sharper reason here: their stored total is not a same-name count at
+  // all. smartRefAxisEntry (dom-intelligence) records roleIndex/roleTotal in
+  // these two fields for an element with no accessible name, measured over its
+  // own full-tree walk, while the number compared against is counted from this
+  // module's snapshot ref map (depth-capped, filtered when it overflows). The
+  // two enumerations do not have to agree on an unchanged page, so demanding
+  // equality would stop flows that nothing is wrong with.
+  //
+  // A NAMED smartRef axis is compared anyway, and the same two enumerations
+  // could in principle disagree there too. The axis carries no record of which
+  // recorder minted it, and giving it one would widen the stored format, so
+  // this takes the trade the whole check is built on: a stop the agent can
+  // finish live costs less than a click on the wrong element.
+  if (axis.name !== '' && population.length !== axis.sameNameTotal) {
+    const grew = population.length > axis.sameNameTotal;
+    return {
+      error:
+        `${describeAxis(axis)} can no longer be identified by position: the page has ` +
+        `${population.length} element(s) with that role and name, the recording had ` +
+        `${axis.sameNameTotal} — ` +
+        (grew
+          ? `element(s) were added, and one added at or above position ` +
+            `${axis.sameNameIndex + 1} moves a different element into that slot`
+          : `element(s) were removed, so position ${axis.sameNameIndex + 1} no longer ` +
+            'counts the same population'),
+      // The page changed shape under the recording. That says nothing about
+      // whether the flow itself is still good, so it must not push the trace
+      // toward quarantine (panel ⑤).
+      inconclusive: true,
+    };
+  }
   const match = population.find((entry) => entry.sameNameIndex === axis.sameNameIndex);
   if (!match) {
     return {
       error:
         `${describeAxis(axis)} is gone — the page now has ${population.length} ` +
         `element(s) with that role and name, none at position ${axis.sameNameIndex + 1}`,
-    };
-  }
-  if (population.length !== axis.sameNameTotal) {
-    return {
-      error:
-        `${describeAxis(axis)} can no longer be identified: the page has ` +
-        `${population.length} element(s) with that role and name, the recording had ` +
-        `${axis.sameNameTotal}. Position ${axis.sameNameIndex + 1} only names the same ` +
-        'element while that population is unchanged — an insertion anywhere, the first ' +
-        'position included, moves something else into that slot, so there is no telling ' +
-        'which one was recorded',
     };
   }
   return { ref: String(match.ref) };
@@ -132,7 +168,22 @@ interface Resolved {
   element: ElementHandle;
 }
 
-async function resolveAxis(page: Page, axis: StepAxis): Promise<Resolved | { error: string }> {
+/**
+ * Why a step could not act, and whether that is evidence about the FLOW.
+ *
+ * `inconclusive` marks a stop caused by the page having changed shape under
+ * the recording — a same-name population that grew or shrank, a ref the live
+ * page moved out from under the snapshot. The flow may well be perfectly good;
+ * refusing was about not guessing which element. Those stops still end the run,
+ * but they are kept out of the failure streak that quarantines a trace, so a
+ * page that sprouts a banner cannot permanently demote a working recording.
+ */
+interface StepFailure {
+  error: string;
+  inconclusive?: boolean;
+}
+
+async function resolveAxis(page: Page, axis: StepAxis): Promise<Resolved | StepFailure> {
   if (axis.kind === 'none') return { error: 'this step names no element' };
   if (axis.kind === 'css') {
     const locator = page.locator(axis.selector);
@@ -147,12 +198,29 @@ async function resolveAxis(page: Page, axis: StepAxis): Promise<Resolved | { err
   }
   const matched = matchRefAxis(page, axis);
   if ('error' in matched) return matched;
-  const element = await resolveRef(page, matched.ref).catch(() => null);
+  // strictCount, because the population compared above was counted from the
+  // internal snapshot — a measurement taken BEFORE this step. Anything the page
+  // added since is invisible to it, and on a singleton population resolveRef's
+  // own count check is off by default, so a decoy that appears in that window
+  // would be clicked as position 0. This closes the window at the moment of
+  // acting, which is the only place it can be closed.
+  let element: ElementHandle | null = null;
+  let moved: string | null = null;
+  try {
+    element = await resolveRef(page, matched.ref, { strictCount: true });
+  } catch (error) {
+    // StaleRefError is resolveRef's "the page is no longer the page this ref
+    // was numbered against" — same class as a changed population, and equally
+    // silent about whether the flow is still good. Anything else keeps the
+    // generic message it has always produced.
+    if (error instanceof StaleRefError) moved = error.message;
+  }
+  if (moved !== null) return { error: `${describeAxis(axis)}: ${moved}`, inconclusive: true };
   if (!element) return { error: `${describeAxis(axis)} could not be resolved to a live element` };
   return { element };
 }
 
-type StepOutcome = { detail: string } | { error: string };
+type StepOutcome = { detail: string } | StepFailure;
 
 /**
  * Separator the recorder joins a browser_select's values on, and the only
@@ -348,6 +416,7 @@ export async function replayTrace(
         steps,
         warnings,
         failedStep: index,
+        ...(outcome.inconclusive === true && { inconclusive: true }),
         recordedShape: trace.surfaceShape,
         liveShape,
       };

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -76,28 +76,27 @@ function shapeWarning(recorded: string, live: string): string | null {
  * The match is role + name + position among the same-named elements in the
  * same frame, i.e. exactly the population resolveRef counts against.
  *
- * What a changed population size means depends entirely on WHERE the recorded
- * element sat in it:
+ * A same-name population whose SIZE changed is a refusal at EVERY position.
+ * Position N names the recorded element only while the population around it is
+ * still the one that was counted: an element inserted anywhere — above the
+ * first one included — shifts every index from the insertion point on, and the
+ * replay would act on whatever moved into the slot.
  *
- *   index 0 — the first "Delete" is still the first "Delete" whether the list
- *     holds two rows or five. Adding rows below it cannot move it. Warn and
- *     continue, because refusing here would make the cache useless on every
- *     page that grows a row.
+ * Index 0 used to be exempt, on the theory that nothing can displace the first
+ * element. A decoy `button "Submit order"` inserted BEFORE the real one
+ * disproved that live: the replay clicked the decoy, the real submit never
+ * fired, and the step was reported `ok` with a warning saying the first one
+ * could not have been displaced. Silently acting on the wrong element is the
+ * one outcome a replay must never produce, so the exemption is gone.
  *
- *   index > 0 — position N only means the same element while the N elements
- *     before it are the same N elements. A row inserted anywhere above shifts
- *     the whole tail by one, and the replay then acts on the row that moved
- *     into that slot: a successful-looking run against the wrong item, which
- *     on a "Delete" is exactly the outcome that must never be guessed at.
- *     Refuse (panel review ⑦).
+ * The axis stores nothing beyond the 4-tuple to disambiguate with, so there is
+ * no cheaper fallback than stopping: the agent takes one snapshot and finishes
+ * the flow live, which is also the next recording.
  *
  * A missing element is always a refusal — that is the other case where
  * continuing would act on something else.
  */
-function matchRefAxis(
-  page: Page,
-  axis: RefAxis,
-): { ref: string; warning?: string } | { error: string } {
+function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | { error: string } {
   const population = listRefEntries(page).filter(
     (entry) =>
       entry.role === axis.role &&
@@ -116,22 +115,14 @@ function matchRefAxis(
     };
   }
   if (population.length !== axis.sameNameTotal) {
-    if (axis.sameNameIndex > 0) {
-      return {
-        error:
-          `${describeAxis(axis)} can no longer be identified: the page has ` +
-          `${population.length} element(s) with that role and name, the recording had ` +
-          `${axis.sameNameTotal}. Position ${axis.sameNameIndex + 1} only names the same ` +
-          'element while everything before it is unchanged, so this would act on whatever ' +
-          'moved into that slot',
-      };
-    }
     return {
-      ref: String(match.ref),
-      warning:
-        `${describeAxis(axis)}: the page now has ${population.length} such element(s), ` +
-        `the recording had ${axis.sameNameTotal} — the first one cannot have been ` +
-        'displaced, so replaying against it',
+      error:
+        `${describeAxis(axis)} can no longer be identified: the page has ` +
+        `${population.length} element(s) with that role and name, the recording had ` +
+        `${axis.sameNameTotal}. Position ${axis.sameNameIndex + 1} only names the same ` +
+        'element while that population is unchanged — an insertion anywhere, the first ' +
+        'position included, moves something else into that slot, so there is no telling ' +
+        'which one was recorded',
     };
   }
   return { ref: String(match.ref) };
@@ -139,7 +130,6 @@ function matchRefAxis(
 
 interface Resolved {
   element: ElementHandle;
-  warning?: string;
 }
 
 async function resolveAxis(page: Page, axis: StepAxis): Promise<Resolved | { error: string }> {
@@ -159,10 +149,10 @@ async function resolveAxis(page: Page, axis: StepAxis): Promise<Resolved | { err
   if ('error' in matched) return matched;
   const element = await resolveRef(page, matched.ref).catch(() => null);
   if (!element) return { error: `${describeAxis(axis)} could not be resolved to a live element` };
-  return { element, ...(matched.warning !== undefined && { warning: matched.warning }) };
+  return { element };
 }
 
-type StepOutcome = { detail: string; warning?: string } | { error: string };
+type StepOutcome = { detail: string } | { error: string };
 
 /**
  * Separator the recorder joins a browser_select's values on, and the only
@@ -206,29 +196,28 @@ async function runStep(
   const resolved = await resolveAxis(page, step.axis);
   if ('error' in resolved) return resolved;
   const { element } = resolved;
-  const warn = resolved.warning !== undefined ? { warning: resolved.warning } : {};
 
   switch (step.tool) {
     case 'browser_click':
       if (args.double === true) await element.dblclick();
       else await element.click();
-      return { detail: `clicked ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `clicked ${describeAxis(step.axis)}` };
     case 'browser_type':
       await element.fill(String(args.text ?? ''));
       if (args.submit === true) await page.keyboard.press('Enter');
-      return { detail: `typed into ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `typed into ${describeAxis(step.axis)}` };
     case 'browser_fill':
       await element.fill(String(args.value ?? ''));
-      return { detail: `filled ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `filled ${describeAxis(step.axis)}` };
     case 'browser_hover':
       await element.hover();
-      return { detail: `hovered ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `hovered ${describeAxis(step.axis)}` };
     case 'browser_select':
       await element.selectOption(String(args.values ?? '').split(SELECT_VALUE_SEPARATOR));
-      return { detail: `selected in ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `selected in ${describeAxis(step.axis)}` };
     case 'browser_scroll_into_view':
       await element.scrollIntoViewIfNeeded();
-      return { detail: `scrolled ${describeAxis(step.axis)} into view`, ...warn };
+      return { detail: `scrolled ${describeAxis(step.axis)} into view` };
     case 'browser_scroll': {
       const px = typeof args.amount === 'number' ? args.amount : 500;
       const direction = String(args.direction ?? 'down');
@@ -238,7 +227,7 @@ async function runStep(
         (node, [x, y]) => { (node as Element).scrollBy(x, y); },
         [dx, dy] as [number, number],
       );
-      return { detail: `scrolled inside ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `scrolled inside ${describeAxis(step.axis)}` };
     }
     case 'browser_drag': {
       if (!step.target2) return { error: 'the recorded drag has no target' };
@@ -251,7 +240,7 @@ async function runStep(
       await page.mouse.down();
       await page.mouse.move(to.x + to.width / 2, to.y + to.height / 2, { steps: 10 });
       await page.mouse.up();
-      return { detail: `dragged ${describeAxis(step.axis)}`, ...warn };
+      return { detail: `dragged ${describeAxis(step.axis)}` };
     }
     default:
       return { error: `${step.tool} cannot be replayed by this version` };
@@ -363,7 +352,6 @@ export async function replayTrace(
         liveShape,
       };
     }
-    if (outcome.warning !== undefined) warnings.push(`step ${index}: ${outcome.warning}`);
     steps.push({ index, tool: step.tool, ok: true, detail: outcome.detail });
 
     // A step that changed the page invalidates the ref map the remaining steps

--- a/src/mcp/browser-replay/tool.ts
+++ b/src/mcp/browser-replay/tool.ts
@@ -407,6 +407,7 @@ export function createReplayToolCatalog(deps: BrowserToolDeps) {
       name,
       ok: result.ok,
       ...(result.failedStep !== undefined && { failedStep: result.failedStep }),
+      ...(result.inconclusive === true && { inconclusive: true }),
     }).catch(() => {
       /* statistics are an optimization for the hint pipe; never fail a run on them */
     });

--- a/src/mcp/playwright/__tests__/snapshot.refstability.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.refstability.test.ts
@@ -228,6 +228,32 @@ describe('resolveRef refuses a stale ref instead of substituting an element', ()
     expect(await resolveRef(page, '0')).toBe('button Copy#0');
   });
 
+  it('DOES block that singleton when the caller asks for strictCount', async () => {
+    // The replay lane opts in: there, index 0 is not reassuring, because a
+    // look-alike inserted above the recorded element between the internal
+    // snapshot and the click takes over position 0 and would be clicked as if
+    // it were the recorded one.
+    const page = makePage(tree([{ backendId: 86, role: 'button', name: 'Submit order' }]));
+    await generateSnapshot(page, { format: 'ai' });
+    (page as unknown as FakePage).liveCounts.set('button Submit order', 2);
+
+    await expect(
+      resolveRef(page, '0', { strictCount: true }),
+    ).rejects.toBeInstanceOf(StaleRefError);
+    expect((page as unknown as FakePage).handles).toEqual([]);
+  });
+
+  it('leaves an unnamed ref alone even under strictCount', async () => {
+    // No name filter means the locator counts named siblings too, so the two
+    // numbers are not comparable at all — strictness there is just a wrong
+    // answer, not a stricter one.
+    const page = makePage(tree([{ backendId: 87, role: 'button', name: '' }]));
+    await generateSnapshot(page, { format: 'ai' });
+    (page as unknown as FakePage).liveCounts.set('button ', 4);
+
+    expect(await resolveRef(page, '0', { strictCount: true })).toBe('button #0');
+  });
+
   it('still resolves the right instance while the page is unchanged', async () => {
     const page = makePage(
       tree([

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -1936,6 +1936,25 @@ export async function generateScopedSnapshot(
   return filterNote ? `${filterNote}\n${output}` : output;
 }
 
+export interface ResolveRefOptions {
+  /**
+   * Also count-check a ref whose snapshot population was a SINGLETON.
+   *
+   * Off by default because the snapshot's count and the locator's count are
+   * not measured the same way (see resolveRefViaAxMap), so on a singleton —
+   * where the index is 0 whatever the count — the comparison mostly costs
+   * false rejections.
+   *
+   * The replay runner turns it on, because there the index being 0 is not
+   * reassuring: a look-alike inserted ABOVE the recorded element between the
+   * internal snapshot and the click takes over position 0, and clicking it
+   * would be the silent wrong-element outcome a replay must never produce. A
+   * replay that stops too often is recoverable — the agent finishes live — so
+   * that lane takes the false rejections in exchange.
+   */
+  strictCount?: boolean;
+}
+
 /**
  * Resolve a ref number (produced by `generateSnapshot` with format='ai')
  * back to a live ElementHandle.
@@ -1954,9 +1973,10 @@ export async function generateScopedSnapshot(
 export async function resolveRef(
   page: Page,
   ref: string,
+  options?: ResolveRefOptions,
 ): Promise<ElementHandle | null> {
   // Primary: the a11y refMap from the last generateSnapshot() on this page.
-  const primary = await resolveRefViaAxMap(page, ref);
+  const primary = await resolveRefViaAxMap(page, ref, options?.strictCount === true);
   if (primary) return primary;
 
   // Fallback: DOM snapshots (the RPC fallback + the root-only fallthrough) tag
@@ -2076,6 +2096,7 @@ async function resolveFrameRoot(
 async function resolveRefViaAxMap(
   page: Page,
   ref: string,
+  strictCount = false,
 ): Promise<ElementHandle | null> {
   const wanted = refNumber(ref);
   if (wanted === null) return null;
@@ -2163,11 +2184,14 @@ async function resolveRefViaAxMap(
   //    counts named siblings too and the totals are not comparable at all.
   //  - Entries the snapshot saw only one of are exempt: the index is 0 either
   //    way, so the count buys no safety and only costs false rejections.
+  //    UNLESS the caller asked for strictCount — see ResolveRefOptions. On a
+  //    replay, a singleton is exactly where a look-alike inserted above the
+  //    recorded element hides, and index 0 then names the look-alike.
   //
   // What is left is exactly the case the index is load-bearing for: the
   // snapshot listed several elements with this role+name, and which one a ref
   // means depends on that population still being what it was.
-  if (target.name && target.sameNameTotal > 1 && count !== target.sameNameTotal) {
+  if (target.name && (strictCount || target.sameNameTotal > 1) && count !== target.sameNameTotal) {
     throw new StaleRefError(
       `ref=${ref} is stale — the page now has ${count} ${target.role} element(s) named ` +
         `"${target.name}", not the ${target.sameNameTotal} the last snapshot listed, so the ref ` +

--- a/src/shared/browserReplay/__tests__/actionTrace.test.ts
+++ b/src/shared/browserReplay/__tests__/actionTrace.test.ts
@@ -267,6 +267,28 @@ describe('applyRunOutcome', () => {
     expect(isQuarantined(second)).toBe(true);
   });
 
+  it('an inconclusive stop moves no counter, so it cannot quarantine a flow', () => {
+    // The page grew a same-name element and the replay refused to guess which
+    // one. That is not evidence the flow is broken, and counting it twice would
+    // retire a working recording because a banner appeared (panel ⑤).
+    const first = applyRunOutcome(trace({ successCount: 3 }), {
+      ok: false,
+      failedStep: 2,
+      inconclusive: true,
+      now: NOW,
+    });
+    const second = applyRunOutcome(first, {
+      ok: false,
+      failedStep: 2,
+      inconclusive: true,
+      now: NOW,
+    });
+    expect(isQuarantined(second)).toBe(false);
+    expect(second.failCount).toBe(0);
+    expect(second.successCount).toBe(3);
+    expect(second.lastUsedAt).toBe(NOW);
+  });
+
   it('does not quarantine when the failures are at different steps', () => {
     const first = applyRunOutcome(trace({ successCount: 3 }), { ok: false, failedStep: 2, now: NOW });
     const second = applyRunOutcome(first, { ok: false, failedStep: 4, now: NOW });

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -401,6 +401,12 @@ export interface RunOutcome {
   ok: boolean;
   /** 1-based step index a failed run stopped at. */
   failedStep?: number;
+  /**
+   * The run stopped because the page changed shape under the recording, not
+   * because the flow is wrong — a same-name population that grew or shrank,
+   * where refusing to guess which element was the correct move.
+   */
+  inconclusive?: boolean;
   now?: number;
 }
 
@@ -414,6 +420,13 @@ export interface RunOutcome {
  */
 export function applyRunOutcome(trace: TraceRecord, outcome: RunOutcome): TraceRecord {
   const now = outcome.now ?? Date.now();
+  // An inconclusive stop is not evidence either way, so it moves no counter but
+  // the clock. Counting it as a failure would let a page that merely sprouted a
+  // second "Save" quarantine a working flow on its second try and drop it out
+  // of the hint pipe for good — a permanent demotion bought by a banner.
+  if (!outcome.ok && outcome.inconclusive === true) {
+    return { ...trace, lastUsedAt: now };
+  }
   if (outcome.ok) {
     return {
       ...trace,


### PR DESCRIPTION
## The defect

Live on 3.50.0 (chrome backend). A flow was recorded on a page holding one
`button "Submit order"` — `sameNameIndex 0`, `sameNameTotal 1`. A decoy button
with the same accessible name was then inserted **before** the real one, and the
flow was replayed:

```
ok 4. browser_click — clicked button "Submit order"
warning: step 4: button "Submit order": the page now has 2 such element(s), the
recording had 1 — the first one cannot have been displaced, so replaying against it
```

The replay clicked the decoy. The real submit never fired, and the step was
reported `ok`. "The first one cannot have been displaced" is false: an insertion
before index 0 displaces it, and index 0 of the live population is then a
different element entirely. This is the silently-wrong-element outcome the
feature was explicitly designed never to produce.

## The fix

`matchRefAxis` refuses at **every** position when the live same-name population
size differs from the recorded `sameNameTotal`, instead of exempting index 0.
Position N identifies the recorded element only while the population around it
is the one that was counted at record time. The step stops the run the way a
vanished element does, naming both counts and which way the count moved, and the
page is left where it stopped so the agent takes one snapshot and finishes live.

Three things the review panel found on top of that:

**The count is re-checked against the live page at the moment of acting.** The
population `matchRefAxis` compares comes from the internal snapshot — a
measurement taken *before* the step — so an element added between that snapshot
and the click is invisible to it. `resolveRef` already re-counts live but
skipped singleton populations, which is exactly where a look-alike inserted
above the recorded element hides. It now takes a `strictCount` option that drops
that exemption; the replay lane is the only caller that passes it, so live tools
keep the looser behaviour that avoids false rejections.

**Unnamed axes are exempt from the comparison.** Their stored total is not a
same-name count: `smartRefAxisEntry` records `roleIndex`/`roleTotal` in those
fields for an element with no accessible name, measured over dom-intelligence's
own walk, while the number compared against is counted from the snapshot ref map
(depth-capped, filtered on overflow). The two enumerations need not agree on an
unchanged page, so strict equality there could stop a flow with nothing wrong
with it. `resolveRef`'s own count check exempts unnamed refs for the same reason.

**A count-change stop no longer counts against the trace.** It fed the per-step
failure streak, so a page that merely grew a second "Save" could quarantine a
working recording on its second try and drop it out of the hint pipe for good.
Such a stop now travels as `inconclusive` from the runner through the stats RPC
to `applyRunOutcome`, which moves no counter but the clock. A vanished element
still counts as a failure — that one *is* evidence about the flow.

Also: the count comparison runs before the index lookup, so a population that
shrank past the recorded position reports the count rather than only "nothing at
that position".

## Known limitation, stated in the code, the docs and the changelog

Count equality is not identity. A change that leaves the count the same — one
look-alike added above, one element removed below — still measures N, still
resolves by index, and still lands on a different element. Telling those apart
needs a disambiguator the recording does not carry; widening the recorded format
is out of scope here.

A named smartRef axis is compared across those two enumerations anyway, since
the axis carries no record of which recorder minted it. That takes the trade the
whole check is built on: a stop the agent can finish live costs less than a click
on the wrong element.

Unchanged: population equal resolves by index at every position; a missing
element and a recorded position that no longer exists still stop with their own
messages.

Removed along the way: the per-step warning plumbing (`StepOutcome.warning`,
`Resolved.warning`, the `...warn` spreads). `matchRefAxis` was its only producer,
so it became unreachable. The page-shape warning is untouched.

## Tests

`src/mcp/browser-replay/__tests__/replayRunner.test.ts`

- decoy inserted before the recorded first element → stops, nothing clicked,
  marked inconclusive (replaces the test that asserted the old warn-and-click)
- population unchanged at index 0 → still resolves, no warnings
- element renamed out of the population → existing stop, and NOT inconclusive
- population shrank past the recorded position → reports the count
- population grew after the internal snapshot → stops on the strict live count
- unnamed axis with a mismatched total → still resolves

`src/mcp/playwright/__tests__/snapshot.refstability.test.ts`

- `strictCount` blocks a singleton whose live count changed
- `strictCount` still leaves an unnamed ref alone
- the existing default-behaviour test is untouched and still passes

`src/shared/browserReplay/__tests__/actionTrace.test.ts`

- two inconclusive stops in a row move no counter and do not quarantine

## Docs

`docs/how-to/replay-browser-flows.md` described the old position-dependent rule.

## Gates

- `npx tsc --noEmit` — clean
- `npx vitest run src/mcp/browser-replay src/shared/browserReplay` plus the
  refstability, browser-session and browser.rpc suites — all pass; the full
  `src/mcp` suite is green at 1022 tests
- `npm run build:mcp && npm run probe:mcp` — clean; tools/list bytes unchanged
  at full 75,457 / core 46,665 / commander 43,314, since no tool description
  text was touched