### PR TITLE
fix(cli): wmux mcp check names the isolated instance it is reading for

### DIFF
--- a/changelog.d/1151.md
+++ b/changelog.d/1151.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`wmux mcp check` now says when it is speaking for an isolated instance.**
+  An instance launched with `WMUX_DATA_SUFFIX` never registers itself in the
+  agent configs, but `check` still listed `~/.claude.json`, `~/.codex/config.toml`
+  and `~/.gemini/settings.json` with no hint of that — so the production entry
+  read like this instance's own, which is exactly the confusion that made the
+  original hijack hard to spot. `check` now prints a heading naming the suffix
+  and saying the rows below belong to your production wmux (`--json` gains a
+  matching `isolated` field), and the `register` / `unregister` warnings read
+  the shared `dataSuffix()` helper instead of the env var directly, so every
+  subcommand agrees with the rest of the suffix-aware paths. (#1151)

--- a/changelog.d/1187.md
+++ b/changelog.d/1187.md
@@ -9,4 +9,4 @@
   and saying the rows below belong to your production wmux (`--json` gains a
   matching `isolated` field), and the `register` / `unregister` warnings read
   the shared `dataSuffix()` helper instead of the env var directly, so every
-  subcommand agrees with the rest of the suffix-aware paths. (#1151)
+  subcommand agrees with the rest of the suffix-aware paths. (#1187)

--- a/src/cli/commands/__tests__/mcp.test.ts
+++ b/src/cli/commands/__tests__/mcp.test.ts
@@ -21,7 +21,12 @@ vi.mock('net', () => ({ connect: connectMock, default: { connect: connectMock } 
 vi.mock('fs');
 
 import * as fs from 'fs';
-import { canConnectBrokerPipe, resolveWmuxScript, selectedProfile } from '../mcp';
+import {
+  canConnectBrokerPipe,
+  isolatedInstanceNotice,
+  resolveWmuxScript,
+  selectedProfile,
+} from '../mcp';
 
 const existsSyncMock = fs.existsSync as unknown as ReturnType<typeof vi.fn>;
 
@@ -189,5 +194,44 @@ describe('selectedProfile — `wmux mcp register --profile`', () => {
     expect(selectedProfile(['register', '--profile', 'cores'])).toBeNull();
     expect(selectedProfile(['register', '--profile', 'commander'])).toBeNull();
     expect(selectedProfile(['register', '--profile'])).toBeNull();
+  });
+});
+
+describe('isolatedInstanceNotice — #1151 isolated instance (WMUX_DATA_SUFFIX)', () => {
+  const saved = process.env.WMUX_DATA_SUFFIX;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.WMUX_DATA_SUFFIX;
+    else process.env.WMUX_DATA_SUFFIX = saved;
+  });
+
+  it('stays silent on the daily (unsuffixed) instance — behavior unchanged', () => {
+    delete process.env.WMUX_DATA_SUFFIX;
+    expect(isolatedInstanceNotice('check')).toBeNull();
+    expect(isolatedInstanceNotice('register')).toBeNull();
+    expect(isolatedInstanceNotice('unregister')).toBeNull();
+  });
+
+  it('treats an empty suffix as unsuffixed (dataSuffix() semantics)', () => {
+    process.env.WMUX_DATA_SUFFIX = '';
+    expect(isolatedInstanceNotice('check')).toBeNull();
+  });
+
+  it('`check` says the instance is isolated and names the suffix', () => {
+    process.env.WMUX_DATA_SUFFIX = '-demo';
+    const notice = isolatedInstanceNotice('check');
+    // The whole point: the rows that follow are the PRODUCTION configs, and an
+    // isolated instance is never the thing registered in them.
+    expect(notice).toContain('isolated instance');
+    expect(notice).toContain('WMUX_DATA_SUFFIX=-demo');
+    expect(notice).toContain('never registers itself');
+  });
+
+  it('`register` / `unregister` warn that the PRODUCTION configs are the target', () => {
+    process.env.WMUX_DATA_SUFFIX = '-demo';
+    // The CLI is an explicit user action, so it proceeds — but it must never do
+    // so silently, because the config paths are suffix-blind.
+    expect(isolatedInstanceNotice('register')).toContain('~/.claude.json');
+    expect(isolatedInstanceNotice('register')).toContain('production agent configs');
+    expect(isolatedInstanceNotice('unregister')).toContain('removes the production');
   });
 });

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as os from 'os';
 import * as path from 'path';
-import { getMcpBrokerPipeName, getPluginTrustPath } from '../../shared/constants';
+import { dataSuffix, getMcpBrokerPipeName, getPluginTrustPath } from '../../shared/constants';
 import {
   MAX_PLUGIN_NAME_LEN,
   NON_IDENTIFYING_CLIENT_NAMES,
@@ -108,6 +108,41 @@ export function profileArgValue(args: string[]): string | undefined {
   return args[i + 1] ?? '';
 }
 
+/**
+ * #1151 — the single place this CLI decides it is speaking for an ISOLATED
+ * instance. Reads the shared `dataSuffix()` helper rather than the env var, so
+ * it agrees with every other suffix-aware path (socket, auth token, data dir).
+ *
+ * Every agent config this command touches lives at a suffix-BLIND path
+ * (`~/.claude.json`, `~/.codex/config.toml`, `~/.gemini/settings.json`), so
+ * there is no isolated variant to read or write: an isolated instance is always
+ * looking at, or editing, the PRODUCTION entries. `McpRegistrar` (an implicit
+ * boot/Settings action) therefore skips outright; this CLI is an explicit user
+ * action, so it says what it is doing and proceeds. `check` gets the same
+ * sentence as a heading so nobody reads the production rows as this instance's
+ * own registration.
+ *
+ * Returns null when this is the user's daily (unsuffixed) instance.
+ */
+export function isolatedInstanceNotice(action: 'check' | 'register' | 'unregister'): string | null {
+  const suffix = dataSuffix();
+  if (suffix === '') return null;
+  const head = `WMUX_DATA_SUFFIX=${suffix} is set — this is an isolated instance`;
+  switch (action) {
+    case 'check':
+      return `note: ${head}. It never registers itself in the agent configs, so the ` +
+        'entries below belong to your production wmux, not to this instance. Agents reach ' +
+        `this instance by running with WMUX_DATA_SUFFIX=${suffix}.`;
+    case 'register':
+      return `warning: ${head} — this writes the production agent configs ` +
+        '(~/.claude.json et al.), and the script path it registers may live inside a ' +
+        'disposable checkout';
+    case 'unregister':
+      return `warning: ${head} — this removes the production agent config entries ` +
+        '(~/.claude.json et al.)';
+  }
+}
+
 function formatModified(d: Date | null): string {
   if (!d) return 'does not exist';
   const pad = (n: number) => String(n).padStart(2, '0');
@@ -118,10 +153,17 @@ function formatModified(d: Date | null): string {
 }
 
 function printCheck(statuses: TargetRegStatus[], jsonMode: boolean): void {
+  // #1151 — an isolated instance reads the PRODUCTION configs here (there is no
+  // suffixed variant of ~/.claude.json), so say so before the rows rather than
+  // letting them be read as this instance's own registration.
+  const notice = isolatedInstanceNotice('check');
   if (jsonMode) {
-    console.log(JSON.stringify({ targets: statuses }, null, 2));
+    // Additive field: existing `--json` consumers keep reading `targets`.
+    const isolated = notice === null ? null : { suffix: dataSuffix(), note: notice };
+    console.log(JSON.stringify({ isolated, targets: statuses }, null, 2));
     return;
   }
+  if (notice) console.log(`${notice}\n`);
   for (const s of statuses) {
     const tag = s.verified ? '' : ' (experimental)';
     console.log(`${s.displayName}${tag}:`);
@@ -424,12 +466,11 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
       // #1151 — explicit user action, so warn rather than skip: the target
       // configs are suffix-blind, so this writes the PRODUCTION entries even
       // when this CLI itself runs inside an isolated instance.
-      if (process.env.WMUX_DATA_SUFFIX) {
-        // stderr in BOTH modes: --json consumers (the most automated callers,
-        // e.g. a CLI run from inside an isolated instance's pane) are exactly
-        // who must see this, and stderr never pollutes the stdout JSON.
-        console.error(`warning: WMUX_DATA_SUFFIX=${process.env.WMUX_DATA_SUFFIX} is set — this writes the production agent configs (~/.claude.json et al.), and the script path it registers may live inside a disposable checkout`);
-      }
+      // stderr in BOTH modes: --json consumers (the most automated callers,
+      // e.g. a CLI run from inside an isolated instance's pane) are exactly
+      // who must see this, and stderr never pollutes the stdout JSON.
+      const registerNotice = isolatedInstanceNotice('register');
+      if (registerNotice) console.error(registerNotice);
       const wmuxScript = await resolveWmuxScript();
       // The wmux MCP script is required; bail if the bundle can't be found.
       if (!wmuxScript) {
@@ -489,11 +530,10 @@ export async function handleMcp(args: string[], jsonMode: boolean): Promise<void
 
     case 'unregister': {
       // #1151 — same warning as `register`: suffix-blind config paths mean
-      // this removes the PRODUCTION entries.
-      if (process.env.WMUX_DATA_SUFFIX) {
-        // stderr in both modes — see the `register` case for why.
-        console.error(`warning: WMUX_DATA_SUFFIX=${process.env.WMUX_DATA_SUFFIX} is set — this removes the production agent config entries (~/.claude.json et al.)`);
-      }
+      // this removes the PRODUCTION entries. stderr in both modes — see the
+      // `register` case for why.
+      const unregisterNotice = isolatedInstanceNotice('unregister');
+      if (unregisterNotice) console.error(unregisterNotice);
       // unregisterTarget propagates write errors — capture per-target (same as
       // register) so one failure neither crashes the CLI nor is swallowed.
       const results = targets.map((t) => {


### PR DESCRIPTION
Follow-up to #1157 (which closed #1151 in 3.50.0).

#1157 stopped an isolated instance (`WMUX_DATA_SUFFIX`) from writing the production agent configs, and `register`/`unregister` warn when run under a suffix. `wmux mcp check` was the one subcommand with no isolation signal: it listed the production `~/.claude.json`, `~/.codex/config.toml` and `~/.gemini/settings.json` exactly as on the daily instance, so the production entry read like this instance's own.

`check` now prints a heading naming the suffix and stating that the rows below belong to the production wmux and that an isolated instance never registers itself; `--json` gains an additive `isolated: { suffix, note }` field. The `register`/`unregister` warnings now read the suffix through the shared `dataSuffix()` helper instead of the env var ad hoc. No write behaviour changes: the warn-and-proceed for explicit CLI actions is the documented owner decision in `externalRegistrationSkipReason()`.

Tests: silent when unsuffixed, empty suffix treated as unsuffixed, `check` names the suffix, `register`/`unregister` name the production configs. Gates: `tsc` clean, vitest 645 passed, `build:mcp && probe:mcp` clean.

Possible follow-up, not in this PR: `wmux setup-hooks` still writes the Codex `notify` entry and the OpenCode plugin under a suffix via `installLifecycleIntegrations`, which #1157 deliberately left alone.