### PR TITLE
fix(browser): let a device preset keep navigator.platform

### DIFF
--- a/changelog.d/1181.md
+++ b/changelog.d/1181.md
@@ -12,8 +12,7 @@
   touch points, a desktop pixel ratio and desktop viewport semantics behind the
   mobile UA. The preset now carries device metrics, screen size, orientation
   and touch on both backends, holds them across navigations, and `device: null`
-  clears all of it. Two limits the result now states outright: on a page under
-  automation `navigator.platform` keeps the host's value, and a non-Chromium
+  clears all of it. One limit the result now states outright: a non-Chromium
   preset such as an iPhone cannot fill `navigator.userAgentData` or the
   `Sec-CH-UA*` headers, which keep answering as Chromium — a Chrome-based
   preset gives a consistent mobile identity. (#1181)

--- a/changelog.d/1183.md
+++ b/changelog.d/1183.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **A device preset now holds `navigator.platform`.** Under `browser_emulate
+  {device: "Pixel 7"}` the page answered `MacIntel` from the next tool call
+  onward, while its User-Agent, Client Hints, pixel ratio and touch points all
+  said Android. Of everything a preset installs, the platform is the one value
+  Chromium keeps as a page-wide setting rather than as state owned by the
+  session that wrote it — and every debugger session that detaches from the
+  page clears that setting, including a session that never set a platform of
+  its own. wmux opens and closes short-lived sessions on the page while
+  resolving which tab a tool is talking to, so the preset was being undone by
+  wmux's own bookkeeping. The override is now re-sent once the page has been
+  resolved, so `navigator.platform` agrees with the rest of the identity across
+  navigations and tool calls, and `device: null` still returns the host's.
+  (#1183)
+
+### Changed
+
+- **`browser_emulate` says what a touch preset does not do.** A phone preset
+  reports a touchscreen — `maxTouchPoints`, `(pointer: coarse)` — but the
+  clicks wmux sends over it are still mouse events, and `page.tap()` is
+  refused, because the browser wmux attaches to owns a context that was built
+  without touch. The result now states this instead of leaving a page that
+  gates on touch events to fail silently. (#1183)

--- a/changelog.d/1186.md
+++ b/changelog.d/1186.md
@@ -12,7 +12,7 @@
   wmux's own bookkeeping. The override is now re-sent once the page has been
   resolved, so `navigator.platform` agrees with the rest of the identity across
   navigations and tool calls, and `device: null` still returns the host's.
-  (#1183)
+  (#1186)
 
 ### Changed
 
@@ -21,4 +21,4 @@
   clicks wmux sends over it are still mouse events, and `page.tap()` is
   refused, because the browser wmux attaches to owns a context that was built
   without touch. The result now states this instead of leaving a page that
-  gates on touch events to fail silently. (#1183)
+  gates on touch events to fail silently. (#1186)

--- a/src/mcp/playwright/PlaywrightEngine.ts
+++ b/src/mcp/playwright/PlaywrightEngine.ts
@@ -14,6 +14,7 @@ import {
   type BrowserTargetScope,
 } from './browserScope';
 import { attachPageCapture } from './pageCapture';
+import { reassertUserAgentEmulation } from './ua-emulation';
 
 export { WORKSPACE_SCOPE_UNRESOLVED_CODE } from './browserScope';
 
@@ -575,6 +576,15 @@ export class PlaywrightEngine {
     if (page && this.workspaceBackend !== 'builtin') {
       attachPageCapture(page);
     }
+    // Last, after every throwaway CDP session this resolution opened has
+    // detached again. Chromium keeps the emulated `navigator.platform` as a
+    // page-wide setting, and a detaching session clears it whether or not it
+    // ever set one — so the id probes above (Target.getTargetInfo on each
+    // candidate, the target listing) were themselves undoing the platform half
+    // of an active device preset, one tool call after it was applied. This is
+    // the single door every browser tool comes through, which makes it the one
+    // place a re-send covers them all. A no-op when nothing is emulated.
+    if (page) await reassertUserAgentEmulation(page);
     return page;
   }
 

--- a/src/mcp/playwright/__tests__/ua-emulation.test.ts
+++ b/src/mcp/playwright/__tests__/ua-emulation.test.ts
@@ -4,6 +4,7 @@ import {
   applyUserAgentEmulation,
   clearUserAgentEmulation,
   hasUserAgentEmulation,
+  reassertUserAgentEmulation,
 } from '../ua-emulation';
 
 // A device preset is one identity, not a UA string with some hardware left over
@@ -59,6 +60,8 @@ function harness() {
       viewportSize: () => ({ width: 390, height: 664 }),
       setViewportSize: vi.fn(async () => undefined),
       isClosed: () => false,
+      // reassertUserAgentEmulation looks the state up from the page.
+      context: () => context,
     } as unknown as Page;
   };
   const page = makePage();
@@ -208,6 +211,41 @@ describe('clearUserAgentEmulation', () => {
   it('is a no-op on a context that was never emulated', async () => {
     const h = harness();
     await clearUserAgentEmulation(h.context);
+    expect(h.sent).toEqual([]);
+  });
+});
+
+describe('reassertUserAgentEmulation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('re-sends the UA override, and nothing else, for an emulated page', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, null, IPHONE_METRICS);
+    h.sent.length = 0;
+
+    await reassertUserAgentEmulation(h.page);
+
+    // Only the override: the metrics and the touch points survive a foreign
+    // session detaching, and every extra command is a round-trip charged to
+    // every tool call.
+    expect(methods(h.sent)).toEqual(['Emulation.setUserAgentOverride']);
+    expect(paramsOf(h.sent, 'Emulation.setUserAgentOverride')!.platform).toBe('iPhone');
+  });
+
+  it('is a no-op on a page whose context is not emulated', async () => {
+    const h = harness();
+    await reassertUserAgentEmulation(h.page);
+    expect(h.sent).toEqual([]);
+  });
+
+  it('is a no-op once the emulation has been cleared', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, null, IPHONE_METRICS);
+    await clearUserAgentEmulation(h.context);
+    h.sent.length = 0;
+
+    await reassertUserAgentEmulation(h.page);
+
     expect(h.sent).toEqual([]);
   });
 });

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -543,12 +543,18 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
               // Chromium's own and there is no Safari value to give them. Say
               // so where the caller reads the result, rather than let them
               // assume the identity is seamless.
-              // Two things a preset does not reach, said here rather than left
-              // for the caller to discover: navigator.platform keeps this
-              // machine's value on a page under automation, and a
-              // non-Chromium preset cannot fill the Client Hints surface at
-              // all.
-              applied.push('note=navigator.platform still reports the host platform');
+              // What a preset does not reach, said here rather than left for
+              // the caller to discover. The page reports a touchscreen, but
+              // the automated input over it is still mouse input: this
+              // process attached to a context that was built without touch,
+              // so page.tap() is refused and browser_click lands as
+              // pointerType "mouse". Only worth saying for a preset that
+              // claims touch in the first place.
+              if (deviceDescriptor.hasTouch) {
+                applied.push(
+                  'note=touch is reported, not dispatched: maxTouchPoints and (pointer:coarse) match the device, but browser_click still sends mouse events. A page that gates behaviour on touch events will not see them.',
+                );
+              }
               if (!isChromiumUserAgent(deviceDescriptor.userAgent)) {
                 applied.push(
                   'note=this preset emulates a non-Chromium browser; navigator.userAgentData and Sec-CH-UA* still report Chromium. A Chrome-based preset (e.g. "Pixel 7") gives a consistent mobile identity.',

--- a/src/mcp/playwright/ua-emulation.ts
+++ b/src/mcp/playwright/ua-emulation.ts
@@ -22,14 +22,35 @@
 // override; the metrics and the touch points need their own commands, sent
 // here so they live and die with the same session.
 //
-// One measured limit, stated where it is implemented rather than hidden: on a
-// page this process drives, `navigator.platform` keeps the host's value even
-// though every override carries the preset's. The same command sequence on a
-// page with no other debugger session attached does change it, so the value is
-// being decided by another session on the target rather than by the payload.
-// Holding it would mean owning the emulation the way a purpose-built mobile
-// context does, which is a larger change than this one; until then the tool
-// says so in its result instead of claiming a platform it did not set.
+// `navigator.platform` needs one more thing than the others, and the reason is
+// measured rather than guessed. Of everything the override carries, platform is
+// the only value Chromium keeps as a page-wide setting instead of as state
+// belonging to the session that wrote it. Every DevTools session that detaches
+// from a target resets that setting on the way out — including a session that
+// never wrote a platform of its own. So a throwaway session opened on the page
+// for something unrelated (asking a target for its id, setting a timezone) put
+// the host's platform back the moment it detached, while the UA string, the
+// hints, the pixel ratio and the touch points all stayed. Measured on a live
+// page: after the preset, `Linux armv8l`; after one unrelated session attached
+// and detached, `MacIntel`, with everything else still emulated. That is why
+// the earlier reading of this — another session outwriting ours — was wrong:
+// nothing else writes a platform, and re-sending the override from the session
+// still held here restores it immediately.
+//
+// Re-sending is therefore not a one-time step but a standing obligation, and
+// `reassertUserAgentEmulation` below is where the page is put back before a
+// tool looks at it.
+//
+// What this still cannot reach, said here rather than left to be discovered:
+// input. `Emulation.setTouchEmulationEnabled` gives the page a touchscreen to
+// report, but automated clicks are still mouse events, and the context this
+// process attached to was built without touch, so `page.tap()` is refused
+// client-side. Two ways out were measured and both are worse than the gap:
+// `Emulation.setEmitTouchEventsForMouse` does convert the clicks into real
+// touch events, but the mouse dispatch that produced them then never returns
+// (>30s, every click), and a device-built context is not this architecture —
+// it would be a fresh incognito-like context with none of the user's cookies,
+// history or extensions, which is a louder signal than the one it removes.
 // ---------------------------------------------------------------------------
 
 import type { Browser, BrowserContext, CDPSession, Page } from 'playwright-core';
@@ -260,6 +281,31 @@ export async function clearUserAgentEmulation(context: BrowserContext): Promise<
   }
   state.sessions.clear();
   state.onNavigated.clear();
+}
+
+/**
+ * Put the emulated identity back on `page` before something reads it.
+ *
+ * Only the UA override is re-sent. The device metrics and the touch points
+ * survive a foreign session detaching — measured — and each extra command is a
+ * round-trip paid on every tool call, so this sends the one that does not.
+ *
+ * A no-op unless this page is under an emulation this module is holding open,
+ * and best-effort otherwise: a page that has gone away must not fail the call
+ * that was about to use it.
+ */
+export async function reassertUserAgentEmulation(page: Page): Promise<void> {
+  let context: BrowserContext;
+  try {
+    context = page.context();
+  } catch {
+    return;
+  }
+  const state = stateByContext.get(context);
+  if (!state) return;
+  const session = state.sessions.get(page);
+  if (!session) return;
+  await loose(session).send('Emulation.setUserAgentOverride', state.override).catch(() => {});
 }
 
 /** Whether `context` currently has an emulated UA applied. */


### PR DESCRIPTION
Closes #1183. **Stacked on #1181** (`fix/browser-fingerprint-consistency`), because it edits the same `ua-emulation.ts`; base this on #1181 or land it after.

## The diagnosis in the issue was wrong, corrected by measurement
The issue blamed Playwright's own `_updateUserAgent` outwriting our `platform`. It does not — that call is gated on context `userAgent`/`locale`, both empty over `connectOverCDP`, so it never fires.

Real cause: of everything the UA override carries, `platform` is the one value Chromium keeps as a **page-wide setting** rather than as state owned by the session that wrote it. **Any** DevTools session detaching from the page resets it — even one that never set a platform. `PlaywrightEngine` opens and detaches throwaway sessions on nearly every tool call (target-info probes in the tab-resolution path), so wmux was wiping its own preset.

```
after emulate                     platform=Linux armv8l
after one unrelated attach+detach  platform=MacIntel      ← wiped
after re-send on the live session  platform=Linux armv8l  ← restored
```

## Fix
`reassertUserAgentEmulation(page)` at the tail of `PlaywrightEngine.getPageForScope()` — the one door every browser tool comes through, after the throwaway sessions are gone. Re-sends only the UA override (metrics and touch survive a detach). No-op when nothing is emulated.

Live, `browser_emulate {device:"Pixel 7"}`: `navigator.platform` = `Linux armv8l` after emulate, after navigation, and after intervening tool calls; `maxTouchPoints 5`, `devicePixelRatio 2.625`, `userAgentData.mobile true`, `Sec-CH-UA-Platform "Android"`. `device:null` restores the host with no residue.

## newContext: rejected
Over `connectOverCDP` a new BrowserContext is incognito-like — no cookies, history or extensions — a louder bot signal than the one it removes, and it abandons the real-tab model and tab/lease identity.

## Touch input: documented residual, not shipped
The one in-place route (`Emulation.setEmitTouchEventsForMouse`) does deliver real touch events, but Playwright's mouse dispatch that produces them never returns (>30s per click) — it would deadlock `browser_click`. Rejected on evidence. The tool result now states it: `maxTouchPoints` and `(pointer:coarse)` match the device, but clicks still dispatch as mouse. The stale "navigator.platform still reports the host platform" note is removed (this PR makes it false).

## Gates
`tsc` clean; `vitest` 3092 passed (+3 new); `build:mcp && probe:mcp` clean, tools/list bytes unchanged.