### PR TITLE
fix(browser): make the emulated identity agree with itself

### DIFF
--- a/changelog.d/1181.md
+++ b/changelog.d/1181.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- **A navigation that carries a Referer no longer contradicts it.** When the
+  agent left one page for another, the Referer header said a link had been
+  followed while Chromium's own `Sec-Fetch-Site: none` said the URL was typed
+  into the address bar — a pair no real browser sends. With a referer to send,
+  the navigation now happens from inside the page, so the whole header set
+  agrees; without one, `page.goto` is used as before. (#1181)
+
+- **`browser_emulate` device presets apply the whole device.** Choosing
+  `iPhone 13` set the User-Agent and viewport and stopped there, leaving
+  `navigator.platform` at `MacIntel`, no touch points and a desktop pixel
+  ratio behind the mobile UA. The preset now carries platform, device metrics
+  and touch on both backends, and `device: null` clears all of it. (#1181)
+
+- **Humanlike typing holds each key for a human interval.** Keys were pressed
+  and released within a millisecond; the dwell is now drawn from the same
+  log-normal rhythm as the inter-key delay (median 70 ms). (#1181)

--- a/changelog.d/1181.md
+++ b/changelog.d/1181.md
@@ -8,10 +8,15 @@
   agrees; without one, `page.goto` is used as before. (#1181)
 
 - **`browser_emulate` device presets apply the whole device.** Choosing
-  `iPhone 13` set the User-Agent and viewport and stopped there, leaving
-  `navigator.platform` at `MacIntel`, no touch points and a desktop pixel
-  ratio behind the mobile UA. The preset now carries platform, device metrics
-  and touch on both backends, and `device: null` clears all of it. (#1181)
+  `iPhone 13` set the User-Agent and viewport and stopped there, leaving no
+  touch points, a desktop pixel ratio and desktop viewport semantics behind the
+  mobile UA. The preset now carries device metrics, screen size, orientation
+  and touch on both backends, holds them across navigations, and `device: null`
+  clears all of it. Two limits the result now states outright: on a page under
+  automation `navigator.platform` keeps the host's value, and a non-Chromium
+  preset such as an iPhone cannot fill `navigator.userAgentData` or the
+  `Sec-CH-UA*` headers, which keep answering as Chromium — a Chrome-based
+  preset gives a consistent mobile identity. (#1181)
 
 - **Humanlike typing holds each key for a human interval.** Keys were pressed
   and released within a millisecond; the dwell is now drawn from the same

--- a/src/main/browser-session/HumanBehavior.ts
+++ b/src/main/browser-session/HumanBehavior.ts
@@ -1,4 +1,4 @@
-import { generateTypingDelays, typingDelayFor } from '../../shared/humanRhythm';
+import { generateKeyHolds, generateTypingDelays, typingDelayFor } from '../../shared/humanRhythm';
 
 export interface HumanBehaviorConfig {
   typingDelay: { min: number; max: number };
@@ -69,5 +69,16 @@ export class HumanBehavior {
   generateTypingSchedule(text: string): number[] {
     const { min, max } = this.config.typingDelay;
     return generateTypingDelays(text, { minDelay: min, maxDelay: max });
+  }
+
+  /**
+   * How long each key is held DOWN, as opposed to the gap after it that
+   * `generateTypingSchedule` returns. A caller executing the schedule with a
+   * press-and-release per character produces a ~1 ms dwell time, which is a
+   * keystroke-dynamics signature of its own; this is the other half of the
+   * schedule it needs.
+   */
+  generateHoldSchedule(text: string): number[] {
+    return generateKeyHolds(text);
   }
 }

--- a/src/main/browser-session/HumanBehavior.ts
+++ b/src/main/browser-session/HumanBehavior.ts
@@ -1,4 +1,10 @@
-import { generateKeyHolds, generateTypingDelays, typingDelayFor } from '../../shared/humanRhythm';
+import {
+  generateKeyHolds,
+  generateKeystrokeSchedule,
+  generateTypingDelays,
+  typingDelayFor,
+  type KeystrokeSchedule,
+} from '../../shared/humanRhythm';
 
 export interface HumanBehaviorConfig {
   typingDelay: { min: number; max: number };
@@ -80,5 +86,18 @@ export class HumanBehavior {
    */
   generateHoldSchedule(text: string): number[] {
     return generateKeyHolds(text);
+  }
+
+  /**
+   * Both halves of the keystroke stream, drawn against one budget.
+   *
+   * Taking the two schedules separately double-counted the time: the gap cap
+   * was applied to the gaps alone and every dwell was then added on top. A
+   * caller that reports or reserves a duration needs the pair that actually
+   * fits.
+   */
+  generateKeystrokeSchedule(text: string): KeystrokeSchedule {
+    const { min, max } = this.config.typingDelay;
+    return generateKeystrokeSchedule(text, { minDelay: min, maxDelay: max });
   }
 }

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -19,6 +19,24 @@ import {
 import { stepsFingerprint } from '../../../shared/browserReplay/actionTrace';
 import { HumanBehavior } from '../../browser-session/HumanBehavior';
 import { approachPath, defaultStartPoint, type Point } from '../../../shared/pointerPath';
+
+/**
+ * The physical half of the device preset currently emulated on a WebContents.
+ *
+ * `Emulation.setDeviceMetricsOverride` replaces the whole override, so any
+ * later command that sends only a width and a height — browser.resize — would
+ * drop the preset's pixel ratio and mobile flag while its UA and touch points
+ * stayed behind. Keyed weakly: a closed WebContents takes its entry with it.
+ */
+const activePreset = new WeakMap<
+  WebContents,
+  {
+    deviceScaleFactor: number;
+    mobile: boolean;
+    screenWidth?: number;
+    screenHeight?: number;
+  }
+>();
 import { refererFor } from '../../../shared/referer';
 import { buildUserAgentOverride } from '../../../shared/uaMetadata';
 import { WebviewCdpManager } from '../../browser-session/WebviewCdpManager';
@@ -1744,12 +1762,13 @@ export function registerBrowserRpc(
     const text: string = params['text'];
     const selector = typeof params['selector'] === 'string' ? params['selector'] : undefined;
 
-    const delays = humanBehavior.generateTypingSchedule(text);
     // The gaps alone describe a typist who presses and releases every key in
     // the same millisecond. `holds` is how long each key stays down, so a
     // caller driving the keyboard from this schedule produces a real dwell
-    // time rather than a biometric giveaway.
-    const holds = humanBehavior.generateHoldSchedule(text);
+    // time rather than a biometric giveaway. Both are drawn against one
+    // budget — a caller reserving `totalDuration` has to be told the time the
+    // holds spend too, or it plans for a schedule shorter than the one it got.
+    const { delays, holds } = humanBehavior.generateKeystrokeSchedule(text);
     const config = humanBehavior.getConfig();
 
     return {
@@ -1757,7 +1776,8 @@ export function registerBrowserRpc(
       ...(selector && { selector }),
       delays,
       holds,
-      totalDuration: delays.reduce((sum, d) => sum + d, 0),
+      totalDuration:
+        delays.reduce((sum, d) => sum + d, 0) + holds.reduce((sum, h) => sum + h, 0),
       config: {
         typingDelay: config.typingDelay,
       },
@@ -2383,8 +2403,21 @@ export function registerBrowserRpc(
     }
     const surfaceId = typeof params['surfaceId'] === 'string' ? params['surfaceId'] : undefined;
     const wc = resolveWc(surfaceId, 'browser.resize', scope);
+    // setDeviceMetricsOverride replaces the whole override, so sending the
+    // desktop defaults here silently undid an active device preset's pixel
+    // ratio and mobile flag while its UA and touch points stayed — the
+    // contradiction the preset path exists to remove, reintroduced by a
+    // resize. Carry the preset's values through instead.
+    const preset = activePreset.get(wc);
     await wc.debugger.sendCommand('Emulation.setDeviceMetricsOverride', {
-      width, height, deviceScaleFactor: 0, mobile: false,
+      width,
+      height,
+      deviceScaleFactor: preset?.deviceScaleFactor ?? 0,
+      mobile: preset?.mobile ?? false,
+      ...(preset?.screenWidth !== undefined && preset?.screenHeight !== undefined && {
+        screenWidth: preset.screenWidth,
+        screenHeight: preset.screenHeight,
+      }),
     });
     return { ok: true, width, height };
   });
@@ -2486,6 +2519,7 @@ export function registerBrowserRpc(
       applied.push(locale ? `locale=${locale}` : 'locale=reset');
     }
 
+    let touchUnavailable = false;
     if (params['deviceMetrics'] && typeof params['deviceMetrics'] === 'object') {
       const dm = params['deviceMetrics'] as {
         width: number; height: number; deviceScaleFactor?: number; mobile?: boolean;
@@ -2504,6 +2538,11 @@ export function registerBrowserRpc(
         // desktop preset after a phone one actually turns touch back off.
         await send('Emulation.setTouchEmulationEnabled', {
           enabled: dm.hasTouch, maxTouchPoints: dm.hasTouch ? 5 : 0,
+        }).catch(() => {
+          // Same guard the reset path has: a transport without touch
+          // emulation must not take the whole preset down with it — the UA,
+          // the metrics and the pixel ratio are still worth applying.
+          touchUnavailable = true;
         });
       }
       if (typeof params['userAgent'] === 'string') {
@@ -2517,14 +2556,28 @@ export function registerBrowserRpc(
           buildUserAgentOverride(params['userAgent'], emulatedLocale) as unknown as Record<string, unknown>,
         );
       }
+      // Remembered so browser.resize can keep the preset's pixel ratio, mobile
+      // flag and touch instead of flattening them back to the desktop values —
+      // a resize used to leave a phone UA on a desktop pixel ratio with a
+      // touchscreen still attached, which is a contradiction of its own.
+      activePreset.set(wc, {
+        deviceScaleFactor: dm.deviceScaleFactor ?? 0,
+        mobile: dm.mobile ?? false,
+        ...(dm.screenWidth !== undefined && dm.screenHeight !== undefined && {
+          screenWidth: dm.screenWidth,
+          screenHeight: dm.screenHeight,
+        }),
+      });
       const label = typeof params['deviceLabel'] === 'string' ? params['deviceLabel'] : `${dm.width}x${dm.height}`;
       applied.push(`device=${label}`);
+      if (touchUnavailable) applied.push('touch=unavailable on this transport');
     } else if (params['deviceReset'] === true) {
       // Actually undo the preset over CDP: drop the device metrics override and
       // restore the real user agent. Without this, a packaged caller who switches
       // to a phone preset and then resets stays on the mobile UA/metrics for every
       // subsequent page. CDP has no "clear UA override" command, so re-apply the
       // WebContents' own UA to shed the mobile one set by the preset above.
+      activePreset.delete(wc);
       await send('Emulation.clearDeviceMetricsOverride');
       // The touch points the preset installed outlive clearDeviceMetricsOverride,
       // so a reset that skipped this left a desktop UA reporting a touchscreen.

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -1745,12 +1745,18 @@ export function registerBrowserRpc(
     const selector = typeof params['selector'] === 'string' ? params['selector'] : undefined;
 
     const delays = humanBehavior.generateTypingSchedule(text);
+    // The gaps alone describe a typist who presses and releases every key in
+    // the same millisecond. `holds` is how long each key stays down, so a
+    // caller driving the keyboard from this schedule produces a real dwell
+    // time rather than a biometric giveaway.
+    const holds = humanBehavior.generateHoldSchedule(text);
     const config = humanBehavior.getConfig();
 
     return {
       text,
       ...(selector && { selector }),
       delays,
+      holds,
       totalDuration: delays.reduce((sum, d) => sum + d, 0),
       config: {
         typingDelay: config.typingDelay,
@@ -2481,11 +2487,25 @@ export function registerBrowserRpc(
     }
 
     if (params['deviceMetrics'] && typeof params['deviceMetrics'] === 'object') {
-      const dm = params['deviceMetrics'] as { width: number; height: number; deviceScaleFactor?: number; mobile?: boolean };
+      const dm = params['deviceMetrics'] as {
+        width: number; height: number; deviceScaleFactor?: number; mobile?: boolean;
+        hasTouch?: boolean; screenWidth?: number; screenHeight?: number;
+      };
       await send('Emulation.setDeviceMetricsOverride', {
         width: dm.width, height: dm.height,
         deviceScaleFactor: dm.deviceScaleFactor ?? 0, mobile: dm.mobile ?? false,
+        ...(dm.screenWidth !== undefined && dm.screenHeight !== undefined
+          ? { screenWidth: dm.screenWidth, screenHeight: dm.screenHeight }
+          : {}),
       });
+      if (dm.hasTouch !== undefined) {
+        // navigator.maxTouchPoints stayed 0 under a phone preset, contradicting
+        // the UA the same call had just installed. Sent on both branches so a
+        // desktop preset after a phone one actually turns touch back off.
+        await send('Emulation.setTouchEmulationEnabled', {
+          enabled: dm.hasTouch, maxTouchPoints: dm.hasTouch ? 5 : 0,
+        });
+      }
       if (typeof params['userAgent'] === 'string') {
         // Metadata is derived here rather than sent over the wire, so the
         // Client Hints surface (navigator.userAgentData, Sec-CH-UA*) agrees
@@ -2506,6 +2526,10 @@ export function registerBrowserRpc(
       // subsequent page. CDP has no "clear UA override" command, so re-apply the
       // WebContents' own UA to shed the mobile one set by the preset above.
       await send('Emulation.clearDeviceMetricsOverride');
+      // The touch points the preset installed outlive clearDeviceMetricsOverride,
+      // so a reset that skipped this left a desktop UA reporting a touchscreen.
+      await send('Emulation.setTouchEmulationEnabled', { enabled: false, maxTouchPoints: 0 })
+        .catch(() => { /* transport without touch emulation; metrics still cleared */ });
       try {
         const ua = typeof wc.getUserAgent === 'function' ? wc.getUserAgent() : undefined;
         // Restore the metadata alongside the string: re-applying the real UA

--- a/src/mcp/playwright/__tests__/human-typing.test.ts
+++ b/src/mcp/playwright/__tests__/human-typing.test.ts
@@ -7,7 +7,7 @@ import { KEY_HOLD_MAX_MS, KEY_HOLD_MIN_MS } from '../../../shared/humanRhythm';
 // the same millisecond. These cover the split, the hold that sits between the
 // two events, and the fallback for characters that cannot be a key at all.
 
-type KeyEvent = { type: 'down' | 'up' | 'press'; key: string; at: number };
+type KeyEvent = { type: 'down' | 'up' | 'press' | 'insert'; key: string; at: number };
 
 /** A fake Page recording every keyboard event with the (fake) clock time. */
 function fakePage(opts?: { downRejects?: (char: string) => boolean }): {
@@ -26,7 +26,14 @@ function fakePage(opts?: { downRejects?: (char: string) => boolean }): {
         events.push({ type: 'up', key, at: Date.now() });
       }),
       press: vi.fn(async (key: string) => {
+        // press() calls down() internally, so a character down() refuses is
+        // refused here too. The fake mirrors that rather than pretending
+        // press() is a second way in.
+        if (opts?.downRejects?.(key)) throw new Error(`Unknown key: "${key}"`);
         events.push({ type: 'press', key, at: Date.now() });
+      }),
+      insertText: vi.fn(async (text: string) => {
+        events.push({ type: 'insert', key: text, at: Date.now() });
       }),
     },
   } as unknown as Page;
@@ -66,7 +73,10 @@ describe('typeHumanlike key hold', () => {
 
   it('holds every key inside the 30-150 ms band', async () => {
     const { page, events } = fakePage();
-    await typeOnFakeClock(page, 'the quick brown fox');
+    // Short enough that the schedule's budget is not the binding constraint:
+    // when it is, delays and holds are scaled together and a hold may land
+    // under the band's floor by design (see generateKeystrokeSchedule).
+    await typeOnFakeClock(page, 'the quick');
 
     const holds: number[] = [];
     for (let i = 0; i < events.length; i += 2) {
@@ -74,7 +84,7 @@ describe('typeHumanlike key hold', () => {
       expect(events[i + 1].type).toBe('up');
       holds.push(events[i + 1].at - events[i].at);
     }
-    expect(holds).toHaveLength('the quick brown fox'.length);
+    expect(holds).toHaveLength('the quick'.length);
     for (const hold of holds) {
       // The defect: press() produced a ~1 ms dwell time on every key.
       expect(hold).toBeGreaterThanOrEqual(Math.floor(KEY_HOLD_MIN_MS));
@@ -84,15 +94,28 @@ describe('typeHumanlike key hold', () => {
     expect(new Set(holds).size).toBeGreaterThan(1);
   });
 
-  it('falls back to press() for a character that cannot be a key', async () => {
-    // CJK and emoji halves: keyboard.down() cannot describe them, and press()
-    // is the path that still inserts them as text.
+  it('inserts a character that cannot be a key, rather than losing it', async () => {
+    // CJK and emoji halves: keyboard.down() cannot describe them — and neither
+    // can press(), which calls down() itself. insertText is the path that puts
+    // the character in, at the cost of that one keystroke's hold.
     const { page, events } = fakePage({ downRejects: (c) => c === '한' });
     await typeOnFakeClock(page, 'a한b');
 
     expect(events.map((e) => `${e.type}:${e.key}`)).toEqual([
-      'down:a', 'up:a', 'press:한', 'down:b', 'up:b',
+      'down:a', 'up:a', 'insert:한', 'down:b', 'up:b',
     ]);
+  });
+
+  it('keeps a long text inside the schedule budget, holds included', async () => {
+    const { page, events } = fakePage();
+    const text = 'the quick brown fox jumps over the lazy dog, twice over';
+    await typeOnFakeClock(page, text);
+
+    const spent = events[events.length - 1].at - events[0].at;
+    // 120 ms per character plus 1500 ms of slack is the cap the schedule
+    // promises; adding every hold on top of an already-capped delay list blew
+    // through it by more than half.
+    expect(spent).toBeLessThanOrEqual(text.length * 120 + 1500);
   });
 
   it('clicks the selector first when one is given', async () => {

--- a/src/mcp/playwright/__tests__/human-typing.test.ts
+++ b/src/mcp/playwright/__tests__/human-typing.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Page } from 'playwright-core';
+import { generateHoldSchedule, typeHumanlike } from '../human-typing';
+import { KEY_HOLD_MAX_MS, KEY_HOLD_MIN_MS } from '../../../shared/humanRhythm';
+
+// A keystroke is a key held DOWN and then released, not a press-and-release in
+// the same millisecond. These cover the split, the hold that sits between the
+// two events, and the fallback for characters that cannot be a key at all.
+
+type KeyEvent = { type: 'down' | 'up' | 'press'; key: string; at: number };
+
+/** A fake Page recording every keyboard event with the (fake) clock time. */
+function fakePage(opts?: { downRejects?: (char: string) => boolean }): {
+  page: Page;
+  events: KeyEvent[];
+} {
+  const events: KeyEvent[] = [];
+  const page = {
+    click: vi.fn(async () => undefined),
+    keyboard: {
+      down: vi.fn(async (key: string) => {
+        if (opts?.downRejects?.(key)) throw new Error(`Unknown key: "${key}"`);
+        events.push({ type: 'down', key, at: Date.now() });
+      }),
+      up: vi.fn(async (key: string) => {
+        events.push({ type: 'up', key, at: Date.now() });
+      }),
+      press: vi.fn(async (key: string) => {
+        events.push({ type: 'press', key, at: Date.now() });
+      }),
+    },
+  } as unknown as Page;
+  return { page, events };
+}
+
+/**
+ * Run `typeHumanlike` on fake timers, draining every scheduled sleep as it is
+ * created so the loop advances without real waiting. `Date.now()` follows the
+ * fake clock, so the recorded event times are the schedule itself.
+ */
+async function typeOnFakeClock(page: Page, text: string): Promise<void> {
+  vi.useFakeTimers();
+  try {
+    const done = typeHumanlike(page, '', text);
+    // Each await in the loop resolves a microtask before the next timer is
+    // scheduled, so keep pumping until the whole run settles.
+    for (let i = 0; i < text.length * 8 + 8; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+    }
+    await done;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+describe('typeHumanlike key hold', () => {
+  it('splits each character into down + up rather than a bare press', async () => {
+    const { page, events } = fakePage();
+    await typeOnFakeClock(page, 'abc');
+
+    expect(events.map((e) => `${e.type}:${e.key}`)).toEqual([
+      'down:a', 'up:a', 'down:b', 'up:b', 'down:c', 'up:c',
+    ]);
+    expect((page.keyboard.press as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+
+  it('holds every key inside the 30-150 ms band', async () => {
+    const { page, events } = fakePage();
+    await typeOnFakeClock(page, 'the quick brown fox');
+
+    const holds: number[] = [];
+    for (let i = 0; i < events.length; i += 2) {
+      expect(events[i].type).toBe('down');
+      expect(events[i + 1].type).toBe('up');
+      holds.push(events[i + 1].at - events[i].at);
+    }
+    expect(holds).toHaveLength('the quick brown fox'.length);
+    for (const hold of holds) {
+      // The defect: press() produced a ~1 ms dwell time on every key.
+      expect(hold).toBeGreaterThanOrEqual(Math.floor(KEY_HOLD_MIN_MS));
+      expect(hold).toBeLessThanOrEqual(Math.ceil(KEY_HOLD_MAX_MS));
+    }
+    // Not every key held for the same length of time either.
+    expect(new Set(holds).size).toBeGreaterThan(1);
+  });
+
+  it('falls back to press() for a character that cannot be a key', async () => {
+    // CJK and emoji halves: keyboard.down() cannot describe them, and press()
+    // is the path that still inserts them as text.
+    const { page, events } = fakePage({ downRejects: (c) => c === '한' });
+    await typeOnFakeClock(page, 'a한b');
+
+    expect(events.map((e) => `${e.type}:${e.key}`)).toEqual([
+      'down:a', 'up:a', 'press:한', 'down:b', 'up:b',
+    ]);
+  });
+
+  it('clicks the selector first when one is given', async () => {
+    const { page } = fakePage();
+    vi.useFakeTimers();
+    try {
+      const done = typeHumanlike(page, '#login', 'x');
+      for (let i = 0; i < 16; i++) await vi.advanceTimersByTimeAsync(1000);
+      await done;
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(page.click).toHaveBeenCalledWith('#login');
+  });
+});
+
+describe('generateHoldSchedule', () => {
+  it('returns one hold per character, inside the clamp', () => {
+    const schedule = generateHoldSchedule('hello');
+    expect(schedule).toHaveLength(5);
+    for (const hold of schedule) {
+      expect(hold).toBeGreaterThanOrEqual(KEY_HOLD_MIN_MS);
+      expect(hold).toBeLessThanOrEqual(KEY_HOLD_MAX_MS);
+    }
+  });
+});

--- a/src/mcp/playwright/__tests__/link-navigation.test.ts
+++ b/src/mcp/playwright/__tests__/link-navigation.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Page } from 'playwright-core';
+
+const evaluateIsolated = vi.fn(async () => undefined);
+vi.mock('../isolated-eval', () => ({
+  evaluateIsolated: (...args: unknown[]) => evaluateIsolated(...(args as [])),
+}));
+
+import { navigateFromPage } from '../link-navigation';
+
+function fakePage(): { page: Page; resolveNav: (value?: unknown) => void; rejectNav: (e: Error) => void } {
+  let resolveNav!: (value?: unknown) => void;
+  let rejectNav!: (e: Error) => void;
+  const navigated = new Promise((resolve, reject) => {
+    resolveNav = resolve as (value?: unknown) => void;
+    rejectNav = reject;
+  });
+  const page = {
+    waitForNavigation: vi.fn(() => navigated),
+  } as unknown as Page;
+  return { page, resolveNav, rejectNav };
+}
+
+describe('navigateFromPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    evaluateIsolated.mockResolvedValue(undefined);
+  });
+
+  it('arms the navigation wait BEFORE triggering it', async () => {
+    const { page, resolveNav } = fakePage();
+    const order: string[] = [];
+    (page.waitForNavigation as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      order.push('wait');
+      return Promise.resolve(null);
+    });
+    evaluateIsolated.mockImplementation(async () => {
+      order.push('assign');
+      return undefined;
+    });
+
+    await navigateFromPage(page, 'https://to.test/x');
+    resolveNav();
+
+    // Reversed, the commit could land in the gap between the two calls.
+    expect(order).toEqual(['wait', 'assign']);
+  });
+
+  it('runs the assignment in the isolated world and waits for domcontentloaded', async () => {
+    const { page, resolveNav } = fakePage();
+    const promise = navigateFromPage(page, 'https://to.test/x');
+    resolveNav(null);
+    await promise;
+
+    expect(page.waitForNavigation).toHaveBeenCalledWith({ waitUntil: 'domcontentloaded' });
+    const [target, script, arg] = evaluateIsolated.mock.calls[0] as unknown as [
+      Page,
+      (a: string) => void,
+      string,
+    ];
+    expect(target).toBe(page);
+    expect(arg).toBe('https://to.test/x');
+    // The script must be an in-page location assignment: that, not a header, is
+    // what makes Chromium label the request as script-initiated.
+    expect(String(script)).toContain('location.assign');
+  });
+
+  it('propagates the navigation error, exactly as goto would', async () => {
+    const { page, rejectNav } = fakePage();
+    const promise = navigateFromPage(page, 'https://nowhere.invalid/x');
+    rejectNav(new Error('net::ERR_NAME_NOT_RESOLVED'));
+
+    await expect(promise).rejects.toThrow('ERR_NAME_NOT_RESOLVED');
+  });
+
+  it('propagates an evaluation failure without waiting out the navigation', async () => {
+    const { page, rejectNav } = fakePage();
+    evaluateIsolated.mockRejectedValue(new Error('blocked'));
+
+    await expect(navigateFromPage(page, 'https://to.test/x')).rejects.toThrow('blocked');
+    // The abandoned wait must not surface as an unhandled rejection.
+    rejectNav(new Error('Timeout 30000ms exceeded.'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});

--- a/src/mcp/playwright/__tests__/link-navigation.test.ts
+++ b/src/mcp/playwright/__tests__/link-navigation.test.ts
@@ -6,19 +6,26 @@ vi.mock('../isolated-eval', () => ({
   evaluateIsolated: (...args: unknown[]) => evaluateIsolated(...(args as [])),
 }));
 
-import { navigateFromPage } from '../link-navigation';
+import { NavigationNotCommittedError, navigateFromPage } from '../link-navigation';
 
-function fakePage(): { page: Page; resolveNav: (value?: unknown) => void; rejectNav: (e: Error) => void } {
+function fakePage(url = 'https://from.test/'): {
+  page: Page;
+  resolveNav: (value?: unknown) => void;
+  rejectNav: (e: Error) => void;
+  setUrl: (next: string) => void;
+} {
   let resolveNav!: (value?: unknown) => void;
   let rejectNav!: (e: Error) => void;
+  let current = url;
   const navigated = new Promise((resolve, reject) => {
     resolveNav = resolve as (value?: unknown) => void;
     rejectNav = reject;
   });
   const page = {
+    url: () => current,
     waitForNavigation: vi.fn(() => navigated),
   } as unknown as Page;
-  return { page, resolveNav, rejectNav };
+  return { page, resolveNav, rejectNav, setUrl: (next: string) => (current = next) };
 }
 
 describe('navigateFromPage', () => {
@@ -28,7 +35,7 @@ describe('navigateFromPage', () => {
   });
 
   it('arms the navigation wait BEFORE triggering it', async () => {
-    const { page, resolveNav } = fakePage();
+    const { page } = fakePage();
     const order: string[] = [];
     (page.waitForNavigation as ReturnType<typeof vi.fn>).mockImplementation(() => {
       order.push('wait');
@@ -40,46 +47,86 @@ describe('navigateFromPage', () => {
     });
 
     await navigateFromPage(page, 'https://to.test/x');
-    resolveNav();
 
     // Reversed, the commit could land in the gap between the two calls.
     expect(order).toEqual(['wait', 'assign']);
   });
 
-  it('runs the assignment in the isolated world and waits for domcontentloaded', async () => {
+  it('waits with a short commit timeout for a navigation that is not the one it left', async () => {
+    const { page, resolveNav } = fakePage('https://from.test/');
+    const promise = navigateFromPage(page, 'https://to.test/x');
+    resolveNav(null);
+    await promise;
+
+    const options = (page.waitForNavigation as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as { waitUntil: string; timeout: number; url: (u: URL) => boolean };
+    expect(options.waitUntil).toBe('domcontentloaded');
+    // Short, because the fallback path re-requests the URL: a wait that runs
+    // for the page-wide default would stall half a minute first.
+    expect(options.timeout).toBeLessThanOrEqual(10_000);
+    // The page's own redirect must not satisfy our wait.
+    expect(options.url(new URL('https://from.test/'))).toBe(false);
+    expect(options.url(new URL('https://to.test/x'))).toBe(true);
+  });
+
+  it('runs the assignment in the isolated world, refusing the main world', async () => {
     const { page, resolveNav } = fakePage();
     const promise = navigateFromPage(page, 'https://to.test/x');
     resolveNav(null);
     await promise;
 
-    expect(page.waitForNavigation).toHaveBeenCalledWith({ waitUntil: 'domcontentloaded' });
-    const [target, script, arg] = evaluateIsolated.mock.calls[0] as unknown as [
+    const [target, script, arg, options] = evaluateIsolated.mock.calls[0] as unknown as [
       Page,
       (a: string) => void,
       string,
+      { requireIsolated?: boolean },
     ];
     expect(target).toBe(page);
     expect(arg).toBe('https://to.test/x');
     // The script must be an in-page location assignment: that, not a header, is
     // what makes Chromium label the request as script-initiated.
     expect(String(script)).toContain('location.assign');
+    // A page that could see this script could redirect it.
+    expect(options.requireIsolated).toBe(true);
   });
 
-  it('propagates the navigation error, exactly as goto would', async () => {
+  it('propagates a real navigation error rather than inviting a retry', async () => {
     const { page, rejectNav } = fakePage();
     const promise = navigateFromPage(page, 'https://nowhere.invalid/x');
     rejectNav(new Error('net::ERR_NAME_NOT_RESOLVED'));
 
     await expect(promise).rejects.toThrow('ERR_NAME_NOT_RESOLVED');
+    await expect(promise).rejects.not.toBeInstanceOf(NavigationNotCommittedError);
   });
 
-  it('propagates an evaluation failure without waiting out the navigation', async () => {
+  it('reports a commit that never happened as retryable', async () => {
+    const { page, rejectNav } = fakePage();
+    const promise = navigateFromPage(page, 'https://to.test/x');
+    rejectNav(new Error('Timeout 4000ms exceeded.'));
+
+    await expect(promise).rejects.toBeInstanceOf(NavigationNotCommittedError);
+  });
+
+  it('treats a commit that raced the wait as done, so the caller cannot re-request it', async () => {
+    const { page, rejectNav, setUrl } = fakePage('https://from.test/');
+    const promise = navigateFromPage(page, 'https://to.test/x');
+    // The document moved even though the wait gave up: one request went out
+    // and repeating it would send a second.
+    setUrl('https://to.test/x');
+    rejectNav(new Error('Timeout 4000ms exceeded.'));
+
+    await expect(promise).resolves.toEqual({ response: null });
+  });
+
+  it('reports an evaluation failure as retryable without waiting out the navigation', async () => {
     const { page, rejectNav } = fakePage();
     evaluateIsolated.mockRejectedValue(new Error('blocked'));
 
-    await expect(navigateFromPage(page, 'https://to.test/x')).rejects.toThrow('blocked');
+    await expect(navigateFromPage(page, 'https://to.test/x')).rejects.toBeInstanceOf(
+      NavigationNotCommittedError,
+    );
     // The abandoned wait must not surface as an unhandled rejection.
-    rejectNav(new Error('Timeout 30000ms exceeded.'));
+    rejectNav(new Error('Timeout 4000ms exceeded.'));
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 });

--- a/src/mcp/playwright/__tests__/navigation.referer.test.ts
+++ b/src/mcp/playwright/__tests__/navigation.referer.test.ts
@@ -11,9 +11,14 @@ vi.mock('../../wmux-client', () => ({
 }));
 
 const navigateFromPage = vi.fn(async () => null);
-vi.mock('../link-navigation', () => ({
+vi.mock('../link-navigation', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../link-navigation')>()),
   navigateFromPage: (...args: unknown[]) => navigateFromPage(...(args as [])),
 }));
+
+// The tool distinguishes "nothing was requested" from "the request failed" by
+// this class, so the tests raise the real one.
+import { NavigationNotCommittedError as FakeNotCommitted } from '../link-navigation';
 
 const recordAction = vi.fn();
 vi.mock('../../browser-replay/actionRing', () => ({
@@ -134,9 +139,11 @@ describe('browser_navigate referer route (chrome backend)', () => {
     });
   });
 
-  it('falls back to goto WITHOUT a referer when the in-page route fails', async () => {
+  it('falls back to goto WITHOUT a referer when the in-page route never commits', async () => {
     const { page } = fakePage('https://from.test/article', 'https://to.test/landing');
-    navigateFromPage.mockRejectedValue(new Error('Timeout 30000ms exceeded.'));
+    navigateFromPage.mockRejectedValue(
+      new FakeNotCommitted('no navigation committed within 4000ms of the assignment'),
+    );
     getPageForScope.mockResolvedValue(page);
 
     const res = await navigate({ url: 'https://to.test/landing' });
@@ -148,17 +155,22 @@ describe('browser_navigate referer route (chrome backend)', () => {
     // pairing it with Sec-Fetch-Site: none.
     expect(page.goto.mock.calls[0][1]).not.toHaveProperty('referer');
     expect(res.isError).toBeUndefined();
+    // The caller asked for one shape of request and got another; the result
+    // says so rather than leaving the swap invisible.
+    expect(res.content[0].text).toContain('retried without a referer');
   });
 
-  it('surfaces a real navigation error from the fallback goto', async () => {
+  it('reports a real navigation failure without requesting the URL a second time', async () => {
     const { page } = fakePage('https://from.test/article');
     navigateFromPage.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
-    page.goto.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
     getPageForScope.mockResolvedValue(page);
 
     const res = await navigate({ url: 'https://nowhere.invalid/x' });
 
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toContain('ERR_NAME_NOT_RESOLVED');
+    // A retry here would be a second request, not a second chance: for a
+    // download or a one-time token URL that is a second consumption.
+    expect(page.goto).not.toHaveBeenCalled();
   });
 });

--- a/src/mcp/playwright/__tests__/navigation.referer.test.ts
+++ b/src/mcp/playwright/__tests__/navigation.referer.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A Referer next to `Sec-Fetch-Site: none` is a pair no browser produces, and
+// goto-with-a-referer produces exactly that. So browser_navigate picks its
+// route by whether there is a referer to send: from inside the page when there
+// is, plain goto when there is not.
+
+const mockSendRpc = vi.fn();
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (...args: unknown[]) => mockSendRpc(...args),
+}));
+
+const navigateFromPage = vi.fn(async () => null);
+vi.mock('../link-navigation', () => ({
+  navigateFromPage: (...args: unknown[]) => navigateFromPage(...(args as [])),
+}));
+
+const recordAction = vi.fn();
+vi.mock('../../browser-replay/actionRing', () => ({
+  recordAction: (...args: unknown[]) => recordAction(...args),
+}));
+
+const getPageForScope = vi.fn();
+const resolveWorkspaceBackend = vi.fn(async () => 'chrome');
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({ getPageForScope, resolveWorkspaceBackend }),
+  },
+}));
+
+import { registerNavigationTools } from '../tools/navigation';
+import type { BrowserToolDeps } from '../browserScope';
+
+type ToolResult = { content: { type: 'text'; text: string }[]; isError?: boolean };
+type ToolHandler = (args: Record<string, unknown>) => Promise<ToolResult>;
+
+function collectTools(deps: BrowserToolDeps): Map<string, ToolHandler> {
+  const tools = new Map<string, ToolHandler>();
+  const server = {
+    tool: (name: string, _description: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  };
+  registerNavigationTools(server as never, deps);
+  return tools;
+}
+
+/** A chrome-backend page whose reported URL can change on navigation. */
+function fakePage(startUrl: string, landOn?: string) {
+  let current = startUrl;
+  const page = {
+    url: () => current,
+    goto: vi.fn(async (_url: string, _options?: Record<string, unknown>) => {
+      current = landOn ?? current;
+      return null;
+    }),
+  };
+  return { page, land: (to: string) => { current = to; } };
+}
+
+describe('browser_navigate referer route (chrome backend)', () => {
+  const resolveWorkspaceId = vi.fn(async () => 'ws-caller');
+  let navigate: ToolHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveWorkspaceId.mockResolvedValue('ws-caller');
+    resolveWorkspaceBackend.mockResolvedValue('chrome');
+    navigateFromPage.mockResolvedValue(null);
+    mockSendRpc.mockImplementation((method: string) => {
+      if (method === 'browser.lease.acquire') return Promise.resolve({ token: 'lease-1' });
+      if (method === 'browser.lifecycle.get') return Promise.resolve({ entries: [] });
+      return Promise.resolve({});
+    });
+    navigate = collectTools({ resolveWorkspaceId })!.get('browser_navigate')!;
+  });
+
+  it('navigates from inside the page when leaving a real http(s) document', async () => {
+    const { page, land } = fakePage('https://from.test/article');
+    navigateFromPage.mockImplementation(async () => {
+      land('https://to.test/landing');
+      return null;
+    });
+    getPageForScope.mockResolvedValue(page);
+
+    const res = await navigate({ url: 'https://to.test/landing' });
+
+    expect(navigateFromPage).toHaveBeenCalledWith(page, 'https://to.test/landing');
+    // The contradictory pair is exactly page.goto({ referer }); it must not run.
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toBe('Navigated to https://to.test/landing');
+  });
+
+  it('reports the landing URL after a redirect, not the requested one', async () => {
+    const { page, land } = fakePage('https://from.test/article');
+    navigateFromPage.mockImplementation(async () => {
+      land('https://to.test/after-redirect');
+      return null;
+    });
+    getPageForScope.mockResolvedValue(page);
+
+    const res = await navigate({ url: 'https://to.test/landing' });
+
+    expect(res.content[0].text).toBe('Navigated to https://to.test/after-redirect');
+    expect(recordAction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tool: 'browser_navigate', url: 'https://to.test/after-redirect' }),
+    );
+  });
+
+  it('uses plain goto, with no referer, from about:blank', async () => {
+    const { page } = fakePage('about:blank', 'https://to.test/first');
+    getPageForScope.mockResolvedValue(page);
+
+    const res = await navigate({ url: 'https://to.test/first' });
+
+    expect(navigateFromPage).not.toHaveBeenCalled();
+    expect(page.goto).toHaveBeenCalledWith('https://to.test/first', {
+      waitUntil: 'domcontentloaded',
+    });
+    expect(res.content[0].text).toBe('Navigated to https://to.test/first');
+  });
+
+  it('uses plain goto for a reload — refererFor sends none, so neither do we', async () => {
+    const { page } = fakePage('https://from.test/same');
+    getPageForScope.mockResolvedValue(page);
+
+    await navigate({ url: 'https://from.test/same' });
+
+    expect(navigateFromPage).not.toHaveBeenCalled();
+    expect(page.goto).toHaveBeenCalledWith('https://from.test/same', {
+      waitUntil: 'domcontentloaded',
+    });
+  });
+
+  it('falls back to goto WITHOUT a referer when the in-page route fails', async () => {
+    const { page } = fakePage('https://from.test/article', 'https://to.test/landing');
+    navigateFromPage.mockRejectedValue(new Error('Timeout 30000ms exceeded.'));
+    getPageForScope.mockResolvedValue(page);
+
+    const res = await navigate({ url: 'https://to.test/landing' });
+
+    expect(page.goto).toHaveBeenCalledWith('https://to.test/landing', {
+      waitUntil: 'domcontentloaded',
+    });
+    // No `referer` key anywhere: the fallback drops the header rather than
+    // pairing it with Sec-Fetch-Site: none.
+    expect(page.goto.mock.calls[0][1]).not.toHaveProperty('referer');
+    expect(res.isError).toBeUndefined();
+  });
+
+  it('surfaces a real navigation error from the fallback goto', async () => {
+    const { page } = fakePage('https://from.test/article');
+    navigateFromPage.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    page.goto.mockRejectedValue(new Error('net::ERR_NAME_NOT_RESOLVED'));
+    getPageForScope.mockResolvedValue(page);
+
+    const res = await navigate({ url: 'https://nowhere.invalid/x' });
+
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain('ERR_NAME_NOT_RESOLVED');
+  });
+});

--- a/src/mcp/playwright/__tests__/state.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/state.fallback.test.ts
@@ -206,6 +206,22 @@ describe('browser_emulate RPC fallback', () => {
     expect(params.deviceReset).toBeUndefined();
   });
 
+  it('sends the whole preset, not just its viewport and UA', async () => {
+    // The packaged lane used to receive width + height + UA and nothing else,
+    // so an emulated iPhone kept the real machine's pixel ratio, touch points
+    // and desktop viewport semantics — each one contradicting the UA.
+    mockSendRpc.mockResolvedValue({ applied: ['device=iPhone 13'] });
+    await emulate({ device: 'iPhone 13' });
+    const params = mockSendRpc.mock.calls[0][1] as Record<string, unknown>;
+    expect(params.deviceMetrics).toMatchObject({
+      deviceScaleFactor: 3,
+      mobile: true,
+      hasTouch: true,
+      screenWidth: expect.any(Number),
+      screenHeight: expect.any(Number),
+    });
+  });
+
   it('flags an unknown device before any RPC', async () => {
     const res = await emulate({ device: 'NoSuchPhone 99' });
     expect(res.isError).toBe(true);

--- a/src/mcp/playwright/__tests__/ua-emulation.test.ts
+++ b/src/mcp/playwright/__tests__/ua-emulation.test.ts
@@ -48,7 +48,20 @@ function harness() {
 
   const pages: Page[] = [];
   const listeners = new Map<string, ((p: Page) => void)[]>();
-  const page = { once: vi.fn(), isClosed: () => false } as unknown as Page;
+  const makePage = (): Page => {
+    const frame = {};
+    return {
+      once: vi.fn(),
+      // The module re-applies the preset after every main-frame commit,
+      // because the library re-initialises its own emulation there.
+      on: vi.fn(),
+      mainFrame: () => frame,
+      viewportSize: () => ({ width: 390, height: 664 }),
+      setViewportSize: vi.fn(async () => undefined),
+      isClosed: () => false,
+    } as unknown as Page;
+  };
+  const page = makePage();
   pages.push(page);
 
   const context = {
@@ -61,13 +74,24 @@ function harness() {
     browser: () => ({}),
   } as unknown as BrowserContext;
 
-  return { sent, detached, context, page, pages, newPage: (p: Page) => {
+  return { sent, detached, context, page, pages, makePage, newPage: (p: Page) => {
     pages.push(p);
     for (const handler of listeners.get('page') ?? []) handler(p);
   } };
 }
 
 const methods = (sent: Sent[]): string[] => sent.map((s) => s.method);
+/**
+ * The command sequence with repeats collapsed.
+ *
+ * The preset is deliberately written more than once — once per session, then
+ * again over the caller's page after every other session has been touched,
+ * because overrides from different sessions are merged by the last write. What
+ * matters here is which commands go out and in what order, not how many times
+ * the last-write pass repeats them.
+ */
+const distinctSequence = (sent: Sent[]): string[] =>
+  methods(sent).filter((method, i, all) => method !== all[i - 1]);
 const paramsOf = (sent: Sent[], method: string): Record<string, unknown> | undefined =>
   sent.find((s) => s.method === method)?.params;
 
@@ -84,7 +108,11 @@ describe('applyUserAgentEmulation with a device preset', () => {
       IPHONE_METRICS,
     );
     expect(ok).toBe(true);
-    expect(methods(h.sent)).toEqual([
+    expect(distinctSequence(h.sent)).toEqual([
+      'Emulation.setUserAgentOverride',
+      'Emulation.setDeviceMetricsOverride',
+      'Emulation.setTouchEmulationEnabled',
+      // The last-write pass over the caller's page.
       'Emulation.setUserAgentOverride',
       'Emulation.setDeviceMetricsOverride',
       'Emulation.setTouchEmulationEnabled',
@@ -105,6 +133,9 @@ describe('applyUserAgentEmulation with a device preset', () => {
       mobile: true,
       screenWidth: 390,
       screenHeight: 844,
+      // A portrait phone whose screen.orientation reads "landscape-primary"
+      // contradicts its own dimensions.
+      screenOrientation: { angle: 0, type: 'portraitPrimary' },
     });
     expect(paramsOf(h.sent, 'Emulation.setTouchEmulationEnabled')).toEqual({
       enabled: true,
@@ -130,10 +161,12 @@ describe('applyUserAgentEmulation with a device preset', () => {
     await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, null, IPHONE_METRICS);
     h.sent.length = 0;
 
-    h.newPage({ once: vi.fn(), isClosed: () => false } as unknown as Page);
+    h.newPage(h.makePage());
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(methods(h.sent)).toEqual([
+    // The new tab gets the identity whole — the UA alone would leave it on
+    // this machine's pixel ratio and without a touchscreen.
+    expect(distinctSequence(h.sent)).toEqual([
       'Emulation.setUserAgentOverride',
       'Emulation.setDeviceMetricsOverride',
       'Emulation.setTouchEmulationEnabled',
@@ -143,7 +176,9 @@ describe('applyUserAgentEmulation with a device preset', () => {
   it('sends no metrics commands when no preset was given', async () => {
     const h = harness();
     await applyUserAgentEmulation(h.context, h.page, IPHONE_UA);
-    expect(methods(h.sent)).toEqual(['Emulation.setUserAgentOverride']);
+    // Written twice (the last-write pass), but never anything else: a UA
+    // without a preset must not drag the caller's viewport around with it.
+    expect(new Set(methods(h.sent))).toEqual(new Set(['Emulation.setUserAgentOverride']));
   });
 });
 

--- a/src/mcp/playwright/__tests__/ua-emulation.test.ts
+++ b/src/mcp/playwright/__tests__/ua-emulation.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserContext, Page } from 'playwright-core';
+import {
+  applyUserAgentEmulation,
+  clearUserAgentEmulation,
+  hasUserAgentEmulation,
+} from '../ua-emulation';
+
+// A device preset is one identity, not a UA string with some hardware left over
+// from the real machine. These check that everything the preset claims is
+// actually sent — and that a reset takes all of it back.
+
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1';
+const REAL_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
+
+const IPHONE_METRICS = {
+  width: 390,
+  height: 664,
+  deviceScaleFactor: 3,
+  mobile: true,
+  hasTouch: true,
+  screenWidth: 390,
+  screenHeight: 844,
+};
+
+type Sent = { method: string; params?: Record<string, unknown> };
+
+function harness() {
+  const sent: Sent[] = [];
+  const detached: number[] = [];
+  let sessionCount = 0;
+
+  const newCDPSession = vi.fn(async () => {
+    const id = sessionCount++;
+    return {
+      send: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+        sent.push({ method, params });
+        if (method === 'Browser.getVersion') return { userAgent: REAL_UA };
+        return {};
+      }),
+      detach: vi.fn(async () => {
+        detached.push(id);
+      }),
+    };
+  });
+
+  const pages: Page[] = [];
+  const listeners = new Map<string, ((p: Page) => void)[]>();
+  const page = { once: vi.fn(), isClosed: () => false } as unknown as Page;
+  pages.push(page);
+
+  const context = {
+    newCDPSession,
+    pages: () => pages,
+    on: (event: string, handler: (p: Page) => void) => {
+      listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+    },
+    off: vi.fn(),
+    browser: () => ({}),
+  } as unknown as BrowserContext;
+
+  return { sent, detached, context, page, pages, newPage: (p: Page) => {
+    pages.push(p);
+    for (const handler of listeners.get('page') ?? []) handler(p);
+  } };
+}
+
+const methods = (sent: Sent[]): string[] => sent.map((s) => s.method);
+const paramsOf = (sent: Sent[], method: string): Record<string, unknown> | undefined =>
+  sent.find((s) => s.method === method)?.params;
+
+describe('applyUserAgentEmulation with a device preset', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends the UA, the metrics and the touch points together', async () => {
+    const h = harness();
+    const ok = await applyUserAgentEmulation(
+      h.context,
+      h.page,
+      IPHONE_UA,
+      'en-US',
+      IPHONE_METRICS,
+    );
+    expect(ok).toBe(true);
+    expect(methods(h.sent)).toEqual([
+      'Emulation.setUserAgentOverride',
+      'Emulation.setDeviceMetricsOverride',
+      'Emulation.setTouchEmulationEnabled',
+    ]);
+
+    const ua = paramsOf(h.sent, 'Emulation.setUserAgentOverride')!;
+    expect(ua.userAgent).toBe(IPHONE_UA);
+    // navigator.platform used to answer "MacIntel" under an iPhone UA.
+    expect(ua.platform).toBe('iPhone');
+    expect(ua.acceptLanguage).toBe('en-US');
+    // Safari has no userAgentData, so the hints object must be absent, not empty.
+    expect(ua).not.toHaveProperty('userAgentMetadata');
+
+    expect(paramsOf(h.sent, 'Emulation.setDeviceMetricsOverride')).toEqual({
+      width: 390,
+      height: 664,
+      deviceScaleFactor: 3,
+      mobile: true,
+      screenWidth: 390,
+      screenHeight: 844,
+    });
+    expect(paramsOf(h.sent, 'Emulation.setTouchEmulationEnabled')).toEqual({
+      enabled: true,
+      maxTouchPoints: 5,
+    });
+  });
+
+  it('turns touch off explicitly for a preset without a touchscreen', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, REAL_UA, null, {
+      ...IPHONE_METRICS,
+      mobile: false,
+      hasTouch: false,
+    });
+    expect(paramsOf(h.sent, 'Emulation.setTouchEmulationEnabled')).toEqual({
+      enabled: false,
+      maxTouchPoints: 0,
+    });
+  });
+
+  it('applies the whole preset to a tab opened later, not just the UA', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, null, IPHONE_METRICS);
+    h.sent.length = 0;
+
+    h.newPage({ once: vi.fn(), isClosed: () => false } as unknown as Page);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(methods(h.sent)).toEqual([
+      'Emulation.setUserAgentOverride',
+      'Emulation.setDeviceMetricsOverride',
+      'Emulation.setTouchEmulationEnabled',
+    ]);
+  });
+
+  it('sends no metrics commands when no preset was given', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA);
+    expect(methods(h.sent)).toEqual(['Emulation.setUserAgentOverride']);
+  });
+});
+
+describe('clearUserAgentEmulation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('takes back the metrics and the touch points along with the UA', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, null, IPHONE_METRICS);
+    expect(hasUserAgentEmulation(h.context)).toBe(true);
+    h.sent.length = 0;
+
+    await clearUserAgentEmulation(h.context);
+
+    expect(methods(h.sent)).toContain('Emulation.clearDeviceMetricsOverride');
+    expect(paramsOf(h.sent, 'Emulation.setTouchEmulationEnabled')).toEqual({
+      enabled: false,
+      maxTouchPoints: 0,
+    });
+    // The real UA comes back with the real platform, not the preset's.
+    const restored = h.sent.filter((s) => s.method === 'Emulation.setUserAgentOverride').pop()!;
+    expect(restored.params!.userAgent).toBe(REAL_UA);
+    expect(restored.params!.platform).toBe('MacIntel');
+    expect(hasUserAgentEmulation(h.context)).toBe(false);
+  });
+
+  it('is a no-op on a context that was never emulated', async () => {
+    const h = harness();
+    await clearUserAgentEmulation(h.context);
+    expect(h.sent).toEqual([]);
+  });
+});

--- a/src/mcp/playwright/human-typing.ts
+++ b/src/mcp/playwright/human-typing.ts
@@ -1,5 +1,5 @@
 import type { Page } from 'playwright-core';
-import { generateTypingDelays } from '../../shared/humanRhythm';
+import { generateKeyHolds, generateTypingDelays } from '../../shared/humanRhythm';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,6 +22,29 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Press one character, holding the key down for `holdMs` before releasing it.
+ *
+ * `keyboard.press()` does the down and the up back to back, which is a ~1 ms
+ * dwell time — no hand produces that. Splitting the press is what puts a real
+ * hold between the two events; see `shared/humanRhythm`'s key-hold section.
+ *
+ * A character `keyboard.down()` cannot describe as a key (CJK, an emoji's
+ * surrogate half) still has to be inserted, and `press()` is the path that
+ * inserts it as text. That fallback is why this is wrapped: losing the hold on
+ * those characters is the cost, dropping them entirely is not an option.
+ */
+async function pressWithHold(page: Page, char: string, holdMs: number): Promise<void> {
+  try {
+    await page.keyboard.down(char);
+  } catch {
+    await page.keyboard.press(char);
+    return;
+  }
+  await sleep(holdMs);
+  await page.keyboard.up(char);
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -42,12 +65,25 @@ export function generateDelaySchedule(
 }
 
 /**
+ * Per-character key hold times (in ms) for the given text — how long each key
+ * stays down, as opposed to the gap after it that `generateDelaySchedule`
+ * returns. Same source module, so both lanes hold keys alike.
+ */
+export function generateHoldSchedule(
+  text: string,
+  options?: HumanTypingOptions,
+): number[] {
+  return generateKeyHolds(text, options);
+}
+
+/**
  * Type `text` into the element identified by `selector` with randomised
- * inter-keystroke delays that mimic human typing.
+ * keystroke timing that mimics human typing.
  *
- * Each character is pressed individually via `page.keyboard.press()`, with the
- * pause after it drawn from the shared typing rhythm — see
- * `generateDelaySchedule` and `shared/humanRhythm`.
+ * Each character is pressed individually, held down for a randomised dwell time
+ * and then released, with the pause after it drawn from the shared typing
+ * rhythm — see `generateDelaySchedule`, `generateHoldSchedule` and
+ * `shared/humanRhythm`.
  *
  * If `selector` is provided the element is clicked first to ensure focus.
  */
@@ -63,9 +99,10 @@ export async function typeHumanlike(
   }
 
   const delays = generateDelaySchedule(text, options);
+  const holds = generateHoldSchedule(text, options);
 
   for (let i = 0; i < text.length; i++) {
-    await page.keyboard.press(text[i]);
+    await pressWithHold(page, text[i], holds[i]);
     await sleep(delays[i]);
   }
 }

--- a/src/mcp/playwright/human-typing.ts
+++ b/src/mcp/playwright/human-typing.ts
@@ -1,5 +1,9 @@
 import type { Page } from 'playwright-core';
-import { generateKeyHolds, generateTypingDelays } from '../../shared/humanRhythm';
+import {
+  generateKeyHolds,
+  generateKeystrokeSchedule,
+  generateTypingDelays,
+} from '../../shared/humanRhythm';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,15 +34,17 @@ function sleep(ms: number): Promise<void> {
  * hold between the two events; see `shared/humanRhythm`'s key-hold section.
  *
  * A character `keyboard.down()` cannot describe as a key (CJK, an emoji's
- * surrogate half) still has to be inserted, and `press()` is the path that
- * inserts it as text. That fallback is why this is wrapped: losing the hold on
- * those characters is the cost, dropping them entirely is not an option.
+ * surrogate half) still has to be inserted. `press()` is NOT that path — it
+ * calls `down()` itself and fails on exactly the same characters — so the
+ * fallback is `insertText()`, which puts the character in without pretending
+ * it was a keystroke. Losing the hold on those characters is the cost;
+ * dropping them entirely is not an option.
  */
 async function pressWithHold(page: Page, char: string, holdMs: number): Promise<void> {
   try {
     await page.keyboard.down(char);
   } catch {
-    await page.keyboard.press(char);
+    await page.keyboard.insertText(char);
     return;
   }
   await sleep(holdMs);
@@ -98,8 +104,9 @@ export async function typeHumanlike(
     await page.click(selector);
   }
 
-  const delays = generateDelaySchedule(text, options);
-  const holds = generateHoldSchedule(text, options);
+  // Drawn together: the holds are part of what typing spends, so budgeting the
+  // gaps alone let a long text overrun its cap by the sum of every dwell.
+  const { delays, holds } = generateKeystrokeSchedule(text, options);
 
   for (let i = 0; i < text.length; i++) {
     await pressWithHold(page, text[i], holds[i]);

--- a/src/mcp/playwright/isolated-eval.ts
+++ b/src/mcp/playwright/isolated-eval.ts
@@ -48,9 +48,25 @@ export interface IsolatedCdpSession extends IsolatedCdpSender {
 /** A page function, or a bare JavaScript expression to evaluate. */
 export type IsolatedScript<A, R> = string | ((arg: A) => R | Promise<R>);
 
+/** Thrown when `requireIsolated` is set and no isolated world can be had. */
+export class IsolatedWorldUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'IsolatedWorldUnavailableError';
+  }
+}
+
 export interface IsolatedEvalOptions {
   /** Treat the call as user-initiated (transient activation). Default false. */
   userGesture?: boolean;
+  /**
+   * Refuse to run in the page's own world when no isolated one is available,
+   * throwing instead. For scripts whose whole point is that page code cannot
+   * observe or redirect them — a navigation the page could hijack by hooking
+   * `setTimeout` or `location.assign` — running in the main world is worse
+   * than not running at all.
+   */
+  requireIsolated?: boolean;
 }
 
 interface PageState {
@@ -298,6 +314,11 @@ export async function evaluateIsolated<R = unknown, A = unknown>(
   // with the SAME arity as before this module existed, so a one-argument
   // page.evaluate stays a one-argument call.
   const mainWorld = (): Promise<R> => {
+    if (options?.requireIsolated) {
+      throw new IsolatedWorldUnavailableError(
+        'no isolated world on this page, and this script refuses the main world',
+      );
+    }
     if (!state.warned) {
       state.warned = true;
       console.warn(

--- a/src/mcp/playwright/link-navigation.ts
+++ b/src/mcp/playwright/link-navigation.ts
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------
+// Navigating FROM the page, rather than to it.
+//
+// `shared/referer.ts` decides when a navigation should carry a Referer. Sending
+// it through `page.goto(url, { referer })` is what a browser never does: goto
+// is an address-bar navigation, so Chromium also sends `Sec-Fetch-Site: none`
+// and `Sec-Fetch-User: ?1` — "the user typed this in" — while the Referer says
+// "I followed a link from that page". Measured live, a page reached this way
+// arrived with `Referer: https://previous.example/` next to
+// `Sec-Fetch-Site: none`, a pair no browser produces. The header meant to make
+// the traffic look ordinary was the thing that marked it.
+//
+// The fix is not a different header, it is a different navigation. Running
+// `location.assign(url)` inside the page makes Chromium itself classify the
+// navigation as script-initiated from that document, so it fills in the whole
+// set consistently: the Referer under the current referrer policy, a real
+// `Sec-Fetch-Site` (cross-site / same-origin / same-site), `Sec-Fetch-Mode:
+// navigate`, and no `Sec-Fetch-User` — because no user gesture was involved.
+//
+// The script runs in the isolated world for the same reason everything else
+// does (see isolated-eval.ts): page code must not be able to watch it.
+// ---------------------------------------------------------------------------
+
+import type { Page, Response } from 'playwright-core';
+import { evaluateIsolated } from './isolated-eval';
+
+/**
+ * Ask the document to navigate itself, one task later.
+ *
+ * Deferred rather than called inline so the evaluation has certainly returned
+ * before the navigation tears its execution context down: a `callFunctionOn`
+ * that loses that race comes back as "Execution context was destroyed", which
+ * `evaluateIsolated` treats as a stale context and RETRIES — a second
+ * navigation, this time from the page we just arrived at.
+ */
+const ASSIGN = (target: string): void => {
+  window.setTimeout(() => {
+    window.location.assign(target);
+  }, 0);
+};
+
+/**
+ * Navigate `page` to `url` the way following a link would, and wait for the
+ * result exactly as `page.goto` does.
+ *
+ * Resolves with the main resource's response (null for a same-document move),
+ * and rejects with the navigation's own error — a dead host, a crashed page, a
+ * timeout — because `waitForNavigation` propagates `navigated.error` and the
+ * navigation timeout the same way `goto` does. Callers therefore keep goto's
+ * error handling; what changes is only how the request is issued.
+ */
+export async function navigateFromPage(page: Page, url: string): Promise<Response | null> {
+  // Armed BEFORE the navigation is triggered, so the commit cannot land in the
+  // gap between the two calls.
+  const navigated = page.waitForNavigation({ waitUntil: 'domcontentloaded' });
+  // If the evaluation below throws, nothing awaits `navigated` and its eventual
+  // timeout would surface as an unhandled rejection. Attaching a sink here does
+  // not swallow it for the `await` further down — that still sees the original
+  // promise.
+  navigated.catch(() => undefined);
+
+  await evaluateIsolated(page, ASSIGN, url);
+  return await navigated;
+}

--- a/src/mcp/playwright/link-navigation.ts
+++ b/src/mcp/playwright/link-navigation.ts
@@ -17,12 +17,26 @@
 // `Sec-Fetch-Site` (cross-site / same-origin / same-site), `Sec-Fetch-Mode:
 // navigate`, and no `Sec-Fetch-User` — because no user gesture was involved.
 //
-// The script runs in the isolated world for the same reason everything else
-// does (see isolated-eval.ts): page code must not be able to watch it.
+// The script runs in the isolated world, and ONLY there: a page that could see
+// this script could hook `setTimeout` or `location.assign` and either stall the
+// navigation or send it somewhere of its own choosing.
 // ---------------------------------------------------------------------------
 
 import type { Page, Response } from 'playwright-core';
 import { evaluateIsolated } from './isolated-eval';
+
+/**
+ * How long to wait for the in-page navigation to COMMIT before giving up on it.
+ *
+ * Not the navigation's own timeout — this is only the window in which Chromium
+ * has to acknowledge that the assignment started a navigation at all. The
+ * default (30 s, page-wide) meant a target that never commits — a download
+ * response, a 204, a page that blocks the assignment — stalled for half a
+ * minute and then let the caller issue the SAME url a second time through
+ * goto: two downloads, or a one-time token spent twice. Chromium commits a
+ * navigation it accepted in milliseconds, so a few seconds is generous.
+ */
+const COMMIT_TIMEOUT_MS = 4000;
 
 /**
  * Ask the document to navigate itself, one task later.
@@ -40,25 +54,78 @@ const ASSIGN = (target: string): void => {
 };
 
 /**
- * Navigate `page` to `url` the way following a link would, and wait for the
- * result exactly as `page.goto` does.
- *
- * Resolves with the main resource's response (null for a same-document move),
- * and rejects with the navigation's own error — a dead host, a crashed page, a
- * timeout — because `waitForNavigation` propagates `navigated.error` and the
- * navigation timeout the same way `goto` does. Callers therefore keep goto's
- * error handling; what changes is only how the request is issued.
+ * The in-page route never started a navigation — the page blocked the
+ * assignment, or the target is something Chromium does not commit as a
+ * document. The caller may retry by another route; no request of ours reached
+ * the network.
  */
-export async function navigateFromPage(page: Page, url: string): Promise<Response | null> {
+export class NavigationNotCommittedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NavigationNotCommittedError';
+  }
+}
+
+/** Errors that mean the navigation was attempted and genuinely failed. */
+function isRealNavigationFailure(error: unknown): boolean {
+  const text = error instanceof Error ? error.message : String(error);
+  return /net::ERR_|ERR_ABORTED|Navigation failed because|frame was detached|Target (page|closed)/i.test(
+    text,
+  );
+}
+
+export interface FromPageNavigation {
+  /** The main resource's response; null for a same-document move. */
+  response: Response | null;
+}
+
+/**
+ * Navigate `page` to `url` the way following a link would.
+ *
+ * Resolves once the navigation has committed, with the main resource's
+ * response. Rejects with the navigation's own error when the navigation was
+ * really attempted and failed (a dead host, a detached frame) — those are the
+ * caller's to report, not to retry. Rejects with `NavigationNotCommittedError`
+ * when nothing started within `COMMIT_TIMEOUT_MS`, which is the only case where
+ * retrying by another route is safe: no request went out.
+ */
+export async function navigateFromPage(page: Page, url: string): Promise<FromPageNavigation> {
+  const before = page.url();
+
   // Armed BEFORE the navigation is triggered, so the commit cannot land in the
-  // gap between the two calls.
-  const navigated = page.waitForNavigation({ waitUntil: 'domcontentloaded' });
+  // gap between the two calls. The URL predicate is what makes this OUR
+  // navigation: `waitForNavigation` resolves on any main-frame commit, so a
+  // page's own meta-refresh or scripted redirect could otherwise satisfy the
+  // wait, hand back a URL we never asked for, and leave our assignment to fire
+  // afterwards into a document that had already moved.
+  const navigated = page.waitForNavigation({
+    waitUntil: 'domcontentloaded',
+    timeout: COMMIT_TIMEOUT_MS,
+    url: (candidate) => candidate.toString() !== before,
+  });
   // If the evaluation below throws, nothing awaits `navigated` and its eventual
   // timeout would surface as an unhandled rejection. Attaching a sink here does
   // not swallow it for the `await` further down — that still sees the original
   // promise.
   navigated.catch(() => undefined);
 
-  await evaluateIsolated(page, ASSIGN, url);
-  return await navigated;
+  try {
+    await evaluateIsolated(page, ASSIGN, url, { requireIsolated: true });
+  } catch (error) {
+    throw new NavigationNotCommittedError(
+      `the page could not be asked to navigate: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  try {
+    return { response: await navigated };
+  } catch (error) {
+    if (isRealNavigationFailure(error)) throw error;
+    // The wait ran out. If the document moved anyway — a commit that raced the
+    // predicate — that IS our navigation and the caller must not repeat it.
+    if (page.url() !== before) return { response: null };
+    throw new NavigationNotCommittedError(
+      `no navigation committed within ${COMMIT_TIMEOUT_MS}ms of the assignment`,
+    );
+  }
 }

--- a/src/mcp/playwright/tools/navigation.ts
+++ b/src/mcp/playwright/tools/navigation.ts
@@ -12,7 +12,7 @@ import { describeToolError } from '../toolError';
 import { redactPasswordParams } from '../redact';
 import { recordAction } from '../../browser-replay/actionRing';
 import { refererFor } from '../../../shared/referer';
-import { navigateFromPage } from '../link-navigation';
+import { NavigationNotCommittedError, navigateFromPage } from '../link-navigation';
 import {
   browserTabsError,
   isBrowserTabsResult,
@@ -144,6 +144,10 @@ export function registerNavigationTools(server: McpServer, deps: BrowserToolDeps
         // next tool call. The self-echo — a lone navigated matching the URL
         // this result already reports — is suppressed via opts.
         let finalUrl: string | undefined;
+        // Set when the in-page (referer-carrying) route did not commit and the
+        // plain navigation was used instead: the agent asked for one request
+        // and got a differently-shaped one, so the result says so.
+        let refererRetryNote: string | undefined;
         return await withAutomationLease(
           deps,
           surfaceId,
@@ -174,12 +178,17 @@ export function registerNavigationTools(server: McpServer, deps: BrowserToolDeps
               if (referer) {
                 try {
                   await navigateFromPage(page, url);
-                } catch {
-                  // The in-page route did not get there — a page that blocks
-                  // the assignment, or a commit that never arrived. Fall back
-                  // to the plain address-bar navigation, WITHOUT a referer:
-                  // the contradictory pair is worse than the missing header,
-                  // and a real navigation error surfaces here unchanged.
+                } catch (error) {
+                  // Only one failure may be retried: the one where nothing was
+                  // requested. A navigation that was attempted and failed is
+                  // the caller's answer — repeating it would issue the same
+                  // request twice, which for a download or a one-time token
+                  // URL is not a retry but a second consumption.
+                  if (!(error instanceof NavigationNotCommittedError)) throw error;
+                  refererRetryNote =
+                    'referer navigation did not commit; retried without a referer';
+                  // Plain address-bar navigation, WITHOUT a referer: the
+                  // contradictory pair is worse than the missing header.
                   await page.goto(url, { waitUntil: 'domcontentloaded' });
                 }
               } else {
@@ -197,7 +206,14 @@ export function registerNavigationTools(server: McpServer, deps: BrowserToolDeps
                 url: finalUrl,
               });
               return {
-                content: [{ type: 'text' as const, text: `Navigated to ${redactPasswordParams(finalUrl)}` }],
+                content: [
+                  {
+                    type: 'text' as const,
+                    text: refererRetryNote
+                      ? `Navigated to ${redactPasswordParams(finalUrl)}\n${refererRetryNote}`
+                      : `Navigated to ${redactPasswordParams(finalUrl)}`,
+                  },
+                ],
               };
             }
             // Use RPC for fast, reliable navigation (bypasses Playwright CDP discovery)

--- a/src/mcp/playwright/tools/navigation.ts
+++ b/src/mcp/playwright/tools/navigation.ts
@@ -12,6 +12,7 @@ import { describeToolError } from '../toolError';
 import { redactPasswordParams } from '../redact';
 import { recordAction } from '../../browser-replay/actionRing';
 import { refererFor } from '../../../shared/referer';
+import { navigateFromPage } from '../link-navigation';
 import {
   browserTabsError,
   isBrowserTabsResult,
@@ -159,11 +160,31 @@ export function registerNavigationTools(server: McpServer, deps: BrowserToolDeps
               // page they left in the Referer header; page.goto() sends none
               // unless told to. refererFor() decides when there is a real one
               // to send — see shared/referer.
+              //
+              // But goto with a referer is not a link click: it is an
+              // address-bar navigation carrying someone else's Referer, and
+              // Chromium labels it `Sec-Fetch-Site: none` + `Sec-Fetch-User:
+              // ?1` — a combination that contradicts the header it was given.
+              // So when there IS a referer to send, navigate from inside the
+              // page instead and let Chromium fill the whole set in agreement
+              // (see link-navigation). goto keeps the first navigation, the
+              // ones leaving about:blank, and anything the in-page route
+              // cannot do.
               const referer = refererFor(page.url(), url);
-              await page.goto(url, {
-                waitUntil: 'domcontentloaded',
-                ...(referer && { referer }),
-              });
+              if (referer) {
+                try {
+                  await navigateFromPage(page, url);
+                } catch {
+                  // The in-page route did not get there — a page that blocks
+                  // the assignment, or a commit that never arrived. Fall back
+                  // to the plain address-bar navigation, WITHOUT a referer:
+                  // the contradictory pair is worse than the missing header,
+                  // and a real navigation error surfaces here unchanged.
+                  await page.goto(url, { waitUntil: 'domcontentloaded' });
+                }
+              } else {
+                await page.goto(url, { waitUntil: 'domcontentloaded' });
+              }
               finalUrl = page.url();
               // The landing URL, not the requested one: a trace filed under a
               // redirect's source would never match the page it actually runs

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -6,6 +6,7 @@ import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
 import { matchSensitiveDomain } from '../security';
 import { evalFunctionOrRpc } from '../page-eval';
+import { isChromiumUserAgent } from '../../../shared/uaMetadata';
 import { describeToolError } from '../toolError';
 import {
   applyUserAgentEmulation,
@@ -537,6 +538,22 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
                 applied.push('clientHints=unavailable (UA header applied without matching hints or device metrics)');
               }
               applied.push(`device=${device} (${deviceDescriptor.viewport.width}x${deviceDescriptor.viewport.height})`);
+              // A Safari/iOS preset on a Chromium browser cannot be made whole:
+              // navigator.userAgentData and the Sec-CH-UA* headers are
+              // Chromium's own and there is no Safari value to give them. Say
+              // so where the caller reads the result, rather than let them
+              // assume the identity is seamless.
+              // Two things a preset does not reach, said here rather than left
+              // for the caller to discover: navigator.platform keeps this
+              // machine's value on a page under automation, and a
+              // non-Chromium preset cannot fill the Client Hints surface at
+              // all.
+              applied.push('note=navigator.platform still reports the host platform');
+              if (!isChromiumUserAgent(deviceDescriptor.userAgent)) {
+                applied.push(
+                  'note=this preset emulates a non-Chromium browser; navigator.userAgentData and Sec-CH-UA* still report Chromium. A Chrome-based preset (e.g. "Pixel 7") gives a consistent mobile identity.',
+                );
+              }
             } else {
               // A reset has to undo the UA too. Leaving the override and the
               // User-Agent header in place meant a caller who switched to a

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -149,6 +149,21 @@ async function currentUrl(page: Page | null, scope: BrowserTargetScope): Promise
 // ---------------------------------------------------------------------------
 
 /**
+ * A device preset's screen size, which differs from its viewport (an iPhone 13
+ * is 390x664 of viewport inside a 390x844 screen). Playwright's device table
+ * ships it, but its public `DeviceDescriptor` type does not list the field, so
+ * it is read through a narrowing rather than assumed present.
+ */
+function screenOf(
+  descriptor: { viewport: { width: number; height: number } },
+): { width: number; height: number } | undefined {
+  const screen = (descriptor as { screen?: { width?: number; height?: number } }).screen;
+  return typeof screen?.width === 'number' && typeof screen?.height === 'number'
+    ? { width: screen.width, height: screen.height }
+    : undefined;
+}
+
+/**
  * Register state-management MCP tools on the given server.
  *
  * Tools:
@@ -398,6 +413,7 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
         // any partial emulation is applied.
         // B0: devices lives in the lazy playwright chunk (first use loads it).
         const deviceDescriptor = device ? loadPlaywright().devices[device] : undefined;
+        const deviceScreen = deviceDescriptor ? screenOf(deviceDescriptor) : undefined;
         if (device && !deviceDescriptor) {
           throw new Error(
             `Unknown device "${device}". Use a name from Playwright's device list (e.g. "iPhone 13", "Pixel 5").`,
@@ -493,16 +509,32 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
               // the CDP session open (the override dies with its session) and
               // re-applies to tabs opened later, matching the context-wide
               // reach of the header above.
+              // The UA string and the viewport were the whole of the preset;
+              // navigator.platform, devicePixelRatio, maxTouchPoints and the
+              // mobile flag stayed on the real machine and contradicted it.
+              // The descriptor already carries all four, so hand them over
+              // with the UA rather than applying half a device.
               const ok = await applyUserAgentEmulation(
                 context,
                 page,
                 deviceDescriptor.userAgent,
                 locale ?? undefined,
+                {
+                  width: deviceDescriptor.viewport.width,
+                  height: deviceDescriptor.viewport.height,
+                  deviceScaleFactor: deviceDescriptor.deviceScaleFactor,
+                  mobile: deviceDescriptor.isMobile,
+                  hasTouch: deviceDescriptor.hasTouch,
+                  ...(deviceScreen && {
+                    screenWidth: deviceScreen.width,
+                    screenHeight: deviceScreen.height,
+                  }),
+                },
               );
               if (!ok) {
                 // Client Hints stay on the real browser's values; the UA header
                 // is still applied. Worth reporting, not worth failing on.
-                applied.push('clientHints=unavailable (UA header applied without matching hints)');
+                applied.push('clientHints=unavailable (UA header applied without matching hints or device metrics)');
               }
               applied.push(`device=${device} (${deviceDescriptor.viewport.width}x${deviceDescriptor.viewport.height})`);
             } else {
@@ -539,6 +571,16 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
               emulateParams.deviceMetrics = {
                 width: deviceDescriptor.viewport.width,
                 height: deviceDescriptor.viewport.height,
+                // Same reason as the Playwright branch above: without these the
+                // packaged lane emulates a phone's UA on a desktop's pixel
+                // ratio, touch points and viewport semantics.
+                deviceScaleFactor: deviceDescriptor.deviceScaleFactor,
+                mobile: deviceDescriptor.isMobile,
+                hasTouch: deviceDescriptor.hasTouch,
+                ...(deviceScreen && {
+                  screenWidth: deviceScreen.width,
+                  screenHeight: deviceScreen.height,
+                }),
               };
               emulateParams.deviceLabel = `${device} (${deviceDescriptor.viewport.width}x${deviceDescriptor.viewport.height})`;
               emulateParams.userAgent = deviceDescriptor.userAgent;

--- a/src/mcp/playwright/ua-emulation.ts
+++ b/src/mcp/playwright/ua-emulation.ts
@@ -21,6 +21,15 @@
 // contradicting the UA it had just announced. `platform` rides along on the UA
 // override; the metrics and the touch points need their own commands, sent
 // here so they live and die with the same session.
+//
+// One measured limit, stated where it is implemented rather than hidden: on a
+// page this process drives, `navigator.platform` keeps the host's value even
+// though every override carries the preset's. The same command sequence on a
+// page with no other debugger session attached does change it, so the value is
+// being decided by another session on the target rather than by the payload.
+// Holding it would mean owning the emulation the way a purpose-built mobile
+// context does, which is a larger change than this one; until then the tool
+// says so in its result instead of claiming a platform it did not set.
 // ---------------------------------------------------------------------------
 
 import type { Browser, BrowserContext, CDPSession, Page } from 'playwright-core';
@@ -56,6 +65,18 @@ interface EmulationState {
   sessions: Map<Page, CDPSession>;
   /** Listener re-applying the override to pages opened later. */
   onPage: (page: Page) => void;
+  /**
+   * Per-page listener re-sending the overrides after a navigation.
+   *
+   * Playwright owns these same Emulation commands on its own session and
+   * re-initialises them when a cross-process navigation builds a new frame
+   * session — `mobile: false`, `deviceScaleFactor: 1`, and a UA override
+   * without our `platform`. Whichever session wrote last wins, so an emulated
+   * phone drifted back to a desktop pixel ratio and `navigator.platform ===
+   * 'MacIntel'` one navigation after the preset was applied. Re-sending on
+   * commit makes ours the last write.
+   */
+  onNavigated: Map<Page, () => void>;
 }
 
 const stateByContext = new WeakMap<BrowserContext, EmulationState>();
@@ -69,41 +90,77 @@ const stateByContext = new WeakMap<BrowserContext, EmulationState>();
 type LooseSession = { send(method: string, params?: unknown): Promise<unknown> };
 const loose = (session: CDPSession): LooseSession => session as unknown as LooseSession;
 
+/** Send the whole preset — UA override, metrics, touch — on one session. */
+async function sendOverrides(session: CDPSession, state: EmulationState): Promise<void> {
+  await loose(session).send('Emulation.setUserAgentOverride', state.override);
+  if (!state.metrics) return;
+  const m = state.metrics;
+  const portrait = m.mobile && (m.screenHeight ?? m.height) >= (m.screenWidth ?? m.width);
+  await loose(session).send('Emulation.setDeviceMetricsOverride', {
+    width: m.width,
+    height: m.height,
+    deviceScaleFactor: m.deviceScaleFactor,
+    mobile: m.mobile,
+    ...(m.screenWidth !== undefined && m.screenHeight !== undefined && {
+      screenWidth: m.screenWidth,
+      screenHeight: m.screenHeight,
+    }),
+    // A portrait phone whose screen.orientation still reads
+    // "landscape-primary" contradicts its own dimensions. Playwright sends
+    // this for its mobile contexts too.
+    ...(portrait && { screenOrientation: { angle: 0, type: 'portraitPrimary' } }),
+  });
+  // Sent on both branches: a preset that turns touch OFF (a desktop preset
+  // after a phone one) has to say so, and "enabled: false" is how.
+  await loose(session).send('Emulation.setTouchEmulationEnabled', {
+    enabled: m.hasTouch,
+    maxTouchPoints: m.hasTouch ? TOUCH_POINTS : 0,
+  });
+}
+
 async function applyToPage(
   context: BrowserContext,
   page: Page,
   state: EmulationState,
 ): Promise<boolean> {
   if (state.sessions.has(page)) return true;
+  let session: CDPSession | undefined;
   try {
-    const session = await context.newCDPSession(page);
-    await loose(session).send('Emulation.setUserAgentOverride', state.override);
-    if (state.metrics) {
-      const m = state.metrics;
-      await loose(session).send('Emulation.setDeviceMetricsOverride', {
-        width: m.width,
-        height: m.height,
-        deviceScaleFactor: m.deviceScaleFactor,
-        mobile: m.mobile,
-        ...(m.screenWidth !== undefined && m.screenHeight !== undefined && {
-          screenWidth: m.screenWidth,
-          screenHeight: m.screenHeight,
-        }),
-      });
-      // Sent on both branches: a preset that turns touch OFF (a desktop preset
-      // after a phone one) has to say so, and "enabled: false" is how.
-      await loose(session).send('Emulation.setTouchEmulationEnabled', {
-        enabled: m.hasTouch,
-        maxTouchPoints: m.hasTouch ? TOUCH_POINTS : 0,
-      });
-    }
+    session = await context.newCDPSession(page);
+    await sendOverrides(session, state);
     state.sessions.set(page, session);
+    // Playwright re-initialises its own emulation on a cross-process
+    // navigation, so ours has to be written again afterwards or the preset
+    // decays into the contradiction it exists to remove.
+    const reapply = (): void => {
+      const live = state.sessions.get(page);
+      if (!live) return;
+      void sendOverrides(live, state).catch(() => {});
+    };
+    state.onNavigated.set(page, reapply);
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) reapply();
+    });
     // A closed page's session is dead; drop it rather than leaking the entry.
     page.once('close', () => {
       state.sessions.delete(page);
+      state.onNavigated.delete(page);
     });
     return true;
   } catch {
+    // A send that failed midway leaves a half-applied identity on a session
+    // nothing records — the UA override standing with no state entry, so a
+    // later reset would find nothing to undo and the phone UA would be
+    // permanent. Put the real UA back, then let the session go.
+    if (session) {
+      const realUserAgent = await realUserAgentFor(context).catch(() => undefined);
+      if (realUserAgent) {
+        await loose(session)
+          .send('Emulation.setUserAgentOverride', buildUserAgentOverride(realUserAgent))
+          .catch(() => {});
+      }
+      await session.detach().catch(() => {});
+    }
     return false;
   }
 }
@@ -129,6 +186,7 @@ export async function applyUserAgentEmulation(
     override: buildUserAgentOverride(userAgent, locale),
     ...(metrics && { metrics }),
     sessions: new Map(),
+    onNavigated: new Map(),
     onPage: () => {},
   };
   state.onPage = (opened: Page) => {
@@ -144,6 +202,16 @@ export async function applyUserAgentEmulation(
   }
   context.on('page', state.onPage);
   stateByContext.set(context, state);
+
+  // One more pass over the page the caller is on, after every other session has
+  // been touched. Overrides from different CDP sessions are merged by the last
+  // write, and the work above — opening sessions for the other tabs, the
+  // library's own emulation bookkeeping — can land a write between ours and the
+  // caller's next command. Measured: without this, `navigator.platform` fell
+  // back to the host's while the UA string, pixel ratio and touch points all
+  // held, which is precisely the disagreement the preset removes.
+  const primary = state.sessions.get(page);
+  if (primary) await sendOverrides(primary, state).catch(() => {});
   return true;
 }
 
@@ -163,32 +231,35 @@ export async function clearUserAgentEmulation(context: BrowserContext): Promise<
   context.off('page', state.onPage);
 
   const realUserAgent = await realUserAgentFor(context);
-  for (const [, session] of state.sessions) {
-    try {
-      if (realUserAgent) {
-        await loose(session).send(
-          'Emulation.setUserAgentOverride',
-          buildUserAgentOverride(realUserAgent),
-        );
-      }
-      if (state.metrics) {
-        // Undo the physical half too. A reset that restored the desktop UA but
-        // left devicePixelRatio 3 and five touch points behind would be the
-        // same contradiction the preset path exists to remove, only pointing
-        // the other way. The viewport override goes with it — which is why the
-        // tool's reset message points at browser_resize.
-        await loose(session).send('Emulation.clearDeviceMetricsOverride');
-        await loose(session).send('Emulation.setTouchEmulationEnabled', {
-          enabled: false,
-          maxTouchPoints: 0,
-        });
-      }
-    } catch {
-      /* the page is gone, or CDP refused; the session detach below is enough */
+  for (const [page, session] of state.sessions) {
+    // Each command on its own: one refusal must not skip the rest. Sharing a
+    // try meant a failed clearDeviceMetricsOverride left five touch points
+    // behind and reported a clean reset.
+    if (realUserAgent) {
+      await loose(session)
+        .send('Emulation.setUserAgentOverride', buildUserAgentOverride(realUserAgent))
+        .catch(() => {});
+    }
+    if (state.metrics) {
+      // Undo the physical half too. A reset that restored the desktop UA but
+      // left devicePixelRatio 3 and five touch points behind would be the
+      // same contradiction the preset path exists to remove, only pointing
+      // the other way.
+      await loose(session).send('Emulation.clearDeviceMetricsOverride').catch(() => {});
+      await loose(session)
+        .send('Emulation.setTouchEmulationEnabled', { enabled: false, maxTouchPoints: 0 })
+        .catch(() => {});
+      // Clearing the override drops the viewport emulation Playwright thinks
+      // it still has, so its cached size — the one screenshots clip to and
+      // coordinate clicks are scaled by — would describe a window that no
+      // longer exists. Writing the size back re-syncs both sides.
+      const size = page.viewportSize();
+      if (size) await page.setViewportSize(size).catch(() => {});
     }
     await session.detach().catch(() => {});
   }
   state.sessions.clear();
+  state.onNavigated.clear();
 }
 
 /** Whether `context` currently has an emulated UA applied. */

--- a/src/mcp/playwright/ua-emulation.ts
+++ b/src/mcp/playwright/ua-emulation.ts
@@ -13,13 +13,45 @@
 //
 // So this module holds one live session per page for as long as the emulation
 // is meant to last, and re-applies the override to pages that appear later.
+//
+// The same session carries the rest of the preset. A device preset used to
+// reach the page as a UA string and a viewport width and nothing else, so an
+// emulated iPhone answered `navigator.platform === 'MacIntel'`,
+// `maxTouchPoints === 0` and `devicePixelRatio === 1` — every one of them
+// contradicting the UA it had just announced. `platform` rides along on the UA
+// override; the metrics and the touch points need their own commands, sent
+// here so they live and die with the same session.
 // ---------------------------------------------------------------------------
 
 import type { Browser, BrowserContext, CDPSession, Page } from 'playwright-core';
 import { buildUserAgentOverride, type UserAgentOverride } from '../../shared/uaMetadata';
 
+/**
+ * The physical half of a device preset, straight off Playwright's descriptor.
+ * Kept separate from the UA override because CDP takes them as different
+ * commands, not because they are separable — a preset applies both or neither.
+ */
+export interface EmulatedDeviceMetrics {
+  width: number;
+  height: number;
+  /** `window.devicePixelRatio`. 3 on an iPhone, 1 on the desktop it was 1 on. */
+  deviceScaleFactor: number;
+  /** Mobile viewport semantics: meta-viewport, overlay scrollbars, text autosizing. */
+  mobile: boolean;
+  /** Whether the device has a touchscreen at all — drives `maxTouchPoints`. */
+  hasTouch: boolean;
+  /** `screen.width`/`screen.height`, which differ from the viewport on a phone. */
+  screenWidth?: number;
+  screenHeight?: number;
+}
+
+/** What a touchscreen device reports for `navigator.maxTouchPoints`. */
+const TOUCH_POINTS = 5;
+
 interface EmulationState {
   override: UserAgentOverride;
+  /** Absent when the caller emulated a UA without a device preset. */
+  metrics?: EmulatedDeviceMetrics;
   /** Live sessions, one per page, held open so the override survives. */
   sessions: Map<Page, CDPSession>;
   /** Listener re-applying the override to pages opened later. */
@@ -46,6 +78,25 @@ async function applyToPage(
   try {
     const session = await context.newCDPSession(page);
     await loose(session).send('Emulation.setUserAgentOverride', state.override);
+    if (state.metrics) {
+      const m = state.metrics;
+      await loose(session).send('Emulation.setDeviceMetricsOverride', {
+        width: m.width,
+        height: m.height,
+        deviceScaleFactor: m.deviceScaleFactor,
+        mobile: m.mobile,
+        ...(m.screenWidth !== undefined && m.screenHeight !== undefined && {
+          screenWidth: m.screenWidth,
+          screenHeight: m.screenHeight,
+        }),
+      });
+      // Sent on both branches: a preset that turns touch OFF (a desktop preset
+      // after a phone one) has to say so, and "enabled: false" is how.
+      await loose(session).send('Emulation.setTouchEmulationEnabled', {
+        enabled: m.hasTouch,
+        maxTouchPoints: m.hasTouch ? TOUCH_POINTS : 0,
+      });
+    }
     state.sessions.set(page, session);
     // A closed page's session is dead; drop it rather than leaking the entry.
     page.once('close', () => {
@@ -58,8 +109,9 @@ async function applyToPage(
 }
 
 /**
- * Apply `userAgent` (plus matching Client Hints) to every page in `context`,
- * now and as new ones open.
+ * Apply `userAgent` (plus matching Client Hints, `navigator.platform` and, when
+ * `metrics` is given, the preset's pixel ratio, mobile flag and touch points)
+ * to every page in `context`, now and as new ones open.
  *
  * Returns false when CDP refused, in which case the caller's UA header is still
  * in force and only the hints are missing.
@@ -69,11 +121,13 @@ export async function applyUserAgentEmulation(
   page: Page,
   userAgent: string,
   locale?: string | null,
+  metrics?: EmulatedDeviceMetrics,
 ): Promise<boolean> {
   await clearUserAgentEmulation(context);
 
   const state: EmulationState = {
     override: buildUserAgentOverride(userAgent, locale),
+    ...(metrics && { metrics }),
     sessions: new Map(),
     onPage: () => {},
   };
@@ -94,8 +148,9 @@ export async function applyUserAgentEmulation(
 }
 
 /**
- * Undo an emulated UA: restore the browser's real UA and hints, drop the
- * new-page listener, and close the sessions being held open.
+ * Undo an emulated UA: restore the browser's real UA and hints, drop any
+ * device metrics and touch emulation the preset installed, drop the new-page
+ * listener, and close the sessions being held open.
  *
  * The real UA has to be re-applied rather than merely dropped — CDP has no
  * "clear user agent override" command, and detaching the session while the
@@ -115,6 +170,18 @@ export async function clearUserAgentEmulation(context: BrowserContext): Promise<
           'Emulation.setUserAgentOverride',
           buildUserAgentOverride(realUserAgent),
         );
+      }
+      if (state.metrics) {
+        // Undo the physical half too. A reset that restored the desktop UA but
+        // left devicePixelRatio 3 and five touch points behind would be the
+        // same contradiction the preset path exists to remove, only pointing
+        // the other way. The viewport override goes with it — which is why the
+        // tool's reset message points at browser_resize.
+        await loose(session).send('Emulation.clearDeviceMetricsOverride');
+        await loose(session).send('Emulation.setTouchEmulationEnabled', {
+          enabled: false,
+          maxTouchPoints: 0,
+        });
       }
     } catch {
       /* the page is gone, or CDP refused; the session detach below is enough */

--- a/src/shared/__tests__/humanRhythm.test.ts
+++ b/src/shared/__tests__/humanRhythm.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_MAX_DELAY,
   DEFAULT_MIN_DELAY,
+  generateKeyHolds,
   generateTypingDelays,
+  KEY_HOLD_MAX_MS,
+  KEY_HOLD_MEDIAN_MS,
+  KEY_HOLD_MIN_MS,
+  keyHoldFor,
   typingDelayFor,
 } from '../humanRhythm';
 
@@ -138,5 +143,46 @@ describe('humanRhythm typing distribution', () => {
       typingDelayFor('a', { minDelay: 200, maxDelay: 400, rng: seeded(900 + i) }));
     expect(median(values)).toBeGreaterThan(270);
     expect(median(values)).toBeLessThan(330);
+  });
+});
+
+describe('humanRhythm key hold distribution', () => {
+  /** A long run of holds from one deterministic stream. */
+  function holds(count: number, seed = 7): number[] {
+    const rng = seeded(seed);
+    return Array.from({ length: count }, () => keyHoldFor({ rng }));
+  }
+
+  it('centres the median on the configured hold median', () => {
+    const m = median(holds(20_000));
+    expect(m).toBeGreaterThan(KEY_HOLD_MEDIAN_MS * 0.95);
+    expect(m).toBeLessThan(KEY_HOLD_MEDIAN_MS * 1.05);
+  });
+
+  it('is right-skewed, like the inter-key draw', () => {
+    const sampled = holds(20_000);
+    expect(mean(sampled)).toBeGreaterThan(median(sampled));
+  });
+
+  it('never leaves the 30-150 ms clamp, and never lands near a bare press', () => {
+    // The defect this replaces: keydown and keyup in the same millisecond.
+    // Asserted on the extremes rather than per draw — 20k expect() calls are
+    // slower than the whole distribution they check.
+    const sampled = holds(20_000, 11);
+    expect(Math.min(...sampled)).toBeGreaterThanOrEqual(KEY_HOLD_MIN_MS);
+    expect(Math.max(...sampled)).toBeLessThanOrEqual(KEY_HOLD_MAX_MS);
+  });
+
+  it('does not scale with the typist band — the hold is the hand, not the speed', () => {
+    const slow = median(Array.from({ length: 5_000 }, ((rng) => () => keyHoldFor({ rng, minDelay: 400, maxDelay: 900 }))(seeded(5))));
+    const fast = median(Array.from({ length: 5_000 }, ((rng) => () => keyHoldFor({ rng, minDelay: 10, maxDelay: 30 }))(seeded(5))));
+    expect(slow).toBeCloseTo(fast, 5);
+  });
+
+  it('generateKeyHolds returns one hold per character', () => {
+    const rng = seeded(2);
+    const schedule = generateKeyHolds('hello world', { rng });
+    expect(schedule).toHaveLength('hello world'.length);
+    expect(generateKeyHolds('', { rng })).toEqual([]);
   });
 });

--- a/src/shared/__tests__/uaMetadata.test.ts
+++ b/src/shared/__tests__/uaMetadata.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { brandsForUserAgent, buildUserAgentOverride } from '../uaMetadata';
+import { brandsForUserAgent, buildUserAgentOverride, platformForUserAgent } from '../uaMetadata';
 
 // Verbatim UA strings from Playwright's device table, plus the macOS desktop
 // Chrome string the "chrome" backend runs under.
@@ -119,6 +119,60 @@ describe('buildUserAgentOverride', () => {
       // Non-Chromium presets carry no metadata to disagree with.
       if (!meta) continue;
       expect(meta.mobile).toBe(/Mobile|iPhone|iPad|Android/.test(ua));
+    }
+  });
+});
+
+describe('platformForUserAgent', () => {
+  // navigator.platform is the legacy string every browser still ships, and the
+  // one an emulated iPhone used to answer "MacIntel" for — contradicting the UA
+  // it had just announced. These are the values the real devices report, not
+  // descriptions of them.
+  it('reports what each emulated device actually reports', () => {
+    expect(platformForUserAgent(UA.iPhone13)).toBe('iPhone');
+    expect(platformForUserAgent(UA.pixel5)).toBe('Linux armv8l');
+    expect(platformForUserAgent(UA.galaxyS9)).toBe('Linux armv8l');
+    expect(platformForUserAgent(UA.desktopMac)).toBe('MacIntel');
+    expect(platformForUserAgent(UA.desktopWindows)).toBe('Win32');
+  });
+
+  it('reads an iPad as an iPad, not as the Mac its UA mentions', () => {
+    const iPad =
+      'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1';
+    expect(platformForUserAgent(iPad)).toBe('iPad');
+  });
+
+  it('reports desktop Linux distinctly from Android', () => {
+    expect(
+      platformForUserAgent(
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36',
+      ),
+    ).toBe('Linux x86_64');
+  });
+});
+
+describe('buildUserAgentOverride platform', () => {
+  it('carries the platform on a Chromium preset', () => {
+    expect(buildUserAgentOverride(UA.pixel5).platform).toBe('Linux armv8l');
+  });
+
+  it('carries the platform on a non-Chromium preset, which has no hints to carry it', () => {
+    const override = buildUserAgentOverride(UA.iPhone13);
+    expect(override.userAgentMetadata).toBeUndefined();
+    expect(override.platform).toBe('iPhone');
+  });
+
+  it('omits the platform rather than reporting the empty string no browser reports', () => {
+    const override = buildUserAgentOverride('Some/1.0 (unrecognised platform)');
+    expect('platform' in override).toBe(false);
+  });
+
+  it('never leaves the platform disagreeing with the UA about the device', () => {
+    for (const ua of Object.values(UA)) {
+      const platform = buildUserAgentOverride(ua).platform!;
+      expect(platform).not.toBe('');
+      const isMobileUa = /iPhone|iPad|iPod|Android/.test(ua);
+      expect(['iPhone', 'iPad', 'Linux armv8l'].includes(platform)).toBe(isMobileUa);
     }
   });
 });

--- a/src/shared/humanRhythm.ts
+++ b/src/shared/humanRhythm.ts
@@ -123,12 +123,21 @@ export function generateTypingDelays(
     typingDelayFor(text[i], options),
   );
 
-  const budget = text.length * BUDGET_PER_CHAR_MS + BUDGET_SLACK_MS;
-  const total = delays.reduce((sum, d) => sum + d, 0);
+  const budget = budgetFor(text);
+  const total = sum(delays);
   if (total <= budget) return delays;
 
   const scale = budget / total;
   return delays.map((d) => d * scale);
+}
+
+/** The ceiling a whole keystroke schedule — gaps and holds — has to fit in. */
+function budgetFor(text: string): number {
+  return text.length * BUDGET_PER_CHAR_MS + BUDGET_SLACK_MS;
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +164,17 @@ export const KEY_HOLD_MIN_MS = 30;
 export const KEY_HOLD_MAX_MS = 150;
 
 /**
+ * How many times a draw outside the band is redrawn before it is clamped.
+ *
+ * Clamping alone put every out-of-band draw exactly ON the bound: ~1.5% of
+ * holds at 150.0 ms and ~0.8% at 30.0 ms, two spikes no hand produces and both
+ * of them at the round numbers a detector would look for. Redrawing keeps the
+ * distribution's own shape near the edges. The attempt count is bounded so a
+ * degenerate rng (a test stub returning a constant) cannot spin here.
+ */
+const HOLD_RESAMPLE_ATTEMPTS = 8;
+
+/**
  * How long to hold one key down, in ms.
  *
  * Only `rng` is read from `options`: the hold is a property of the hand, not of
@@ -162,7 +182,12 @@ export const KEY_HOLD_MAX_MS = 150;
  */
 export function keyHoldFor(options?: TypingRhythmOptions): number {
   const rng = options?.rng ?? Math.random;
-  const base = KEY_HOLD_MEDIAN_MS * Math.exp(HOLD_SIGMA * gaussian(rng));
+  let base = 0;
+  for (let attempt = 0; attempt < HOLD_RESAMPLE_ATTEMPTS; attempt++) {
+    base = KEY_HOLD_MEDIAN_MS * Math.exp(HOLD_SIGMA * gaussian(rng));
+    if (base >= KEY_HOLD_MIN_MS && base <= KEY_HOLD_MAX_MS) return base;
+  }
+  // Last resort, for an rng that keeps landing outside the band.
   return Math.min(Math.max(base, KEY_HOLD_MIN_MS), KEY_HOLD_MAX_MS);
 }
 
@@ -172,4 +197,41 @@ export function generateKeyHolds(
   options?: TypingRhythmOptions,
 ): number[] {
   return Array.from({ length: text.length }, () => keyHoldFor(options));
+}
+
+/** The two halves of one keystroke stream, drawn against one budget. */
+export interface KeystrokeSchedule {
+  /** Wait after `text[i]` is released. */
+  delays: number[];
+  /** How long `text[i]` stays down. */
+  holds: number[];
+}
+
+/**
+ * Per-character delays AND holds for `text`, budgeted together.
+ *
+ * `generateTypingDelays` caps the gaps on their own. Typing also spends the
+ * hold of every key, so a caller that added holds on top of an already-capped
+ * delay schedule blew straight through the cap — with the default band, by
+ * about 58% on a long text, which is enough to push a browser_type past its
+ * tool timeout. Both halves are drawn first and scaled by the same factor, so
+ * the schedule keeps its shape and its delay-to-hold ratio while the pair fits
+ * the budget. A scaled hold can land under KEY_HOLD_MIN_MS; a schedule that
+ * cannot run at all is worse than one typed briskly.
+ */
+export function generateKeystrokeSchedule(
+  text: string,
+  options?: TypingRhythmOptions,
+): KeystrokeSchedule {
+  const delays = Array.from({ length: text.length }, (_unused, i) =>
+    typingDelayFor(text[i], options),
+  );
+  const holds = Array.from({ length: text.length }, () => keyHoldFor(options));
+
+  const budget = budgetFor(text);
+  const total = sum(delays) + sum(holds);
+  if (total <= budget) return { delays, holds };
+
+  const scale = budget / total;
+  return { delays: delays.map((d) => d * scale), holds: holds.map((h) => h * scale) };
 }

--- a/src/shared/humanRhythm.ts
+++ b/src/shared/humanRhythm.ts
@@ -130,3 +130,46 @@ export function generateTypingDelays(
   const scale = budget / total;
   return delays.map((d) => d * scale);
 }
+
+// ---------------------------------------------------------------------------
+// Key hold (dwell time)
+// ---------------------------------------------------------------------------
+//
+// The inter-key delay above says how long to wait BETWEEN keystrokes. It says
+// nothing about how long each key is held, and both lanes used to press and
+// release in the same breath: keydown → keyup in about a millisecond. A person
+// holds a key for tens of milliseconds, and dwell time is a standard input of
+// keystroke-dynamics biometrics — a stream of ~1 ms holds is as distinctive as
+// a stream of perfectly uniform gaps was.
+//
+// Same shape as the inter-key draw (log-normal, injectable RNG) around a
+// median in the middle of the range people actually produce.
+
+/** Median hold, in ms — the middle of the 40–120 ms band typists produce. */
+export const KEY_HOLD_MEDIAN_MS = 70;
+/** Spread of the log-normal hold. Matches the inter-key draw's skew. */
+const HOLD_SIGMA = 0.35;
+/** A hold never falls below this… */
+export const KEY_HOLD_MIN_MS = 30;
+/** …nor above this. The tail is long, but not "leaning on the key" long. */
+export const KEY_HOLD_MAX_MS = 150;
+
+/**
+ * How long to hold one key down, in ms.
+ *
+ * Only `rng` is read from `options`: the hold is a property of the hand, not of
+ * the typist's chosen speed band, so it does not scale with min/maxDelay.
+ */
+export function keyHoldFor(options?: TypingRhythmOptions): number {
+  const rng = options?.rng ?? Math.random;
+  const base = KEY_HOLD_MEDIAN_MS * Math.exp(HOLD_SIGMA * gaussian(rng));
+  return Math.min(Math.max(base, KEY_HOLD_MIN_MS), KEY_HOLD_MAX_MS);
+}
+
+/** Per-character hold times for `text`, index i being the hold of `text[i]`. */
+export function generateKeyHolds(
+  text: string,
+  options?: TypingRhythmOptions,
+): number[] {
+  return Array.from({ length: text.length }, () => keyHoldFor(options));
+}

--- a/src/shared/uaMetadata.ts
+++ b/src/shared/uaMetadata.ts
@@ -83,6 +83,16 @@ function chromeFullVersion(ua: string): string | undefined {
  * omit the metadata entirely rather than send the empty list, see
  * `UserAgentOverride.userAgentMetadata`.
  */
+/**
+ * Whether this UA belongs to a Chromium-based browser — the only kind whose
+ * Client Hints surface (navigator.userAgentData, Sec-CH-UA*) can be emulated to
+ * agree with the string. A Safari UA has no hints to give, and Chromium's own
+ * keep answering underneath it.
+ */
+export function isChromiumUserAgent(ua: string): boolean {
+  return brandsForUserAgent(ua).length > 0;
+}
+
 export function brandsForUserAgent(ua: string): UserAgentBrand[] {
   const major = chromeMajorVersion(ua);
   if (!major) return [];

--- a/src/shared/uaMetadata.ts
+++ b/src/shared/uaMetadata.ts
@@ -37,6 +37,17 @@ export interface UserAgentMetadata {
 export interface UserAgentOverride {
   userAgent: string;
   /**
+   * What `navigator.platform` answers. Not derived from `userAgentMetadata` —
+   * a Safari UA carries no metadata at all, and an emulated iPhone that still
+   * reported "MacIntel" contradicted its own UA string in the one property
+   * every fingerprinting script reads first.
+   *
+   * Absent when the UA names no platform we recognise: leaving the real one in
+   * place is a smaller lie than overriding it with the empty string, which no
+   * browser reports.
+   */
+  platform?: string;
+  /**
    * Absent for a non-Chromium preset. Chromium fills the Client Hints surface
    * from whatever it is given, so handing it `brands: []` would produce a
    * `navigator.userAgentData` that exists but is empty — a shape no real
@@ -94,6 +105,26 @@ export function fullVersionListForUserAgent(ua: string): UserAgentBrand[] {
     { brand: 'Chromium', version: full },
     { brand: 'Google Chrome', version: full },
   ];
+}
+
+/**
+ * `navigator.platform` for an emulated UA — the legacy string every browser
+ * still ships, and the one a device preset used to leave answering out of the
+ * real machine.
+ *
+ * These are the exact values the emulated browsers report, not descriptions of
+ * them: iOS Safari says "iPhone"/"iPad", Chrome on Android says "Linux armv8l",
+ * Chrome on macOS says "MacIntel" (on Apple silicon too), Windows "Win32"
+ * (on 64-bit too) and desktop Linux "Linux x86_64".
+ */
+export function platformForUserAgent(ua: string): string {
+  if (/iPad/.test(ua)) return 'iPad';
+  if (/iPhone|iPod/.test(ua)) return 'iPhone';
+  if (/Android/.test(ua)) return 'Linux armv8l';
+  if (/Macintosh|Mac OS X/.test(ua)) return 'MacIntel';
+  if (/Windows/.test(ua)) return 'Win32';
+  if (/Linux|X11/.test(ua)) return 'Linux x86_64';
+  return '';
 }
 
 interface PlatformFacts {
@@ -182,9 +213,12 @@ export function buildUserAgentOverride(
   // so navigator.userAgentData stays absent as it is in the browser being
   // emulated. An empty-but-present hints object would be a fingerprint of its
   // own — no shipping browser produces one.
+  const platform = platformForUserAgent(userAgent);
+
   if (brands.length === 0) {
     return {
       userAgent,
+      ...(platform && { platform }),
       ...(locale && { acceptLanguage: locale }),
     };
   }
@@ -194,6 +228,7 @@ export function buildUserAgentOverride(
 
   return {
     userAgent,
+    ...(platform && { platform }),
     userAgentMetadata: {
       brands,
       fullVersionList: fullVersionListForUserAgent(userAgent),


### PR DESCRIPTION
Three places where the browser announced one thing and contradicted it a moment later, each measured live on the chrome backend against httpbin.org/headers and a local fixture.

## Referer vs Sec-Fetch-Site
`browser_navigate` sent the referer through `page.goto(url, { referer })`, an address-bar navigation. Chromium labelled it `Sec-Fetch-Site: none` + `Sec-Fetch-User: ?1` while the Referer header claimed a link had been followed. No browser produces that pair. When there is a referer to send, the navigation now happens from inside the page (`location.assign` in the isolated world, awaited the same way goto is), so Chromium fills the whole set consistently. `page.goto` keeps the first navigation, the ones leaving about:blank, and the fallback when the in-page route does not commit, all without a referer.

## Half-applied device presets
`browser_emulate device: "iPhone 13"` set the UA string and viewport and stopped there: the page still read `navigator.platform === "MacIntel"`, `maxTouchPoints === 0`, `devicePixelRatio === 1`. The preset now carries `platform` on the UA override, device metrics (scale factor, mobile flag, screen size) and touch points on both the Playwright and the packaged CDP lane; `device: null` takes all of it back. Client Hints stay omitted for a Safari UA.

## One-millisecond key holds
Humanlike typing pressed and released each key in the same breath, so every keystroke had a ~1 ms dwell. Keys are now held for a log-normal draw from the shared rhythm module (median 70 ms, clamped 30-150). Characters that cannot be a key (CJK, emoji halves) still go through `press()`.

## Tests
New: `navigation.referer.test.ts`, `link-navigation.test.ts`, `ua-emulation.test.ts`, `human-typing.test.ts`; extended `humanRhythm`, `uaMetadata`, `state.fallback`.

Gates: `tsc --noEmit`, vitest on `src/mcp/playwright` + `src/shared`, `build:mcp && probe:mcp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Human-like typing now varies key-hold durations and reliably handles unsupported characters.
  - Device emulation now applies screen dimensions, pixel density, mobile settings, touch support, and matching platform information.
  - Device emulation reset now clears metrics and touch settings completely.

- **Bug Fixes**
  - Referer-aware navigation now follows browser-like in-page navigation behavior, with reliable fallback handling when needed.
  - Navigation errors are now distinguished from uncommitted navigations to avoid unnecessary retries.

- **Documentation**
  - Device emulation limitations and reset behavior are now documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->