### PR TITLE
perf(browser): keep browser_repl snapshots diffed, with a complete refs list

### DIFF
--- a/changelog.d/1188.md
+++ b/changelog.d/1188.md
@@ -12,4 +12,4 @@
   still says `[snapshot: full]` or `[snapshot: diff …]` — while `refs[]` keeps
   every element on the page. `full: true` still forces the whole tree, and the
   entries are unchanged: `ref` is a string for `snapshot`, a number for
-  `smart_snapshot`.
+  `smart_snapshot`. (#1188)

--- a/changelog.d/repl-diff.md
+++ b/changelog.d/repl-diff.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **`browser_repl` snapshots return a diff again, with the refs still
+  complete.** A `browser.snapshot()` or `browser.smart_snapshot()` inside a
+  script used to be forced to render the whole tree, because the script's
+  `refs[]` was parsed out of the returned text and a diff names only what
+  moved — so an act-then-verify loop paid for a full listing on every
+  iteration (a Node.js API page cost about 78 KB and 7–8 seconds each time,
+  where the direct tool answered with a few lines). The handler now hands the
+  bridge the complete listing alongside whatever it returned, so the script's
+  `text` is the ordinary diff-or-full the direct tools give — its first line
+  still says `[snapshot: full]` or `[snapshot: diff …]` — while `refs[]` keeps
+  every element on the page. `full: true` still forces the whole tree, and the
+  entries are unchanged: `ref` is a string for `snapshot`, a number for
+  `smart_snapshot`.

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "c52e49c7e4af2c2f98830232b675274da4a77d753a21842da69ead106d40e42d",
+      "wireResultSha256": "0dd5f49dd55a3ada047100d74b93242d14ee1a823556e86263b4fa34c24135c0",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/mcp/browser-repl/__tests__/browserRepl.test.ts
+++ b/src/mcp/browser-repl/__tests__/browserRepl.test.ts
@@ -9,6 +9,7 @@ import {
   type ConnectionScope,
 } from '../../connectionScope';
 import { hintBlockMeta } from '../../playwright/hintBlock';
+import { captureSnapshotListing } from '../../playwright/snapshotListing';
 import {
   BROWSER_REPL_TOOLS,
   createBrowserBridge,
@@ -42,8 +43,8 @@ function fail(text: string): CallToolResult {
   return { content: [{ type: 'text' as const, text }], isError: true };
 }
 
-const SNAPSHOT_TEXT = [
-  '[snapshot: full]',
+/** The complete listing a snapshot handler renders from, before diffing. */
+const SNAPSHOT_BODY = [
   '- document "Home"',
   '  - link "Log in" ref="3"',
   '  - button "Search" focused ref="7"',
@@ -51,13 +52,32 @@ const SNAPSHOT_TEXT = [
   '  - StaticText "no ref here"',
 ].join('\n');
 
-const SMART_TEXT = [
+const SNAPSHOT_TEXT = `[snapshot: full]\n${SNAPSHOT_BODY}`;
+
+/** What a repeat call returns: one hunk, naming one of the three refs. */
+const SNAPSHOT_DIFF = [
+  '[snapshot: diff vs previous — unchanged lines omitted; pass full:true for the complete tree]',
+  '@ line 4',
+  '- textbox "Email" ref="9" value="a@b"',
+  '+ textbox "Email" ref="9" value="c@d"',
+].join('\n');
+
+const SMART_BODY = [
   'Interactive elements (2):',
   '  [1] link "Log in"',
   '  [2] button "Search" - primary action',
   '',
   'Page text:',
   'Welcome',
+].join('\n');
+
+const SMART_TEXT = `[snapshot: full]\n${SMART_BODY}`;
+
+const SMART_DIFF = [
+  '[snapshot: diff vs previous — unchanged lines omitted; pass full:true for the complete tree]',
+  '@ line 6',
+  '- Welcome',
+  '+ Welcome back',
 ].join('\n');
 
 const SMART_DOM_TEXT = ['  [ref=4] a "Log in"', '  [ref=5] input[type=submit] "Go"'].join('\n');
@@ -89,8 +109,27 @@ function harness(overrides: Partial<Record<string, (args: Record<string, unknown
     ok(`Clicked ${String(a.ref ?? a.smartRef)}`),
   );
   add('type', { ref: z.string(), text: z.string() }, async () => ok('Typed'));
-  add('snapshot', { full: z.boolean().optional(), surfaceId: z.string().optional() }, async () => ok(SNAPSHOT_TEXT));
-  add('smart_snapshot', { full: z.boolean().optional() }, async () => ok(SMART_TEXT));
+  // Both snapshot tools behave as the real handlers do: the first call renders
+  // the whole tree, a repeat renders a diff unless full:true forces otherwise,
+  // and either way the complete listing goes out on the side channel.
+  const rendered = new Map<string, number>();
+  const snapshotImpl = (tool: string, body: string, full: string, diff: string) =>
+    async (a: Record<string, unknown>) => {
+      captureSnapshotListing(body);
+      const seen = rendered.get(tool) ?? 0;
+      rendered.set(tool, seen + 1);
+      return ok(a.full === true || seen === 0 ? full : diff);
+    };
+  add(
+    'snapshot',
+    { full: z.boolean().optional(), surfaceId: z.string().optional() },
+    snapshotImpl('snapshot', SNAPSHOT_BODY, SNAPSHOT_TEXT, SNAPSHOT_DIFF),
+  );
+  add(
+    'smart_snapshot',
+    { full: z.boolean().optional() },
+    snapshotImpl('smart_snapshot', SMART_BODY, SMART_TEXT, SMART_DIFF),
+  );
   add('extract_text', { surfaceId: z.string().optional() }, async () => ok('Hello world'));
   add('wait', { ms: z.number().optional() }, async (a) => {
     await new Promise((r) => setTimeout(r, Number(a.ms ?? 0)));
@@ -142,27 +181,70 @@ describe('browser_repl bridge', () => {
     expect(h.calls.map((c) => c.args.surfaceId)).toEqual(['surf-1', 'surf-2', undefined]);
   });
 
-  it('defaults snapshot tools to full:true and parses refs for both listing formats', async () => {
+  const SNAPSHOT_REFS = [
+    { ref: '3', param: 'ref', role: 'link', name: 'Log in' },
+    { ref: '7', param: 'ref', role: 'button', name: 'Search' },
+    { ref: '9', param: 'ref', role: 'textbox', name: 'Email' },
+  ];
+  const SMART_REFS = [
+    { ref: 1, param: 'smartRef', role: 'link', name: 'Log in' },
+    { ref: 2, param: 'smartRef', role: 'button', name: 'Search' },
+  ];
+
+  it('parses refs for both listing formats and leaves `full` to the tool', async () => {
     const h = harness();
     const bridge = createBrowserBridge(h.tools, {});
     const snap = await bridge('snapshot', {});
-    expect(h.calls[0].args.full).toBe(true);
-    expect(snap.ok && snap.value.refs).toEqual([
-      { ref: '3', param: 'ref', role: 'link', name: 'Log in' },
-      { ref: '7', param: 'ref', role: 'button', name: 'Search' },
-      { ref: '9', param: 'ref', role: 'textbox', name: 'Email' },
-    ]);
+    expect(h.calls[0].args.full).toBeUndefined();
+    expect(snap.ok && snap.value.refs).toEqual(SNAPSHOT_REFS);
     const smart = await bridge('smart_snapshot', { full: false });
     expect(h.calls[1].args.full).toBe(false);
-    expect(smart.ok && smart.value.refs).toEqual([
-      { ref: 1, param: 'smartRef', role: 'link', name: 'Log in' },
-      { ref: 2, param: 'smartRef', role: 'button', name: 'Search' },
-    ]);
+    expect(smart.ok && smart.value.refs).toEqual(SMART_REFS);
     expect(parseSnapshotRefs(SMART_DOM_TEXT, 'smart_snapshot')).toEqual([
       { ref: 4, param: 'smartRef', role: 'a', name: 'Log in' },
       { ref: 5, param: 'smartRef', role: 'input', name: 'Go' },
     ]);
     expect(parseSnapshotRefs('garbage', 'snapshot')).toEqual([]);
+  });
+
+  it('lets a repeat snapshot return diff text while refs stay the complete listing', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    await bridge('snapshot', {});
+    const second = await bridge('snapshot', {});
+    expect(second.ok && second.value.text.split('\n')[0]).toBe(
+      '[snapshot: diff vs previous — unchanged lines omitted; pass full:true for the complete tree]',
+    );
+    // The diff names one ref; the value still carries all three, unchanged in
+    // shape and in type — that is the whole point of the side channel.
+    expect(second.ok && second.value.text).not.toContain('ref="3"');
+    expect(second.ok && second.value.refs).toEqual(SNAPSHOT_REFS);
+    expect(second.ok && second.value.refs?.every((r) => typeof r.ref === 'string')).toBe(true);
+
+    await bridge('smart_snapshot', {});
+    const smartSecond = await bridge('smart_snapshot', {});
+    expect(smartSecond.ok && smartSecond.value.text.split('\n')[0]).toContain('[snapshot: diff');
+    expect(smartSecond.ok && smartSecond.value.refs).toEqual(SMART_REFS);
+    expect(smartSecond.ok && smartSecond.value.refs?.every((r) => typeof r.ref === 'number')).toBe(
+      true,
+    );
+  });
+
+  it('still forces the full tree when the script asks for full:true', async () => {
+    const h = harness();
+    const bridge = createBrowserBridge(h.tools, {});
+    await bridge('snapshot', {});
+    const forced = await bridge('snapshot', { full: true });
+    expect(h.calls[1].args.full).toBe(true);
+    expect(forced.ok && forced.value.text.split('\n')[0]).toBe('[snapshot: full]');
+    expect(forced.ok && forced.value.refs).toEqual(SNAPSHOT_REFS);
+  });
+
+  it('falls back to the returned text when no handler published a listing', async () => {
+    const h = harness({ snapshot: async () => ok(SNAPSHOT_TEXT) });
+    const bridge = createBrowserBridge(h.tools, {});
+    const snap = await bridge('snapshot', {});
+    expect(snap.ok && snap.value.refs).toEqual(SNAPSHOT_REFS);
   });
 
   it('splits lease event blocks into events, lifts the hints out of the value, keeps the body', () => {
@@ -303,7 +385,7 @@ describe('browser_repl session', () => {
     expect(out.result?.text).toBe('Hello world');
     expect(out.console.text).toBe('clicked 3\n');
     expect(out.ledger).toHaveLength(3);
-    expect(out.ledger[0]).toMatch(/^snapshot\(full:true\) ok \d+ms$/);
+    expect(out.ledger[0]).toMatch(/^snapshot\(\) ok \d+ms$/);
     expect(out.ledger[1]).toMatch(/^click\(ref:"3"\) ok/);
     expect(h.calls.map((c) => c.name)).toEqual(['snapshot', 'click', 'extract_text']);
     expect(out.freshRuntime).toBe(true);

--- a/src/mcp/browser-repl/bridge.ts
+++ b/src/mcp/browser-repl/bridge.ts
@@ -14,6 +14,7 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { CollectedTool } from '../playwright/toolCollector';
 import { isHintBlock } from '../playwright/hintBlock';
 import { redactPasswordParams } from '../playwright/redact';
+import { withSnapshotListingCapture } from '../playwright/snapshotListing';
 import {
   getConnectionScope,
   runInConnectionScope,
@@ -55,7 +56,7 @@ export const BROWSER_REPL_TOOLS: readonly string[] = Object.freeze([
   'dialog',
 ]);
 
-/** Snapshot tools default to `full:true` inside a script — see `shapeResult`. */
+/** Tools whose value carries a parsed `refs[]` — see `shapeResult`. */
 const SNAPSHOT_TOOLS = new Set(['snapshot', 'smart_snapshot']);
 
 /** Argument keys whose values are typed into the page and never shown in the ledger. */
@@ -100,7 +101,11 @@ export interface BridgeValue {
   readonly text: string;
   /** `[browser events]` lines the lease reported alongside this call. */
   readonly events: readonly string[];
-  /** Snapshot tools only: refs parsed from the listing. Empty when the format is not recognized. */
+  /**
+   * Snapshot tools only: every ref the snapshot minted, even when `text` is a
+   * diff that names only a few of them. Empty when the format is not
+   * recognized.
+   */
   readonly refs?: readonly SnapshotRef[];
 }
 
@@ -203,7 +208,17 @@ export interface ShapedResult {
   readonly hints: readonly string[];
 }
 
-export function shapeResult(result: CallToolResult, tool: string): ShapedResult {
+/**
+ * `listing` is the complete snapshot listing the handler published on the side
+ * channel (snapshotListing.ts). It exists so `refs` can stay complete while
+ * `text` is a diff; without one — an unrecognized route, or a tool that is not
+ * a snapshot — the returned text is the only source there is.
+ */
+export function shapeResult(
+  result: CallToolResult,
+  tool: string,
+  listing?: string,
+): ShapedResult {
   const events: string[] = [];
   const hints: string[] = [];
   const body: string[] = [];
@@ -228,7 +243,7 @@ export function shapeResult(result: CallToolResult, tool: string): ShapedResult 
   }
   const text = body.join('\n');
   if (SNAPSHOT_TOOLS.has(tool)) {
-    return { value: { text, events, refs: parseSnapshotRefs(text, tool) }, hints };
+    return { value: { text, events, refs: parseSnapshotRefs(listing ?? text, tool) }, hints };
   }
   return { value: { text, events }, hints };
 }
@@ -283,12 +298,6 @@ export function createBrowserBridge(
     if (options.surfaceId !== undefined && 'surfaceId' in collected.shape && args.surfaceId === undefined) {
       args.surfaceId = options.surfaceId;
     }
-    // A diff is a saving for the model reading it; for code parsing refs it is
-    // a listing with most of the elements missing.
-    if (SNAPSHOT_TOOLS.has(name) && 'full' in collected.shape && args.full === undefined) {
-      args.full = true;
-    }
-
     let validator = validators.get(name);
     if (!validator) {
       validator = z.object(collected.shape);
@@ -307,10 +316,24 @@ export function createBrowserBridge(
     }
 
     const invoke = () => collected.handler(parsed.data as Record<string, unknown>);
-    let result: CallToolResult;
-    try {
+    const scoped = async (): Promise<CallToolResult> => {
       const scope = options.scope ?? getConnectionScope();
-      result = scope ? await runInConnectionScope(scope, invoke) : await invoke();
+      return scope ? await runInConnectionScope(scope, invoke) : await invoke();
+    };
+    let result: CallToolResult;
+    // The script gets the same diff-or-full text a direct call would (its
+    // first line says which), and the refs come from the full listing the
+    // handler publishes alongside it — so `refs.find(...)` still sees every
+    // element without the snapshot being taken in full every time.
+    let listing: string | undefined;
+    try {
+      if (SNAPSHOT_TOOLS.has(name)) {
+        const captured = await withSnapshotListingCapture(scoped);
+        result = captured.result;
+        listing = captured.listing;
+      } else {
+        result = await scoped();
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return { ok: false, error: `browser.${name}: ${message}`, ledger: ledgerFor(args, 'THREW') };
@@ -318,7 +341,7 @@ export function createBrowserBridge(
     if (result.isError) {
       return { ok: false, error: `browser.${name}: ${errorText(result)}`, ledger: ledgerFor(args, 'FAILED') };
     }
-    const { value, hints } = shapeResult(result, name);
+    const { value, hints } = shapeResult(result, name, listing);
     const eventNote = value.events.length > 0 ? ` · ${value.events.length} event(s)` : '';
     return { ok: true, value, ledger: `${ledgerFor(args, 'ok')}${eventNote}`, hints };
   };

--- a/src/mcp/browser-repl/tool.ts
+++ b/src/mcp/browser-repl/tool.ts
@@ -186,7 +186,7 @@ export function formatBrowserReplOutcome(outcome: BrowserReplRunOutcome): string
 const BROWSER_REPL_DESCRIPTION =
   'Run a JavaScript snippet that drives the browser through many steps in ONE call. ' +
   'Each allowed browser_X tool is `await browser.X(args)` with the same args, resolving to ' +
-  '{text, events} (+ refs:[{ref,param,role,name}] for snapshot/smart_snapshot, full listing by default; ' +
+  '{text, events} (+ refs:[{ref,param,role,name}] for snapshot/smart_snapshot, diff text, all refs; ' +
   'pass refs[i].ref as the arg named refs[i].param). A failed step throws (catchable). ' +
   `Allowed: ${BROWSER_REPL_TOOLS.join(', ')}. ` +
   'Other browser_* tools stay separate calls. Top-level await works; state persists between calls ' +

--- a/src/mcp/playwright/__tests__/extraction.diff.test.ts
+++ b/src/mcp/playwright/__tests__/extraction.diff.test.ts
@@ -24,6 +24,7 @@ vi.mock('../PlaywrightEngine', () => ({
 import { registerExtractionTools } from '../tools/extraction';
 import { clearElementCache } from '../dom-intelligence';
 import { invalidateSnapshotBaseline } from '../snapshotCache';
+import { withSnapshotListingCapture } from '../snapshotListing';
 
 // browser_smart_snapshot's auto-diff. Refs are keyed on DOM node identity on
 // the Playwright/CDP lane (dom-intelligence.refstability.test.ts), which is
@@ -264,6 +265,32 @@ describe('a diff never crosses a document or a page', () => {
 
     expect(other.startsWith('[snapshot: full]')).toBe(true);
     expect(other).toContain('Item 30');
+  });
+});
+
+describe('the complete listing on the side channel', () => {
+  it('publishes every element even on the call that returns a diff', async () => {
+    const page = makePage(tree(ROWS));
+    getPage.mockResolvedValue(page);
+    await snapshot();
+
+    page.nodes = tree([{ backendId: 999, role: 'button', name: 'Inserted' }, ...ROWS]);
+    const captured = await withSnapshotListingCapture(() => snapshot());
+
+    // The text is the diff; the listing is what full:true would have returned,
+    // which is what browser_repl parses its refs from (snapshotListing.ts).
+    expect(captured.result.startsWith('[snapshot: diff vs previous')).toBe(true);
+    expect(captured.result).not.toContain('Item 30');
+    expect(captured.listing).toBeDefined();
+    expect(captured.listing).toContain('Item 30');
+    expect(captured.listing).toContain('Inserted');
+    // The header belongs to the rendering, not the listing.
+    expect(captured.listing?.startsWith('[snapshot:')).toBe(false);
+  });
+
+  it('costs nothing when no capture is active', async () => {
+    getPage.mockResolvedValue(makePage(tree(ROWS)));
+    expect((await snapshot()).startsWith('[snapshot: full]')).toBe(true);
   });
 });
 

--- a/src/mcp/playwright/snapshotListing.ts
+++ b/src/mcp/playwright/snapshotListing.ts
@@ -1,0 +1,53 @@
+/**
+ * A side channel carrying the COMPLETE snapshot listing out of a snapshot
+ * handler, for a caller that needs the whole element inventory even when the
+ * text it gets back is a diff.
+ *
+ * `browser_repl` is that caller. The script's `browser.snapshot()` value is
+ * read twice over: once by whoever prints `.text` (a diff is the saving the
+ * auto-diff exists for) and once by code doing `refs.find(...)` (a diff is a
+ * listing with most of the elements missing). The bridge used to reconcile
+ * those by forcing `full:true` on every in-script snapshot — ~78KB and 7-8s
+ * per act-then-verify iteration, paid so that a `find` would not miss an
+ * unchanged element.
+ *
+ * The handler already holds both halves: `text` is the full listing and
+ * `formatSnapshotResult` decides what to return. Publishing the full listing
+ * here lets the bridge parse a complete `refs[]` off it while the returned
+ * text stays a diff. AsyncLocalStorage rather than a module global for the
+ * reason connectionScope.ts gives: the broker hosts N callers in one process,
+ * and two concurrent snapshots must not read each other's listing.
+ *
+ * Nothing is published when no capture is active, so a direct MCP call pays
+ * neither the bytes nor the bookkeeping.
+ */
+import { AsyncLocalStorage } from 'async_hooks';
+
+interface ListingSink {
+  listing?: string;
+}
+
+const storage = new AsyncLocalStorage<ListingSink>();
+
+/**
+ * Publish the complete listing the current snapshot was rendered from.
+ * A no-op outside a capture, and cheap enough to call unconditionally.
+ */
+export function captureSnapshotListing(text: string): void {
+  const sink = storage.getStore();
+  if (sink) sink.listing = text;
+}
+
+/**
+ * Run `fn` with a capture active. `listing` is the last complete listing a
+ * snapshot handler published inside it, or undefined when it published none
+ * (an error before the render, or a tool that is not a snapshot) — callers
+ * treat that as "no better source than the returned text".
+ */
+export async function withSnapshotListingCapture<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; listing: string | undefined }> {
+  const sink: ListingSink = {};
+  const result = await storage.run(sink, fn);
+  return { result, listing: sink.listing };
+}

--- a/src/mcp/playwright/tools/extraction.ts
+++ b/src/mcp/playwright/tools/extraction.ts
@@ -7,6 +7,7 @@ import { extractMarkdown, extractStructuredData } from '../markdown-extractor';
 import { resolveEvaluator, rpcEvaluator } from '../page-eval';
 import { formatSnapshotResult } from '../snapshotDiff';
 import { getSnapshotBaseline, setSnapshotBaseline, snapshotSurfaceKey } from '../snapshotCache';
+import { captureSnapshotListing } from '../snapshotListing';
 import { allowScopedRpcFallback, type BrowserToolDeps } from '../browserScope';
 import { describeToolError } from '../toolError';
 
@@ -134,6 +135,9 @@ export function registerExtractionTools(server: McpServer, deps: BrowserToolDeps
           full || !page ? null : getSnapshotBaseline(key, attrs, snapshot.url || undefined);
         const rendered = formatSnapshotResult(baseline?.text ?? null, text);
         setSnapshotBaseline(key, attrs, text, snapshot.url || undefined);
+        // The complete listing, for a caller that needs every ref even when
+        // it is handed a diff (snapshotListing.ts).
+        captureSnapshotListing(text);
 
         // The content summary is cut at maxContentLength, so a diff — "(no
         // changes)" most of all — speaks only for what fits (review 10).

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -15,6 +15,7 @@ import { buildDomSnapshotExpression } from '../dom-intelligence';
 import { pageEvaluator, rpcEvaluator } from '../page-eval';
 import { formatSnapshotResult } from '../snapshotDiff';
 import { getSnapshotBaseline, setSnapshotBaseline, snapshotSurfaceKey } from '../snapshotCache';
+import { captureSnapshotListing } from '../snapshotListing';
 import { evaluateWithGesture } from '../user-gesture';
 import { evaluateIsolated } from '../isolated-eval';
 import { detectDangerousPatterns } from '../security';
@@ -396,6 +397,10 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
         const baseline = full ? null : getSnapshotBaseline(key, attrs, currentUrl);
         const rendered = formatSnapshotResult(baseline?.text ?? null, text);
         setSnapshotBaseline(key, attrs, text, currentUrl);
+        // `text` is the whole tree whatever `rendered` turned out to be; a
+        // caller that needs every ref (browser_repl) reads it from here
+        // instead of forcing full:true (snapshotListing.ts).
+        captureSnapshotListing(text);
 
         return {
           content: [{ type: 'text' as const, text: rendered.text }],


### PR DESCRIPTION
Inside a `browser_repl` script, `browser.snapshot()` and `browser.smart_snapshot()` forced `full:true` whenever the caller left `full` unset. The reason was sound — the bridge parsed `refs[]` out of the returned text, and a diff only holds changed lines, so `refs.find(...)` would silently miss unchanged elements — but the cost was real: on the Node.js `fs` docs an act-then-verify loop paid ~78 KB and several seconds per snapshot, every iteration, while a direct call returned a diff of a few lines.

## What changes
The bridge no longer forces `full:true`; snapshots in a script get the same diff-or-full rendering a direct call gets, and `refs[]` comes from a separate, complete listing.

A small `AsyncLocalStorage` side channel (`snapshotListing.ts`): both snapshot handlers already hold the complete listing in a local at the moment they decide what to return, so each publishes it there — one line each, right after the baseline is set. The bridge wraps the handler call in the capture and parses refs from that listing. Nothing is published when no capture is active, so direct MCP calls are byte-identical to before. ALS rather than a module global because the broker hosts several callers in one process and two concurrent snapshots must not read each other's listing. Refs are parsed by the same `parseSnapshotRefs` from text equal to what `full:true` would have returned, so `ref` stays a string on the snapshot lane and a number for `smartRef` (#1180). The first line of `text` still says `[snapshot: full]` or `[snapshot: diff …]`.

The `browser_repl` description said "full listing by default", now false; edited to "diff text, all refs" (4 bytes smaller). `scripts/mcp-protocol-baseline.json` updated for the changed full-profile hash.

## Live (installed app, chrome backend, nodejs.org/api/fs.html)
| step | before text/refs | after text/refs |
|---|---|---|
| `snapshot()` #2 | 50,033 / 468 | **129** / 468 |
| `smart_snapshot()` #2 | 78,428 / 2,814 | **209** / 2,814 |
| `snapshot({full:true})` | 50,033 / 468 | 50,033 / 468 |

A ref taken from the diff call's `refs[]` for a line absent from the diff text was passed straight to `browser.highlight` and resolved — the property the old forcing existed to protect.

## Gates
`tsc` clean; vitest browser-repl + playwright 776 passed; `build:mcp && probe:mcp` clean. tools/list: full 75,453 / core 46,665 / commander 43,314.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `browser.snapshot()` and `browser.smart_snapshot()` now return concise diffs again during repeated script interactions, while still providing references for all page elements.
  * The first snapshot and requests using `full: true` continue to return the complete page tree.
  * Snapshot behavior now works consistently across direct calls and scripted browser interactions.

* **Tests**
  * Added coverage for diff responses, complete reference listings, forced full snapshots, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->