### PR TITLE
feat(browser): dispatch real touch under a device preset

### DIFF
--- a/changelog.d/1190.md
+++ b/changelog.d/1190.md
@@ -15,4 +15,4 @@
   gestures. Two gestures a touchscreen does not have stay on the mouse and say
   so in the result: a double click, and `browser_hover`, which would otherwise
   turn every hover-revealed menu into a silent failure. Nothing changes without
-  a device preset. (#1183)
+  a device preset. (#1190) (#1190)

--- a/changelog.d/touch.md
+++ b/changelog.d/touch.md
@@ -1,0 +1,18 @@
+### Changed
+
+- **A touch preset now dispatches touch.** Under `browser_emulate {device:
+  "Pixel 7"}` the page reported a touchscreen — `maxTouchPoints: 5`,
+  `(pointer: coarse)` — and then received mouse input, so anything gated on
+  `touchstart`, or reading `pointerdown.pointerType`, saw a desktop pressing
+  the button. `browser_click` now sends a real `touchStart`/`touchEnd` pair on
+  the session the preset is already held open on, and `browser_drag` sends
+  `touchStart` → moves → `touchEnd`. Measured on the same fixture and click:
+  before, `pointerdown: mouse` and no touch events at all; after,
+  `pointerdown: touch`, `touchstart`, `touchend`, then the `click` Chrome
+  derives from them, all `isTrusted`. The element is still checked for
+  actionability exactly as a mouse click checks it, and the approach the mouse
+  walks is skipped — a touchscreen has no pointer resting on the page between
+  gestures. Two gestures a touchscreen does not have stay on the mouse and say
+  so in the result: a double click, and `browser_hover`, which would otherwise
+  turn every hover-revealed menu into a silent failure. Nothing changes without
+  a device preset. (#1183)

--- a/src/main/pipe/handlers/__tests__/browser.rpc.touch.test.ts
+++ b/src/main/pipe/handlers/__tests__/browser.rpc.touch.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import { RpcRouter } from '../../RpcRouter';
+import type { RpcMethod } from '../../../../shared/rpc';
+import { registerBrowserRpc } from '../browser.rpc';
+
+// The packaged lane's half of touch dispatch. A device preset here installs the
+// touch emulation over `webContents.debugger`, so the input that follows has to
+// go out on the same channel as touch — otherwise the page reports five touch
+// points and receives mouse events, which is exactly the contradiction the
+// preset exists to remove.
+
+const sent: Array<{ method: string; params: Record<string, unknown> }> = [];
+
+const mockWebContents = {
+  isDestroyed: vi.fn(() => false),
+  getUserAgent: vi.fn(() => 'real-ua'),
+  on: vi.fn(),
+  off: vi.fn(),
+  once: vi.fn(),
+  debugger: {
+    sendCommand: vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      sent.push({ method, params: params ?? {} });
+      if (method === 'Runtime.evaluate') {
+        const expression = String(params?.expression ?? '');
+        // pointIsOnTarget asks whether the point still hits the element;
+        // elementCenter asks where the element is.
+        if (expression.includes('elementFromPoint')) return { result: { value: true } };
+        return { result: { value: { x: 120, y: 240 } } };
+      }
+      return {};
+    }),
+    isAttached: vi.fn(() => true),
+    attach: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+};
+
+vi.mock('electron', () => ({
+  webContents: { fromId: vi.fn(() => mockWebContents) },
+}));
+vi.mock('../../../security/navigationPolicy', () => ({
+  validateResolvedNavigationUrl: vi.fn(async () => ({ valid: true })),
+}));
+vi.mock('../_bridge', () => ({ sendToRenderer: vi.fn(async () => ({ ok: true })) }));
+
+const TARGET = { surfaceId: 'surface-own', targetId: 'T-own', webContentsId: 7, workspaceId: 'ws-a' };
+
+function register() {
+  const cdp = {
+    getTarget: vi.fn(() => TARGET),
+    ensureAwake: vi.fn(async () => null),
+    listTargets: vi.fn(() => [TARGET]),
+    getCdpPort: vi.fn(() => 18800),
+    setCaptureCleanup: vi.fn(),
+    setCaptureAttach: vi.fn(),
+    withAutomationLease: vi.fn(async (_s: string, fn: () => Promise<unknown>) => fn()),
+    acquireRpcLease: vi.fn((sid: string) => `lease-${sid}`),
+    renewRpcLease: vi.fn(() => true),
+    releaseRpcLease: vi.fn(() => true),
+  };
+  const router = new RpcRouter();
+  registerBrowserRpc(router, () => null as unknown as BrowserWindow, cdp as never);
+  return router;
+}
+
+async function call(
+  router: RpcRouter,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const response = await router.dispatch({
+    id: `c-${method}`,
+    method: method as RpcMethod,
+    params: { ...params, workspaceId: 'ws-a' },
+  });
+  if (!response.ok) throw new Error(`${method} failed: ${response.error}`);
+  return (response.result ?? {}) as Record<string, unknown>;
+}
+
+async function emulate(router: RpcRouter, hasTouch: boolean): Promise<void> {
+  await call(router, 'browser.emulate', {
+    deviceMetrics: { width: 412, height: 915, deviceScaleFactor: 3, mobile: true, hasTouch },
+    deviceLabel: 'Pixel 7 (412x915)',
+    userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 7) Chrome/140.0.0.0 Mobile Safari/537.36',
+  });
+  sent.length = 0;
+}
+
+const types = (method: string): string[] =>
+  sent.filter((s) => s.method === method).map((s) => String(s.params.type));
+
+describe('browser.click.cdp under a touchscreen preset', () => {
+  beforeEach(() => {
+    sent.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('dispatches a touch tap and no mouse event', async () => {
+    const router = register();
+    await emulate(router, true);
+
+    const res = await call(router, 'browser.click.cdp', { selector: '[data-wmux-ref="3"]' });
+
+    expect(res.dispatch).toBe('touch');
+    expect(types('Input.dispatchTouchEvent')).toEqual(['touchStart', 'touchEnd']);
+    expect(sent.some((s) => s.method === 'Input.dispatchMouseEvent')).toBe(false);
+  });
+
+  it('leaves the mouse path alone when the preset has no touchscreen', async () => {
+    const router = register();
+    await emulate(router, false);
+
+    const res = await call(router, 'browser.click.cdp', { selector: '[data-wmux-ref="3"]' });
+
+    expect(res.dispatch).toBe('mouse');
+    expect(sent.some((s) => s.method === 'Input.dispatchTouchEvent')).toBe(false);
+    expect(types('Input.dispatchMouseEvent')).toContain('mousePressed');
+    expect(types('Input.dispatchMouseEvent')).toContain('mouseReleased');
+  });
+
+  it('drags with one finger: press, moves, lift', async () => {
+    const router = register();
+    await emulate(router, true);
+
+    const res = await call(router, 'browser.drag.cdp', {
+      sourceSelector: '[data-wmux-ref="3"]',
+      targetSelector: '[data-wmux-ref="4"]',
+    });
+
+    expect(res.dispatch).toBe('touch');
+    const touch = types('Input.dispatchTouchEvent');
+    expect(touch[0]).toBe('touchStart');
+    expect(touch[touch.length - 1]).toBe('touchEnd');
+    expect(sent.some((s) => s.method === 'Input.dispatchMouseEvent')).toBe(false);
+  });
+
+  it('still hovers with the mouse, and says the device could not', async () => {
+    const router = register();
+    await emulate(router, true);
+
+    const res = await call(router, 'browser.hover.cdp', { selector: '[data-wmux-ref="3"]' });
+
+    // A touchscreen cannot hover, but refusing would turn every hover-gated
+    // menu into a silent failure. The move goes out; the caller is told.
+    expect(res.touchPreset).toBe(true);
+    expect(types('Input.dispatchMouseEvent')).toContain('mouseMoved');
+  });
+});

--- a/src/main/pipe/handlers/browser.rpc.ts
+++ b/src/main/pipe/handlers/browser.rpc.ts
@@ -19,6 +19,11 @@ import {
 import { stepsFingerprint } from '../../../shared/browserReplay/actionTrace';
 import { HumanBehavior } from '../../browser-session/HumanBehavior';
 import { approachPath, defaultStartPoint, type Point } from '../../../shared/pointerPath';
+import {
+  dispatchTouchDrag,
+  dispatchTouchTap,
+  type TouchSender,
+} from '../../../shared/touchInput';
 
 /**
  * The physical half of the device preset currently emulated on a WebContents.
@@ -33,6 +38,8 @@ const activePreset = new WeakMap<
   {
     deviceScaleFactor: number;
     mobile: boolean;
+    /** Whether the preset gave the page a touchscreen — see `touchSenderFor`. */
+    hasTouch: boolean;
     screenWidth?: number;
     screenHeight?: number;
   }
@@ -518,6 +525,45 @@ async function approachElement(
     );
   }
   return point;
+}
+
+/**
+ * Is a device preset with a touchscreen active on this WebContents?
+ *
+ * When one is, input has to arrive as touch: the preset already told the page
+ * it has `maxTouchPoints: 5` and matches `(pointer: coarse)`, and a mouse press
+ * under that identity contradicts it in the one place a page can check cheaply.
+ */
+function touchPresetActive(wc: WebContents): boolean {
+  return activePreset.get(wc)?.hasTouch === true;
+}
+
+/** The debugger, in the shape the shared touch dispatch asks for. */
+function touchSenderFor(wc: WebContents): TouchSender {
+  return { send: (method: string, params?: unknown) => wc.debugger.sendCommand(method, params as Record<string, unknown>) };
+}
+
+/**
+ * The point a tap should land on, without walking a pointer to it.
+ *
+ * A touchscreen has nothing resting on the glass between gestures, so the
+ * approach the mouse path performs would be input the emulated device cannot
+ * produce. The rest of `approachElement`'s contract is kept: the element is
+ * scrolled into view, and a target that has slid out from under the
+ * coordinates is refused rather than tapped through.
+ */
+async function touchTargetPoint(
+  wc: WebContents,
+  selector: string,
+  method: string,
+): Promise<Point> {
+  const point = await elementCenter(wc, selector);
+  if (!point) throw new Error(`Element not found: ${selector}`);
+  if (await pointIsOnTarget(wc, selector, point)) return point;
+  throw new Error(
+    `${method}: ${selector} is not the element at (${Math.round(point.x)}, ${Math.round(point.y)}) ` +
+    `— it is moving, or something is covering it. Refusing to tap what is there instead.`,
+  );
 }
 
 /** The intermediate points between two positions, step count from the distance. */
@@ -2163,6 +2209,10 @@ export function registerBrowserRpc(
     let x = typeof params['x'] === 'number' ? params['x'] : 0;
     let y = typeof params['y'] === 'number' ? params['y'] : 0;
 
+    // Under a touchscreen preset this is a tap, not a press, and a tap has no
+    // pointer to walk to the target first.
+    const touch = touchPresetActive(wc);
+
     if (selector) {
       // Walk the pointer to the target before pressing. A single mouseMoved
       // onto the exact spot, from a pointer that has never been anywhere else,
@@ -2171,11 +2221,25 @@ export function registerBrowserRpc(
       // Vue) need hover state before a click registers on a hover-revealed
       // element. approachElement also scrolls the target into view, and refuses
       // rather than pressing on something that slid under the coordinates.
-      const point = await approachElement(wc, target.webContentsId, selector, 'browser.click.cdp');
+      const point = touch
+        ? await touchTargetPoint(wc, selector, 'browser.click.cdp')
+        : await approachElement(wc, target.webContentsId, selector, 'browser.click.cdp');
       x = point.x;
       y = point.y;
-    } else {
+    } else if (!touch) {
       await movePointerTo(wc, target.webContentsId, x, y);
+    }
+
+    if (touch) {
+      try {
+        await dispatchTouchTap(touchSenderFor(wc), { x, y });
+        return { ok: true, x, y, dispatch: 'touch' };
+      } catch {
+        // Touch dispatch refused on this transport. A click that lands is worth
+        // more than one that matches the emulated hardware, so fall through to
+        // the mouse — including the approach that was skipped for the tap.
+        await movePointerTo(wc, target.webContentsId, x, y);
+      }
     }
 
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
@@ -2187,7 +2251,7 @@ export function registerBrowserRpc(
       type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1,
     });
 
-    return { ok: true, x, y };
+    return { ok: true, x, y, dispatch: 'mouse' };
   });
 
   /**
@@ -2211,7 +2275,11 @@ export function registerBrowserRpc(
     if (!wc || wc.isDestroyed()) throw new Error('browser.hover.cdp: WebContents unavailable');
 
     const point = await approachElement(wc, target.webContentsId, selector, 'browser.hover.cdp');
-    return { ok: true, x: point.x, y: point.y };
+    // Still a mouse move under a touchscreen preset, deliberately: a hover has
+    // no touch equivalent, and refusing would turn every hover-gated menu into
+    // a silent failure. Reported so the caller is told rather than left to
+    // assume the emulated device produced it.
+    return { ok: true, x: point.x, y: point.y, touchPreset: touchPresetActive(wc) };
   });
 
   /**
@@ -2243,9 +2311,25 @@ export function registerBrowserRpc(
     // pointer-event one. Falling back to synthesised DragEvents for draggable
     // sources would trade real input for events carrying isTrusted === false,
     // which is the thing this handler exists to stop doing.
-    const from = await approachElement(wc, target.webContentsId, sourceSelector, 'browser.drag.cdp');
+    const touch = touchPresetActive(wc);
+    const from = touch
+      ? await touchTargetPoint(wc, sourceSelector, 'browser.drag.cdp')
+      : await approachElement(wc, target.webContentsId, sourceSelector, 'browser.drag.cdp');
     const to = await elementCenter(wc, targetSelector);
     if (!to) throw new Error(`Element not found: ${targetSelector}`);
+
+    // A drag under a touchscreen preset is a finger sliding across the glass:
+    // the same three phases as below, on the input the emulated device has.
+    if (touch) {
+      try {
+        await dispatchTouchDrag(touchSenderFor(wc), from, to);
+        return { ok: true, from, to, dispatch: 'touch' };
+      } catch {
+        // Touch dispatch refused; the mouse drag below still performs the
+        // gesture, and the pointer has to be walked to the source first.
+        await movePointerTo(wc, target.webContentsId, from.x, from.y);
+      }
+    }
 
     await wc.debugger.sendCommand('Input.dispatchMouseEvent', {
       type: 'mousePressed', x: from.x, y: from.y, button: 'left', buttons: 1, clickCount: 1,
@@ -2262,7 +2346,7 @@ export function registerBrowserRpc(
     });
     setPointerPosition(wc, target.webContentsId, to);
 
-    return { ok: true, from, to };
+    return { ok: true, from, to, dispatch: 'mouse' };
   });
 
   /**
@@ -2564,6 +2648,10 @@ export function registerBrowserRpc(
       activePreset.set(wc, {
         deviceScaleFactor: dm.deviceScaleFactor ?? 0,
         mobile: dm.mobile ?? false,
+        // Recorded so the input handlers can dispatch touch rather than mouse.
+        // False when the transport refused the touch emulation: a page that was
+        // never given a touchscreen must not be sent touch events.
+        hasTouch: dm.hasTouch === true && !touchUnavailable,
         ...(dm.screenWidth !== undefined && dm.screenHeight !== undefined && {
           screenWidth: dm.screenWidth,
           screenHeight: dm.screenHeight,

--- a/src/mcp/playwright/__tests__/interaction.touch.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.touch.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+// vi.mock is hoisted above the imports, so the mocks below are in place by the
+// time interaction.ts is evaluated.
+import { clickWithApproach } from '../tools/interaction';
+
+// interaction.ts pulls in the whole tool-registration graph; the module mocks
+// below keep this focused on clickWithApproach alone.
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: { getInstance: () => ({}) },
+}));
+vi.mock('../automationLease', () => ({ withAutomationLease: vi.fn() }));
+vi.mock('../snapshot', () => ({
+  browserScopeKey: vi.fn(),
+  frameRefFallbackMessage: vi.fn(),
+  isOutstandingFrameRef: () => false,
+  resolveRef: vi.fn(),
+}));
+vi.mock('../dom-intelligence', () => ({ getLocatorByRef: vi.fn() }));
+vi.mock('../human-typing', () => ({ typeHumanlike: vi.fn() }));
+vi.mock('../browserScope', () => ({
+  allowScopedRpcFallback: vi.fn(),
+  sendScopedBrowserRpc: vi.fn(),
+}));
+vi.mock('../../browser-replay/actionRing', () => ({ recordAction: vi.fn() }));
+
+const BOX = { x: 400, y: 300, width: 200, height: 60 };
+
+function makePage() {
+  const move = vi.fn(async (_x: number, _y: number) => undefined);
+  return {
+    // A fresh object each time, so the per-page pointer WeakMap starts empty.
+    page: { mouse: { move }, viewportSize: () => ({ width: 1280, height: 720 }) },
+    move,
+  };
+}
+
+function makeEl(box: typeof BOX | null, opts: { trialThrows?: boolean } = {}) {
+  const calls: string[] = [];
+  return {
+    calls,
+    el: {
+      boundingBox: vi.fn(async () => box),
+      scrollIntoViewIfNeeded: vi.fn(async () => { calls.push('scroll'); }),
+      click: vi.fn(async (options?: { position?: { x: number; y: number }; trial?: boolean }) => {
+        if (options?.trial) {
+          calls.push('trial');
+          if (opts.trialThrows) throw new Error('element is not visible');
+          return;
+        }
+        calls.push(options?.position ? 'click:positioned' : 'click:plain');
+      }),
+      dblclick: vi.fn(async (options?: { position?: { x: number; y: number } }) => {
+        calls.push(options?.position ? 'dblclick:positioned' : 'dblclick:plain');
+      }),
+    },
+  };
+}
+
+// A device preset with a touchscreen changes what a click IS. These check that
+// the touch path replaces the mouse rather than joining it, and that everything
+// without a preset is byte-for-byte the behaviour it had before.
+
+describe('clickWithApproach under a touchscreen preset', () => {
+  it('taps at the target point and sends no mouse move at all', async () => {
+    const { page, move } = makePage();
+    const { el, calls } = makeEl(BOX);
+    const tap = vi.fn(async (_p: { x: number; y: number }) => undefined);
+
+    const dispatch = await clickWithApproach(page, el, false, tap);
+
+    expect(dispatch).toBe('touch');
+    expect(tap).toHaveBeenCalledTimes(1);
+    // A touchscreen has nothing resting on the page between gestures, so the
+    // approach path is skipped outright.
+    expect(move).not.toHaveBeenCalled();
+    expect(calls).not.toContain('click:positioned');
+    expect(calls).not.toContain('click:plain');
+    // The tap lands where the mouse would have: inside the box, off-centre.
+    const point = tap.mock.calls[0][0];
+    expect(point.x).toBeGreaterThan(BOX.x);
+    expect(point.x).toBeLessThan(BOX.x + BOX.width);
+    expect(point.y).toBeGreaterThan(BOX.y);
+    expect(point.y).toBeLessThan(BOX.y + BOX.height);
+  });
+
+  it('runs the actionability checks first, as a trial that dispatches nothing', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX);
+    const order: string[] = [];
+    el.click.mockImplementation(async () => { order.push('trial'); });
+    const tap = vi.fn(async () => { order.push('tap'); });
+
+    await clickWithApproach(page, el, false, tap);
+
+    expect(order).toEqual(['trial', 'tap']);
+    expect(el.click.mock.calls[0]?.[0]?.trial).toBe(true);
+    expect(calls).toContain('scroll');
+  });
+
+  it('leaves the click to the mouse when the element is not actionable', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX, { trialThrows: true });
+    const tap = vi.fn(async () => undefined);
+
+    const dispatch = await clickWithApproach(page, el, false, tap);
+
+    expect(dispatch).toBe('mouse');
+    expect(tap).not.toHaveBeenCalled();
+    expect(calls).toContain('click:plain');
+  });
+
+  it('falls back to the mouse when touch dispatch itself refuses', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX);
+    const tap = vi.fn(async () => { throw new Error('touch not supported'); });
+
+    const dispatch = await clickWithApproach(page, el, false, tap);
+
+    // A click that lands is worth more than one that matches the hardware.
+    expect(dispatch).toBe('mouse');
+    expect(calls).toContain('click:plain');
+  });
+
+  it('keeps a double click on the mouse — a touchscreen has no such gesture', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(BOX);
+    const tap = vi.fn(async () => undefined);
+
+    const dispatch = await clickWithApproach(page, el, true, tap);
+
+    expect(dispatch).toBe('mouse');
+    expect(tap).not.toHaveBeenCalled();
+    expect(calls).toContain('dblclick:positioned');
+  });
+
+  it('falls back to the mouse for an element with no box', async () => {
+    const { page } = makePage();
+    const { el, calls } = makeEl(null);
+    const tap = vi.fn(async () => undefined);
+
+    const dispatch = await clickWithApproach(page, el, false, tap);
+
+    expect(dispatch).toBe('mouse');
+    expect(tap).not.toHaveBeenCalled();
+    expect(calls).toContain('click:plain');
+  });
+});
+
+describe('clickWithApproach without a preset', () => {
+  it('is the mouse path it always was', async () => {
+    const { page, move } = makePage();
+    const { el, calls } = makeEl(BOX);
+
+    const dispatch = await clickWithApproach(page, el, false);
+
+    expect(dispatch).toBe('mouse');
+    expect(move).toHaveBeenCalled();
+    expect(calls).toContain('click:positioned');
+    expect(calls).not.toContain('trial');
+  });
+});

--- a/src/mcp/playwright/__tests__/ua-emulation.test.ts
+++ b/src/mcp/playwright/__tests__/ua-emulation.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BrowserContext, Page } from 'playwright-core';
 import {
+  activeTouchSession,
   applyUserAgentEmulation,
   clearUserAgentEmulation,
   hasUserAgentEmulation,
@@ -247,5 +248,47 @@ describe('reassertUserAgentEmulation', () => {
     await reassertUserAgentEmulation(h.page);
 
     expect(h.sent).toEqual([]);
+  });
+});
+
+// Touch input travels on the session this module is already holding open: one
+// opened for the tap and detached afterwards would put navigator.platform back
+// to the host's on the way out, which is the reason these sessions are held at
+// all.
+describe('activeTouchSession', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hands back the live session for a preset with a touchscreen', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, 'en-US', IPHONE_METRICS);
+
+    const session = activeTouchSession(h.page);
+    expect(session).toBeDefined();
+
+    const before = h.sent.length;
+    await session!.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [] });
+    // The very session that installed the touch emulation, not a new one.
+    expect(h.sent.length).toBe(before + 1);
+    expect(h.sent[before].method).toBe('Input.dispatchTouchEvent');
+  });
+
+  it('is undefined for a preset without a touchscreen', async () => {
+    const h = harness();
+    await applyUserAgentEmulation(h.context, h.page, REAL_UA, undefined, {
+      ...IPHONE_METRICS,
+      hasTouch: false,
+    });
+
+    expect(activeTouchSession(h.page)).toBeUndefined();
+  });
+
+  it('is undefined with no preset, and again after a reset', async () => {
+    const h = harness();
+    expect(activeTouchSession(h.page)).toBeUndefined();
+
+    await applyUserAgentEmulation(h.context, h.page, IPHONE_UA, 'en-US', IPHONE_METRICS);
+    await clearUserAgentEmulation(h.context);
+
+    expect(activeTouchSession(h.page)).toBeUndefined();
   });
 });

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -21,6 +21,7 @@ import {
   setLastPointer,
   stepsForDistance,
 } from '../pointer-path';
+import { hasTouchEmulation, touchDragFor, touchTapFor } from '../touch-input';
 import { describeToolError } from '../toolError';
 import {
   PASSWORD_FIELD_PREDICATE_JS,
@@ -146,6 +147,42 @@ function refNotFound(ref: string): string {
   return REF_NOT_FOUND_HINT.replace('{ref}', ref);
 }
 
+/**
+ * What a hover reports under a touchscreen preset.
+ *
+ * The move still goes out, deliberately. A touchscreen cannot hover, so the
+ * consistent thing would be to refuse — but browser_hover exists to reveal
+ * hover-gated UI, and a no-op would turn every such call into a silent failure
+ * with no touch equivalent to replace it. So the caller is told what happened
+ * instead, and can drop the preset if it wants that fidelity.
+ */
+const TOUCH_HOVER_NOTE =
+  ' — as a mouse move; the emulated device has a touchscreen, which cannot hover';
+
+/**
+ * How a click that ran under a touchscreen preset is described.
+ *
+ * Silent when no preset with touch is active — that is the ordinary case and
+ * it reads exactly as it always has. When one IS active, every outcome is
+ * named, because "clicked" means two different things on the two paths and a
+ * caller emulating a phone is emulating it for a reason.
+ */
+function dispatchNote(
+  touchAvailable: boolean,
+  double: boolean | undefined,
+  dispatch: 'touch' | 'mouse',
+): string {
+  if (!touchAvailable) return '';
+  if (dispatch === 'touch') return ' (touch tap)';
+  if (double) {
+    // Two taps in quick succession are their own gesture on a phone, not a
+    // dblclick, and inventing a mapping between them would be a guess about
+    // what the page meant. The mouse double click is the honest fallback.
+    return ' (mouse double click — a touchscreen has no double click)';
+  }
+  return ' (mouse click — touch dispatch was unavailable for this element)';
+}
+
 // ---------------------------------------------------------------------------
 // RPC-based interaction helpers (used when Playwright page is unavailable)
 // These resolve elements via data-wmux-ref attributes set by browser_snapshot.
@@ -188,7 +225,7 @@ export function sanitizeRef(ref: string, scope: BrowserTargetScope): string {
  */
 interface ApproachTarget {
   boundingBox(): Promise<{ x: number; y: number; width: number; height: number } | null>;
-  click(options?: { position?: { x: number; y: number } }): Promise<void>;
+  click(options?: { position?: { x: number; y: number }; trial?: boolean }): Promise<void>;
   dblclick(options?: { position?: { x: number; y: number } }): Promise<void>;
   scrollIntoViewIfNeeded?(): Promise<void>;
 }
@@ -218,15 +255,23 @@ const MIN_OFFSET_SIZE_PX = 24;
  * An element with no box — detached, `display:none`, still animating in — has
  * no path to walk, so it falls straight through to the plain click and lets
  * Playwright's own waiting produce the error or the retry.
+ *
+ * `tap` is passed when the page is under a device preset with a touchscreen
+ * (see `touch-input`). The landing point is computed exactly as it is for the
+ * mouse, and then a finger is put on it instead of a cursor. Returns which of
+ * the two the click actually went out as, because a fallback to the mouse is
+ * something the caller has to be told rather than left to assume.
  */
 export async function clickWithApproach(
   page: ApproachPage,
   el: ApproachTarget,
   double: boolean,
-): Promise<void> {
-  const plainClick = async (): Promise<void> => {
+  tap?: (point: { x: number; y: number }) => Promise<void>,
+): Promise<'touch' | 'mouse'> {
+  const plainClick = async (): Promise<'mouse'> => {
     if (double) await el.dblclick();
     else await el.click();
+    return 'mouse';
   };
 
   // Scroll first, THEN measure. A box read before scrolling describes where the
@@ -238,8 +283,7 @@ export async function clickWithApproach(
 
   const box = await el.boundingBox().catch(() => null);
   if (!box || box.width <= 0 || box.height <= 0) {
-    await plainClick();
-    return;
+    return plainClick();
   }
 
   // A small control has no room for a meaningful offset — aim at the centre.
@@ -256,8 +300,40 @@ export async function clickWithApproach(
     target.y < 0 ||
     (viewport && (target.x > viewport.width || target.y > viewport.height))
   ) {
-    await plainClick();
-    return;
+    return plainClick();
+  }
+
+  const position = { x: target.x - box.x, y: target.y - box.y };
+
+  // `!double` as well as `tap`: a double click has no touch equivalent worth
+  // inventing, so it stays on the mouse whoever asks for it.
+  if (tap && !double) {
+    // A touchscreen has no pointer to walk. There is nothing resting on the
+    // page between one tap and the next, so the approach path is skipped
+    // outright — emitting mouse moves here would be the emulated device
+    // producing input it does not have — and `setLastPointer` is skipped with
+    // it, because the mouse genuinely did not move.
+    //
+    // The actionability the mouse path gets from `el.click()` is not given up
+    // with it: a trial click runs every one of those checks (attached, visible,
+    // stable, enabled, receiving events at this exact point) and dispatches
+    // nothing. A trial that refuses means the element is not clickable at all,
+    // which is not a touch-specific problem, so the mouse path takes it from
+    // there and reports its own error.
+    try {
+      await el.click({ position, trial: true });
+    } catch {
+      return plainClick();
+    }
+    try {
+      await tap(target);
+      return 'touch';
+    } catch {
+      // Touch dispatch refused (a transport without it, a target that went
+      // away mid-tap). A click that lands is worth more than one that matches
+      // the emulated hardware, so fall through rather than fail.
+      return plainClick();
+    }
   }
 
   const from = getLastPointer(page) ?? defaultStartPoint(viewport ?? undefined);
@@ -267,7 +343,6 @@ export async function clickWithApproach(
   }
   setLastPointer(page, target);
 
-  const position = { x: target.x - box.x, y: target.y - box.y };
   try {
     if (double) await el.dblclick({ position });
     else await el.click({ position });
@@ -278,14 +353,23 @@ export async function clickWithApproach(
     // three, so give it exactly one go before surfacing the failure.
     await plainClick();
   }
+  return 'mouse';
 }
 
-async function rpcClick(ref: string, scope: BrowserTargetScope, _double?: boolean): Promise<void> {
+async function rpcClick(
+  ref: string,
+  scope: BrowserTargetScope,
+  _double?: boolean,
+): Promise<'touch' | 'mouse'> {
   // Use CDP click: first get element coordinates via JS, then dispatch mouse events
   const safeRef = sanitizeRef(ref, scope);
-  await sendScopedBrowserRpc('browser.click.cdp', scope, {
+  // The handler decides between a tap and a press — it is the side that knows
+  // whether a device preset with a touchscreen is on this WebContents — and
+  // names which one it sent.
+  const res = await sendScopedBrowserRpc<{ dispatch?: string }>('browser.click.cdp', scope, {
     selector: `[data-wmux-ref="${safeRef}"]`,
   });
+  return res?.dispatch === 'touch' ? 'touch' : 'mouse';
 }
 
 async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): Promise<void> {
@@ -575,6 +659,14 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             : null;
           const popupNote = async () => (popupWatch ? await popupWatch.note() : '');
 
+          // Under a device preset with a touchscreen the click goes out as a
+          // real touch sequence rather than a mouse press — the page reported
+          // `maxTouchPoints: 5` and `(pointer: coarse)` the moment the preset
+          // was applied, and a mouse event under that identity contradicts it.
+          // Resolved once here so both ref shapes take the same path.
+          const tapper = touchTapFor(page);
+          const tap = double ? undefined : tapper;
+
           try {
             if (smartRef !== undefined) {
               // Ref-keyed, not `cache[smartRef - 1]`: smart refs are keyed on
@@ -582,7 +674,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
               // range. Throws StaleSmartRefError rather than clicking a
               // substitute when the ref no longer names one live element.
               const locator = await resolveSmartRefLocator(page, smartRef);
-              await clickWithApproach(page as unknown as ApproachPage, locator, !!double);
+              const dispatch = await clickWithApproach(
+                page as unknown as ApproachPage,
+                locator,
+                !!double,
+                tap,
+              );
               // A ref axis, not the css axis this used to record: the CDP
               // lane's stored "locator" is getByRole SOURCE TEXT, which
               // page.locator() cannot parse, so every replay of such a step
@@ -598,7 +695,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
                 ...(double && { args: { double: true } }),
               });
               return {
-                content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element smartRef=${smartRef}${await popupNote()}` }],
+                content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element smartRef=${smartRef}${dispatchNote(!!tapper, double, dispatch)}${await popupNote()}` }],
               };
             }
 
@@ -606,7 +703,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
             const el = await resolveRef(page, ref);
             if (!el) throw new Error(refNotFound(ref));
-            await clickWithApproach(page as unknown as ApproachPage, el, !!double);
+            const dispatch = await clickWithApproach(
+              page as unknown as ApproachPage,
+              el,
+              !!double,
+              tap,
+            );
             recordAction(deps, {
               scope,
               tool: 'browser_click',
@@ -615,7 +717,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
               ...(double && { args: { double: true } }),
             });
             return {
-              content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element ref=${ref}${await popupNote()}` }],
+              content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element ref=${ref}${dispatchNote(!!tapper, double, dispatch)}${await popupNote()}` }],
             };
           } finally {
             // Every exit — success, a ref that vanished, a click that threw —
@@ -627,10 +729,10 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
         // RPC fallback
         if (!ref && smartRef === undefined) throw new Error('Either ref or smartRef must be provided.');
         const resolvedRef = ref ?? String(smartRef);
-        await rpcClick(resolvedRef, scope, double);
+        const rpcDispatch = await rpcClick(resolvedRef, scope, double);
         recordAction(deps, { scope, tool: 'browser_click', page: null, ref: resolvedRef });
         return {
-          content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element ref=${resolvedRef}` }],
+          content: [{ type: 'text' as const, text: `Clicked${double ? ' (double)' : ''} element ref=${resolvedRef}${rpcDispatch === 'touch' ? ' (touch tap)' : ''}` }],
         };
       } catch (error) {
         const message = describeToolError(error);
@@ -829,10 +931,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     async ({ ref, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
+        let touchNote = '';
 
         if (page) {
           const el = await resolveRef(page, ref);
           if (!el) throw new Error(refNotFound(ref));
+          if (hasTouchEmulation(page)) touchNote = TOUCH_HOVER_NOTE;
           await el.hover();
         } else {
           // RPC fallback: real pointer movement over CDP Input. The synthetic
@@ -840,15 +944,18 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           // handler on the page can read — a single boolean separating our
           // hover from every hover a person performs.
           const safeRef = sanitizeRef(ref, scope);
-          await sendScopedBrowserRpc('browser.hover.cdp', scope, {
-            selector: `[data-wmux-ref="${safeRef}"]`,
-          });
+          const res = await sendScopedBrowserRpc<{ touchPreset?: boolean }>(
+            'browser.hover.cdp',
+            scope,
+            { selector: `[data-wmux-ref="${safeRef}"]` },
+          );
+          if (res?.touchPreset) touchNote = TOUCH_HOVER_NOTE;
         }
 
         recordAction(deps, { scope, tool: 'browser_hover', page, ref });
 
         return {
-          content: [{ type: 'text' as const, text: `Hovered over element ref=${ref}` }],
+          content: [{ type: 'text' as const, text: `Hovered over element ref=${ref}${touchNote}` }],
         };
       } catch (error) {
         const message = describeToolError(error);
@@ -870,6 +977,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     async ({ sourceRef, targetRef, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
+        let dragNote = '';
 
         if (page) {
           const sourceEl = await resolveRef(page, sourceRef);
@@ -888,10 +996,30 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           const targetX = targetBox.x + targetBox.width / 2;
           const targetY = targetBox.y + targetBox.height / 2;
 
-          await page.mouse.move(sourceX, sourceY);
-          await page.mouse.down();
-          await page.mouse.move(targetX, targetY, { steps: 10 });
-          await page.mouse.up();
+          // A drag under a touchscreen preset is a finger sliding across the
+          // glass: press, a bounded run of moves, lift — the same three phases
+          // the mouse performs below, on the input the emulated device has.
+          // Both endpoints are already measured, so nothing else is needed.
+          const touchDrag = touchDragFor(page);
+          let dragged = false;
+          if (touchDrag) {
+            try {
+              await touchDrag({ x: sourceX, y: sourceY }, { x: targetX, y: targetY });
+              dragged = true;
+              dragNote = ' (touch drag)';
+            } catch {
+              // Touch dispatch refused; the mouse drag below still performs the
+              // gesture, and the note says which one the page actually saw.
+              dragNote = ' (mouse drag — touch dispatch was unavailable)';
+            }
+          }
+
+          if (!dragged) {
+            await page.mouse.move(sourceX, sourceY);
+            await page.mouse.down();
+            await page.mouse.move(targetX, targetY, { steps: 10 });
+            await page.mouse.up();
+          }
         } else {
           // RPC fallback: press, move, release over CDP Input — the same shape
           // as the Playwright path above. The synthesised DragEvents this
@@ -899,16 +1027,17 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           // on pointer events rather than HTML5 drag-and-drop.
           const safeSrc = sanitizeRef(sourceRef, scope);
           const safeTgt = sanitizeRef(targetRef, scope);
-          await sendScopedBrowserRpc('browser.drag.cdp', scope, {
+          const res = await sendScopedBrowserRpc<{ dispatch?: string }>('browser.drag.cdp', scope, {
             sourceSelector: `[data-wmux-ref="${safeSrc}"]`,
             targetSelector: `[data-wmux-ref="${safeTgt}"]`,
           });
+          if (res?.dispatch === 'touch') dragNote = ' (touch drag)';
         }
 
         recordAction(deps, { scope, tool: 'browser_drag', page, ref: sourceRef, targetRef });
 
         return {
-          content: [{ type: 'text' as const, text: `Dragged element ref=${sourceRef} to ref=${targetRef}` }],
+          content: [{ type: 'text' as const, text: `Dragged element ref=${sourceRef} to ref=${targetRef}${dragNote}` }],
         };
       } catch (error) {
         const message = describeToolError(error);

--- a/src/mcp/playwright/tools/state.ts
+++ b/src/mcp/playwright/tools/state.ts
@@ -543,16 +543,16 @@ export function registerStateTools(server: McpServer, deps: BrowserToolDeps): vo
               // Chromium's own and there is no Safari value to give them. Say
               // so where the caller reads the result, rather than let them
               // assume the identity is seamless.
-              // What a preset does not reach, said here rather than left for
-              // the caller to discover. The page reports a touchscreen, but
-              // the automated input over it is still mouse input: this
-              // process attached to a context that was built without touch,
-              // so page.tap() is refused and browser_click lands as
-              // pointerType "mouse". Only worth saying for a preset that
-              // claims touch in the first place.
-              if (deviceDescriptor.hasTouch) {
+              // What the touchscreen half of the preset now means for input,
+              // said where the caller reads the result: browser_click stops
+              // being a mouse press and becomes a real touch sequence, and the
+              // two gestures a touchscreen does not have keep the mouse. Only
+              // worth saying for a preset that claims touch in the first place.
+              // `ok` gates it: without the held session there is no emulated
+              // touchscreen to report and nothing to dispatch a tap on.
+              if (deviceDescriptor.hasTouch && ok) {
                 applied.push(
-                  'note=touch is reported, not dispatched: maxTouchPoints and (pointer:coarse) match the device, but browser_click still sends mouse events. A page that gates behaviour on touch events will not see them.',
+                  'note=touch is dispatched: browser_click sends touchstart/touchend, so a page gating on touch events sees them. A double click and browser_hover stay mouse input — a touchscreen has neither.',
                 );
               }
               if (!isChromiumUserAgent(deviceDescriptor.userAgent)) {

--- a/src/mcp/playwright/touch-input.ts
+++ b/src/mcp/playwright/touch-input.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// Touch input for the chrome lane.
+//
+// The gesture itself is shared with the main-process webview lane and lives in
+// `src/shared/touchInput`. What is specific to this lane is where the events go
+// out: on the CDP session `ua-emulation` is already holding open for the page.
+//
+// Reusing that session rather than opening one is not an economy. A session
+// opened for the tap and detached afterwards would reset `navigator.platform`
+// back to the host's on the way out — measured, and the whole reason that
+// module holds its sessions instead of using them and leaving.
+// ---------------------------------------------------------------------------
+
+import type { Page } from 'playwright-core';
+import { activeTouchSession } from './ua-emulation';
+import { dispatchTouchDrag, dispatchTouchTap } from '../../shared/touchInput';
+import type { Point } from './pointer-path';
+
+export { dispatchTouchDrag, dispatchTouchTap } from '../../shared/touchInput';
+export type { TouchSender } from '../../shared/touchInput';
+
+/** Is a device preset with a touchscreen currently emulated on `page`? */
+export function hasTouchEmulation(page: Page): boolean {
+  return activeTouchSession(page) !== undefined;
+}
+
+/**
+ * A tap function for `page`, or undefined when no touchscreen is emulated on it
+ * — in which case every caller keeps the mouse path it had before.
+ */
+export function touchTapFor(page: Page): ((point: Point) => Promise<void>) | undefined {
+  const session = activeTouchSession(page);
+  if (!session) return undefined;
+  return (point: Point) => dispatchTouchTap(session, point);
+}
+
+/** The drag equivalent of `touchTapFor`. */
+export function touchDragFor(page: Page): ((from: Point, to: Point) => Promise<void>) | undefined {
+  const session = activeTouchSession(page);
+  if (!session) return undefined;
+  return (from: Point, to: Point) => dispatchTouchDrag(session, from, to);
+}

--- a/src/mcp/playwright/ua-emulation.ts
+++ b/src/mcp/playwright/ua-emulation.ts
@@ -41,16 +41,20 @@
 // `reassertUserAgentEmulation` below is where the page is put back before a
 // tool looks at it.
 //
-// What this still cannot reach, said here rather than left to be discovered:
-// input. `Emulation.setTouchEmulationEnabled` gives the page a touchscreen to
-// report, but automated clicks are still mouse events, and the context this
-// process attached to was built without touch, so `page.tap()` is refused
-// client-side. Two ways out were measured and both are worse than the gap:
-// `Emulation.setEmitTouchEventsForMouse` does convert the clicks into real
-// touch events, but the mouse dispatch that produced them then never returns
-// (>30s, every click), and a device-built context is not this architecture —
-// it would be a fresh incognito-like context with none of the user's cookies,
-// history or extensions, which is a louder signal than the one it removes.
+// Input reaches the page too, and by the same route. `page.tap()` is refused
+// client-side — the context this process attached to was built without touch —
+// and two ways round that were measured and rejected:
+// `Emulation.setEmitTouchEventsForMouse` does convert clicks into real touch
+// events, but the mouse dispatch that produced them then never returns (>30s,
+// every click), and a device-built context is not this architecture — it would
+// be a fresh incognito-like context with none of the user's cookies, history or
+// extensions, which is a louder signal than the one it removes.
+//
+// So the touch events are sent directly, as `Input.dispatchTouchEvent`, on the
+// session held here (`activeTouchSession` below, dispatched from
+// `touch-input.ts`). Reusing this session rather than opening one is not an
+// economy: a session opened for the tap and detached afterwards would reset
+// `navigator.platform` on the way out, for the reason set out above.
 // ---------------------------------------------------------------------------
 
 import type { Browser, BrowserContext, CDPSession, Page } from 'playwright-core';
@@ -306,6 +310,34 @@ export async function reassertUserAgentEmulation(page: Page): Promise<void> {
   const session = state.sessions.get(page);
   if (!session) return;
   await loose(session).send('Emulation.setUserAgentOverride', state.override).catch(() => {});
+}
+
+/**
+ * The live session for `page` when the preset on it claims a touchscreen, or
+ * undefined when there is no preset, no touch in it, or no session for this
+ * page.
+ *
+ * This is what makes touch input possible at all: the emulation that told the
+ * page it has a touchscreen and the commands that put a finger on it have to
+ * travel on the same session, or the second is a mouse pretending again.
+ *
+ * Deliberately narrow: callers get something they can `send` on and nothing
+ * they can detach, because detaching this session is what would undo the
+ * emulation it belongs to.
+ */
+export function activeTouchSession(
+  page: Page,
+): { send(method: string, params?: unknown): Promise<unknown> } | undefined {
+  let context: BrowserContext;
+  try {
+    context = page.context();
+  } catch {
+    return undefined;
+  }
+  const state = stateByContext.get(context);
+  if (!state?.metrics?.hasTouch) return undefined;
+  const session = state.sessions.get(page);
+  return session ? loose(session) : undefined;
 }
 
 /** Whether `context` currently has an emulated UA applied. */

--- a/src/shared/__tests__/touchInput.test.ts
+++ b/src/shared/__tests__/touchInput.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dispatchTouchDrag, dispatchTouchTap } from '../touchInput';
+import { MAX_STEPS } from '../pointerPath';
+
+// The gesture a device preset with a touchscreen produces. What matters here is
+// the shape on the wire: a page reading TouchEvent.touches, or Blink deriving
+// pointer/mouse/click events from the sequence, sees exactly these.
+
+function sender() {
+  const sent: Array<{ method: string; params: { type?: string; touchPoints?: Array<Record<string, number>> } }> = [];
+  return {
+    sent,
+    session: {
+      send: vi.fn(async (method: string, params?: unknown) => {
+        sent.push({ method, params: (params ?? {}) as { type?: string } });
+        return {};
+      }),
+    },
+  };
+}
+
+describe('dispatchTouchTap', () => {
+  it('sends touchStart then touchEnd, and no mouse event at all', async () => {
+    const { sent, session } = sender();
+
+    await dispatchTouchTap(session, { x: 120, y: 240 }, () => 0);
+
+    expect(sent.map((s) => s.method)).toEqual([
+      'Input.dispatchTouchEvent',
+      'Input.dispatchTouchEvent',
+    ]);
+    expect(sent.map((s) => s.params.type)).toEqual(['touchStart', 'touchEnd']);
+    expect(sent.some((s) => s.method.includes('Mouse'))).toBe(false);
+  });
+
+  it('puts one contact at the point, with a fingertip-sized radius', async () => {
+    const { sent, session } = sender();
+
+    await dispatchTouchTap(session, { x: 120, y: 240 }, () => 0);
+
+    const start = sent[0].params.touchPoints;
+    if (!start) throw new Error('expected touchStart to carry a contact');
+    expect(start).toHaveLength(1);
+    expect(start[0].x).toBe(120);
+    expect(start[0].y).toBe(240);
+    // A 1px default radius is a stylus; a finger is an order of magnitude wider.
+    expect(start[0].radiusX).toBeGreaterThan(5);
+    expect(start[0].radiusY).toBeGreaterThan(5);
+  });
+
+  it('lifts with an empty touchPoints — nothing is left on the glass', async () => {
+    const { sent, session } = sender();
+
+    await dispatchTouchTap(session, { x: 10, y: 10 }, () => 0);
+
+    expect(sent[1].params.touchPoints).toEqual([]);
+  });
+
+  it('holds between the press and the lift instead of tapping in zero time', async () => {
+    const { session } = sender();
+    const started = Date.now();
+
+    await dispatchTouchTap(session, { x: 10, y: 10 }, () => 0);
+
+    // The floor of the randomised hold, minus timer slack.
+    expect(Date.now() - started).toBeGreaterThanOrEqual(40);
+  });
+});
+
+describe('dispatchTouchDrag', () => {
+  it('presses, moves along the path, and lifts', async () => {
+    const { sent, session } = sender();
+
+    await dispatchTouchDrag(session, { x: 100, y: 100 }, { x: 300, y: 400 });
+
+    const types = sent.map((s) => s.params.type);
+    expect(types[0]).toBe('touchStart');
+    expect(types[types.length - 1]).toBe('touchEnd');
+    expect(types.filter((t) => t === 'touchMove').length).toBeGreaterThan(0);
+    expect(sent.every((s) => s.method === 'Input.dispatchTouchEvent')).toBe(true);
+  });
+
+  it('keeps one contact id across the whole gesture', async () => {
+    const { sent, session } = sender();
+
+    await dispatchTouchDrag(session, { x: 0, y: 0 }, { x: 200, y: 0 });
+
+    const ids = sent
+      .filter((s) => s.params.type !== 'touchEnd')
+      .map((s) => s.params.touchPoints?.[0].id);
+    expect(new Set(ids).size).toBe(1);
+  });
+
+  it('bounds the moves however far the drag runs', async () => {
+    const { sent, session } = sender();
+
+    await dispatchTouchDrag(session, { x: 0, y: 0 }, { x: 8000, y: 6000 });
+
+    const moves = sent.filter((s) => s.params.type === 'touchMove').length;
+    expect(moves).toBeLessThanOrEqual(MAX_STEPS + 1);
+  });
+});

--- a/src/shared/touchInput.ts
+++ b/src/shared/touchInput.ts
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------
+// Touch dispatch for a page emulating a device with a touchscreen.
+//
+// A device preset installs `Emulation.setTouchEmulationEnabled`, so the page
+// reports `maxTouchPoints: 5` and matches `(pointer: coarse)` — and then every
+// click still arrived as `pointerType: "mouse"`, because an automated click is
+// a mouse press whatever the page has been told about its hardware. Two ways
+// round that were measured and rejected: `Emulation.setEmitTouchEventsForMouse`
+// does convert the press into real touch events, but the mouse dispatch that
+// produced them then never returns (>30 s, every click), and building the
+// context from a device descriptor would mean a fresh incognito-like context
+// with none of the user's cookies, history or extensions.
+//
+// What is left is to stop asking the mouse. `Input.dispatchTouchEvent` puts a
+// real touch sequence into the same input pipeline, and Blink derives the
+// pointer, mouse and click events from it exactly as it does for a finger.
+//
+// Here in `src/shared` for the same reason the pointer path is: the chrome lane
+// sends these on the CDP session ua-emulation holds open, the builtin webview
+// lane on `webContents.debugger`, and one gesture should not be two
+// implementations.
+// ---------------------------------------------------------------------------
+
+import { distance, pathPoints, stepsForDistance, type Point } from './pointerPath';
+
+/** The one CDP capability this module needs, structurally. */
+export interface TouchSender {
+  send(method: string, params?: unknown): Promise<unknown>;
+}
+
+/**
+ * Contact size, in CSS px. CDP defaults a touch point to a 1 px radius, which
+ * is a stylus at best; a fingertip is an order of magnitude wider, and a page
+ * sizing its hit testing from `Touch.radiusX` reads the difference.
+ */
+const TOUCH_RADIUS_PX = 12;
+
+/**
+ * How long a tap holds before it lifts. A touchStart and a touchEnd in the same
+ * millisecond is not a gesture any hand produces, and a page measuring press
+ * duration (long-press menus, hold-to-confirm) sees the zero. Randomised for
+ * the same reason the pointer path is.
+ */
+const TAP_HOLD_MIN_MS = 45;
+const TAP_HOLD_MAX_MS = 95;
+
+function tapHoldMs(rng: () => number): number {
+  return TAP_HOLD_MIN_MS + rng() * (TAP_HOLD_MAX_MS - TAP_HOLD_MIN_MS);
+}
+
+function touchPoint(point: Point): Record<string, number> {
+  return {
+    x: point.x,
+    y: point.y,
+    radiusX: TOUCH_RADIUS_PX,
+    radiusY: TOUCH_RADIUS_PX,
+    force: 1,
+    // One finger, one id, held constant across a drag's moves so the sequence
+    // describes one contact travelling rather than a new one each frame.
+    id: 0,
+  };
+}
+
+/**
+ * One finger down and up at `point`.
+ *
+ * `touchEnd` carries an empty `touchPoints`: the field lists the contacts still
+ * on the glass, and after a single-finger lift there are none.
+ */
+export async function dispatchTouchTap(
+  session: TouchSender,
+  point: Point,
+  rng: () => number = Math.random,
+): Promise<void> {
+  await session.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [touchPoint(point)],
+  });
+  await new Promise((resolve) => setTimeout(resolve, tapHoldMs(rng)));
+  await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+}
+
+/**
+ * One finger down at `from`, dragged to `to`, lifted there.
+ *
+ * The intermediate points come from the same shared path a mouse drag walks, so
+ * the number of moves is bounded by its `MAX_STEPS` however far the drag runs.
+ */
+export async function dispatchTouchDrag(
+  session: TouchSender,
+  from: Point,
+  to: Point,
+): Promise<void> {
+  await session.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [touchPoint(from)],
+  });
+  for (const point of pathPoints(from, to, stepsForDistance(distance(from, to)))) {
+    await session.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [touchPoint(point)],
+    });
+  }
+  await session.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+}


### PR DESCRIPTION
Closes the touch half of #1183. #1186 gave a device preset `maxTouchPoints`, `(pointer:coarse)` and a held `navigator.platform`, but a click still dispatched as `pointerType:"mouse"` — a touchscreen that never produced a touch event.

## Design
- `shared/touchInput.ts`: the gesture, shared by both lanes the way `shared/pointerPath.ts` is. `dispatchTouchTap` (touchStart → randomised 45–95 ms hold → touchEnd) and `dispatchTouchDrag` (touchStart → moves along the shared path → touchEnd). Contact carries `radiusX/radiusY: 12` (CDP's 1 px default is a stylus).
- `ua-emulation.ts`: `activeTouchSession(page)` hands back the session the preset already holds, only when the preset has `hasTouch`. Reusing it is load-bearing: a session opened for the tap and detached would reset `navigator.platform` on the way out (the #1186 finding).
- Playwright lane: `clickWithApproach` computes the same landing point, skips the pointer walk (a touchscreen has nothing resting on the page), keeps actionability via a trial click that dispatches nothing, then taps. `recordAction` unchanged, so replay records the step identically.
- RPC lane: `activePreset` now carries `hasTouch`; click/drag dispatch touch via the WebContents debugger with the same scroll-into-view and covered-element refusal.
- The emulate result's "touch is reported, not dispatched" note is replaced by one saying touch is dispatched.

## Falls back to mouse, each with a note in the result
Double click (two taps are a different gesture on a phone, not `dblclick`); `browser_hover` stays a mouse move because the tool exists to reveal hover-gated UI and a no-op would be a silent failure; no box / off-viewport / trial refusal / dispatch error.

## Live (installed app, chrome backend)
| | events on the button | tool result | ms |
|---|---|---|---|
| Pixel 7 click | `pointerdown:touch`, `touchstart(r=12)`, `touchend`, `click`, all trusted | `(touch tap)` | 773 |
| reset click | `pointerdown:mouse`, `click` | plain | 969 |
| Pixel 7 drag | `touchstart`, 11×`touchmove`, `touchend` | `(touch drag)` | 804 |

No sign of the `setEmitTouchEventsForMouse` hang. The packaged RPC lane is covered by unit tests only.

## Gates
`tsc` clean; vitest playwright + pipe + shared 2854 passed (+21); `build:mcp && probe:mcp` byte-identical to baseline (full 75,457 / core 46,665 / commander 43,314).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Touchscreen device presets now dispatch touch events for single clicks and drags.
  * Clicks and drags automatically fall back to mouse input when touch dispatch is unavailable.
  * Interaction results identify whether touch or mouse input was used.
  * Hover and double-click continue to use mouse input on touch-enabled devices.
* **Bug Fixes**
  * Preserved existing actionability checks and mouse behavior when no touchscreen preset is active.
* **Tests**
  * Added coverage for touch taps, drags, fallbacks, emulation states, and event sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->