### PR TITLE
docs(cli): list --profile on mcp register in the help text

### DIFF
--- a/changelog.d/1184.md
+++ b/changelog.d/1184.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **`wmux --help` now shows `mcp register --profile`.** The `core` profile
+  shipped in 3.50.0 but the help text still listed `mcp register` bare, so the
+  flag could only be found in the changelog. The row names it and says what
+  `full` and `core` mean. (#1184)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -139,7 +139,8 @@ BROWSER COMMANDS
 MCP COMMANDS
   mcp check                         Show whether wmux MCP servers are registered
   mcp clients                       List MCP clients wmux saw, by reported name
-  mcp register                      Add wmux entries to ~/.claude.json
+  mcp register [--profile <name>]   Add wmux entries to ~/.claude.json
+                                    (full: every tool, the default; core: no browser_* tools)
   mcp unregister                    Remove wmux entries from ~/.claude.json
 
 CLAUDE CODE INTEGRATION


### PR DESCRIPTION
`wmux mcp register --profile core` shipped in 3.50.0, but `wmux --help` still listed `mcp register` bare — the only way to learn the flag existed was the changelog. The row now names the flag and says what the two profiles are.

Help text only; no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated `wmux --help` to document the optional `mcp register --profile` flag.
  - Clarified that the `full` profile registers all tools by default, while the `core` profile excludes browser tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->