### PR TITLE
fix(browser-replay): let a step's navigation land before the next step, and record browser_wait

### DIFF
--- a/changelog.d/1194.md
+++ b/changelog.d/1194.md
@@ -1,3 +1,3 @@
 ### Fixed
 - `browser_replay` now lets a step's navigation land before looking for the next element. A click that started a Turbo/SPA navigation used to have the next step measured against the old page and stopped with "no … on the page any more" while the element was there a moment later (#1193).
-- `browser_wait` is recorded as a replay step (url, selector, text, network idle). A wait on a JS predicate is listed as a `stored-script` hole rather than dropped, since a replay never evaluates a script from the cache file.
+- `browser_wait` is recorded as a replay step (url, selector, text, network idle) and counts toward the ring and per-flow step limits like any other action. A wait on a JS predicate is not recorded: a replay never evaluates a script from the cache file.

--- a/changelog.d/1194.md
+++ b/changelog.d/1194.md
@@ -1,0 +1,3 @@
+### Fixed
+- `browser_replay` now lets a step's navigation land before looking for the next element. A click that started a Turbo/SPA navigation used to have the next step measured against the old page and stopped with "no … on the page any more" while the element was there a moment later (#1193).
+- `browser_wait` is recorded as a replay step (url, selector, text, network idle). A wait on a JS predicate is listed as a `stored-script` hole rather than dropped, since a replay never evaluates a script from the cache file.

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "0dd5f49dd55a3ada047100d74b93242d14ee1a823556e86263b4fa34c24135c0",
+      "wireResultSha256": "64e84f5161fc63162ef9115ffd0fe4931711d4b5d97658c876991ba1e981d3bf",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -944,12 +944,12 @@ describe('settling after a step (#1193)', () => {
       { role: 'link', name: 'Closed', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 2 },
     ];
     // Snapshot 1 (pre-flight), then the click navigates; the page is still
-    // the OLD document on the next two reads and becomes the destination
-    // only afterwards — which is exactly the window #1193 fell into.
+    // the OLD document on the next read and becomes the destination only
+    // afterwards — which is exactly the window #1193 fell into.
     let reads = 0;
     vi.spyOn(mod, 'generateSnapshot').mockImplementation(async () => {
       reads++;
-      if (reads >= 4) refEntries = destination;
+      if (reads >= 3) refEntries = destination;
       return '';
     });
     resolved.add('2');
@@ -967,12 +967,15 @@ describe('settling after a step (#1193)', () => {
     expect(result.steps.map((s) => s.ok)).toEqual([true, true]);
     expect(waits).toEqual(['load:domcontentloaded']);
     expect(navListeners.size).toBe(0);
+    // pre-flight 1 + settle reads until two agree (old, new, new) = 4, with
+    // no extra re-charge dump after the settle.
+    expect(reads).toBe(4);
     mockedResolve.mockRestore();
   });
 
   it('replays a recorded browser_wait by its condition, text through the isolated poll', async () => {
     const waitText: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { text: 'Closed', timeout: 5000 } };
-    const waitUrl: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { url: '**/pulls**' } };
+    const waitUrl: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { urlGlob: '**/pulls**' } };
     const waitIdle: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: {} };
 
     const result = await replayTrace(page, trace([waitText, waitUrl, waitIdle]), undefined);
@@ -988,17 +991,34 @@ describe('settling after a step (#1193)', () => {
   });
 
   it('clamps a hostile wait timeout from the cache file instead of waiting for ever', async () => {
-    const forever: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { url: '**/x', timeout: 0 } };
-    const huge: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { url: '**/y', timeout: 1e9 } };
+    const forever: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { urlGlob: '**/x', timeout: 0 } };
+    const huge: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { urlGlob: '**/y', timeout: 1e9 } };
     const timeouts: number[] = [];
     const waitForURL = async (_url: string, opts: { timeout: number }) => { timeouts.push(opts.timeout); };
     const result = await replayTrace({ ...(page as object), waitForURL } as never, trace([forever, huge]), undefined);
     expect(result.ok).toBe(true);
     expect(timeouts).toEqual([30000, 60000]);
   });
+});
 
-  it('refuses a trace whose wait was on a stored script', () => {
-    const hole: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: {}, unrecordable: 'stored-script' };
-    expect(replayBlockedReason(trace([hole]))).toContain('step 1 (stored-script)');
+describe('navigation watch (#1193)', () => {
+  it('treats a main-frame navigation REQUEST as a navigation, so a slow origin is not missed', async () => {
+    const mod = await import('../../playwright/snapshot');
+    let reads = 0;
+    vi.spyOn(mod, 'generateSnapshot').mockImplementation(async () => { reads++; return ''; });
+    const mockedResolve = vi.spyOn(mod, 'resolveRef').mockImplementation(async (_p, ref) => {
+      if (ref === '1') {
+        for (const fn of navListeners) {
+          (fn as (arg: unknown) => void)({ isNavigationRequest: () => true, frame: () => ({ parentFrame: () => null }) });
+        }
+      }
+      return resolved.has(ref) ? ({ click: async () => undefined } as never) : null;
+    });
+    const result = await replayTrace(page, trace([refStep(), refStep()]), undefined);
+    expect(result.ok).toBe(true);
+    expect(waits).toEqual(['load:domcontentloaded']);
+    // A settle ran: at least two reads after the pre-flight one.
+    expect(reads).toBeGreaterThanOrEqual(3);
+    mockedResolve.mockRestore();
   });
 });

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -51,14 +51,21 @@ import { refMapShapeHash, type TraceRecord, type TraceStep } from '../../../shar
 const clicks: string[] = [];
 const pressed: string[] = [];
 const goneTo: string[] = [];
-/** Every page-level wait the runner asked for, in order, interleaved with clicks. */
+/** Every page-level wait the runner asked for, in order. */
 const waits: string[] = [];
+const navListeners = new Set<(frame: unknown) => void>();
+/** Simulate the main frame navigating (a Turbo click, a pushState). */
+function fireNavigation(): void {
+  for (const fn of navListeners) fn({ parentFrame: () => null });
+}
 
 const page = {
   url: () => 'https://example.com/app',
   goto: async (url: string) => { goneTo.push(url); },
   keyboard: { press: async (key: string) => { pressed.push(key); } },
   waitForLoadState: async (state: string) => { waits.push(`load:${state}`); },
+  on: (_event: string, fn: (frame: unknown) => void) => { navListeners.add(fn); },
+  off: (_event: string, fn: (frame: unknown) => void) => { navListeners.delete(fn); },
   waitForURL: async (url: string) => { waits.push(`url:${url}`); },
   waitForSelector: async (selector: string) => { waits.push(`selector:${selector}`); },
   locator: () => ({ count: async () => 0, elementHandle: async () => null }),
@@ -116,6 +123,7 @@ beforeEach(() => {
   goneTo.length = 0;
   waits.length = 0;
   isolatedWaits.length = 0;
+  navListeners.clear();
   resolved.clear();
   snapshotText = 'button "Sign in" [ref=1]';
   smartCount = null;
@@ -923,17 +931,43 @@ describe('replayTrace — flow control', () => {
 });
 
 describe('settling after a step (#1193)', () => {
-  it('waits for the page to go quiet between a click and the next step, not after the last', async () => {
-    const single = await replayTrace(page, trace([refStep()]), undefined);
-    expect(single.ok).toBe(true);
-    // Nothing follows the last step, so nothing is waited for.
-    expect(waits).toEqual([]);
-
+  it('does not wait after a step that did not navigate', async () => {
     const result = await replayTrace(page, trace([refStep(), refStep()]), undefined);
     expect(result.ok).toBe(true);
-    // A click that starts a soft navigation must land before the next step's
-    // population is measured — once, between the two steps.
-    expect(waits).toEqual(['load:domcontentloaded', 'load:networkidle']);
+    expect(waits).toEqual([]);
+    expect(navListeners.size).toBe(0);
+  });
+
+  it('after a step that navigated, waits until two consecutive page shapes agree before the next step', async () => {
+    const mod = await import('../../playwright/snapshot');
+    const destination: FakeRefEntry[] = [
+      { role: 'link', name: 'Closed', sameNameIndex: 0, sameNameTotal: 1, frameKey: '', ref: 2 },
+    ];
+    // Snapshot 1 (pre-flight), then the click navigates; the page is still
+    // the OLD document on the next two reads and becomes the destination
+    // only afterwards — which is exactly the window #1193 fell into.
+    let reads = 0;
+    vi.spyOn(mod, 'generateSnapshot').mockImplementation(async () => {
+      reads++;
+      if (reads >= 4) refEntries = destination;
+      return '';
+    });
+    resolved.add('2');
+    const clickSignIn = refStep();
+    const clickClosed = refStep({
+      axis: { kind: 'ref', role: 'link', name: 'Closed', sameNameIndex: 0, sameNameTotal: 1, frameKey: '' },
+    });
+    const mockedResolve = vi.spyOn(mod, 'resolveRef').mockImplementation(async (_p, ref) => {
+      if (ref === '1') fireNavigation();
+      return resolved.has(ref) ? ({ click: async () => undefined } as never) : null;
+    });
+
+    const result = await replayTrace(page, trace([clickSignIn, clickClosed]), undefined);
+
+    expect(result.steps.map((s) => s.ok)).toEqual([true, true]);
+    expect(waits).toEqual(['load:domcontentloaded']);
+    expect(navListeners.size).toBe(0);
+    mockedResolve.mockRestore();
   });
 
   it('replays a recorded browser_wait by its condition, text through the isolated poll', async () => {
@@ -951,6 +985,16 @@ describe('settling after a step (#1193)', () => {
     ]);
     expect(isolatedWaits).toEqual(['Closed']);
     expect(waits).toContain('url:**/pulls**');
+  });
+
+  it('clamps a hostile wait timeout from the cache file instead of waiting for ever', async () => {
+    const forever: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { url: '**/x', timeout: 0 } };
+    const huge: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { url: '**/y', timeout: 1e9 } };
+    const timeouts: number[] = [];
+    const waitForURL = async (_url: string, opts: { timeout: number }) => { timeouts.push(opts.timeout); };
+    const result = await replayTrace({ ...(page as object), waitForURL } as never, trace([forever, huge]), undefined);
+    expect(result.ok).toBe(true);
+    expect(timeouts).toEqual([30000, 60000]);
   });
 
   it('refuses a trace whose wait was on a stored script', () => {

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -33,6 +33,11 @@ vi.mock('../../playwright/snapshot', () => ({
 let smartCount: number | null = null;
 const smartCountCalls: Array<[string, string]> = [];
 
+const isolatedWaits: string[] = [];
+vi.mock('../../playwright/isolated-eval', () => ({
+  waitForIsolated: async (_page: unknown, _fn: unknown, arg: string) => { isolatedWaits.push(arg); },
+}));
+
 vi.mock('../../playwright/dom-intelligence', () => ({
   countSmartNamedPopulation: async (_page: unknown, role: string, name: string) => {
     smartCountCalls.push([role, name]);
@@ -46,11 +51,16 @@ import { refMapShapeHash, type TraceRecord, type TraceStep } from '../../../shar
 const clicks: string[] = [];
 const pressed: string[] = [];
 const goneTo: string[] = [];
+/** Every page-level wait the runner asked for, in order, interleaved with clicks. */
+const waits: string[] = [];
 
 const page = {
   url: () => 'https://example.com/app',
   goto: async (url: string) => { goneTo.push(url); },
   keyboard: { press: async (key: string) => { pressed.push(key); } },
+  waitForLoadState: async (state: string) => { waits.push(`load:${state}`); },
+  waitForURL: async (url: string) => { waits.push(`url:${url}`); },
+  waitForSelector: async (selector: string) => { waits.push(`selector:${selector}`); },
   locator: () => ({ count: async () => 0, elementHandle: async () => null }),
   evaluate: async () => undefined,
   mouse: {
@@ -104,6 +114,8 @@ beforeEach(() => {
   clicks.length = 0;
   pressed.length = 0;
   goneTo.length = 0;
+  waits.length = 0;
+  isolatedWaits.length = 0;
   resolved.clear();
   snapshotText = 'button "Sign in" [ref=1]';
   smartCount = null;
@@ -907,5 +919,42 @@ describe('replayTrace — flow control', () => {
     const result = await replayTrace(page, trace([refStep()]), undefined);
     expect(result.ok).toBe(false);
     expect(result.steps[0].detail).toContain('not visible');
+  });
+});
+
+describe('settling after a step (#1193)', () => {
+  it('waits for the page to go quiet between a click and the next step, not after the last', async () => {
+    const single = await replayTrace(page, trace([refStep()]), undefined);
+    expect(single.ok).toBe(true);
+    // Nothing follows the last step, so nothing is waited for.
+    expect(waits).toEqual([]);
+
+    const result = await replayTrace(page, trace([refStep(), refStep()]), undefined);
+    expect(result.ok).toBe(true);
+    // A click that starts a soft navigation must land before the next step's
+    // population is measured — once, between the two steps.
+    expect(waits).toEqual(['load:domcontentloaded', 'load:networkidle']);
+  });
+
+  it('replays a recorded browser_wait by its condition, text through the isolated poll', async () => {
+    const waitText: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { text: 'Closed', timeout: 5000 } };
+    const waitUrl: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: { url: '**/pulls**' } };
+    const waitIdle: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: {} };
+
+    const result = await replayTrace(page, trace([waitText, waitUrl, waitIdle]), undefined);
+
+    expect(result.ok).toBe(true);
+    expect(result.steps.map((s) => s.detail)).toEqual([
+      'waited for text "Closed"',
+      'waited for URL "**/pulls**"',
+      'waited for network idle',
+    ]);
+    expect(isolatedWaits).toEqual(['Closed']);
+    expect(waits).toContain('url:**/pulls**');
+  });
+
+  it('refuses a trace whose wait was on a stored script', () => {
+    const hole: TraceStep = { tool: 'browser_wait', axis: { kind: 'none' }, args: {}, unrecordable: 'stored-script' };
+    expect(replayBlockedReason(trace([hole]))).toContain('step 1 (stored-script)');
   });
 });

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -1,5 +1,6 @@
 import type { ElementHandle, Page } from 'playwright-core';
 import { generateSnapshot, listRefEntries, resolveRef, StaleRefError } from '../playwright/snapshot';
+import { waitForIsolated } from '../playwright/isolated-eval';
 import { countSmartNamedPopulation } from '../playwright/dom-intelligence';
 import { describeToolError } from '../playwright/toolError';
 import { validateNavigationUrl } from '../../shared/types';
@@ -427,6 +428,30 @@ async function runStep(
     await page.goto(stripped.url, { waitUntil: 'domcontentloaded' });
     return { detail: `navigated to ${page.url()}` };
   }
+  if (step.tool === 'browser_wait') {
+    // The same priority order as the live tool. `fn` is never here: a wait on
+    // a stored script is recorded as a hole and blocks the run before this.
+    const timeout = typeof args.timeout === 'number' ? args.timeout : 30000;
+    if (typeof args.url === 'string' && args.url !== '') {
+      await page.waitForURL(args.url, { timeout });
+      return { detail: `waited for URL "${args.url}"` };
+    }
+    if (typeof args.selector === 'string' && args.selector !== '') {
+      await page.waitForSelector(args.selector, { timeout });
+      return { detail: `waited for selector "${args.selector}"` };
+    }
+    if (typeof args.text === 'string' && args.text !== '') {
+      await waitForIsolated(
+        page,
+        (t: string) => !!(document.body && document.body.innerText.includes(t)),
+        args.text,
+        timeout,
+      );
+      return { detail: `waited for text "${args.text}"` };
+    }
+    await page.waitForLoadState('networkidle', { timeout });
+    return { detail: 'waited for network idle' };
+  }
   if (step.tool === 'browser_press_key') {
     await page.keyboard.press(String(args.key));
     return { detail: `pressed ${String(args.key)}` };
@@ -492,6 +517,36 @@ async function runStep(
     default:
       return { error: `${step.tool} cannot be replayed by this version` };
   }
+}
+
+/**
+ * How long a replay lets the page catch up after a step before re-charging
+ * the ref map. Bounded: a page that never goes quiet (long polling) costs each
+ * step this much and nothing more.
+ */
+const SETTLE_TIMEOUT_MS = 2000;
+
+/**
+ * Let a navigation the step started land before the next step looks for its
+ * element.
+ *
+ * Re-snapshotting the instant a click resolves reads the document the click
+ * happened ON, not the one it led to: on a Turbo/SPA site the fetch and render
+ * come after the click, so the next step's role+name population is measured
+ * against the old page and reported as "no <element> on the page any more"
+ * while the element is plainly there a moment later (#1193, three of three
+ * runs on github.com). The recording never had this problem because a human
+ * or an agent looks at the page before acting; the runner acts blind, so it
+ * has to wait on its own.
+ *
+ * 'networkidle' rather than 'load': a same-document navigation fires no load
+ * event, and 500ms of network silence is the one signal both kinds share. A
+ * timeout is swallowed — a page that keeps polling still gets a re-snapshot,
+ * just a later one.
+ */
+async function settleAfterStep(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded', { timeout: SETTLE_TIMEOUT_MS }).catch(() => undefined);
+  await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT_MS }).catch(() => undefined);
 }
 
 /** A trace that cannot run at all, and why. Checked before any page work. */
@@ -605,6 +660,7 @@ export async function replayTrace(
     // A step that changed the page invalidates the ref map the remaining steps
     // resolve against, so re-charge it. Still internal, still never shown.
     if (i + 1 < trace.steps.length) {
+      await settleAfterStep(page);
       await generateSnapshot(page, { format: 'ai' }).catch(() => '');
       // The leading navigate has now landed, so this is the flow's own page —
       // the point the recorder's baseline was taken at.

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -430,13 +430,14 @@ async function runStep(
   }
   if (step.tool === 'browser_wait') {
     // The same priority order as the live tool. `fn` is never here: a wait on
-    // a stored script is recorded as a hole and blocks the run before this.
-    // The timeout comes from the cache file, so it is clamped: 0 means "for
-    // ever" to Playwright, and a hand-edited value must not hang a replay.
+    // a JS predicate is not recorded. The timeout comes from the cache file,
+    // so it is clamped: 0 means "for ever" to Playwright, and a hand-edited
+    // value must not hang a replay. The URL is a glob under its own key so
+    // the recorder's credential scrub of `url` never rewrites it.
     const timeout = clampWaitTimeout(args.timeout);
-    if (typeof args.url === 'string' && args.url !== '') {
-      await page.waitForURL(args.url, { timeout });
-      return { detail: `waited for URL "${args.url}"` };
+    if (typeof args.urlGlob === 'string' && args.urlGlob !== '') {
+      await page.waitForURL(args.urlGlob, { timeout });
+      return { detail: `waited for URL "${args.urlGlob}"` };
     }
     if (typeof args.selector === 'string' && args.selector !== '') {
       await page.waitForSelector(args.selector, { timeout });
@@ -530,8 +531,13 @@ async function runStep(
 const SETTLE_TIMEOUT_MS = 3000;
 /** Gap between two shape reads that have to agree before the page counts as settled. */
 const SETTLE_POLL_MS = 250;
-/** How long after a step a navigation is still attributed to that step. */
+/**
+ * How long after a step a navigation is still attributed to that step. Paid
+ * in full only by a step that did NOT navigate; a navigation ends it early.
+ */
 const NAVIGATION_GRACE_MS = 300;
+/** Most shape reads a settle may spend; each one is a full a11y dump. */
+const SETTLE_MAX_READS = 4;
 
 /**
  * Watch the main frame for a navigation the step is about to start. Returns
@@ -547,16 +553,27 @@ const NAVIGATION_GRACE_MS = 300;
  */
 function watchNavigation(page: Page): { didNavigate: () => Promise<boolean>; stop: () => void } {
   let navigated = false;
+  const isMainFrame = (frame: { parentFrame?: () => unknown } | null | undefined): boolean =>
+    !!frame && (typeof frame.parentFrame !== 'function' || frame.parentFrame() === null);
+  // Only the main frame: an ad iframe navigating is not the page moving.
   const onNavigated = (frame: { parentFrame?: () => unknown }): void => {
-    // Only the main frame: an ad iframe navigating is not the page moving.
-    if (typeof frame.parentFrame !== 'function' || frame.parentFrame() === null) navigated = true;
+    if (isMainFrame(frame)) navigated = true;
+  };
+  // A hard navigation commits only after the server answers, which can be
+  // well past the grace period on a slow origin; its REQUEST starts at once.
+  const onRequest = (request: { isNavigationRequest?: () => boolean; frame?: () => unknown }): void => {
+    if (request.isNavigationRequest?.() && isMainFrame(request.frame?.() as never)) navigated = true;
   };
   const events = page as unknown as {
-    on?: (event: 'framenavigated', fn: typeof onNavigated) => void;
-    off?: (event: 'framenavigated', fn: typeof onNavigated) => void;
+    on?: (event: string, fn: (arg: never) => void) => void;
+    off?: (event: string, fn: (arg: never) => void) => void;
   };
   events.on?.('framenavigated', onNavigated);
-  const stop = (): void => { events.off?.('framenavigated', onNavigated); };
+  events.on?.('request', onRequest);
+  const stop = (): void => {
+    events.off?.('framenavigated', onNavigated);
+    events.off?.('request', onRequest);
+  };
   return {
     didNavigate: async () => {
       const deadline = Date.now() + NAVIGATION_GRACE_MS;
@@ -587,7 +604,7 @@ async function settleAfterNavigation(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded', { timeout: SETTLE_TIMEOUT_MS }).catch(() => undefined);
   const deadline = Date.now() + SETTLE_TIMEOUT_MS;
   let previous = '';
-  while (Date.now() < deadline) {
+  for (let reads = 0; reads < SETTLE_MAX_READS && Date.now() < deadline; reads++) {
     await generateSnapshot(page, { format: 'ai' }).catch(() => '');
     const shape = refMapShapeHash(listRefEntries(page));
     if (shape !== '' && shape === previous) return;
@@ -615,8 +632,7 @@ export function replayBlockedReason(trace: TraceRecord): string | null {
       .join(', ');
     return (
       `the trace has unreplayable steps — ${holes}. Perform this flow live; ` +
-      'a password step is never stored and never can be, and a wait on a JS ' +
-      'predicate is never replayed from the cache file.'
+      'a password step is never stored and never can be.'
     );
   }
   return null;
@@ -719,8 +735,10 @@ export async function replayTrace(
     // A step that changed the page invalidates the ref map the remaining steps
     // resolve against, so re-charge it. Still internal, still never shown.
     if (i + 1 < trace.steps.length) {
+      // The settle's last read IS the re-charge; a second dump would only
+      // renumber the refs it just minted.
       if (await navigation.didNavigate()) await settleAfterNavigation(page);
-      await generateSnapshot(page, { format: 'ai' }).catch(() => '');
+      else await generateSnapshot(page, { format: 'ai' }).catch(() => '');
       // The leading navigate has now landed, so this is the flow's own page —
       // the point the recorder's baseline was taken at.
       if (i === 0 && startsWithNavigate) measureShape();

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -431,7 +431,9 @@ async function runStep(
   if (step.tool === 'browser_wait') {
     // The same priority order as the live tool. `fn` is never here: a wait on
     // a stored script is recorded as a hole and blocks the run before this.
-    const timeout = typeof args.timeout === 'number' ? args.timeout : 30000;
+    // The timeout comes from the cache file, so it is clamped: 0 means "for
+    // ever" to Playwright, and a hand-edited value must not hang a replay.
+    const timeout = clampWaitTimeout(args.timeout);
     if (typeof args.url === 'string' && args.url !== '') {
       await page.waitForURL(args.url, { timeout });
       return { detail: `waited for URL "${args.url}"` };
@@ -520,33 +522,87 @@ async function runStep(
 }
 
 /**
- * How long a replay lets the page catch up after a step before re-charging
- * the ref map. Bounded: a page that never goes quiet (long polling) costs each
- * step this much and nothing more.
+ * How long a replay lets the page catch up after a step that navigated
+ * before re-charging the ref map. Bounded: a page that never goes quiet
+ * (long polling, a perpetual spinner) costs each such step this much and
+ * nothing more.
  */
-const SETTLE_TIMEOUT_MS = 2000;
+const SETTLE_TIMEOUT_MS = 3000;
+/** Gap between two shape reads that have to agree before the page counts as settled. */
+const SETTLE_POLL_MS = 250;
+/** How long after a step a navigation is still attributed to that step. */
+const NAVIGATION_GRACE_MS = 300;
 
 /**
- * Let a navigation the step started land before the next step looks for its
- * element.
+ * Watch the main frame for a navigation the step is about to start. Returns
+ * a function that reports whether one happened, waiting up to a short grace
+ * period for a late one, and detaches the listener.
+ *
+ * `framenavigated` fires for same-document navigations too (pushState), which
+ * is the case that matters: a Turbo/SPA click changes the page without any
+ * load state ever resetting, so `waitForLoadState` resolves at once against
+ * the state the OLD document reached (#1193, three of three runs on
+ * github.com stopped at the step after the click). The navigation event is
+ * the one signal both hard and soft navigations share.
+ */
+function watchNavigation(page: Page): { didNavigate: () => Promise<boolean>; stop: () => void } {
+  let navigated = false;
+  const onNavigated = (frame: { parentFrame?: () => unknown }): void => {
+    // Only the main frame: an ad iframe navigating is not the page moving.
+    if (typeof frame.parentFrame !== 'function' || frame.parentFrame() === null) navigated = true;
+  };
+  const events = page as unknown as {
+    on?: (event: 'framenavigated', fn: typeof onNavigated) => void;
+    off?: (event: 'framenavigated', fn: typeof onNavigated) => void;
+  };
+  events.on?.('framenavigated', onNavigated);
+  const stop = (): void => { events.off?.('framenavigated', onNavigated); };
+  return {
+    didNavigate: async () => {
+      const deadline = Date.now() + NAVIGATION_GRACE_MS;
+      while (!navigated && Date.now() < deadline) {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      stop();
+      return navigated;
+    },
+    stop,
+  };
+}
+
+/**
+ * After a step that navigated, wait until the page has stopped changing
+ * shape before the next step looks for its element.
  *
  * Re-snapshotting the instant a click resolves reads the document the click
- * happened ON, not the one it led to: on a Turbo/SPA site the fetch and render
- * come after the click, so the next step's role+name population is measured
- * against the old page and reported as "no <element> on the page any more"
- * while the element is plainly there a moment later (#1193, three of three
- * runs on github.com). The recording never had this problem because a human
- * or an agent looks at the page before acting; the runner acts blind, so it
- * has to wait on its own.
- *
- * 'networkidle' rather than 'load': a same-document navigation fires no load
- * event, and 500ms of network silence is the one signal both kinds share. A
- * timeout is swallowed — a page that keeps polling still gets a re-snapshot,
- * just a later one.
+ * happened ON, not the one it led to. The recording never had this problem
+ * because the agent looks at the page before acting; the runner acts blind,
+ * so it has to wait on its own. "Settled" is two consecutive ref-map shapes
+ * that agree, read a poll apart, after any load state a hard navigation
+ * resets — the same shape hash the recording is compared against. A timeout
+ * is swallowed: a page that keeps changing still gets its re-snapshot, just a
+ * later one, and the per-step element check remains the correctness test.
  */
-async function settleAfterStep(page: Page): Promise<void> {
+async function settleAfterNavigation(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded', { timeout: SETTLE_TIMEOUT_MS }).catch(() => undefined);
-  await page.waitForLoadState('networkidle', { timeout: SETTLE_TIMEOUT_MS }).catch(() => undefined);
+  const deadline = Date.now() + SETTLE_TIMEOUT_MS;
+  let previous = '';
+  while (Date.now() < deadline) {
+    await generateSnapshot(page, { format: 'ai' }).catch(() => '');
+    const shape = refMapShapeHash(listRefEntries(page));
+    if (shape !== '' && shape === previous) return;
+    previous = shape;
+    await new Promise((r) => setTimeout(r, SETTLE_POLL_MS));
+  }
+}
+
+const WAIT_TIMEOUT_DEFAULT_MS = 30000;
+const WAIT_TIMEOUT_MAX_MS = 60000;
+const WAIT_TIMEOUT_MIN_MS = 250;
+
+function clampWaitTimeout(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return WAIT_TIMEOUT_DEFAULT_MS;
+  return Math.min(WAIT_TIMEOUT_MAX_MS, Math.max(WAIT_TIMEOUT_MIN_MS, raw));
 }
 
 /** A trace that cannot run at all, and why. Checked before any page work. */
@@ -559,7 +615,8 @@ export function replayBlockedReason(trace: TraceRecord): string | null {
       .join(', ');
     return (
       `the trace has unreplayable steps — ${holes}. Perform this flow live; ` +
-      'a password step is never stored and never can be.'
+      'a password step is never stored and never can be, and a wait on a JS ' +
+      'predicate is never replayed from the cache file.'
     );
   }
   return null;
@@ -638,12 +695,14 @@ export async function replayTrace(
     }
 
     let outcome: StepOutcome;
+    const navigation = watchNavigation(page);
     try {
       outcome = await runStep(page, step, substituted.args);
     } catch (error) {
       outcome = { error: describeToolError(error) };
     }
     if ('error' in outcome) {
+      navigation.stop();
       steps.push({ index, tool: step.tool, ok: false, detail: outcome.error });
       return {
         ok: false,
@@ -660,11 +719,13 @@ export async function replayTrace(
     // A step that changed the page invalidates the ref map the remaining steps
     // resolve against, so re-charge it. Still internal, still never shown.
     if (i + 1 < trace.steps.length) {
-      await settleAfterStep(page);
+      if (await navigation.didNavigate()) await settleAfterNavigation(page);
       await generateSnapshot(page, { format: 'ai' }).catch(() => '');
       // The leading navigate has now landed, so this is the flow's own page —
       // the point the recorder's baseline was taken at.
       if (i === 0 && startsWithNavigate) measureShape();
+    } else {
+      navigation.stop();
     }
   }
 

--- a/src/mcp/browser-replay/tool.ts
+++ b/src/mcp/browser-replay/tool.ts
@@ -64,7 +64,7 @@ const BROWSER_REPLAY_SHAPE = {
     .int()
     .positive()
     .optional()
-    .describe('save: how many of your most recent actions to keep. Default: everything since your last navigate.'),
+    .describe('save: how many of your most recent actions to keep (a browser_wait counts as one). Default: everything since your last navigate.'),
   variables: z
     .record(z.string(), z.string())
     .optional()

--- a/src/mcp/playwright/__tests__/wait.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/wait.fallback.test.ts
@@ -33,6 +33,7 @@ import {
   registerWaitTools,
 } from '../tools/wait';
 import type { WmuxToolProfile } from '../../toolCatalog';
+import { ActionRing } from '../../browser-replay/actionRing';
 import {
   expectCommanderCatalogLockstep,
   expectCoreCatalogLockstep,
@@ -289,5 +290,35 @@ describe('browser_wait RPC fallback', () => {
       ['browser.lease.acquire', { workspaceId: 'ws-test', surfaceId: 'surface-1' }],
       ['browser.lease.release', { token: 'lease-1' }],
     ]);
+  });
+});
+
+describe('browser_wait recording (#1193)', () => {
+  function pageWith(): { url: () => string; waitForURL: () => Promise<void>; waitForLoadState: () => Promise<void> } {
+    return { url: () => 'https://example.com/pulls', waitForURL: async () => undefined, waitForLoadState: async () => undefined };
+  }
+
+  it('records a url wait under urlGlob with no page shape, and skips a fn wait', async () => {
+    const actionRing = new ActionRing();
+    const tools = new Map<string, ToolHandler>();
+    registerWaitTools(
+      { registerTool: (name: string, _c: unknown, h: ToolHandler) => { tools.set(name, h); } } as never,
+      { ...browserToolDeps, actionRing } as never,
+      { profile: 'full', context: { principal: { kind: 'unattributed' } } },
+    );
+    getPage.mockResolvedValue(pageWith());
+    const handler = tools.get('browser_wait');
+    if (!handler) throw new Error('browser_wait failed to register');
+
+    await handler({ url: '**/pulls**', timeout: 5000 });
+    await handler({});
+    await handler({ fn: 'true' });
+
+    const steps = actionRing.all();
+    expect(steps.map((a) => a.step.tool)).toEqual(['browser_wait', 'browser_wait']);
+    expect(steps[0].step.args).toEqual({ timeout: 5000, urlGlob: '**/pulls**' });
+    expect(steps[0].step.unrecordable).toBeUndefined();
+    expect(steps[0].urlKey).toBe('https://example.com/pulls');
+    expect(steps[0].surfaceShape).toBe('');
   });
 });

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -147,20 +147,25 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
       const resolvedTimeout = timeout ?? 30000;
       // A wait is part of the flow: a replay that skips it acts on the page
       // before the thing the agent waited for has happened (#1193). Recorded
-      // on success only, like every other step. A `fn` wait is a hole — the
-      // stored script would be evaluated from an untrusted cache file.
-      const record = (page: Parameters<typeof recordAction>[1]['page']): void => {
+      // on success only, like every other step, and only on the Playwright
+      // lane — the RPC lane has no page to key a urlKey off. A `fn` wait is
+      // not recorded at all: the cache file is untrusted input by the time a
+      // replay reads it, so a stored script would never be evaluated, and a
+      // hole would refuse the whole flow for a step the runner's own settle
+      // covers in practice. No page and no shape are stamped: a wait touches
+      // no element, so it must not become the trace's shape baseline either.
+      const record = (page: { url?: () => string }): void => {
+        if (fn && !url && !selector && !text) return;
         const args: Record<string, string | number> = { timeout: resolvedTimeout };
-        if (url) args.url = url;
+        if (url) args.urlGlob = url;
         else if (selector) args.selector = selector;
         else if (text) args.text = text;
-        recordAction(deps, {
-          scope,
-          tool: 'browser_wait',
-          page,
-          args,
-          ...(!url && !selector && !text && fn && { unrecordable: 'stored-script' as const }),
-        });
+        // Never lets a recording problem fail the wait that just succeeded.
+        try {
+          recordAction(deps, { scope, tool: 'browser_wait', page: null, url: page.url?.() ?? '', args });
+        } catch {
+          /* recording is observation only */
+        }
       };
 
       try {
@@ -244,7 +249,6 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
               // Otherwise transient (e.g. body not ready mid-navigation): keep polling.
             }
             if (ok) {
-              record(null);
               return {
                 content: [{ type: 'text' as const, text: warningPrefix + `Wait completed: ${label}` }],
               };

--- a/src/mcp/playwright/tools/wait.ts
+++ b/src/mcp/playwright/tools/wait.ts
@@ -7,6 +7,7 @@ import { rpcEvaluator } from '../page-eval';
 import { waitForIsolated } from '../isolated-eval';
 import { allowScopedRpcFallback, type BrowserToolDeps } from '../browserScope';
 import { describeToolError } from '../toolError';
+import { recordAction } from '../../browser-replay/actionRing';
 import {
   defineWmuxTool,
   registerWmuxTools,
@@ -144,6 +145,23 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
     profiles: ['full'],
     invoke: async ({ url, selector, text, fn, timeout, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       const resolvedTimeout = timeout ?? 30000;
+      // A wait is part of the flow: a replay that skips it acts on the page
+      // before the thing the agent waited for has happened (#1193). Recorded
+      // on success only, like every other step. A `fn` wait is a hole — the
+      // stored script would be evaluated from an untrusted cache file.
+      const record = (page: Parameters<typeof recordAction>[1]['page']): void => {
+        const args: Record<string, string | number> = { timeout: resolvedTimeout };
+        if (url) args.url = url;
+        else if (selector) args.selector = selector;
+        else if (text) args.text = text;
+        recordAction(deps, {
+          scope,
+          tool: 'browser_wait',
+          page,
+          args,
+          ...(!url && !selector && !text && fn && { unrecordable: 'stored-script' as const }),
+        });
+      };
 
       try {
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
@@ -226,6 +244,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
               // Otherwise transient (e.g. body not ready mid-navigation): keep polling.
             }
             if (ok) {
+              record(null);
               return {
                 content: [{ type: 'text' as const, text: warningPrefix + `Wait completed: ${label}` }],
               };
@@ -240,6 +259,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
         // Priority: url > selector > text > fn > networkidle
         if (url) {
           await page.waitForURL(url, { timeout: resolvedTimeout });
+          record(page);
           return {
             content: [{ type: 'text' as const, text: `Wait completed: URL matched "${url}"` }],
           };
@@ -247,6 +267,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
 
         if (selector) {
           await page.waitForSelector(selector, { timeout: resolvedTimeout });
+          record(page);
           return {
             content: [{ type: 'text' as const, text: `Wait completed: selector "${selector}" found` }],
           };
@@ -263,6 +284,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
             text,
             resolvedTimeout,
           );
+          record(page);
           return {
             content: [{ type: 'text' as const, text: `Wait completed: text "${text}" found` }],
           };
@@ -279,6 +301,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
           // (a DOM node) still satisfies the wait.
           const expression = isFunctionExpression(fn) ? `!!((${fn})())` : `!!(${fn})`;
           await waitForIsolated(page, expression, undefined, resolvedTimeout);
+          record(page);
           const warningPrefix = warnings.length > 0
             ? `⚠ Security warning: fn contains potentially dangerous patterns: ${warnings.join(', ')}.\n`
             : '';
@@ -289,6 +312,7 @@ export function createWaitToolCatalog(deps: BrowserToolDeps) {
 
         // Default: wait for network idle
         await page.waitForLoadState('networkidle', { timeout: resolvedTimeout });
+        record(page);
         return {
           content: [{ type: 'text' as const, text: `Wait completed: network idle` }],
         };

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -154,13 +154,7 @@ export type UnrecordableReason =
    * the stored URL different from the one that worked, so the step is a hole
    * rather than a step that would replay a broken URL.
    */
-  | 'redacted-url'
-  /**
-   * A browser_wait whose condition was a JS predicate. The cache file is
-   * untrusted input by the time a replay reads it, so a stored script is never
-   * evaluated; the wait is listed as a hole rather than silently dropped.
-   */
-  | 'stored-script';
+  | 'redacted-url';
 
 export interface TraceStep {
   tool: ReplayableTool;
@@ -719,7 +713,6 @@ const UNRECORDABLE_REASONS: readonly UnrecordableReason[] = [
   'rpc-transport',
   'unresolved-axis',
   'redacted-url',
-  'stored-script',
 ];
 
 function sanitizeAxis(raw: unknown): StepAxis | null {

--- a/src/shared/browserReplay/actionTrace.ts
+++ b/src/shared/browserReplay/actionTrace.ts
@@ -38,6 +38,7 @@ export const REPLAYABLE_TOOLS = [
   'browser_select',
   'browser_scroll_into_view',
   'browser_scroll',
+  'browser_wait',
 ] as const;
 
 export type ReplayableTool = (typeof REPLAYABLE_TOOLS)[number];
@@ -153,7 +154,13 @@ export type UnrecordableReason =
    * the stored URL different from the one that worked, so the step is a hole
    * rather than a step that would replay a broken URL.
    */
-  | 'redacted-url';
+  | 'redacted-url'
+  /**
+   * A browser_wait whose condition was a JS predicate. The cache file is
+   * untrusted input by the time a replay reads it, so a stored script is never
+   * evaluated; the wait is listed as a hole rather than silently dropped.
+   */
+  | 'stored-script';
 
 export interface TraceStep {
   tool: ReplayableTool;
@@ -712,6 +719,7 @@ const UNRECORDABLE_REASONS: readonly UnrecordableReason[] = [
   'rpc-transport',
   'unresolved-axis',
   'redacted-url',
+  'stored-script',
 ];
 
 function sanitizeAxis(raw: unknown): StepAxis | null {


### PR DESCRIPTION
Closes #1193.

## Problem

A replay re-snapshotted the instant a click resolved. On a Turbo/SPA page the click's fetch and render come after, so the next step was resolved against the document the click happened ON and stopped with "no link … on the page any more" while the element was there a moment later. Live on github.com this failed 3/3 runs; the same flow driven by hand succeeded every time.

The natural workaround, recording a `browser_wait` between the two clicks, did nothing: `wait.ts` never called `recordAction`, so waits vanished from the trace.

## Fix

- **Settle on the navigation signal, not on load state.** `waitForLoadState` resolves at once against the state the OLD document reached, so a same-document navigation was never waited for. The runner now watches the main frame's `framenavigated` (commit) and its navigation `request` (start, so a slow origin is not missed) around each step. When one fired, it waits for `domcontentloaded` and then until two consecutive ref-map shapes agree (250 ms apart, at most four reads, 3 s cap). The settle's last read is the re-charge, so there is no second dump. A step that did not navigate pays only the 300 ms grace.
- **`browser_wait` is recorded** (url as `urlGlob`, selector, text, network idle) on the Playwright lane, with no page shape stamped so it can never become the trace baseline. A `fn` wait is not recorded: the cache file is untrusted input and a stored script is never evaluated, and a hole would refuse the whole flow. The replayed timeout is clamped (0 means "for ever" to Playwright).
- Wire baseline refreshed for the `steps` description wording.

## Verification

- Unit: replayRunner (settle between steps, none after the last, request-signal path, wait replay by condition, timeout clamp), wait recording (`urlGlob`, no shape, fn skipped). 242 tests in the touched suites pass; `tsc -p tsconfig.mcp.json`, eslint, `build:mcp`, `probe:mcp` clean.
- Live: worktree MCP bundle attached to the installed 3.50.1 app, chrome backend, real github.com. The exact flow from #1193 (Issues → Pull requests → Closed) replayed 3/3 after failing 3/3 before; a 3-step flow with two soft navigations replayed 3/3.

## Known limit

The wait-recording half needs an app release: the installed main process's trace sanitizer drops steps whose tool it does not know, so a flow containing a `browser_wait` is refused by `save` until the app ships with this change.

## Review

Three-model panel (Claude, GLM; Codex unavailable, 402). Folded: cache-file timeout clamp, request-start navigation signal, no double dump after settle, read cap, fn-wait not recorded instead of a whole-flow hole, url stored as `urlGlob` outside the credential scrub, no shape stamped on a wait, RPC lane records nothing, recording tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser replays now wait for navigation to settle before continuing, improving reliability in Turbo and single-page applications.
  * Successful `browser_wait` actions are recorded and can be replayed using URL, selector, text, or network-idle conditions.
  * Recorded waits count toward flow and action limits, while JavaScript predicate waits remain unrecorded.
* **Bug Fixes**
  * Added bounded timeouts for replayed wait conditions to prevent excessively long waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->