### PR TITLE
fix(browser-replay): verify a replayed element by its neighbourhood, not only its position

### DIFF
--- a/changelog.d/1182.md
+++ b/changelog.d/1182.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- `browser_replay` now records the accessible name of the nearest named
+  container each element sat in, and checks it before acting. A flow whose
+  page was restructured underneath it — a look-alike inserted above the
+  recorded element and another removed below, which leaves the same-name count
+  unchanged and used to resolve silently by position — now stops at that step
+  and hands the page back live instead of clicking a stranger. Recordings made
+  before this release keep replaying under the previous rules.
+
+### Changed
+
+- A replay whose same-name population merely changed SIZE no longer stops when
+  the recorded element can be positively identified by its container, which
+  turns some of the previous refusals back into successful runs.

--- a/docs/how-to/replay-browser-flows.md
+++ b/docs/how-to/replay-browser-flows.md
@@ -53,6 +53,13 @@ name, and position among the same-named elements in the same frame — not by a
 DOM path. A page that was restructured, or whose refs were renumbered by a
 restart, still replays as long as the button still reads as the same button.
 
+A recording also notes the *neighbourhood* each element sat in: the accessible
+name of the nearest container that has one — `region "Express checkout"`,
+`row "Alice Chen"`. It is never used to find the element, only to check the
+one the position found. That is what catches a swap the count cannot see (a
+look-alike inserted above the recorded element and another removed below
+leaves the count unchanged, so position alone still "resolves").
+
 ## When a replay stops
 
 A step whose element is gone stops the run at that step and reports which
@@ -73,6 +80,26 @@ A change that leaves the count the *same* is not detected — one look-alike
 added above and one element removed below still measures N, the position still
 resolves, and the element it lands on is a different one. Telling those apart
 needs something the recording does not store.
+
+The neighbourhood check runs first and can override both, in both directions:
+
+- exactly one element on the page is under the recorded neighbourhood, and it
+  is where the recording put it → the step runs, even if the count changed
+  around it (a positive identification beats a count heuristic);
+- exactly one is under it but somewhere else in the population → the run
+  stops. The replay does not follow the element to its new position: doing so
+  would be resolving by position again, one level up;
+- none is under it while other elements do carry a neighbourhood → the run
+  stops. The section the recording named is gone, or was renamed. A renamed
+  section therefore stops a flow that would have worked — that is the intended
+  side to be wrong on for a step that might be a `Delete`, and the recovery is
+  the ordinary one (finish live, `save` under the same name).
+
+**What this still cannot see:** two elements that are genuinely identical —
+same role, same name, same container, differing only in their position. There
+the check abstains and the count rules decide, exactly as before. Telling
+those apart needs a positional or DOM-path axis, which is the brittleness this
+design refuses on purpose.
 
 ## Variables
 

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -7,6 +7,7 @@ interface FakeRefEntry {
   sameNameTotal: number;
   frameKey: string;
   ref: number;
+  context?: string;
 }
 
 /** What the page's "last snapshot" currently holds. Mutated per case. */
@@ -311,6 +312,139 @@ describe('replayTrace — resolution on the 4-tuple axis', () => {
     ];
     const result = await replayTrace(page, trace([refStep()]), undefined);
     expect(result.ok).toBe(false);
+  });
+});
+
+describe('replayTrace — the context verifier (#1182)', () => {
+  // #1179 stops on a CHANGED same-name count. These are the cases where the
+  // count is a liar: it stays put while the elements underneath it are swapped.
+
+  it('STOPS the same-count swap that the population count cannot see', async () => {
+    // Recorded against the one and only "Submit order", in the express
+    // checkout panel. Since then that panel's button was removed and a
+    // look-alike appeared in another panel: still exactly one, still index 0,
+    // so every count and position check passes.
+    refEntries = [
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 1,
+        frameKey: '', ref: 7, context: 'region "Saved carts"',
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('decoy'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 1,
+        frameKey: '', context: 'region "Express checkout"',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.failedStep).toBe(1);
+    expect(result.steps[0].detail).toContain('region "Express checkout"');
+    expect(clicks).toEqual([]);
+  });
+
+  it('STOPS when the recorded element is still there but the population shifted under it', async () => {
+    // A row inserted above: "Delete" for Alice moved from position 1 to 2 with
+    // the count unchanged, so the index now names Zoe's row.
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1, context: 'row "Zoe"' },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2, context: 'row "Alice"' },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('zoe-delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', context: 'row "Alice"',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].detail).toContain('sits at position 2');
+    // Never followed to its new index — that would be resolving by position.
+    expect(clicks).toEqual([]);
+  });
+
+  it('confirms a count change that #1179 alone would have refused', async () => {
+    // Index 1 of 2 recorded, the page now holds 3 — the #1179 refusal case.
+    // Alice's row is still the only one under that context and still at the
+    // recorded position, so the context outranks the count.
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 3, frameKey: '', ref: 1, context: 'row "Zoe"' },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 3, frameKey: '', ref: 2, context: 'row "Alice"' },
+      { role: 'button', name: 'Delete', sameNameIndex: 2, sameNameTotal: 3, frameKey: '', ref: 3, context: 'row "Bob"' },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('alice-delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2,
+        frameKey: '', context: 'row "Alice"',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['alice-delete']);
+    // #1179 removed the step-level warning channel along with the "replay
+    // against it anyway" path it annotated, so a confirmed step reports
+    // nothing extra — the click on the right element is the result.
+    expect(result.warnings.filter((w) => w.includes('such element(s)'))).toEqual([]);
+  });
+
+  it('gives no verdict when the siblings are genuinely identical', async () => {
+    // Two buttons in the same container: the context cannot tell them apart,
+    // so the pre-#1182 population rules decide and the step runs as before.
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1, context: 'row "Alice"' },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2, context: 'row "Alice"' },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('second-delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2,
+        frameKey: '', context: 'row "Alice"',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['second-delete']);
+  });
+
+  it('gives no verdict when the live page mints no context at all', async () => {
+    // A recording made after this field existed, replayed against a snapshot
+    // that carries none: the verifier stays silent instead of stopping every
+    // step it cannot check.
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('sign-in'));
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 1,
+        frameKey: '', context: 'region "Express checkout"',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['sign-in']);
+  });
+
+  it('replays a trace recorded before the field existed exactly as before', async () => {
+    // The live page now carries contexts; the stored axis does not. Additive
+    // means the old trace must not start stopping.
+    refEntries = [
+      { role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 1, context: 'region "Anything"' },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('sign-in'));
+    const result = await replayTrace(page, trace([refStep()]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['sign-in']);
   });
 });
 

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -75,6 +75,75 @@ function shapeWarning(recorded: string, live: string): string | null {
   );
 }
 
+/** What the live page says about the element the axis points at. */
+interface LiveEntry {
+  ref: number;
+  sameNameIndex: number;
+  context?: string;
+}
+
+/**
+ * The context verifier (#1182).
+ *
+ * #1179 stops a replay when the same-name POPULATION changed size. It cannot
+ * see a swap that keeps the size — one look-alike inserted above the recorded
+ * element and one removed below leaves N alone, so the index still resolves
+ * and the click lands on a stranger while the step reports ok.
+ *
+ * The recorded `context` (the nearest named ancestor, minted by the snapshot
+ * walk) is the only extra evidence, and it is used as EVIDENCE ONLY — three
+ * verdicts, and the element is never located by it:
+ *
+ *   exactly one live element carries the recorded context
+ *     at the recorded index  → confirmed. Stronger than the count check, so it
+ *       also clears a population that merely changed size around it.
+ *     at a different index    → the recorded element is still on the page but
+ *       the population shifted under it. Stop; do NOT follow it to its new
+ *       index, which would be re-resolving by position with extra steps and
+ *       would act on the wrong element the moment the context is not unique
+ *       for the reason we think it is.
+ *
+ *   no live element carries it, but some live element carries SOMETHING → the
+ *     neighbourhood the recording named is gone. Stop.
+ *
+ *   no live element carries any context, or several carry the recorded one →
+ *     no verdict. The context cannot tell these elements apart (identical
+ *     siblings), or the page mints none, so the pre-#1182 population rules
+ *     decide and nothing regresses.
+ *
+ * The accepted cost of the second verdict: a section renamed between recording
+ * and replay stops a flow that would have worked. That is the designed failure
+ * mode — the run stops at the step, says why, and hands the page back live —
+ * and it is the right side to be wrong on for a step that may be a `Delete`.
+ */
+function contextVerdict(
+  axis: RefAxis,
+  population: readonly LiveEntry[],
+): { ref: string } | { error: string } | null {
+  if (!axis.context) return null;
+  const matches = population.filter((entry) => (entry.context ?? '') === axis.context);
+  if (matches.length === 1) {
+    const found = matches[0];
+    if (found.sameNameIndex === axis.sameNameIndex) return { ref: String(found.ref) };
+    return {
+      error:
+        `${describeAxis(axis)} was recorded under ${axis.context}, and the only element ` +
+        `with that context now sits at position ${found.sameNameIndex + 1}, not ` +
+        `${axis.sameNameIndex + 1}. The population shifted under this step, so replaying ` +
+        'it would act on whatever took its place',
+    };
+  }
+  if (matches.length === 0 && population.some((entry) => (entry.context ?? '').length > 0)) {
+    return {
+      error:
+        `${describeAxis(axis)} was recorded under ${axis.context}, and no element with that ` +
+        'role and name is under it any more — the element at the recorded position is a ' +
+        'different one, or its section was renamed',
+    };
+  }
+  return null;
+}
+
 /**
  * Find the live ref number for a stored axis.
  *
@@ -106,6 +175,10 @@ function shapeWarning(recorded: string, live: string): string | null {
  *
  * A missing element is always a refusal — that is the other case where
  * continuing would act on something else.
+ *
+ * All of that is the fallback. When the recorded axis carries a `context` and
+ * the live page carries one too, contextVerdict runs first and may settle the
+ * step outright — including the same-count swap this reasoning is blind to.
  */
 function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure {
   const population = listRefEntries(page).filter(
@@ -116,6 +189,19 @@ function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure 
   );
   if (population.length === 0) {
     return { error: `no ${describeAxis(axis)} on the page any more` };
+  }
+  // Before the positional reasoning, not after: when the context can identify
+  // the element it is better evidence than the index, in both directions.
+  const verdict = contextVerdict(axis, population);
+  if (verdict !== null) {
+    if ('error' in verdict) return verdict;
+    // A changed population size is what the count rules below stop on. A
+    // unique context match at the recorded position is better evidence than
+    // that count: it says which element this is, not merely how many look
+    // alike. So it clears the size change and the step runs. (The step-level
+    // warning channel that used to annotate this went away with #1179, whose
+    // stop replaced it; the verdict itself is the reasoning.)
+    return verdict;
   }
   // Before the index lookup, not after: a population that shrank past the
   // recorded index would otherwise report only "no element at that position"

--- a/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
@@ -502,6 +502,44 @@ describe('replay axis for a smart ref', () => {
     });
   });
 
+  it('carries the nearest named ancestor as context, matching the a11y lane', async () => {
+    clearElementCache();
+    // region "Primary checkout" > button "Submit order" — the #1182 fixture.
+    // A smartRef-recorded click must get the same context an a11y-recorded one
+    // does, or a flow recorded on one lane cannot be verified on the other.
+    const nodes: CdpNode[] = [
+      { nodeId: '1', backendDOMNodeId: 1, role: role('RootWebArea'), name: name('Checkout'), childIds: ['2'] },
+      { nodeId: '2', backendDOMNodeId: 2, role: role('region'), name: name('Primary checkout'), childIds: ['3'] },
+      { nodeId: '3', backendDOMNodeId: 3, role: role('button'), name: name('Submit order'), childIds: [] },
+    ];
+    await getSmartSnapshot(makePage(nodes));
+
+    expect(getSmartElementByRef(1)?.context).toBe('region "Primary checkout"');
+    expect(smartRefAxisEntry(1)).toMatchObject({ context: 'region "Primary checkout"' });
+  });
+
+  it('inherits the nearest ancestor through an ignored wrapper', async () => {
+    clearElementCache();
+    const nodes: CdpNode[] = [
+      { nodeId: '1', backendDOMNodeId: 1, role: role('RootWebArea'), name: name('People'), childIds: ['2'] },
+      { nodeId: '2', backendDOMNodeId: 2, role: role('row'), name: name('Alice Chen'), childIds: ['3'] },
+      // A generic, unnamed wrapper between the row and the button contributes
+      // no context of its own — the row still wins.
+      { nodeId: '3', role: role('generic'), name: name(''), childIds: ['4'] },
+      { nodeId: '4', backendDOMNodeId: 4, role: role('button'), name: name('Delete'), childIds: [] },
+    ];
+    await getSmartSnapshot(makePage(nodes));
+    expect(getSmartElementByRef(1)?.context).toBe('row "Alice Chen"');
+  });
+
+  it('leaves context empty when nothing above is a named container', async () => {
+    clearElementCache();
+    await getSmartSnapshot(makePage(tree([{ backendId: 5, role: 'button', name: 'OK' }])));
+    expect(getSmartElementByRef(1)?.context).toBe('');
+    // ...and smartRefAxisEntry omits the key entirely, like refEntryToAxis.
+    expect(smartRefAxisEntry(1)).not.toHaveProperty('context');
+  });
+
   it('has no ref axis on the RPC lane, whose selector is a real one', async () => {
     clearElementCache();
     const evaluate = async () => ({

--- a/src/mcp/playwright/__tests__/dom-intelligence.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.test.ts
@@ -45,8 +45,9 @@ describe('getSmartSnapshotViaEval', () => {
     expect(snap.title).toBe('X');
     expect(snap.content).toBe('hello');
     // The populations are inert on this lane — its locator is a CSS selector
-    // naming one tagged element — but they are part of the shape.
-    const inert = { sameNameIndex: 0, sameNameTotal: 1, roleIndex: 0, roleTotal: 1 };
+    // naming one tagged element — but they are part of the shape. The RPC lane
+    // mints no ancestor context (it records no ref axis to carry one).
+    const inert = { context: '', sameNameIndex: 0, sameNameTotal: 1, roleIndex: 0, roleTotal: 1 };
     expect(snap.elements).toEqual([
       { ref: 1, role: 'button', name: 'OK', locator: '[data-wmux-ref="1"]', ...inert },
       {

--- a/src/mcp/playwright/__tests__/snapshot.refcontext.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.refcontext.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { generateSnapshot, listRefEntries } from '../snapshot';
+import { generateSnapshot, listRefEntries, getRefEntry } from '../snapshot';
 import { MAX_CONTEXT_CHARS } from '../../../shared/browserReplay/actionTrace';
 
 // The ancestor context a RefEntry carries (#1182). The replay runner compares
@@ -122,6 +122,39 @@ describe('RefEntry.context', () => {
     const context = listRefEntries(page as never)[0].context;
     expect(context.length).toBe(MAX_CONTEXT_CHARS);
     expect(context.endsWith('…')).toBe(true);
+  });
+
+  it('survives filter:interactive and reaches getRefEntry — the recording path', async () => {
+    // The recorder reads context off getRefEntry(page, ref) after a snapshot.
+    // filter:'interactive' keeps a named container that holds a control, so
+    // the context is still stamped on the ref the click records against
+    // (the #1182 dogfood path: browser.snapshot({filter:'interactive'})).
+    const page = makePage([
+      node(1, 'RootWebArea', 'Checkout', [2]),
+      node(2, 'region', 'Primary checkout', [3]),
+      node(3, 'button', 'Submit order'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai', filter: 'interactive' });
+    const entry = listRefEntries(page as never)[0];
+    expect(entry.context).toBe('region "Primary checkout"');
+    expect(getRefEntry(page as never, String(entry.ref))?.context).toBe('region "Primary checkout"');
+  });
+
+  it('inherits the container through a generic wrapper and a text child', async () => {
+    // A realistic Chrome shape: region > generic > button, with the button's
+    // label carried by a StaticText child. Context must still be the region.
+    const page = makePage([
+      node(1, 'RootWebArea', 'Checkout', [2]),
+      node(2, 'region', 'Express checkout', [3]),
+      node(3, 'generic', '', [4]),
+      { ...node(4, 'button', 'Submit order', [5]) },
+      node(5, 'StaticText', 'Submit order'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai', filter: 'interactive' });
+    const button = listRefEntries(page as never).find((e) => e.role === 'button');
+    expect(button?.context).toBe('region "Express checkout"');
   });
 
   it('stays out of the snapshot the agent reads', async () => {

--- a/src/mcp/playwright/__tests__/snapshot.refcontext.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.refcontext.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateSnapshot, listRefEntries } from '../snapshot';
+import { MAX_CONTEXT_CHARS } from '../../../shared/browserReplay/actionTrace';
+
+// The ancestor context a RefEntry carries (#1182). The replay runner compares
+// it against the recorded one so a same-count swap of same-name elements stops
+// instead of clicking a look-alike; what it needs from here is that the value
+// names the nearest MEANINGFUL container and nothing else. Same fake-Page
+// harness as snapshot.refstability.test.ts.
+
+interface CdpNode {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+const role = (value: string) => ({ type: 'role', value });
+const name = (value: string) => ({ type: 'name', value });
+
+function node(id: number, r: string, n: string, children: number[] = []): CdpNode {
+  return {
+    nodeId: String(id),
+    backendDOMNodeId: id,
+    role: role(r),
+    name: name(n),
+    childIds: children.map(String),
+  };
+}
+
+function makePage(nodes: CdpNode[]) {
+  const page = {
+    nodes,
+    url: () => 'https://example.test/checkout',
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string) =>
+          method === 'Accessibility.getFullAXTree' ? { nodes: page.nodes } : {},
+        ),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    evaluate: vi.fn(async () => ''),
+    locator: vi.fn(),
+  };
+  return page as unknown as Parameters<typeof generateSnapshot>[0];
+}
+
+describe('RefEntry.context', () => {
+  it('names the section each same-name button sits in', async () => {
+    // Two `button "Submit order"` — the #1182 shape. Nothing in the 4-tuple
+    // tells them apart; the section name does.
+    const page = makePage([
+      node(1, 'RootWebArea', 'Checkout', [2, 4]),
+      node(2, 'region', 'Express checkout', [3]),
+      node(3, 'button', 'Submit order'),
+      node(4, 'region', 'Saved carts', [5]),
+      node(5, 'button', 'Submit order'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai' });
+    const entries = listRefEntries(page as never);
+    expect(entries.map((e) => e.context)).toEqual([
+      'region "Express checkout"',
+      'region "Saved carts"',
+    ]);
+  });
+
+  it('takes the NEAREST named container, so a row beats its table', async () => {
+    const page = makePage([
+      node(1, 'RootWebArea', 'People', [2]),
+      node(2, 'table', 'Members', [3]),
+      node(3, 'row', 'Alice Chen', [4]),
+      node(4, 'button', 'Delete'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai' });
+    expect(listRefEntries(page as never)[0].context).toBe('row "Alice Chen"');
+  });
+
+  it('ignores unnamed and non-structural wrappers', async () => {
+    // `generic` is markup, not meaning: taking its name (or its place in the
+    // tree) would be the DOM-path brittleness the axis refuses.
+    const page = makePage([
+      node(1, 'RootWebArea', 'Page', [2]),
+      node(2, 'generic', 'wrapper', [3]),
+      node(3, 'region', '', [4]),
+      node(4, 'button', 'Delete'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai' });
+    expect(listRefEntries(page as never)[0].context).toBe('');
+  });
+
+  it('cannot separate two identical siblings — the residual #1182 leaves open', async () => {
+    // Both buttons sit under the same named row, so both carry the same
+    // context and the verifier abstains. Nothing short of a positional axis
+    // tells these apart, and a positional axis is what this whole design
+    // refuses; the replay falls back to the population rules.
+    const page = makePage([
+      node(1, 'RootWebArea', 'People', [2]),
+      node(2, 'row', 'Alice Chen', [3, 4]),
+      node(3, 'button', 'Delete'),
+      node(4, 'button', 'Delete'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai' });
+    const entries = listRefEntries(page as never);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].context).toBe(entries[1].context);
+  });
+
+  it('caps a long container name so the stored and live strings cut alike', async () => {
+    const page = makePage([
+      node(1, 'RootWebArea', 'Page', [2]),
+      node(2, 'region', 'x'.repeat(200), [3]),
+      node(3, 'button', 'Delete'),
+    ]);
+
+    await generateSnapshot(page, { format: 'ai' });
+    const context = listRefEntries(page as never)[0].context;
+    expect(context.length).toBe(MAX_CONTEXT_CHARS);
+    expect(context.endsWith('…')).toBe(true);
+  });
+
+  it('stays out of the snapshot the agent reads', async () => {
+    const page = makePage([
+      node(1, 'RootWebArea', 'Page', [2]),
+      node(2, 'region', 'Express checkout', [3]),
+      node(3, 'button', 'Submit order'),
+    ]);
+
+    const text = await generateSnapshot(page, { format: 'ai' });
+    expect(text).toContain('button "Submit order"');
+    expect(text).not.toContain('context=');
+  });
+});

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -6,6 +6,7 @@ import {
   REDACTED_PASSWORD,
   getPasswordFieldBackendIds,
 } from './redact';
+import { ancestorContext } from '../../shared/browserReplay/actionTrace';
 
 // ---------------------------------------------------------------------------
 // Shared interactive-element selector
@@ -138,6 +139,15 @@ export interface IndexedElement {
    */
   roleIndex: number;
   roleTotal: number;
+  /**
+   * `role "name"` of the nearest named structural ancestor at snapshot time —
+   * the same string the accessibility-lane snapshot mints (see
+   * ancestorContext). `''` when nothing above it is named. The replay runner
+   * uses it to stop a same-count swap of same-name elements (#1182); it is
+   * never used to LOCATE the element. Absent on the RPC lane, which records no
+   * ref axis to carry it.
+   */
+  context: string;
 }
 
 export interface SmartSnapshot {
@@ -544,6 +554,7 @@ function collectInteractiveElements(
   passwordBackendIds: Set<number>,
   identity: SmartRefIdentity,
   seen: Set<number>,
+  inheritedContext = '',
 ): void {
   const role = node.role?.value ?? 'none';
   const name = node.name?.value ?? '';
@@ -568,6 +579,9 @@ function collectInteractiveElements(
       role,
       name,
       locator: buildLocatorString(role, name),
+      // Where the element sits, not what it is: the same value the a11y lane
+      // stamps, so a flow recorded here replays against a snapshot taken there.
+      context: inheritedContext,
       // Filled in by finalizeSmartPopulations once the whole walk is known.
       sameNameIndex: 0,
       sameNameTotal: 0,
@@ -588,12 +602,17 @@ function collectInteractiveElements(
     elements.push(element);
   }
 
-  // Recurse into children
+  // Recurse into children. An ignored wrapper contributes no context of its
+  // own — ancestorContext returns the inherited value for it — so a named
+  // container survives an ignored generic between it and the control.
+  const childContext = ancestorContext(role, name, inheritedContext);
   if (node.childIds) {
     for (const childId of node.childIds) {
       const child = nodeMap.get(childId);
       if (child) {
-        collectInteractiveElements(nodeMap, child, elements, passwordBackendIds, identity, seen);
+        collectInteractiveElements(
+          nodeMap, child, elements, passwordBackendIds, identity, seen, childContext,
+        );
       }
     }
   }
@@ -794,6 +813,9 @@ export async function getSmartSnapshotViaEval(
     ...(e.value !== undefined && { value: e.value }),
     ...(e.description !== undefined && { description: e.description }),
     locator: `[data-wmux-ref="${e.ref}"]`,
+    // No named-ancestor pass on the RPC lane, and none is needed: this lane
+    // records no ref axis (smartRefAxisEntry returns null for its locator).
+    context: '',
     // The populations are unused on this lane: its locator is a CSS selector
     // naming one tagged element, so nothing counts a role or a name.
     sameNameIndex: 0,
@@ -993,6 +1015,7 @@ export function smartRefAxisEntry(ref: number): {
   sameNameIndex: number;
   sameNameTotal: number;
   frameKey: string;
+  context?: string;
 } | null {
   const element = getSmartElementByRef(ref);
   if (!element || element.locator.startsWith('[data-wmux-ref=')) return null;
@@ -1004,6 +1027,10 @@ export function smartRefAxisEntry(ref: number): {
     sameNameTotal: named ? element.sameNameTotal : element.roleTotal,
     // Always the main frame: this walk never leaves it (see SmartRefIdentity).
     frameKey: '',
+    // The nearest named ancestor, so a smartRef-recorded step gets the same
+    // #1182 verifier a snapshot-recorded one does. Omitted when empty, exactly
+    // as refEntryToAxis would drop it.
+    ...(element.context.length > 0 && { context: element.context }),
   };
 }
 

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -9,7 +9,7 @@ import { collectOcclusion, occlusionNote, type OcclusionInfo } from './occlusion
 import { collectPageFacts, formatPageFactsFooter } from './pageFacts';
 import { peekRecentPendingRequests } from './pageCapture';
 import { evaluateIsolated, isolatedProbeTarget } from './isolated-eval';
-import { MAX_CONTEXT_CHARS } from '../../shared/browserReplay/actionTrace';
+import { ancestorContext } from '../../shared/browserReplay/actionTrace';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -958,71 +958,6 @@ function frameOf(node: AXNode, inherited: FrameCoord): FrameCoord {
   return node.frameCoord ?? inherited;
 }
 
-/**
- * Ancestor roles whose accessible name says WHERE an element sits.
- *
- * Landmarks, table rows, list items, cards, and dialogs — the containers a
- * page names because a human needs to tell one copy of a repeated control from
- * another ("Delete" in row "Alice Chen" versus row "Bob Lee"). A `generic` or
- * an unnamed wrapper is deliberately absent: it would contribute a label that
- * changes with the markup rather than with the meaning, which is the DOM-path
- * brittleness this whole axis refuses.
- *
- * The element's own accessible DESCRIPTION was considered as a second
- * component and left out: aria-describedby routinely carries live text (a
- * running total, a countdown), and a verifier that changes on its own turns
- * every replay into a stop.
- */
-const CONTEXT_ANCESTOR_ROLES = new Set([
-  // landmarks
-  'region',
-  'form',
-  'search',
-  'navigation',
-  'main',
-  'banner',
-  'contentinfo',
-  'complementary',
-  // grouping
-  'article',
-  'group',
-  'figure',
-  'toolbar',
-  'menu',
-  'menubar',
-  'tabpanel',
-  'dialog',
-  'alertdialog',
-  // collections
-  'list',
-  'listitem',
-  'table',
-  'grid',
-  'treegrid',
-  'rowgroup',
-  'row',
-  'cell',
-  'gridcell',
-  'columnheader',
-  'rowheader',
-]);
-
-/**
- * The context an element's CHILDREN inherit: this node when it is a named
- * container, otherwise whatever it inherited itself. Nearest wins, so a row
- * beats the table it sits in.
- *
- * Truncation happens HERE rather than at the storage layer so that the string
- * the recorder saves and the string the replay compares it against were cut by
- * the same rule — a label clipped one way at record and another at replay
- * would never match itself.
- */
-function contextForChildren(role: string, name: string, inherited: string): string {
-  if (name.length === 0 || !CONTEXT_ANCESTOR_ROLES.has(role)) return inherited;
-  const label = `${role} "${name}"`;
-  return label.length <= MAX_CONTEXT_CHARS ? label : `${label.slice(0, MAX_CONTEXT_CHARS - 1)}\u2026`;
-}
-
 function serializeNode(
   node: AXNode,
   ctx: SerializeCtx,
@@ -1037,7 +972,7 @@ function serializeNode(
   const pad = '  '.repeat(indent);
   const role = node.role;
   const name = node.name || '';
-  const childContext = contextForChildren(role, name, inheritedContext);
+  const childContext = ancestorContext(role, name, inheritedContext);
 
   // Build attribute string
   const attrs: string[] = [];

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -9,6 +9,7 @@ import { collectOcclusion, occlusionNote, type OcclusionInfo } from './occlusion
 import { collectPageFacts, formatPageFactsFooter } from './pageFacts';
 import { peekRecentPendingRequests } from './pageCapture';
 import { evaluateIsolated, isolatedProbeTarget } from './isolated-eval';
+import { MAX_CONTEXT_CHARS } from '../../shared/browserReplay/actionTrace';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -507,6 +508,18 @@ export interface RefEntry {
   framePath: FrameHop[];
   /** frameKeyOf(framePath). `''` = main frame. */
   frameKey: string;
+  /**
+   * Where this element sits, said semantically: `role "name"` of the nearest
+   * ancestor that has both a structural role and an accessible name (see
+   * CONTEXT_ANCESTOR_ROLES). `''` when nothing above it is named.
+   *
+   * Not part of the ref's identity and not printed in any snapshot — it exists
+   * for the replay runner, which compares a recorded element's context against
+   * the live one's and stops rather than clicking a look-alike that inherited
+   * its position (#1182). Costs one string comparison per interactive node
+   * during a walk that is already visiting every node.
+   */
+  context: string;
 }
 
 /**
@@ -945,12 +958,78 @@ function frameOf(node: AXNode, inherited: FrameCoord): FrameCoord {
   return node.frameCoord ?? inherited;
 }
 
+/**
+ * Ancestor roles whose accessible name says WHERE an element sits.
+ *
+ * Landmarks, table rows, list items, cards, and dialogs — the containers a
+ * page names because a human needs to tell one copy of a repeated control from
+ * another ("Delete" in row "Alice Chen" versus row "Bob Lee"). A `generic` or
+ * an unnamed wrapper is deliberately absent: it would contribute a label that
+ * changes with the markup rather than with the meaning, which is the DOM-path
+ * brittleness this whole axis refuses.
+ *
+ * The element's own accessible DESCRIPTION was considered as a second
+ * component and left out: aria-describedby routinely carries live text (a
+ * running total, a countdown), and a verifier that changes on its own turns
+ * every replay into a stop.
+ */
+const CONTEXT_ANCESTOR_ROLES = new Set([
+  // landmarks
+  'region',
+  'form',
+  'search',
+  'navigation',
+  'main',
+  'banner',
+  'contentinfo',
+  'complementary',
+  // grouping
+  'article',
+  'group',
+  'figure',
+  'toolbar',
+  'menu',
+  'menubar',
+  'tabpanel',
+  'dialog',
+  'alertdialog',
+  // collections
+  'list',
+  'listitem',
+  'table',
+  'grid',
+  'treegrid',
+  'rowgroup',
+  'row',
+  'cell',
+  'gridcell',
+  'columnheader',
+  'rowheader',
+]);
+
+/**
+ * The context an element's CHILDREN inherit: this node when it is a named
+ * container, otherwise whatever it inherited itself. Nearest wins, so a row
+ * beats the table it sits in.
+ *
+ * Truncation happens HERE rather than at the storage layer so that the string
+ * the recorder saves and the string the replay compares it against were cut by
+ * the same rule — a label clipped one way at record and another at replay
+ * would never match itself.
+ */
+function contextForChildren(role: string, name: string, inherited: string): string {
+  if (name.length === 0 || !CONTEXT_ANCESTOR_ROLES.has(role)) return inherited;
+  const label = `${role} "${name}"`;
+  return label.length <= MAX_CONTEXT_CHARS ? label : `${label.slice(0, MAX_CONTEXT_CHARS - 1)}\u2026`;
+}
+
 function serializeNode(
   node: AXNode,
   ctx: SerializeCtx,
   currentDepth: number,
   indent: number,
   inheritedFrame: FrameCoord = MAIN_FRAME,
+  inheritedContext = '',
 ): string {
   if (currentDepth > ctx.maxDepth) return '';
 
@@ -958,6 +1037,7 @@ function serializeNode(
   const pad = '  '.repeat(indent);
   const role = node.role;
   const name = node.name || '';
+  const childContext = contextForChildren(role, name, inheritedContext);
 
   // Build attribute string
   const attrs: string[] = [];
@@ -974,6 +1054,9 @@ function serializeNode(
       sameNameTotal: 0,
       framePath: frame.path,
       frameKey: frame.key,
+      // The element's own label is already `name`; what is recorded here is
+      // where it SITS, so an element is never its own context.
+      context: inheritedContext,
     });
     attrs.push(`ref="${ref}"`);
   }
@@ -1040,7 +1123,7 @@ function serializeNode(
       // the agent cannot see is a ref it cannot have meant to use.
       const refMark = ctx.refs.length;
       const remainingBefore = ctx.frameBudgetRemaining;
-      const childStr = serializeNode(child, ctx, currentDepth + 1, indent + 1, frame);
+      const childStr = serializeNode(child, ctx, currentDepth + 1, indent + 1, frame, childContext);
       if (!childStr) continue;
       if (metered) {
         // A nested grafted frame inside this child has already charged its own

--- a/src/shared/browserReplay/__tests__/actionTrace.test.ts
+++ b/src/shared/browserReplay/__tests__/actionTrace.test.ts
@@ -16,6 +16,7 @@ import {
   isValidTraceName,
   normalizeUrlKey,
   pruneTraces,
+  MAX_CONTEXT_CHARS,
   refEntryToAxis,
   refMapShapeHash,
   sanitizeTraceRecord,
@@ -169,6 +170,23 @@ describe('refEntryToAxis', () => {
   it('repairs a non-positive total instead of dropping the ref', () => {
     expect(refEntryToAxis({ role: 'button', name: '', sameNameIndex: 0, sameNameTotal: 0, frameKey: '' }))
       .toMatchObject({ sameNameTotal: 1 });
+  });
+
+  it('carries the ancestor context through, capped', () => {
+    const long = `region "${'x'.repeat(MAX_CONTEXT_CHARS)}"`;
+    expect(
+      refEntryToAxis({
+        role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1, frameKey: '',
+        context: long,
+      }),
+    ).toMatchObject({ context: long.slice(0, MAX_CONTEXT_CHARS) });
+  });
+
+  it('omits the context rather than storing an empty one', () => {
+    const axis = refEntryToAxis({
+      role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', context: '',
+    });
+    expect(axis).not.toHaveProperty('context');
   });
 });
 
@@ -335,6 +353,28 @@ describe('sanitizeTraceStep', () => {
     expect(out).not.toBeNull();
     expect(out?.unrecordable).toBe('unresolved-axis');
     expect(out?.axis).toEqual({ kind: 'none' });
+  });
+
+  it('keeps a stored context, capped, and drops a non-string one without failing the step', () => {
+    const kept = sanitizeTraceStep(step({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1,
+        frameKey: '', context: 'row "Alice"',
+      },
+    }));
+    expect(kept?.axis).toMatchObject({ context: 'row "Alice"' });
+
+    // A hand-edited cache file: the axis is still usable without its verifier,
+    // so the step survives with the pre-#1182 contract instead of becoming a hole.
+    const stripped = sanitizeTraceStep({
+      ...step(),
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1,
+        frameKey: '', context: { evil: true },
+      },
+    });
+    expect(stripped?.unrecordable).toBeUndefined();
+    expect(stripped?.axis).not.toHaveProperty('context');
   });
 
   it('keeps a declared unrecordable reason', () => {

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -55,6 +55,15 @@ export function isReplayableTool(value: unknown): value is ReplayableTool {
 // the "the population changed, refuse rather than guess" rule — instead of
 // inventing a second, weaker one. A DOM restructure that leaves the button
 // still reading as `button "Sign in"` re-resolves; an XPath would not.
+//
+// The 4-tuple alone cannot see a swap that keeps the count: insert one
+// look-alike above the recorded element and remove one below, and N is
+// unchanged, so the index still resolves and the click lands on a stranger
+// (#1182). The axis therefore carries one more field, `context` — the
+// accessible name of the nearest named ancestor. It is a VERIFIER, never a
+// locator: nothing is ever found by it, it can only contradict what the index
+// found and stop the run. That keeps the refusal to key on position intact
+// while removing the case where position lies silently.
 
 /** An element addressed the way browser_snapshot addresses it. */
 export interface RefAxis {
@@ -65,6 +74,20 @@ export interface RefAxis {
   sameNameTotal: number;
   /** frameKeyOf(RefEntry.framePath). `''` = main frame. */
   frameKey: string;
+  /**
+   * The element's semantic neighbourhood at record time — `role "name"` of the
+   * nearest ancestor that both carries an accessible name and has a structural
+   * role (a landmark, a row, a list item, a dialog). Absent when the element
+   * sat under nothing named, and absent from every trace recorded before this
+   * field existed, which is what keeps the format additive.
+   *
+   * It is NOT a second way to FIND the element. It is only ever compared
+   * against the live page's own value for the element the index picked out, so
+   * a page that has been restructured under the recording stops instead of
+   * clicking a look-alike (#1182). Re-resolving BY it would be the positional
+   * brittleness this axis exists to avoid, one level up.
+   */
+  context?: string;
 }
 
 /** An element addressed by the CSS selector browser_smart_snapshot minted. */
@@ -148,6 +171,18 @@ export const MAX_TRACES_PER_WORKSPACE = 40;
 export const MAX_STEPS_PER_TRACE = 30;
 /** Bytes per single argument value. Longer values are truncation-marked. */
 export const MAX_ARG_BYTES = 512;
+/**
+ * Characters of `RefAxis.context` kept.
+ *
+ * Small on purpose: the context is stored on EVERY element step of every
+ * trace, so it is multiplied by MAX_STEPS_PER_TRACE x
+ * MAX_TRACES_PER_WORKSPACE before MAX_FILE_BYTES gets a say. 96 characters
+ * holds a real section or row label (`row "Alice Chen alice@example.com"`)
+ * and refuses to hold a paragraph. The truncation is applied by whoever
+ * MINTS the value, so the recorded and the live string are cut the same way
+ * and a long label still compares equal to itself.
+ */
+export const MAX_CONTEXT_CHARS = 96;
 /** Whole-file ceiling; over it the oldest workspaces are dropped. */
 export const MAX_FILE_BYTES = 512 * 1024;
 /** A trace unused for this long is forgotten on the next load. */
@@ -222,6 +257,8 @@ export interface RefEntryLike {
   sameNameIndex: number;
   sameNameTotal: number;
   frameKey: string;
+  /** See RefAxis.context. Absent on a snapshot that minted no ancestor label. */
+  context?: string;
 }
 
 
@@ -267,6 +304,7 @@ export function refEntryToAxis(entry: RefEntryLike | null | undefined): RefAxis 
   const total = Number.isInteger(entry.sameNameTotal) && entry.sameNameTotal > 0
     ? entry.sameNameTotal
     : 1;
+  const context = typeof entry.context === 'string' ? entry.context.slice(0, MAX_CONTEXT_CHARS) : '';
   return {
     kind: 'ref',
     role: entry.role,
@@ -274,6 +312,9 @@ export function refEntryToAxis(entry: RefEntryLike | null | undefined): RefAxis 
     sameNameIndex: index,
     sameNameTotal: total,
     frameKey: typeof entry.frameKey === 'string' ? entry.frameKey : '',
+    // Omitted rather than stored empty: an absent field and an empty one mean
+    // the same thing (no verdict available) and the absent one costs nothing.
+    ...(context.length > 0 && { context }),
   };
 }
 
@@ -520,6 +561,10 @@ function sanitizeAxis(raw: unknown): StepAxis | null {
     ? (a.sameNameTotal as number)
     : 1;
   if (sameNameIndex < 0 || sameNameIndex >= sameNameTotal) return null;
+  // A context that cannot be trusted is DROPPED, not fatal: without it the
+  // step falls back to the pre-#1182 population rules, which is the same
+  // contract every trace recorded before this field had.
+  const context = typeof a.context === 'string' ? a.context.slice(0, MAX_CONTEXT_CHARS) : '';
   return {
     kind: 'ref',
     role: a.role,
@@ -527,6 +572,7 @@ function sanitizeAxis(raw: unknown): StepAxis | null {
     sameNameIndex,
     sameNameTotal,
     frameKey: typeof a.frameKey === 'string' ? a.frameKey.slice(0, 256) : '',
+    ...(context.length > 0 && { context }),
   };
 }
 

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -183,6 +183,79 @@ export const MAX_ARG_BYTES = 512;
  * and a long label still compares equal to itself.
  */
 export const MAX_CONTEXT_CHARS = 96;
+
+// ── Ancestor context ─────────────────────────────────────────────────────────
+//
+// The `context` an element carries is `role "name"` of the nearest ancestor
+// that both has a structural role and is named. It is minted during the
+// accessibility walk (snapshot.ts) AND the smart-snapshot walk
+// (dom-intelligence.ts), and the two MUST produce the identical string: a flow
+// recorded on one lane is replayed by re-resolving against the other, and a
+// verifier that read `region "Checkout"` at record time but `Checkout` at
+// replay would stop every replay it was meant to pass. So the role set and the
+// formatting live here, in the one layer both lanes already depend on, rather
+// than as two copies that drift.
+
+/**
+ * Ancestor roles whose accessible name says WHERE an element sits.
+ *
+ * Landmarks, table rows, list items, cards, and dialogs — the containers a
+ * page names because a human needs to tell one copy of a repeated control from
+ * another ("Delete" in row "Alice Chen" versus row "Bob Lee"). A `generic` or
+ * an unnamed wrapper is deliberately absent: it would contribute a label that
+ * changes with the markup rather than with the meaning, which is the DOM-path
+ * brittleness the ref axis refuses.
+ */
+export const CONTEXT_ANCESTOR_ROLES: ReadonlySet<string> = new Set([
+  // landmarks
+  'region',
+  'form',
+  'search',
+  'navigation',
+  'main',
+  'banner',
+  'contentinfo',
+  'complementary',
+  // grouping
+  'article',
+  'group',
+  'figure',
+  'toolbar',
+  'menu',
+  'menubar',
+  'tabpanel',
+  'dialog',
+  'alertdialog',
+  // collections
+  'list',
+  'listitem',
+  'table',
+  'grid',
+  'treegrid',
+  'rowgroup',
+  'row',
+  'cell',
+  'gridcell',
+  'columnheader',
+  'rowheader',
+]);
+
+/**
+ * The context an element's CHILDREN inherit: this node when it is a named
+ * container, otherwise whatever it inherited itself. Nearest wins, so a row
+ * beats the table it sits in, and an element is never its own context (the walk
+ * passes the INHERITED value to the element and this value to its children).
+ *
+ * Truncation happens here, at the mint site, so the string a recording saves
+ * and the string a replay compares it against are cut by the same rule — a
+ * label clipped one way at record and another at replay would never match
+ * itself.
+ */
+export function ancestorContext(role: string, name: string, inherited: string): string {
+  if (name.length === 0 || !CONTEXT_ANCESTOR_ROLES.has(role)) return inherited;
+  const label = `${role} "${name}"`;
+  return label.length <= MAX_CONTEXT_CHARS ? label : `${label.slice(0, MAX_CONTEXT_CHARS - 1)}\u2026`;
+}
 /** Whole-file ceiling; over it the oldest workspaces are dropped. */
 export const MAX_FILE_BYTES = 512 * 1024;
 /** A trace unused for this long is forgotten on the next load. */


### PR DESCRIPTION
Closes #1182.

#1179 stops a replay when the number of same-name elements changed. It cannot see a swap that keeps the count: one look-alike inserted above the recorded element and one removed below leaves the count unchanged, so the step resolved by index and clicked a different element while reporting ok.

## What ships
Each recorded ref now carries a `context` field: the accessible name of the nearest ancestor with a structural role (a landmark, `row`, `listitem`, `dialog`, a table cell). It is minted inside the accessibility walk the snapshot already does — no extra CDP call, no DOM query, and it is not printed in the snapshot the agent reads. Capped at 96 characters.

At replay it is a verifier, never a locator. Nothing is ever located by it; it can only contradict what the index found and stop the run:
- exactly one live element carries the recorded context, at the recorded index → confirmed (this also clears a merely-changed population size, so some #1179 refusals become successful runs again);
- one carries it at a different index, or none carries it while others carry something → STOP, hand the page back live;
- nothing carries any context, or several carry the same → no verdict, the pre-existing count rules decide.

The element is deliberately not followed to its new index — that would be resolving by position, the brittleness this design refuses. The accessible description was considered as a second signal and rejected: `aria-describedby` routinely carries live text, so a verifier built on it would stop every replay.

## Residual, left open by design
Two genuinely identical siblings — same role, same name, same container, differing only in position — still cannot be told apart; the check abstains and the count rules decide. Separating those needs a positional/DOM-path axis. Documented in `actionTrace.ts`, in the replay runner, and in `docs/how-to/replay-browser-flows.md`, and pinned by a test.

## Accepted cost
A section or row renamed between recording and replay now stops a flow that would have worked. That is the module's designed failure mode, and the right side to be wrong on for a step that may be a Delete.

## Tests / gates
`tsc` clean; `vitest` on browser-replay + shared + playwright 818 passed (+15); `build:mcp && probe:mcp` clean, tools/list bytes unchanged.

Note: `stepsFingerprint` hashes the axis, so re-saving a pre-existing flow under the same name resets its success/fail history once — a cache reset, no correctness impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser replays now verify an element’s surrounding named container before performing actions, helping detect look-alike elements that have been structurally replaced.
  * Replays can continue safely when the number of matching elements changes, provided the recorded element is positively identified.

* **Bug Fixes**
  * Replays now stop and return control to the live page when the intended element is missing or has been replaced.

* **Documentation**
  * Updated replay guidance to explain container verification, its precedence, and its limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->