### PR TITLE
fix(browser-replay): verify by the element's own attribute, and count with the recorder's enumeration

### DIFF
--- a/changelog.d/1191.md
+++ b/changelog.d/1191.md
@@ -34,4 +34,4 @@
   a difference that is only between the two ways of counting no longer does.
   The extra reading happens only on a disagreement, so ordinary replays are
   unaffected, and traces recorded before this release keep the behaviour they
-  had.
+  had. (#1191)

--- a/changelog.d/replay2.md
+++ b/changelog.d/replay2.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- **A replay can now tell two identical siblings apart by the attribute the
+  page gives them.** The neighbourhood check added in the previous release
+  abstains on the one shape it was built around: two elements with the same
+  role, the same accessible name, and the same container are under the same
+  neighbourhood, so it has nothing to say about them and the count rules decide
+  by position. Real pages almost always distinguish those siblings on the
+  element itself — a `data-testid`, an `id`, a `name`, or an `aria-label` — and
+  a recorded step now carries whichever of those the element had, as a second
+  verify-only signal. Where the neighbourhood gives no verdict, the sibling
+  carrying the recorded attribute wins if it is unique and still at the
+  recorded position; if it moved, or if the population carries attributes but
+  not that one, the run stops and hands the page back live instead of clicking
+  the twin. Nothing is ever *located* by the attribute, and a population that
+  carries none at all abstains exactly as before, so no existing flow changes
+  behaviour. Both recording lanes — `browser_snapshot` and
+  `browser_smart_snapshot` — mint the value from the same pass, so a flow
+  recorded on one replays against the other. Traces recorded before this
+  release replay unchanged. The irreducible case is now genuinely irreducible:
+  identical siblings that carry no identifying attribute at all.

--- a/changelog.d/replay2.md
+++ b/changelog.d/replay2.md
@@ -19,3 +19,19 @@
   recorded on one replays against the other. Traces recorded before this
   release replay unchanged. The irreducible case is now genuinely irreducible:
   identical siblings that carry no identifying attribute at all.
+
+- **A flow recorded from `browser_smart_snapshot` no longer stops on a page
+  that has not changed.** A replay refuses to act when the number of
+  same-named elements differs from the recording, which is right — but the two
+  snapshot tools do not walk a page the same way: `browser_snapshot`'s listing
+  is depth-capped and trimmed when the output runs long, while
+  `browser_smart_snapshot`'s is neither. A step recorded from the smart
+  listing therefore had its count compared against a *different* measurement
+  at replay, and could stop on an untouched page, reporting a population
+  change that had never happened. Each step now records which listing its
+  numbers came from, and a disagreement is re-read from that same listing
+  before it is treated as a change — so a real change still stops the run, and
+  a difference that is only between the two ways of counting no longer does.
+  The extra reading happens only on a disagreement, so ordinary replays are
+  unaffected, and traces recorded before this release keep the behaviour they
+  had.

--- a/docs/how-to/replay-browser-flows.md
+++ b/docs/how-to/replay-browser-flows.md
@@ -76,6 +76,14 @@ means the position no longer counts the same population. Take a snapshot and
 finish the flow live instead. A stop like this is not held against the flow;
 it does not count toward the failure streak that retires a recording.
 
+A step recorded from `browser_smart_snapshot` is counted against *that* tool's
+listing rather than `browser_snapshot`'s: the two walk the page differently —
+one is depth-capped and trimmed when the output is long, the other is not — so
+comparing a total taken from one against a population counted by the other used
+to stop replays on pages that had not changed at all. Each step now records
+which listing its numbers came from, and the count is re-read from that same
+listing before a mismatch is treated as a change.
+
 A change that leaves the count the *same* is not detected — one look-alike
 added above and one element removed below still measures N, the position still
 resolves, and the element it lands on is a different one. Telling those apart

--- a/docs/how-to/replay-browser-flows.md
+++ b/docs/how-to/replay-browser-flows.md
@@ -95,11 +95,31 @@ The neighbourhood check runs first and can override both, in both directions:
   side to be wrong on for a step that might be a `Delete`, and the recovery is
   the ordinary one (finish live, `save` under the same name).
 
+Where the neighbourhood abstains — several elements share it, or the page
+names no containers at all — a second check takes over: the element's **own
+identifying attribute**. A recording stores one of `data-testid`, `id`,
+`name`, or `aria-label` (that order of preference), as `attr=value`, and the
+replay compares it the same three ways:
+
+- exactly one live element carries the recorded attribute, at the recorded
+  position → the step runs, count change or not;
+- exactly one carries it, somewhere else → the run stops, and again does not
+  follow the element to its new position;
+- none carries it while other elements carry attributes of their own → the run
+  stops.
+
+If no element in the population carries any such attribute, nothing is
+concluded from the absence and the count rules decide as before. Neither check
+ever LOCATES an element — both can only confirm or contradict what the
+position found.
+
 **What this still cannot see:** two elements that are genuinely identical —
-same role, same name, same container, differing only in their position. There
-the check abstains and the count rules decide, exactly as before. Telling
-those apart needs a positional or DOM-path axis, which is the brittleness this
-design refuses on purpose.
+same role, same name, same container, *and* no `data-testid`, `id`, `name`, or
+`aria-label` on either — differing only in their position. There both checks
+abstain and the count rules decide, exactly as before. Telling those apart
+needs a positional or DOM-path axis, which is the brittleness this design
+refuses on purpose. Giving the two elements distinct `data-testid`s in the
+page is the fix, and it is the one the page owner can actually make.
 
 ## Variables
 

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -8,6 +8,7 @@ interface FakeRefEntry {
   frameKey: string;
   ref: number;
   context?: string;
+  own?: string;
 }
 
 /** What the page's "last snapshot" currently holds. Mutated per case. */
@@ -445,6 +446,175 @@ describe('replayTrace — the context verifier (#1182)', () => {
     const result = await replayTrace(page, trace([refStep()]), undefined);
     expect(result.ok).toBe(true);
     expect(clicks).toEqual(['sign-in']);
+  });
+});
+
+describe('replayTrace — the own-attribute verifier', () => {
+  // Where the context verifier gives up: two siblings in the SAME container,
+  // same role, same name. The page tells them apart with an attribute on the
+  // element itself, so the replay can too.
+
+  it('resolves identical siblings by data-testid after they were swapped', async () => {
+    // Recorded position 0 = the primary submit. The two were then reordered:
+    // same container, same count, same names — nothing positional can see it.
+    refEntries = [
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', ref: 1, context: 'region "Checkout"', own: 'data-testid=submit-secondary',
+      },
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 1, sameNameTotal: 2,
+        frameKey: '', ref: 2, context: 'region "Checkout"', own: 'data-testid=submit-primary',
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('primary'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', context: 'region "Checkout"', own: 'data-testid=submit-primary',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    // It MOVED, so the run stops rather than following it to index 1 — which
+    // is the same refusal the context verifier makes, one signal deeper.
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].detail).toContain('sits at position 2');
+    expect(clicks).toEqual([]);
+  });
+
+  it('confirms the recorded sibling when its own attribute still sits there', async () => {
+    // The other half of the swap case: the page grew a third look-alike, so
+    // #1179 alone would refuse, but the recorded element is still at index 0
+    // and still carries its own testid.
+    refEntries = [
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 3,
+        frameKey: '', ref: 1, context: 'region "Checkout"', own: 'data-testid=submit-primary',
+      },
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 1, sameNameTotal: 3,
+        frameKey: '', ref: 2, context: 'region "Checkout"', own: 'data-testid=submit-secondary',
+      },
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 2, sameNameTotal: 3,
+        frameKey: '', ref: 3, context: 'region "Checkout"', own: 'data-testid=submit-tertiary',
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('primary'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', context: 'region "Checkout"', own: 'data-testid=submit-primary',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['primary']);
+  });
+
+  it('STOPS when no sibling carries the recorded attribute any more', async () => {
+    refEntries = [
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', ref: 1, context: 'region "Checkout"', own: 'data-testid=submit-a',
+      },
+      {
+        role: 'button', name: 'Submit order', sameNameIndex: 1, sameNameTotal: 2,
+        frameKey: '', ref: 2, context: 'region "Checkout"', own: 'data-testid=submit-b',
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('stranger'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', context: 'region "Checkout"', own: 'data-testid=submit-primary',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].detail).toContain('data-testid=submit-primary');
+    expect(clicks).toEqual([]);
+  });
+
+  it('ABSTAINS on identical siblings that carry no attributes — the irreducible case', async () => {
+    // Nothing recorded can separate these. The verifier must stay silent and
+    // let the count rules decide, exactly as before the field existed.
+    refEntries = [
+      {
+        role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', ref: 1, context: 'row "Alice"',
+      },
+      {
+        role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2,
+        frameKey: '', ref: 2, context: 'row "Alice"',
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('second-delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2,
+        frameKey: '', context: 'row "Alice"',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['second-delete']);
+  });
+
+  it('ABSTAINS when the recording has an attribute and the live page mints none', async () => {
+    // A recording made where the labels could be read, replayed where the DOM
+    // pass could not run. Absence is not a mismatch.
+    refEntries = [
+      {
+        role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1,
+      },
+      {
+        role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2,
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('first-delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', own: 'id=delete-alice',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['first-delete']);
+  });
+
+  it('never runs when the CONTEXT already decided — the context outranks it', async () => {
+    // One element under the recorded context, at the recorded index: settled
+    // there, whatever the own labels say.
+    refEntries = [
+      {
+        role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 1,
+        context: 'row "Alice"', own: 'id=something-else',
+      },
+    ];
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('alice-delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1,
+        frameKey: '', context: 'row "Alice"', own: 'id=delete-alice',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['alice-delete']);
   });
 });
 

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -29,6 +29,17 @@ vi.mock('../../playwright/snapshot', () => ({
   StaleRefError,
 }));
 
+/** What the smart lane says its own walk currently counts. Scripted per case. */
+let smartCount: number | null = null;
+const smartCountCalls: Array<[string, string]> = [];
+
+vi.mock('../../playwright/dom-intelligence', () => ({
+  countSmartNamedPopulation: async (_page: unknown, role: string, name: string) => {
+    smartCountCalls.push([role, name]);
+    return smartCount;
+  },
+}));
+
 import { replayBlockedReason, replayTrace } from '../replayRunner';
 import { refMapShapeHash, type TraceRecord, type TraceStep } from '../../../shared/browserReplay/actionTrace';
 
@@ -95,6 +106,8 @@ beforeEach(() => {
   goneTo.length = 0;
   resolved.clear();
   snapshotText = 'button "Sign in" [ref=1]';
+  smartCount = null;
+  smartCountCalls.length = 0;
   refEntries = [
     { role: 'button', name: 'Sign in', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 1 },
   ];
@@ -615,6 +628,116 @@ describe('replayTrace — the own-attribute verifier', () => {
     const result = await replayTrace(page, trace([step]), undefined);
     expect(result.ok).toBe(true);
     expect(clicks).toEqual(['alice-delete']);
+  });
+});
+
+describe('replayTrace — provenance, so the count compares like with like', () => {
+  // The smart lane walks the whole accessibility tree; this module counts from
+  // browser_snapshot's ref map, which is depth-capped and filtered on
+  // overflow. A named axis minted over there used to be compared against a
+  // number measured over here, and stopped replays on unchanged pages.
+
+  it('does not STOP a smart-recorded step when only the ENUMERATIONS differ', async () => {
+    // The ref map lists two; the smart walk that recorded the step saw three.
+    // Nothing about the page changed — the two walks simply see different sets.
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
+    ];
+    smartCount = 3;
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 3,
+        frameKey: '', via: 'smart',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['delete']);
+    // Asked the lane that minted the number, not a second guess at it.
+    expect(smartCountCalls).toEqual([['button', 'Delete']]);
+  });
+
+  it('still STOPS a smart-recorded step when that lane\u2019s OWN count changed', async () => {
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
+    ];
+    // The smart walk saw three at record time and sees two now: a real change.
+    smartCount = 2;
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('delete'));
+
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 3,
+        frameKey: '', via: 'smart',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(result.steps[0].detail).toContain('element(s) with that role and name');
+    expect(clicks).toEqual([]);
+  });
+
+  it('keeps the stop when the smart walk cannot answer', async () => {
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
+    ];
+    smartCount = null;
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 3,
+        frameKey: '', via: 'smart',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(clicks).toEqual([]);
+  });
+
+  it('does not consult the smart lane for an axis that did not come from it', async () => {
+    // Absent `via` means the accessibility lane, which is the enumeration this
+    // module already counts — there is nothing to reconcile, and an old trace
+    // must keep the exact behaviour it had.
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
+    ];
+    smartCount = 3;
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 3, frameKey: '',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(smartCountCalls).toEqual([]);
+  });
+
+  it('still refuses a position the live population does not have', async () => {
+    // The enumerations reconcile, but the ref map has no index 2 to act on —
+    // the reconciliation clears the COUNT, never the position.
+    refEntries = [
+      { role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', ref: 1 },
+      { role: 'button', name: 'Delete', sameNameIndex: 1, sameNameTotal: 2, frameKey: '', ref: 2 },
+    ];
+    smartCount = 3;
+    const step = refStep({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Delete', sameNameIndex: 2, sameNameTotal: 3,
+        frameKey: '', via: 'smart',
+      },
+    });
+    const result = await replayTrace(page, trace([step]), undefined);
+    expect(result.ok).toBe(false);
+    expect(result.steps[0].detail).toContain('none at position 3');
+    expect(clicks).toEqual([]);
   });
 });
 

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -80,6 +80,7 @@ interface LiveEntry {
   ref: number;
   sameNameIndex: number;
   context?: string;
+  own?: string;
 }
 
 /**
@@ -145,6 +146,70 @@ function contextVerdict(
 }
 
 /**
+ * The own-attribute verifier.
+ *
+ * What contextVerdict cannot do: two siblings that are genuinely identical —
+ * same role, same name, same container — sit under the SAME context, so it
+ * abstains on exactly the shape it was built to catch. Most real pages do
+ * distinguish those siblings, just not in the accessibility tree: they give
+ * one a `data-testid`, an `id`, a `name`, or an `aria-label`.
+ *
+ * Runs only where the context gave no verdict, which is precisely "several
+ * candidates share the recorded context" or "the page mints no context", and
+ * decides on the same three-way shape, with the element never LOCATED by it:
+ *
+ *   exactly one live element carries the recorded label
+ *     at the recorded index → confirmed, and (like the context) that outranks
+ *       a population whose size changed around it.
+ *     at a different index  → the element is still on the page but something
+ *       moved it; stop rather than follow it, which would be resolving by
+ *       position with extra steps.
+ *
+ *   none carries it, but some live element carries SOME label → the element
+ *     the recording identified is not in this population any more. Stop.
+ *
+ *   no live element carries any label at all → no verdict. The page mints
+ *     none (or the DOM pass could not run), so nothing may be concluded from
+ *     the absence, and the count rules decide exactly as before.
+ *
+ * The irreducible residual after this: siblings that are identical AND carry
+ * no attributes of their own. Nothing recorded can tell those apart, and the
+ * count rules are what decide — see the docs' "what this still cannot see".
+ */
+function ownVerdict(
+  axis: RefAxis,
+  population: readonly LiveEntry[],
+): { ref: string } | { error: string } | null {
+  if (!axis.own) return null;
+  // Absence is not evidence: a page whose labels this build could not read
+  // must abstain, not stop every step.
+  if (!population.some((entry) => (entry.own ?? '').length > 0)) return null;
+  const matches = population.filter((entry) => (entry.own ?? '') === axis.own);
+  if (matches.length === 1) {
+    const found = matches[0];
+    if (found.sameNameIndex === axis.sameNameIndex) return { ref: String(found.ref) };
+    return {
+      error:
+        `${describeAxis(axis)} was recorded as ${axis.own}, and the only element carrying ` +
+        `that now sits at position ${found.sameNameIndex + 1}, not ${axis.sameNameIndex + 1}. ` +
+        'The population shifted under this step, so replaying it would act on whatever ' +
+        'took its place',
+    };
+  }
+  if (matches.length === 0) {
+    return {
+      error:
+        `${describeAxis(axis)} was recorded as ${axis.own}, and no element with that role ` +
+        'and name carries it any more — the element at the recorded position is a ' +
+        'different one',
+    };
+  }
+  // Several carry the same label (a page with a duplicated id, say). It cannot
+  // tell them apart either, so it says nothing.
+  return null;
+}
+
+/**
  * Find the live ref number for a stored axis.
  *
  * The match is role + name + position among the same-named elements in the
@@ -176,9 +241,10 @@ function contextVerdict(
  * A missing element is always a refusal — that is the other case where
  * continuing would act on something else.
  *
- * All of that is the fallback. When the recorded axis carries a `context` and
- * the live page carries one too, contextVerdict runs first and may settle the
- * step outright — including the same-count swap this reasoning is blind to.
+ * All of that is the fallback. Two verifiers run before it and may settle the
+ * step outright — including the same-count swap this reasoning is blind to:
+ * contextVerdict on the neighbourhood the element sat in, then, where that
+ * abstains, ownVerdict on the element's own identifying attribute.
  */
 function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure {
   const population = listRefEntries(page).filter(
@@ -203,6 +269,11 @@ function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure 
     // stop replaced it; the verdict itself is the reasoning.)
     return verdict;
   }
+  // The context abstained: either several candidates share it, or the page
+  // mints none. That is exactly where the element's own attribute is the last
+  // evidence available, and it clears a size change on the same terms.
+  const byOwn = ownVerdict(axis, population);
+  if (byOwn !== null) return byOwn;
   // Before the index lookup, not after: a population that shrank past the
   // recorded index would otherwise report only "no element at that position"
   // and never say that the count is what changed.

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -1,5 +1,6 @@
 import type { ElementHandle, Page } from 'playwright-core';
 import { generateSnapshot, listRefEntries, resolveRef, StaleRefError } from '../playwright/snapshot';
+import { countSmartNamedPopulation } from '../playwright/dom-intelligence';
 import { describeToolError } from '../playwright/toolError';
 import { validateNavigationUrl } from '../../shared/types';
 import {
@@ -246,7 +247,7 @@ function ownVerdict(
  * contextVerdict on the neighbourhood the element sat in, then, where that
  * abstains, ownVerdict on the element's own identifying attribute.
  */
-function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure {
+async function matchRefAxis(page: Page, axis: RefAxis): Promise<{ ref: string } | StepFailure> {
   const population = listRefEntries(page).filter(
     (entry) =>
       entry.role === axis.role &&
@@ -281,18 +282,28 @@ function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure 
   // Unnamed axes are exempt, exactly as resolveRef's own count check is, and
   // for a sharper reason here: their stored total is not a same-name count at
   // all. smartRefAxisEntry (dom-intelligence) records roleIndex/roleTotal in
-  // these two fields for an element with no accessible name, measured over its
-  // own full-tree walk, while the number compared against is counted from this
-  // module's snapshot ref map (depth-capped, filtered when it overflows). The
-  // two enumerations do not have to agree on an unchanged page, so demanding
-  // equality would stop flows that nothing is wrong with.
+  // these two fields for an element with no accessible name, so the number
+  // would not even be a same-name count to compare.
   //
-  // A NAMED smartRef axis is compared anyway, and the same two enumerations
-  // could in principle disagree there too. The axis carries no record of which
-  // recorder minted it, and giving it one would widen the stored format, so
-  // this takes the trade the whole check is built on: a stop the agent can
-  // finish live costs less than a click on the wrong element.
+  // The comparison is otherwise between two DIFFERENT enumerations whenever
+  // the axis was minted by the smart lane: that lane walks the whole
+  // accessibility tree, while the number counted here comes from this module's
+  // snapshot ref map, which is depth-capped and filtered when the output
+  // overflows. The two do not have to agree on a page that has not changed,
+  // and a named smartRef axis used to be compared across them anyway — so an
+  // unchanged page could stop a replay for no reason. The axis now records
+  // WHICH lane minted it (`via`), and a disagreement is put to that lane's own
+  // count before it is treated as a change. Only a disagreement, so the
+  // ordinary path costs nothing extra.
   if (axis.name !== '' && population.length !== axis.sameNameTotal) {
+    if (axis.via === 'smart') {
+      const smartCount = await countSmartNamedPopulation(page, axis.role, axis.name);
+      // Same measurement on both sides now. Equal means the page did not
+      // change and the a11y map merely counts a different set; the step
+      // proceeds to the index lookup below, which is what it did before this
+      // check existed. A null answer (the walk could not run) keeps the stop.
+      if (smartCount === axis.sameNameTotal) return indexLookup(axis, population);
+    }
     const grew = population.length > axis.sameNameTotal;
     return {
       error:
@@ -310,6 +321,17 @@ function matchRefAxis(page: Page, axis: RefAxis): { ref: string } | StepFailure 
       inconclusive: true,
     };
   }
+  return indexLookup(axis, population);
+}
+
+/**
+ * The last resort: the recorded position, in a population whose size the
+ * checks above have accepted.
+ *
+ * Its own refusal matters — a population that no longer HAS the recorded
+ * position must stop rather than clamp onto the nearest one.
+ */
+function indexLookup(axis: RefAxis, population: readonly LiveEntry[]): { ref: string } | StepFailure {
   const match = population.find((entry) => entry.sameNameIndex === axis.sameNameIndex);
   if (!match) {
     return {
@@ -353,7 +375,7 @@ async function resolveAxis(page: Page, axis: StepAxis): Promise<Resolved | StepF
     const element = await locator.elementHandle().catch(() => null);
     return element ? { element } : { error: `css ${axis.selector} could not be resolved` };
   }
-  const matched = matchRefAxis(page, axis);
+  const matched = await matchRefAxis(page, axis);
   if ('error' in matched) return matched;
   // strictCount, because the population compared above was counted from the
   // internal snapshot — a measurement taken BEFORE this step. Anything the page

--- a/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.refstability.test.ts
@@ -498,6 +498,10 @@ describe('replay axis for a smart ref', () => {
       name: 'Row',
       sameNameIndex: 1,
       sameNameTotal: 2,
+      // Which walk those counts were measured over, so the replay runner can
+      // count the live population the same way rather than across two
+      // different enumerations.
+      via: 'smart',
       frameKey: '',
     });
   });

--- a/src/mcp/playwright/__tests__/dom-intelligence.test.ts
+++ b/src/mcp/playwright/__tests__/dom-intelligence.test.ts
@@ -46,8 +46,11 @@ describe('getSmartSnapshotViaEval', () => {
     expect(snap.content).toBe('hello');
     // The populations are inert on this lane — its locator is a CSS selector
     // naming one tagged element — but they are part of the shape. The RPC lane
-    // mints no ancestor context (it records no ref axis to carry one).
-    const inert = { context: '', sameNameIndex: 0, sameNameTotal: 1, roleIndex: 0, roleTotal: 1 };
+    // mints no ancestor context and no own-attribute label (it records no ref
+    // axis to carry either).
+    const inert = {
+      context: '', own: '', sameNameIndex: 0, sameNameTotal: 1, roleIndex: 0, roleTotal: 1,
+    };
     expect(snap.elements).toEqual([
       { ref: 1, role: 'button', name: 'OK', locator: '[data-wmux-ref="1"]', ...inert },
       {

--- a/src/mcp/playwright/__tests__/interaction.smartref.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.smartref.test.ts
@@ -161,6 +161,9 @@ describe('browser_click({ smartRef }) on the Playwright lane', () => {
       sameNameIndex: 1,
       sameNameTotal: 2,
       frameKey: '',
+      // The counts came from the smart walk, which is not the enumeration the
+      // replay runner counts by default — the axis says so.
+      via: 'smart',
     });
     // The old shape: a css axis holding a string page.locator() cannot parse.
     expect(recorded.step.axis.kind).not.toBe('css');

--- a/src/mcp/playwright/__tests__/snapshot.ownattr.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.ownattr.test.ts
@@ -171,6 +171,9 @@ describe('IndexedElement.own — the smart lane mints the identical string', () 
       name: 'Submit order',
       context: 'region "Checkout"',
       own: 'data-testid=submit-secondary',
+      // The counts above were measured over THIS walk, so the axis says so —
+      // the replay runner counts the live population the same way.
+      via: 'smart',
     });
   });
 

--- a/src/mcp/playwright/__tests__/snapshot.ownattr.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.ownattr.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateSnapshot, listRefEntries } from '../snapshot';
+import { clearElementCache, getSmartSnapshot, smartRefAxisEntry } from '../dom-intelligence';
+import { MAX_OWN_CHARS } from '../../../shared/browserReplay/actionTrace';
+
+// RefEntry.own — the element's own identifying attribute, the second
+// verify-only signal on the replay axis.
+//
+// The point the two `describe` blocks below make together is the one that
+// matters: BOTH minting lanes read the attributes from the same CDP pass
+// through the same helper, so the string a flow recorded on one lane is
+// compared against at replay on the other is identical. A value read one way
+// here and another there would stop every cross-lane replay it was built to
+// pass, which is the same trap ancestorContext was written to avoid.
+
+interface CdpAX {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+interface CdpDom {
+  backendNodeId?: number;
+  attributes?: string[];
+  children?: CdpDom[];
+}
+
+const role = (value: string) => ({ type: 'role', value });
+const name = (value: string) => ({ type: 'name', value });
+
+function ax(id: number, r: string, n: string, children: number[] = []): CdpAX {
+  return {
+    nodeId: String(id),
+    backendDOMNodeId: id,
+    role: role(r),
+    name: name(n),
+    childIds: children.map(String),
+  };
+}
+
+function dom(backendNodeId: number, attributes: string[]): CdpDom {
+  return { backendNodeId, attributes };
+}
+
+/**
+ * One page both lanes can be pointed at: the same a11y nodes and the same
+ * `DOM.getDocument` answer, so any difference in the minted label is the code's
+ * and not the fixture's.
+ */
+function makePage(nodes: CdpAX[], domNodes: CdpDom[]) {
+  const page = {
+    nodes,
+    url: () => 'https://example.test/checkout',
+    title: async () => 'Checkout',
+    innerText: async () => 'body text',
+    on: () => undefined,
+    mainFrame: () => ({ id: 'main' }),
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string) => {
+          if (method === 'Accessibility.getFullAXTree') return { nodes: page.nodes };
+          if (method === 'DOM.getDocument') {
+            return { root: { backendNodeId: 0, children: domNodes } };
+          }
+          return {};
+        }),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    evaluate: vi.fn(async () => ''),
+    locator: vi.fn(),
+    getByRole: vi.fn(),
+  };
+  return page as never;
+}
+
+/** Two `button "Submit order"` in one section, told apart only by a testid. */
+const IDENTICAL_SIBLINGS: CdpAX[] = [
+  ax(1, 'RootWebArea', 'Checkout', [2]),
+  ax(2, 'region', 'Checkout', [3, 4]),
+  ax(3, 'button', 'Submit order'),
+  ax(4, 'button', 'Submit order'),
+];
+
+const SIBLING_ATTRS: CdpDom[] = [
+  dom(3, ['data-testid', 'submit-primary', 'class', 'btn btn-lg']),
+  dom(4, ['data-testid', 'submit-secondary', 'class', 'btn']),
+];
+
+describe('RefEntry.own — the accessibility lane', () => {
+  it('separates two identical siblings the context cannot', async () => {
+    const page = makePage(IDENTICAL_SIBLINGS, SIBLING_ATTRS);
+    await generateSnapshot(page, { format: 'ai' });
+    const entries = listRefEntries(page);
+    // The context is the same string for both — this is the residual #1185
+    // left behind, and `own` is what closes it.
+    expect(entries.map((e) => e.context)).toEqual([
+      'region "Checkout"',
+      'region "Checkout"',
+    ]);
+    expect(entries.map((e) => e.own)).toEqual([
+      'data-testid=submit-primary',
+      'data-testid=submit-secondary',
+    ]);
+  });
+
+  it('prefers data-testid over id, name and aria-label', async () => {
+    const page = makePage(
+      [ax(1, 'RootWebArea', 'Page', [2]), ax(2, 'button', 'Go')],
+      [dom(2, ['aria-label', 'Go now', 'name', 'go', 'id', 'go-btn', 'data-testid', 'go-cta'])],
+    );
+    await generateSnapshot(page, { format: 'ai' });
+    expect(listRefEntries(page)[0].own).toBe('data-testid=go-cta');
+  });
+
+  it('leaves an element with none of the four attributes without a label', async () => {
+    const page = makePage(
+      [ax(1, 'RootWebArea', 'Page', [2]), ax(2, 'button', 'Go')],
+      [dom(2, ['class', 'btn'])],
+    );
+    await generateSnapshot(page, { format: 'ai' });
+    // '' and not a guess: an absent label abstains at replay, it never stops.
+    expect(listRefEntries(page)[0].own).toBe('');
+  });
+
+  it('abstains rather than failing when the DOM pass cannot run', async () => {
+    // A page whose CDP session answers nothing but the a11y tree — the
+    // best-effort contract getPasswordFieldBackendIds already has.
+    const page = makePage(IDENTICAL_SIBLINGS, []);
+    await generateSnapshot(page, { format: 'ai' });
+    expect(listRefEntries(page).map((e) => e.own)).toEqual(['', '']);
+  });
+
+  it('caps a long value at the mint site', async () => {
+    const page = makePage(
+      [ax(1, 'RootWebArea', 'Page', [2]), ax(2, 'button', 'Go')],
+      [dom(2, ['data-testid', 'z'.repeat(MAX_OWN_CHARS * 2)])],
+    );
+    await generateSnapshot(page, { format: 'ai' });
+    expect(listRefEntries(page)[0].own).toHaveLength(MAX_OWN_CHARS);
+  });
+});
+
+describe('IndexedElement.own — the smart lane mints the identical string', () => {
+  it('gives both lanes the same label for the same element', async () => {
+    clearElementCache();
+    const a11yPage = makePage(IDENTICAL_SIBLINGS, SIBLING_ATTRS);
+    await generateSnapshot(a11yPage, { format: 'ai' });
+    const fromA11y = listRefEntries(a11yPage).map((e) => e.own);
+
+    const smartPage = makePage(IDENTICAL_SIBLINGS, SIBLING_ATTRS);
+    const smart = await getSmartSnapshot(smartPage);
+    const fromSmart = smart.elements.map((e) => e.own);
+
+    expect(fromSmart).toEqual(fromA11y);
+    expect(fromSmart).toEqual([
+      'data-testid=submit-primary',
+      'data-testid=submit-secondary',
+    ]);
+  });
+
+  it('puts the label on the axis a smartRef click records', async () => {
+    clearElementCache();
+    const page = makePage(IDENTICAL_SIBLINGS, SIBLING_ATTRS);
+    const smart = await getSmartSnapshot(page);
+    const axis = smartRefAxisEntry(smart.elements[1].ref);
+    expect(axis).toMatchObject({
+      role: 'button',
+      name: 'Submit order',
+      context: 'region "Checkout"',
+      own: 'data-testid=submit-secondary',
+    });
+  });
+
+  it('omits the field entirely when the element carries no attribute', async () => {
+    clearElementCache();
+    const page = makePage(
+      [ax(1, 'RootWebArea', 'Page', [2]), ax(2, 'button', 'Go')],
+      [dom(2, ['class', 'btn'])],
+    );
+    const smart = await getSmartSnapshot(page);
+    expect(smartRefAxisEntry(smart.elements[0].ref)).not.toHaveProperty('own');
+  });
+});

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -7,6 +7,7 @@ import {
   getPasswordFieldBackendIds,
 } from './redact';
 import { ancestorContext } from '../../shared/browserReplay/actionTrace';
+import { getOwnAttributeLabels } from './ownAttributes';
 
 // ---------------------------------------------------------------------------
 // Shared interactive-element selector
@@ -148,6 +149,16 @@ export interface IndexedElement {
    * ref axis to carry it.
    */
   context: string;
+  /**
+   * The element's own `attr=value` identifier — the same string, from the same
+   * `DOM.getDocument` pass and the same ownAttributeLabel rule, that the
+   * accessibility-lane snapshot stamps on its RefEntry. `''` when the element
+   * carries none of the four attributes, and on the RPC lane.
+   *
+   * It is what tells two genuinely identical siblings apart, which `context`
+   * cannot — they share a container. Verify-only: never used to LOCATE.
+   */
+  own: string;
 }
 
 export interface SmartSnapshot {
@@ -554,6 +565,7 @@ function collectInteractiveElements(
   passwordBackendIds: Set<number>,
   identity: SmartRefIdentity,
   seen: Set<number>,
+  ownLabels: Map<number, string>,
   inheritedContext = '',
 ): void {
   const role = node.role?.value ?? 'none';
@@ -582,6 +594,9 @@ function collectInteractiveElements(
       // Where the element sits, not what it is: the same value the a11y lane
       // stamps, so a flow recorded here replays against a snapshot taken there.
       context: inheritedContext,
+      // What it IS, for the case where where-it-sits cannot decide. Same
+      // source and same rule as the a11y lane, for the same cross-lane reason.
+      own: ownLabels.get(backendId) ?? '',
       // Filled in by finalizeSmartPopulations once the whole walk is known.
       sameNameIndex: 0,
       sameNameTotal: 0,
@@ -611,7 +626,7 @@ function collectInteractiveElements(
       const child = nodeMap.get(childId);
       if (child) {
         collectInteractiveElements(
-          nodeMap, child, elements, passwordBackendIds, identity, seen, childContext,
+          nodeMap, child, elements, passwordBackendIds, identity, seen, ownLabels, childContext,
         );
       }
     }
@@ -639,13 +654,22 @@ async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
       client as unknown as { send: (method: string, params?: unknown) => Promise<unknown> },
     );
 
+    // The element's own identifying attribute, over the same bridge and from
+    // the same shared helper snapshot.ts uses — a value read differently here
+    // would stop every replay that crosses lanes (see IndexedElement.own).
+    const ownLabels = await getOwnAttributeLabels(
+      client as unknown as { send: (method: string, params?: unknown) => Promise<unknown> },
+    );
+
     // Build a map for quick lookup by nodeId
     const nodeMap = new Map<string, CdpAXNode>();
     for (const n of nodes) nodeMap.set(n.nodeId, n);
 
     const elements: IndexedElement[] = [];
     const seen = new Set<number>();
-    collectInteractiveElements(nodeMap, nodes[0], elements, passwordBackendIds, identity, seen);
+    collectInteractiveElements(
+      nodeMap, nodes[0], elements, passwordBackendIds, identity, seen, ownLabels,
+    );
     capSmartRefIdentity(identity, seen);
     finalizeSmartPopulations(elements);
     return elements;
@@ -816,6 +840,8 @@ export async function getSmartSnapshotViaEval(
     // No named-ancestor pass on the RPC lane, and none is needed: this lane
     // records no ref axis (smartRefAxisEntry returns null for its locator).
     context: '',
+    // Same reason: nothing on this lane carries a ref axis to verify.
+    own: '',
     // The populations are unused on this lane: its locator is a CSS selector
     // naming one tagged element, so nothing counts a role or a name.
     sameNameIndex: 0,
@@ -1016,6 +1042,7 @@ export function smartRefAxisEntry(ref: number): {
   sameNameTotal: number;
   frameKey: string;
   context?: string;
+  own?: string;
 } | null {
   const element = getSmartElementByRef(ref);
   if (!element || element.locator.startsWith('[data-wmux-ref=')) return null;
@@ -1031,6 +1058,9 @@ export function smartRefAxisEntry(ref: number): {
     // #1182 verifier a snapshot-recorded one does. Omitted when empty, exactly
     // as refEntryToAxis would drop it.
     ...(element.context.length > 0 && { context: element.context }),
+    // The second verifier, for the identical siblings the context cannot
+    // separate. Same string the a11y lane would have stamped on this element.
+    ...(element.own.length > 0 && { own: element.own }),
   };
 }
 

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -634,18 +634,26 @@ function collectInteractiveElements(
 }
 
 /**
- * Fetch the full accessibility tree via CDP and return indexed interactive
- * elements.
+ * One walk of the page's accessibility tree, indexed.
+ *
+ * Split out of getInteractiveElements so the replay runner's population
+ * recount can reuse it EXACTLY — a second, parallel counting walk would drift
+ * from this one, and a count that disagrees with the one the recording was
+ * made from is the whole defect being fixed. The caller supplies the ref
+ * identity, which is what lets the recount use a scratch one and leave the
+ * live smart-ref numbering untouched.
  */
-async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
-  const identity = beginSmartRefGeneration(page);
+async function walkInteractiveElements(
+  page: Page,
+  identity: SmartRefIdentity,
+): Promise<{ elements: IndexedElement[]; seen: Set<number> }> {
   const client = await page.context().newCDPSession(page);
   try {
     const { nodes } = (await client.send('Accessibility.getFullAXTree' as any)) as {
       nodes: CdpAXNode[];
     };
 
-    if (nodes.length === 0) return [];
+    if (nodes.length === 0) return { elements: [], seen: new Set<number>() };
 
     // Password fields are identified DOM-side and matched to a11y nodes through
     // backendNodeId — the a11y node itself carries neither `type` nor
@@ -670,13 +678,63 @@ async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
     collectInteractiveElements(
       nodeMap, nodes[0], elements, passwordBackendIds, identity, seen, ownLabels,
     );
-    capSmartRefIdentity(identity, seen);
     finalizeSmartPopulations(elements);
-    return elements;
+    return { elements, seen };
   } finally {
     await client.detach().catch(() => {
       /* best-effort cleanup */
     });
+  }
+}
+
+/**
+ * Fetch the full accessibility tree via CDP and return indexed interactive
+ * elements.
+ */
+async function getInteractiveElements(page: Page): Promise<IndexedElement[]> {
+  const identity = beginSmartRefGeneration(page);
+  const { elements, seen } = await walkInteractiveElements(page, identity);
+  capSmartRefIdentity(identity, seen);
+  return elements;
+}
+
+/**
+ * How many elements THIS lane's walk currently sees with `role` + `name`.
+ *
+ * The replay runner asks when a step whose axis was minted here reports a
+ * changed same-name count: that count came from this uncapped walk, while the
+ * number it was compared against came from browser_snapshot's depth-capped,
+ * overflow-filtered ref map. The two enumerations need not agree on a page
+ * that has not changed, and the disagreement stopped replays that nothing was
+ * wrong with (#1179 review). Counting here puts both sides of the comparison
+ * on the same measurement.
+ *
+ * A SCRATCH identity, deliberately: this is a measurement taken mid-replay,
+ * not a snapshot the agent asked for, and numbering it into the page's live
+ * ref space would renumber refs under an agent that is holding them. Nothing
+ * about the page's smart-ref state is touched.
+ *
+ * Returns null when the walk cannot run at all, which the caller reads as "no
+ * second opinion" and falls back to the count it already has.
+ */
+export async function countSmartNamedPopulation(
+  page: Page,
+  role: string,
+  name: string,
+): Promise<number | null> {
+  try {
+    const scratch: SmartRefIdentity = {
+      byBackendId: new Map<number, number>(),
+      next: 1,
+      url: undefined,
+      generation: 0,
+      documentEpoch: 0,
+    };
+    const { elements } = await walkInteractiveElements(page, scratch);
+    if (elements.length === 0) return null;
+    return elements.filter((e) => e.role === role && e.name === name).length;
+  } catch {
+    return null;
   }
 }
 
@@ -1043,6 +1101,7 @@ export function smartRefAxisEntry(ref: number): {
   frameKey: string;
   context?: string;
   own?: string;
+  via: 'smart';
 } | null {
   const element = getSmartElementByRef(ref);
   if (!element || element.locator.startsWith('[data-wmux-ref=')) return null;
@@ -1061,6 +1120,10 @@ export function smartRefAxisEntry(ref: number): {
     // The second verifier, for the identical siblings the context cannot
     // separate. Same string the a11y lane would have stamped on this element.
     ...(element.own.length > 0 && { own: element.own }),
+    // Which walk the counts above were measured over. This one is uncapped and
+    // unfiltered; browser_snapshot's ref map is neither, so a replay that
+    // compared the two would stop on pages nothing had happened to.
+    via: 'smart',
   };
 }
 

--- a/src/mcp/playwright/ownAttributes.ts
+++ b/src/mcp/playwright/ownAttributes.ts
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// The element's own identifying attribute, read once per snapshot.
+//
+// Both minting lanes walk the ACCESSIBILITY tree (snapshot.ts serializeNode,
+// dom-intelligence collectInteractiveElements), and an a11y node carries no
+// DOM attributes at all — only a `backendDOMNodeId`. So the attributes have to
+// come from the DOM domain and be joined back through that id, exactly the
+// bridge redact.ts already uses to find password fields.
+//
+// One `DOM.getDocument` for the whole document, not one lookup per ref: a
+// per-ref `DOM.describeNode` would be a round trip per interactive element on
+// a page that has hundreds, which is the cost that would make this feature not
+// worth having. The single pass is the same order as the `getFullAXTree` call
+// the snapshot already makes, and everything after it is local.
+//
+// Only nodes that actually carry one of the four attributes get a map entry,
+// so the map that survives the pass is small even when the document is not.
+// ---------------------------------------------------------------------------
+
+import { ownAttributeLabel } from '../../shared/browserReplay/actionTrace';
+
+type CdpSender = { send: (method: string, params?: unknown) => Promise<unknown> };
+
+/** The `DOM.getDocument` node fields this pass reads. */
+interface CdpDomNode {
+  backendNodeId?: number;
+  /** Flat `[name, value, name, value, ...]`, which is how CDP ships them. */
+  attributes?: string[];
+  children?: CdpDomNode[];
+  shadowRoots?: CdpDomNode[];
+  contentDocument?: CdpDomNode;
+}
+
+/**
+ * `backendDOMNodeId` → the element's own `attr=value` label, for every element
+ * in the document that has one.
+ *
+ * Best-effort in the same way getPasswordFieldBackendIds is: a detached target
+ * or a missing DOM domain costs the verifier its extra signal and nothing
+ * else, because `own` is verify-only — an absent label abstains rather than
+ * stops.
+ *
+ * `pierce: true` so a control inside a web component's shadow root is covered.
+ * Same-process iframes come back too; their nodes are numbered in this
+ * target's id space, so joining them is sound. An OUT-OF-PROCESS frame is a
+ * different target with a colliding id space, which is why the caller applies
+ * this map to main-frame refs only.
+ */
+export async function getOwnAttributeLabels(client: CdpSender): Promise<Map<number, string>> {
+  const labels = new Map<number, string>();
+  try {
+    const doc = (await client.send('DOM.getDocument', { depth: -1, pierce: true })) as {
+      root?: CdpDomNode;
+    };
+    if (doc?.root) indexDocument(doc.root, labels);
+  } catch {
+    /* no DOM domain / detached target — the verifier abstains */
+  }
+  return labels;
+}
+
+/**
+ * Iterative rather than recursive: a deep DOM (a chat log, a deeply nested
+ * table) is exactly the page this runs on, and blowing the stack here would
+ * cost the snapshot its whole result.
+ */
+function indexDocument(root: CdpDomNode, labels: Map<number, string>): void {
+  const stack: CdpDomNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop() as CdpDomNode;
+    if (node.backendNodeId !== undefined && node.attributes && node.attributes.length > 0) {
+      const label = labelFor(node.attributes);
+      if (label.length > 0) labels.set(node.backendNodeId, label);
+    }
+    if (node.children) for (const child of node.children) stack.push(child);
+    if (node.shadowRoots) for (const shadow of node.shadowRoots) stack.push(shadow);
+    if (node.contentDocument) stack.push(node.contentDocument);
+  }
+}
+
+function labelFor(attributes: readonly string[]): string {
+  return ownAttributeLabel((wanted) => {
+    for (let i = 0; i + 1 < attributes.length; i += 2) {
+      if (attributes[i] === wanted) return attributes[i + 1];
+    }
+    return undefined;
+  });
+}

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -10,6 +10,7 @@ import { collectPageFacts, formatPageFactsFooter } from './pageFacts';
 import { peekRecentPendingRequests } from './pageCapture';
 import { evaluateIsolated, isolatedProbeTarget } from './isolated-eval';
 import { ancestorContext } from '../../shared/browserReplay/actionTrace';
+import { getOwnAttributeLabels } from './ownAttributes';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -520,6 +521,24 @@ export interface RefEntry {
    * during a walk that is already visiting every node.
    */
   context: string;
+  /**
+   * The element's OWN identifying attribute, as `attr=value` — `data-testid`,
+   * `id`, `name`, or `aria-label`, whichever comes first (ownAttributeLabel).
+   * `''` when it carries none of them.
+   *
+   * `context` abstains on two genuinely identical siblings, because they sit
+   * in the same place; this is what tells THOSE apart. Like `context` it is a
+   * verifier for the replay runner and nothing else: it is not part of the
+   * ref's identity and is never printed in a snapshot.
+   *
+   * MAIN FRAME ONLY. The attributes are joined to a11y nodes through
+   * `backendDOMNodeId`, and that id space belongs to a CDP target: an
+   * out-of-process frame numbers its own DOM from its own space, so a
+   * page-target map would hand a frame's element a main-document label. The
+   * smart lane never leaves the main frame either, which is what keeps the two
+   * lanes minting the identical string everywhere they overlap.
+   */
+  own: string;
 }
 
 /**
@@ -921,6 +940,12 @@ interface SerializeCtx {
   /** Null when nothing is covering the page, which is the normal case. */
   occlusion: OcclusionInfo | null;
   /**
+   * backendDOMNodeId → the element's own `attr=value` label, for the page
+   * target's document. Empty when the DOM pass could not run, or when the
+   * caller asked for 'aria' (which mints no refs to carry it).
+   */
+  ownLabels: Map<number, string>;
+  /**
    * Characters left for frame content — ONE pool for the whole snapshot,
    * drawn down by every grafted frame in it.
    *
@@ -992,6 +1017,13 @@ function serializeNode(
       // The element's own label is already `name`; what is recorded here is
       // where it SITS, so an element is never its own context.
       context: inheritedContext,
+      // Main frame only — see RefEntry.own for why the id space forbids the
+      // rest. An element outside it simply carries no label, which the
+      // verifier reads as "no verdict available", not as a mismatch.
+      own:
+        frame.key === MAIN_FRAME.key && node.backendDOMNodeId !== undefined
+          ? ctx.ownLabels.get(node.backendDOMNodeId) ?? ''
+          : '',
     });
     attrs.push(`ref="${ref}"`);
   }
@@ -1657,9 +1689,19 @@ async function occlusionFor(page: Page, fallback: CdpClient): Promise<OcclusionI
 interface SnapshotSource {
   tree: AXNode | null;
   occlusion: OcclusionInfo | null;
+  /** See SerializeCtx.ownLabels. Empty when `wantOwnLabels` was false. */
+  ownLabels: Map<number, string>;
 }
 
-async function getAccessibilityTree(page: Page): Promise<SnapshotSource> {
+/**
+ * @param wantOwnLabels adds ONE `DOM.getDocument` to the session, which is
+ *   only worth paying for on the 'ai' path — 'aria' mints no RefEntry to hang
+ *   the label on.
+ */
+async function getAccessibilityTree(
+  page: Page,
+  wantOwnLabels: boolean,
+): Promise<SnapshotSource> {
   // Sessions opened for out-of-process frames during the graft. Detached here
   // rather than inside the walk so one frame's cleanup cannot abort the rest.
   const extraSessions: CdpClient[] = [];
@@ -1668,6 +1710,10 @@ async function getAccessibilityTree(page: Page): Promise<SnapshotSource> {
       page,
       async (client) => ({
         tree: (await fetchAccessibilityTree(client, { page, extraSessions }))?.root ?? null,
+        // On the same session as the tree, so the DOM the attributes are read
+        // from is the DOM the a11y nodes were computed against. Its own
+        // failures are swallowed inside — a missing label abstains.
+        ownLabels: wantOwnLabels ? await getOwnAttributeLabels(client) : new Map(),
       // After the tree, never instead of it: a thrown occlusion probe must not
       // cost the caller its snapshot (collectOcclusion swallows its own
       // failures, and this ordering keeps the tree even if that ever changes).
@@ -1678,7 +1724,7 @@ async function getAccessibilityTree(page: Page): Promise<SnapshotSource> {
         // world, exactly as before, when there is no isolated world.
         occlusion: await occlusionFor(page, client),
       }),
-      { tree: null, occlusion: null },
+      { tree: null, occlusion: null, ownLabels: new Map() },
     );
   } finally {
     for (const extra of extraSessions) {
@@ -1714,7 +1760,7 @@ export async function generateSnapshot(
   // fallthroughs below — stamps the same generation onto the page.
   const identity = beginRefGeneration(page);
 
-  const { tree, occlusion } = await getAccessibilityTree(page);
+  const { tree, occlusion, ownLabels } = await getAccessibilityTree(page, format === 'ai');
 
   // A null tree (no CDP session / getFullAXTree threw / zero nodes) OR a root-only
   // tree (the a11y path collapsed — a background surface with no layout, or a page
@@ -1781,6 +1827,7 @@ export async function generateSnapshot(
     refs,
     identity,
     occlusion,
+    ownLabels,
     frameBudgetRemaining: Math.floor(maxLength * FRAME_BUDGET_SHARE),
   };
   let output = serializeTree(effectiveTree, ctx);
@@ -1870,29 +1917,36 @@ export async function generateScopedSnapshot(
   // was given whether it was reached through a selector or the whole page.
   const identity = beginRefGeneration(page);
 
-  const found = await withCdpSession<{ forest: AXNode[] | null; occlusion: OcclusionInfo | null }>(
+  const found = await withCdpSession<{
+    forest: AXNode[] | null;
+    occlusion: OcclusionInfo | null;
+    ownLabels: Map<number, string>;
+  }>(
     page,
     async (client) => {
       // Resolve the selector FIRST: a miss costs nothing and must reach the DOM
       // listing, which owns the user-facing "No element matches selector:" error.
       const backendId = await resolveSelectorBackendId(client, selector);
-      if (backendId === null) return { forest: null, occlusion: null };
+      if (backendId === null) return { forest: null, occlusion: null, ownLabels: new Map() };
 
       const built = await fetchAccessibilityTree(client);
-      if (!built || isRootOnly(built.root)) return { forest: null, occlusion: null };
+      if (!built || isRootOnly(built.root)) {
+        return { forest: null, occlusion: null, ownLabels: new Map() };
+      }
 
       return {
         forest: built.byBackendId.get(backendId) ?? null,
+        ownLabels: format === 'ai' ? await getOwnAttributeLabels(client) : new Map(),
         // Occlusion is a whole-page fact, so it is worth just as much inside a
         // scope — a selector aimed at the page behind an overlay is exactly the
         // case where the agent is about to click something inert.
         occlusion: await occlusionFor(page, client),
       };
     },
-    { forest: null, occlusion: null },
+    { forest: null, occlusion: null, ownLabels: new Map() },
   );
 
-  const { forest, occlusion } = found;
+  const { forest, occlusion, ownLabels } = found;
   if (!forest || forest.length === 0) return null;
 
   let scoped = forest;
@@ -1918,6 +1972,7 @@ export async function generateScopedSnapshot(
     refs,
     identity,
     occlusion,
+    ownLabels,
     frameBudgetRemaining: Math.floor(maxLength * FRAME_BUDGET_SHARE),
   };
   // Unlike the page-level tree, the matched element is content, not a container

--- a/src/shared/browserReplay/__tests__/actionTrace.test.ts
+++ b/src/shared/browserReplay/__tests__/actionTrace.test.ts
@@ -17,6 +17,8 @@ import {
   normalizeUrlKey,
   pruneTraces,
   MAX_CONTEXT_CHARS,
+  MAX_OWN_CHARS,
+  ownAttributeLabel,
   refEntryToAxis,
   refMapShapeHash,
   sanitizeTraceRecord,
@@ -187,6 +189,55 @@ describe('refEntryToAxis', () => {
       role: 'button', name: 'Delete', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', context: '',
     });
     expect(axis).not.toHaveProperty('context');
+  });
+
+  it('carries the element\u2019s own attribute through, capped, and omits an empty one', () => {
+    const long = `data-testid=${'x'.repeat(MAX_OWN_CHARS)}`;
+    expect(
+      refEntryToAxis({
+        role: 'button', name: 'Submit', sameNameIndex: 0, sameNameTotal: 2, frameKey: '',
+        own: long,
+      }),
+    ).toMatchObject({ own: long.slice(0, MAX_OWN_CHARS) });
+
+    expect(
+      refEntryToAxis({
+        role: 'button', name: 'Submit', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', own: '',
+      }),
+    ).not.toHaveProperty('own');
+  });
+
+  it('leaves an entry that carries neither verifier exactly as it was', () => {
+    // Additive: the fields cost a pre-#1182 recording nothing.
+    expect(
+      refEntryToAxis({ role: 'link', name: 'Docs', sameNameIndex: 0, sameNameTotal: 1, frameKey: '' }),
+    ).toEqual({ kind: 'ref', role: 'link', name: 'Docs', sameNameIndex: 0, sameNameTotal: 1, frameKey: '' });
+  });
+});
+
+describe('ownAttributeLabel', () => {
+  it('takes the first attribute in preference order, not the first present', () => {
+    const attrs: Record<string, string> = {
+      'aria-label': 'Submit the order',
+      id: 'submit-1',
+      'data-testid': 'submit-primary',
+    };
+    expect(ownAttributeLabel((a) => attrs[a])).toBe('data-testid=submit-primary');
+    delete attrs['data-testid'];
+    expect(ownAttributeLabel((a) => attrs[a])).toBe('id=submit-1');
+    delete attrs.id;
+    expect(ownAttributeLabel((a) => attrs[a])).toBe('aria-label=Submit the order');
+  });
+
+  it('says nothing when the element carries none of them', () => {
+    expect(ownAttributeLabel(() => undefined)).toBe('');
+    expect(ownAttributeLabel(() => '')).toBe('');
+  });
+
+  it('truncates at the mint site, so both lanes cut a long value identically', () => {
+    const label = ownAttributeLabel(() => 'y'.repeat(MAX_OWN_CHARS * 2));
+    expect(label.length).toBe(MAX_OWN_CHARS);
+    expect(label.endsWith('\u2026')).toBe(true);
   });
 });
 
@@ -375,6 +426,26 @@ describe('sanitizeTraceStep', () => {
     });
     expect(stripped?.unrecordable).toBeUndefined();
     expect(stripped?.axis).not.toHaveProperty('context');
+  });
+
+  it('keeps a stored own attribute, capped, and drops an untrusted one without failing the step', () => {
+    const kept = sanitizeTraceStep(step({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', own: 'data-testid=submit-primary',
+      },
+    }));
+    expect(kept?.axis).toMatchObject({ own: 'data-testid=submit-primary' });
+
+    const stripped = sanitizeTraceStep({
+      ...step(),
+      axis: {
+        kind: 'ref', role: 'button', name: 'Submit order', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', own: { evil: true },
+      },
+    });
+    expect(stripped?.unrecordable).toBeUndefined();
+    expect(stripped?.axis).not.toHaveProperty('own');
   });
 
   it('keeps a declared unrecordable reason', () => {

--- a/src/shared/browserReplay/__tests__/actionTrace.test.ts
+++ b/src/shared/browserReplay/__tests__/actionTrace.test.ts
@@ -207,6 +207,21 @@ describe('refEntryToAxis', () => {
     ).not.toHaveProperty('own');
   });
 
+  it('records the minting lane only when it is the smart one', () => {
+    // 'a11y' is what an absent field already means, so storing it would cost
+    // every step bytes to say nothing.
+    expect(
+      refEntryToAxis({
+        role: 'button', name: 'Go', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', via: 'smart',
+      }),
+    ).toMatchObject({ via: 'smart' });
+    expect(
+      refEntryToAxis({
+        role: 'button', name: 'Go', sameNameIndex: 0, sameNameTotal: 2, frameKey: '', via: 'a11y',
+      }),
+    ).not.toHaveProperty('via');
+  });
+
   it('leaves an entry that carries neither verifier exactly as it was', () => {
     // Additive: the fields cost a pre-#1182 recording nothing.
     expect(
@@ -446,6 +461,28 @@ describe('sanitizeTraceStep', () => {
     });
     expect(stripped?.unrecordable).toBeUndefined();
     expect(stripped?.axis).not.toHaveProperty('own');
+  });
+
+  it('keeps the smart-lane marker and drops anything else it finds there', () => {
+    const smart = sanitizeTraceStep(step({
+      axis: {
+        kind: 'ref', role: 'button', name: 'Go', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', via: 'smart',
+      },
+    }));
+    expect(smart?.axis).toMatchObject({ via: 'smart' });
+
+    // Anything unrecognised reads as the accessibility lane, which selects the
+    // stricter count check — the conservative direction to be wrong in.
+    const junk = sanitizeTraceStep({
+      ...step(),
+      axis: {
+        kind: 'ref', role: 'button', name: 'Go', sameNameIndex: 0, sameNameTotal: 2,
+        frameKey: '', via: 'whatever',
+      },
+    });
+    expect(junk?.unrecordable).toBeUndefined();
+    expect(junk?.axis).not.toHaveProperty('via');
   });
 
   it('keeps a declared unrecordable reason', () => {

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -59,11 +59,13 @@ export function isReplayableTool(value: unknown): value is ReplayableTool {
 // The 4-tuple alone cannot see a swap that keeps the count: insert one
 // look-alike above the recorded element and remove one below, and N is
 // unchanged, so the index still resolves and the click lands on a stranger
-// (#1182). The axis therefore carries one more field, `context` — the
-// accessible name of the nearest named ancestor. It is a VERIFIER, never a
-// locator: nothing is ever found by it, it can only contradict what the index
-// found and stop the run. That keeps the refusal to key on position intact
-// while removing the case where position lies silently.
+// (#1182). The axis therefore carries two more fields — `context`, the
+// accessible name of the nearest named ancestor, and `own`, the element's own
+// identifying attribute for the identical siblings a shared container cannot
+// separate. Both are VERIFIERS, never locators: nothing is ever found by
+// them, they can only contradict what the index found and stop the run. That
+// keeps the refusal to key on position intact while removing the cases where
+// position lies silently.
 
 /** An element addressed the way browser_snapshot addresses it. */
 export interface RefAxis {
@@ -88,6 +90,21 @@ export interface RefAxis {
    * brittleness this axis exists to avoid, one level up.
    */
   context?: string;
+  /**
+   * The element's OWN identifying attribute at record time, as `attr=value`
+   * (see ownAttributeLabel). Absent when the element carried none of them, and
+   * absent from every trace recorded before this field existed.
+   *
+   * `context` says where the element sat; two genuinely identical siblings sit
+   * in the same place, so it abstains on them. This is the second verify-only
+   * signal for exactly that case: most real pages give look-alike siblings a
+   * `data-testid`, an `id`, a `name`, or an `aria-label` of their own, and
+   * that is what tells them apart when the neighbourhood cannot.
+   *
+   * Verify-only on the same terms as `context`: nothing is ever LOCATED by it.
+   * It can only confirm or contradict the element the index found.
+   */
+  own?: string;
 }
 
 /** An element addressed by the CSS selector browser_smart_snapshot minted. */
@@ -183,6 +200,60 @@ export const MAX_ARG_BYTES = 512;
  * and a long label still compares equal to itself.
  */
 export const MAX_CONTEXT_CHARS = 96;
+
+/**
+ * Characters of `RefAxis.own` kept.
+ *
+ * Same budget and the same arithmetic as MAX_CONTEXT_CHARS — the value is
+ * stored on every element step of every trace — and the truncation is likewise
+ * applied by whoever MINTS it, so a long `data-testid` is cut identically at
+ * record and at replay and still compares equal to itself.
+ */
+export const MAX_OWN_CHARS = 96;
+
+/**
+ * Attributes that identify an element in its OWN right, most trustworthy first.
+ *
+ * `data-testid` is deliberately at the top: it exists to name one element and
+ * nothing else, and a page that has it has already done the disambiguation for
+ * us. `id` and `name` come next (unique by contract, though pages break that),
+ * then `aria-label`, which is the weakest of the four because it is often the
+ * accessible name the axis already stores.
+ *
+ * Class names, `href`, and positional attributes are absent on purpose: they
+ * change with styling and routing rather than with identity, which is the
+ * DOM-path brittleness the ref axis refuses.
+ */
+export const OWN_IDENTITY_ATTRIBUTES: readonly string[] = [
+  'data-testid',
+  'id',
+  'name',
+  'aria-label',
+];
+
+/**
+ * The `attr=value` label an element's own attributes yield, or `''`.
+ *
+ * ONE attribute, the first present in preference order — not a set. A set
+ * would compare unequal the moment a page adds an unrelated attribute to the
+ * element, turning the verifier into a source of stops on unchanged flows.
+ *
+ * Lives here, in the layer both minting lanes already depend on, for the same
+ * reason ancestorContext does: a value read one way on the accessibility lane
+ * and another on the smart lane would stop every cross-lane replay it was
+ * meant to pass.
+ */
+export function ownAttributeLabel(
+  read: (attribute: string) => string | null | undefined,
+): string {
+  for (const attribute of OWN_IDENTITY_ATTRIBUTES) {
+    const value = read(attribute);
+    if (typeof value !== 'string' || value.length === 0) continue;
+    const label = `${attribute}=${value}`;
+    return label.length <= MAX_OWN_CHARS ? label : `${label.slice(0, MAX_OWN_CHARS - 1)}\u2026`;
+  }
+  return '';
+}
 
 // ── Ancestor context ─────────────────────────────────────────────────────────
 //
@@ -332,6 +403,8 @@ export interface RefEntryLike {
   frameKey: string;
   /** See RefAxis.context. Absent on a snapshot that minted no ancestor label. */
   context?: string;
+  /** See RefAxis.own. Absent when the element carries none of the four. */
+  own?: string;
 }
 
 
@@ -378,6 +451,7 @@ export function refEntryToAxis(entry: RefEntryLike | null | undefined): RefAxis 
     ? entry.sameNameTotal
     : 1;
   const context = typeof entry.context === 'string' ? entry.context.slice(0, MAX_CONTEXT_CHARS) : '';
+  const own = typeof entry.own === 'string' ? entry.own.slice(0, MAX_OWN_CHARS) : '';
   return {
     kind: 'ref',
     role: entry.role,
@@ -388,6 +462,7 @@ export function refEntryToAxis(entry: RefEntryLike | null | undefined): RefAxis 
     // Omitted rather than stored empty: an absent field and an empty one mean
     // the same thing (no verdict available) and the absent one costs nothing.
     ...(context.length > 0 && { context }),
+    ...(own.length > 0 && { own }),
   };
 }
 
@@ -638,6 +713,10 @@ function sanitizeAxis(raw: unknown): StepAxis | null {
   // step falls back to the pre-#1182 population rules, which is the same
   // contract every trace recorded before this field had.
   const context = typeof a.context === 'string' ? a.context.slice(0, MAX_CONTEXT_CHARS) : '';
+  // Same rule as context, for the same reason: an own label that cannot be
+  // trusted is DROPPED, leaving the step exactly the contract it had before
+  // the field existed.
+  const own = typeof a.own === 'string' ? a.own.slice(0, MAX_OWN_CHARS) : '';
   return {
     kind: 'ref',
     role: a.role,
@@ -646,6 +725,7 @@ function sanitizeAxis(raw: unknown): StepAxis | null {
     sameNameTotal,
     frameKey: typeof a.frameKey === 'string' ? a.frameKey.slice(0, 256) : '',
     ...(context.length > 0 && { context }),
+    ...(own.length > 0 && { own }),
   };
 }
 

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -105,6 +105,23 @@ export interface RefAxis {
    * It can only confirm or contradict the element the index found.
    */
   own?: string;
+  /**
+   * WHICH lane minted this axis, and therefore which enumeration
+   * `sameNameTotal` was counted over.
+   *
+   * The two lanes do not count the same set. browser_snapshot's ref map is
+   * depth-capped and filtered when the output overflows; the smart lane walks
+   * the whole tree with no cap. Comparing a total recorded by one against a
+   * population counted by the other is comparing two different measurements,
+   * and it stopped replays on pages that had not changed at all (#1179
+   * review). The replay runner reads this to count the live population the
+   * same way the recording did.
+   *
+   * Omitted for 'a11y', which is both the common case and what an axis
+   * recorded before this field existed must be read as — the smart lane is
+   * the one that has to declare itself.
+   */
+  via?: 'a11y' | 'smart';
 }
 
 /** An element addressed by the CSS selector browser_smart_snapshot minted. */
@@ -405,6 +422,8 @@ export interface RefEntryLike {
   context?: string;
   /** See RefAxis.own. Absent when the element carries none of the four. */
   own?: string;
+  /** See RefAxis.via. Absent means 'a11y' — only the smart lane declares. */
+  via?: 'a11y' | 'smart';
 }
 
 
@@ -463,6 +482,9 @@ export function refEntryToAxis(entry: RefEntryLike | null | undefined): RefAxis 
     // the same thing (no verdict available) and the absent one costs nothing.
     ...(context.length > 0 && { context }),
     ...(own.length > 0 && { own }),
+    // Only the smart lane is stored. 'a11y' is what an absent field already
+    // means, so writing it would cost every step bytes to say nothing.
+    ...(entry.via === 'smart' && { via: 'smart' as const }),
   };
 }
 
@@ -726,6 +748,9 @@ function sanitizeAxis(raw: unknown): StepAxis | null {
     frameKey: typeof a.frameKey === 'string' ? a.frameKey.slice(0, 256) : '',
     ...(context.length > 0 && { context }),
     ...(own.length > 0 && { own }),
+    // Anything but the one recognised marker reads as 'a11y', which is the
+    // conservative direction: the count check it selects is the stricter one.
+    ...(a.via === 'smart' && { via: 'smart' as const }),
   };
 }
 


### PR DESCRIPTION
Two follow-ups to #1185, as two commits.

## 1. The element's own attribute as a second verify-only signal
#1185 left identical siblings — same role, same name, same container — indistinguishable. Most real pages do distinguish them on the element itself: `data-testid`, `id`, `name`, `aria-label`, in that order of preference. Each recorded ref now carries one of those as `own` (`data-testid=submit-secondary`), capped at 96 characters, sanitized, additive (old traces replay unchanged).

Both lanes walk the CDP accessibility tree, not the DOM, so neither had attributes. `ownAttributes.ts` does one `DOM.getDocument` on the session that just fetched the AX tree and builds a `backendDOMNodeId → label` map — the same bridge `redact.ts` already uses for password fields — so both lanes mint the identical string by construction. Main frame only: `backendDOMNodeId` is per target, so an out-of-process iframe would collide; frame refs get no `own`, which the verifier reads as "no verdict", never as a mismatch.

`ownVerdict` runs only where the context verdict abstained (several share the context, or the page mints none), and decides the same three ways: unique match at the recorded index runs; elsewhere or missing while others carry one → STOP; nothing carries any → abstain. Never a locator.

## 2. Provenance, so a count compares like with like
A named smartRef axis recorded `sameNameTotal` from dom-intelligence's walk, while replay counted from the depth-capped snapshot ref map, so an unchanged page could STOP. The axis now carries `via: 'smart'` when the smart lane minted it (absent means a11y, so old traces are unchanged). On a count disagreement only, a smart axis is re-counted with the recorder's own walk on a scratch identity, so a mid-replay measurement cannot renumber refs an agent holds. Reconciling clears the count, never the position.

## Live (installed app, chrome backend, two `button "Submit order"` in one section differing only by data-testid)
Emitted axis at the transport boundary, both lanes: `context: region "Checkout"`, `own: data-testid=submit-secondary`; `via: smart` only on the smart lane. A smart-recorded flow replayed through the new path: `2/2 steps ran … clicked button "Submit order" (#2 of 2)`. (The installed 3.50.0 app's `sanitizeAxis` strips the new fields from disk, as with #1185; this PR updates the sanitizer.)

## Residual
Identical siblings carrying none of the four attributes remain irreducible; both verifiers abstain and a test pins it. Out-of-process iframes get no `own`.

## Gates
`tsc` clean; vitest browser-replay + shared + playwright 886 passed (+7 net, ~19 new cases); `build:mcp && probe:mcp` byte-identical (full 75,457 / core 46,665 / commander 43,314).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser replay reliability when multiple elements share the same role, name, and container.
  - Replay can now use identifying attributes such as `data-testid`, `id`, `name`, or `aria-label` to distinguish elements.
  - Smart snapshot replays now verify element counts against the same snapshot listing used during recording, reducing false change detections.
  - Elements without identifying attributes continue to use position and count-based verification.

- **Documentation**
  - Updated replay guidance with the new disambiguation and verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->