### PR TITLE
chore(mcp): raise the commander tools/list budget to 60000

### DIFF
--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -151,7 +151,7 @@
       ]
     },
     "commander": {
-      "maxListBytes": 45000,
+      "maxListBytes": 60000,
       "wireResultSha256": "de1a64379698f49626012b826d8d03e4a28c43a1fb54028f9dd54a7cfe6c16a5",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [

--- a/scripts/probe-commander-surface.mjs
+++ b/scripts/probe-commander-surface.mjs
@@ -49,6 +49,11 @@ const packageJson = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8'));
 //   headroom. The task-ledger / gate / adopt tools (ledger_*, task_*,
 //   git_*) add about nine schemas, roughly 7-8 KB, so a 15 KB raise lands
 //   them with one more small tool of cushion before this is re-argued.
+//   Note the budget now exceeds core (49000): today the subset invariant
+//   (commander ⊆ core ⊆ full, below) makes the gap unreachable, on purpose —
+//   the brain tools land as commander-ONLY registrations that relax that
+//   invariant to "commander ⊆ core ∪ COMMANDER_ONLY_TOOLS", at which point
+//   this number is the one that binds.
 const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
 
 function sha256(value) {

--- a/scripts/probe-commander-surface.mjs
+++ b/scripts/probe-commander-surface.mjs
@@ -42,8 +42,13 @@ const packageJson = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8'));
 //   74,652 bytes with 92 tools, i.e. 348 bytes of headroom — less than a
 //   single tool's schema. One more tool could not be added at all without a
 //   raise, and a 3 KB cushion buys roughly one more tool after this one
-//   before the question has to be re-argued. core (49000) and commander
-//   (45000) are untouched; browser_replay is full-only.
+//   before the question has to be re-argued. core (49000) is untouched;
+//   browser_replay is full-only.
+//   commander: 45000 -> 60000 (orchestrator track, 2026-09). The commander
+//   profile measured ~43,000 bytes against 45,000 — under one tool of
+//   headroom. The task-ledger / gate / adopt tools (ledger_*, task_*,
+//   git_*) add about nine schemas, roughly 7-8 KB, so a 15 KB raise lands
+//   them with one more small tool of cushion before this is re-argued.
 const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
 
 function sha256(value) {

--- a/src/shared/__tests__/ledger.test.ts
+++ b/src/shared/__tests__/ledger.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   LEDGER_STATUSES,
+  canActorSet,
   LEDGER_TRANSITIONS,
   WORKER_SETTABLE_STATUSES,
   canTransition,
@@ -11,7 +12,7 @@ describe('ledger vocabulary', () => {
   it('reserves completed for the brain and reaches it only from review_requested', () => {
     expect(WORKER_SETTABLE_STATUSES).not.toContain('completed');
     expect(WORKER_SETTABLE_STATUSES).not.toContain('cancelled');
-    const sources = LEDGER_STATUSES.filter((s) => canTransition(s, 'completed'));
+    const sources = LEDGER_STATUSES.filter((s) => s !== 'completed' && canTransition(s, 'completed'));
     expect(sources).toEqual(['review_requested']);
   });
 
@@ -23,5 +24,33 @@ describe('ledger vocabulary', () => {
     expect(isLedgerStatus('done')).toBe(false);
     expect(canTransition('done', 'working')).toBe(false);
     expect(canTransition('working', 'done')).toBe(false);
+  });
+});
+
+describe('ledger authorization and idempotency', () => {
+  const entry = {
+    schemaVersion: 1 as const,
+    id: 't1',
+    taskWorkspaceId: 'ws-task',
+    ownerWorkspaceId: 'ws-brain',
+    title: 't',
+    status: 'working' as const,
+    rev: 3,
+    updatedAt: 0,
+    updatedBy: { kind: 'system' as const, workspaceId: 'daemon' },
+  };
+
+  it('scopes workers to their own task and worker-settable statuses only', () => {
+    expect(canActorSet({ kind: 'worker', workspaceId: 'ws-task' }, entry, 'review_requested')).toBe(true);
+    expect(canActorSet({ kind: 'worker', workspaceId: 'ws-task' }, entry, 'completed')).toBe(false);
+    expect(canActorSet({ kind: 'worker', workspaceId: 'ws-other' }, entry, 'working')).toBe(false);
+    expect(canActorSet({ kind: 'brain', workspaceId: 'ws-brain' }, entry, 'cancelled')).toBe(true);
+    expect(canActorSet({ kind: 'brain', workspaceId: 'ws-other' }, entry, 'cancelled')).toBe(false);
+  });
+
+  it('treats a same-status resubmit as an allowed no-op', () => {
+    expect(canTransition('working', 'working')).toBe(true);
+    expect(canTransition('completed', 'completed')).toBe(true);
+    expect(canTransition('review_requested', 'input_required')).toBe(true);
   });
 });

--- a/src/shared/__tests__/ledger.test.ts
+++ b/src/shared/__tests__/ledger.test.ts
@@ -21,5 +21,7 @@ describe('ledger vocabulary', () => {
     for (const s of LEDGER_STATUSES) expect(Object.keys(LEDGER_TRANSITIONS)).toContain(s);
     expect(isLedgerStatus('review_requested')).toBe(true);
     expect(isLedgerStatus('done')).toBe(false);
+    expect(canTransition('done', 'working')).toBe(false);
+    expect(canTransition('working', 'done')).toBe(false);
   });
 });

--- a/src/shared/__tests__/ledger.test.ts
+++ b/src/shared/__tests__/ledger.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LEDGER_STATUSES,
+  LEDGER_TRANSITIONS,
+  WORKER_SETTABLE_STATUSES,
+  canTransition,
+  isLedgerStatus,
+} from '../ledger';
+
+describe('ledger vocabulary', () => {
+  it('reserves completed for the brain and reaches it only from review_requested', () => {
+    expect(WORKER_SETTABLE_STATUSES).not.toContain('completed');
+    expect(WORKER_SETTABLE_STATUSES).not.toContain('cancelled');
+    const sources = LEDGER_STATUSES.filter((s) => canTransition(s, 'completed'));
+    expect(sources).toEqual(['review_requested']);
+  });
+
+  it('keeps completed and cancelled terminal, and every status in the transition table', () => {
+    expect(LEDGER_TRANSITIONS.completed).toEqual([]);
+    expect(LEDGER_TRANSITIONS.cancelled).toEqual([]);
+    for (const s of LEDGER_STATUSES) expect(Object.keys(LEDGER_TRANSITIONS)).toContain(s);
+    expect(isLedgerStatus('review_requested')).toBe(true);
+    expect(isLedgerStatus('done')).toBe(false);
+  });
+});

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -39,12 +39,19 @@ export interface LedgerActor {
 
 /** Result of one gate run, recorded by the gate runner. `command` is the
  *  allow-listed command that ran — never caller-supplied text. */
+/** Hard cap on `LedgerGateResult.tail`, enforced by the writer (truncate from
+ *  the front, keep the end). The tail is UNTRUSTED text: it is whatever the
+ *  gate command printed, and the gate runs code a worker wrote. Consumers
+ *  render it as data (a fenced block), never as instructions. */
+export const LEDGER_GATE_TAIL_MAX_BYTES = 8 * 1024;
+
 export interface LedgerGateResult {
   /** Process exit code; `null` when the gate died on a signal (timeout,
    *  cancel, OOM). Consumers MUST treat `null` as a failure — only an
    *  explicit 0 is a pass. */
   exitCode: number | null;
-  /** Last lines of combined output, bounded by the runner. */
+  /** Last lines of combined stdout+stderr, ≤ LEDGER_GATE_TAIL_MAX_BYTES.
+   *  Untrusted — see the constant. */
   tail: string;
   /** Epoch ms. */
   at: number;
@@ -61,10 +68,24 @@ export interface LedgerEntry {
   status: LedgerStatus;
   gate?: LedgerGateResult;
   summary?: string;
+  /** Monotonic revision, +1 per accepted write. Every update names the
+   *  `expectedRev` it read; the writer refuses a stale one (compare-and-swap),
+   *  so two concurrent writers cannot both pass `canTransition` against the
+   *  same snapshot and leave a state the table forbids. */
+  rev: number;
   /** Epoch ms of the last transition. */
   updatedAt: number;
   updatedBy: LedgerActor;
 }
+
+// Lifecycle rules the writer enforces (stated here so the three consumers
+// agree):
+// - When the WorkTask is closed or detached, the writer force-terminates its
+//   entry: `cancelled` if not yet `completed`. A closed task never stays
+//   `working` in the ledger.
+// - Terminal entries (`completed` / `cancelled`) are pruned after
+//   LEDGER_TERMINAL_RETENTION_MS; the JSONL log rotates independently.
+export const LEDGER_TERMINAL_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 /** Statuses a WORKER may set on its own task. Everything else is the brain's
  *  or the daemon's. */
@@ -84,7 +105,9 @@ export const LEDGER_TRANSITIONS: Readonly<Record<LedgerStatus, readonly LedgerSt
   // A blocked worker may clear its own blocker and hand the task straight to
   // review; forcing a `working` hop in between would only add a write.
   input_required: ['working', 'review_requested', 'failed', 'cancelled'],
-  review_requested: ['working', 'completed', 'failed', 'cancelled'],
+  // The brain may bounce a review back with a question (input_required)
+  // without pretending the worker resumed (working).
+  review_requested: ['working', 'input_required', 'completed', 'failed', 'cancelled'],
   completed: [],
   failed: ['working', 'cancelled'],
   cancelled: [],
@@ -94,9 +117,30 @@ export function isLedgerStatus(value: unknown): value is LedgerStatus {
   return typeof value === 'string' && (LEDGER_STATUSES as readonly string[]).includes(value);
 }
 
-/** False for any unknown status on either side — the MCP surface hands this
- *  raw strings, and a lookup miss must be a refusal, not a TypeError. */
+/** False for any unknown status on either side — the MCP surface and the log
+ *  replay hand this raw strings, and a lookup miss must be a refusal, not a
+ *  TypeError. A same-status resubmit is a no-op and allowed, so a retry after
+ *  an ambiguous timeout is not rejected as an illegal transition. */
 export function canTransition(from: string, to: string): boolean {
   if (!isLedgerStatus(from) || !isLedgerStatus(to)) return false;
+  if (from === to) return true;
   return LEDGER_TRANSITIONS[from].includes(to);
+}
+
+/** The single authorization predicate every writer calls. A worker may only
+ *  move ITS OWN task (the entry's task workspace is the caller's verified
+ *  workspace) to a worker-settable status; a brain may move tasks its
+ *  workspace owns; the daemon (`system`) may move anything. Transition
+ *  legality is `canTransition`, checked separately. */
+export function canActorSet(actor: LedgerActor, entry: LedgerEntry, next: LedgerStatus): boolean {
+  switch (actor.kind) {
+    case 'system':
+      return true;
+    case 'brain':
+      return entry.ownerWorkspaceId === actor.workspaceId;
+    case 'worker':
+      return entry.taskWorkspaceId === actor.workspaceId && WORKER_SETTABLE_STATUSES.includes(next);
+    default:
+      return false;
+  }
 }

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -40,7 +40,10 @@ export interface LedgerActor {
 /** Result of one gate run, recorded by the gate runner. `command` is the
  *  allow-listed command that ran — never caller-supplied text. */
 export interface LedgerGateResult {
-  exitCode: number;
+  /** Process exit code; `null` when the gate died on a signal (timeout,
+   *  cancel, OOM). Consumers MUST treat `null` as a failure — only an
+   *  explicit 0 is a pass. */
+  exitCode: number | null;
   /** Last lines of combined output, bounded by the runner. */
   tail: string;
   /** Epoch ms. */
@@ -78,6 +81,8 @@ export const WORKER_SETTABLE_STATUSES: readonly LedgerStatus[] = [
  *  not expressible here). */
 export const LEDGER_TRANSITIONS: Readonly<Record<LedgerStatus, readonly LedgerStatus[]>> = {
   working: ['input_required', 'review_requested', 'failed', 'cancelled'],
+  // A blocked worker may clear its own blocker and hand the task straight to
+  // review; forcing a `working` hop in between would only add a write.
   input_required: ['working', 'review_requested', 'failed', 'cancelled'],
   review_requested: ['working', 'completed', 'failed', 'cancelled'],
   completed: [],
@@ -89,6 +94,9 @@ export function isLedgerStatus(value: unknown): value is LedgerStatus {
   return typeof value === 'string' && (LEDGER_STATUSES as readonly string[]).includes(value);
 }
 
-export function canTransition(from: LedgerStatus, to: LedgerStatus): boolean {
+/** False for any unknown status on either side — the MCP surface hands this
+ *  raw strings, and a lookup miss must be a refusal, not a TypeError. */
+export function canTransition(from: string, to: string): boolean {
+  if (!isLedgerStatus(from) || !isLedgerStatus(to)) return false;
   return LEDGER_TRANSITIONS[from].includes(to);
 }

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -1,0 +1,94 @@
+// ─── Task Ledger — shared vocabulary (types only, no runtime) ────────────────
+//
+// The orchestrator track gives the daemon a task ledger: a STATUS LOG keyed by
+// the existing WorkTask id. WorkTask stays the source of identity and
+// ownership; the ledger never invents tasks, it records what happened to them
+// so the brain, the workers and the Stop gate read ONE state instead of each
+// inferring it from pane screens. This file is the contract the daemon
+// (writer), the MCP surface (ledger_* tools) and the gate runner (task_gate_run)
+// share — it lands ahead of all three so no lane has to stub it.
+//
+// Status vocabulary mirrors MCP Tasks (working | input_required | completed |
+// failed | cancelled) plus `review_requested`: the state a worker hands back
+// when it believes it is done. `completed` is reserved for the brain, after a
+// gate pass — a worker cannot self-certify.
+
+export const LEDGER_SCHEMA_VERSION = 1 as const;
+
+export const LEDGER_STATUSES = [
+  'working',
+  'input_required',
+  'review_requested',
+  'completed',
+  'failed',
+  'cancelled',
+] as const;
+
+export type LedgerStatus = (typeof LEDGER_STATUSES)[number];
+
+/** Who wrote an entry. `worker` writes are scoped to the task whose workspace
+ *  matches the verified caller; `brain` writes are scoped to tasks the brain's
+ *  workspace owns; `system` is the daemon itself (fan-out lifecycle, gate
+ *  runner). */
+export type LedgerActorKind = 'brain' | 'worker' | 'system';
+
+export interface LedgerActor {
+  kind: LedgerActorKind;
+  workspaceId: string;
+}
+
+/** Result of one gate run, recorded by the gate runner. `command` is the
+ *  allow-listed command that ran — never caller-supplied text. */
+export interface LedgerGateResult {
+  exitCode: number;
+  /** Last lines of combined output, bounded by the runner. */
+  tail: string;
+  /** Epoch ms. */
+  at: number;
+  command: string;
+}
+
+export interface LedgerEntry {
+  schemaVersion: typeof LEDGER_SCHEMA_VERSION;
+  /** WorkTask id. */
+  id: string;
+  taskWorkspaceId: string;
+  ownerWorkspaceId: string;
+  title: string;
+  status: LedgerStatus;
+  gate?: LedgerGateResult;
+  summary?: string;
+  /** Epoch ms of the last transition. */
+  updatedAt: number;
+  updatedBy: LedgerActor;
+}
+
+/** Statuses a WORKER may set on its own task. Everything else is the brain's
+ *  or the daemon's. */
+export const WORKER_SETTABLE_STATUSES: readonly LedgerStatus[] = [
+  'working',
+  'input_required',
+  'review_requested',
+  'failed',
+];
+
+/** Allowed transitions. A status maps to the statuses it may move to; a
+ *  missing key is terminal. `completed` is reachable only from
+ *  `review_requested` (and only with a passing gate — enforced by the writer,
+ *  not expressible here). */
+export const LEDGER_TRANSITIONS: Readonly<Record<LedgerStatus, readonly LedgerStatus[]>> = {
+  working: ['input_required', 'review_requested', 'failed', 'cancelled'],
+  input_required: ['working', 'review_requested', 'failed', 'cancelled'],
+  review_requested: ['working', 'completed', 'failed', 'cancelled'],
+  completed: [],
+  failed: ['working', 'cancelled'],
+  cancelled: [],
+};
+
+export function isLedgerStatus(value: unknown): value is LedgerStatus {
+  return typeof value === 'string' && (LEDGER_STATUSES as readonly string[]).includes(value);
+}
+
+export function canTransition(from: LedgerStatus, to: LedgerStatus): boolean {
+  return LEDGER_TRANSITIONS[from].includes(to);
+}


### PR DESCRIPTION
## Why

The commander profile measures 43,314 bytes against its 45,000-byte tools/list budget — less than one tool schema of headroom. The orchestrator track (task ledger, gate runner, per-task adopt/close/pr, read-only git tools) adds about nine schemas, roughly 7–8 KB, which cannot land under the current cap.

## What

- `scripts/mcp-protocol-baseline.json`: `commander.maxListBytes` 45000 → 60000. full (75,484 / 78,000) and core (46,665 / 49,000) are untouched: the brain tools will be registered commander-only, so they do not enter the full profile.
- `scripts/probe-commander-surface.mjs`: record the reasoning next to the earlier `full` raise.
- `src/shared/ledger.ts` (+ test): the task-ledger status vocabulary, transition table and actor model, types only. Landed first so the daemon writer, the MCP tools and the gate runner share one definition. `completed` is reachable only from `review_requested`, never worker-settable.

Tool surface, schemas, descriptions and server instructions are unchanged; the baseline SHAs are untouched.

## Verification

- `node scripts/build-mcp.js && npm run probe:mcp` — commander: 41 tools, 43,314 bytes, SHAs match.
- `npx vitest run src/shared/__tests__/ledger.test.ts` — 2 passed. `eslint` clean on the new files.
- No changelog fragment: internal budget constant and a type-only module, no user-facing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared task ledger for tracking work status, ownership, summaries, timestamps, and completion details.
  - Supports standardized statuses including working, input required, review requested, completed, failed, and cancelled.
  - Added validation for permitted status changes and worker-managed transitions.
  - Added optional gate results and command summaries to task records.

- **Improvements**
  - Increased the Commander profile’s list-size budget from 45,000 to 60,000 bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->