### PR TITLE
feat(deck): task ledger, worker-event routing to the owning brain, and a ledger-backed Stop gate

### DIFF
--- a/changelog.d/orch-f.md
+++ b/changelog.d/orch-f.md
@@ -1,0 +1,5 @@
+### Added
+- Task ledger: a status log keyed by WorkTask id (`~/.wmux/task-ledger.jsonl`, WMUX_DATA_SUFFIX-scoped) recording `working → input_required / review_requested → completed / failed / cancelled` with compare-and-swap revisions, actor authorization and a gate-pass requirement for `completed`.
+
+### Fixed
+- Orchestrator: a brain that fanned out work now learns when its workers stop or wait for input — worker lifecycle events are copied to the owning workspace tagged with the task, bypass the owner's `none` wake policy, and are parked as a backlog when the owner has no brain yet.

--- a/changelog.d/orch-f.md
+++ b/changelog.d/orch-f.md
@@ -1,5 +1,7 @@
 ### Added
 - Task ledger: a status log keyed by WorkTask id (`~/.wmux/task-ledger.jsonl`, WMUX_DATA_SUFFIX-scoped) recording `working → input_required / review_requested → completed / failed / cancelled` with compare-and-swap revisions, actor authorization and a gate-pass requirement for `completed`.
 
+- MCP: `ledger_update` (every profile) lets a fan-out worker record `review_requested` / `input_required` on its own task; `ledger_list` is a commander-only tool (registered only under `--commander`, never in the full or core profile) that shows the brain the tasks it owns. Fan-out prompts now tell workers to report through the ledger instead of a chat "done".
+
 ### Fixed
 - Orchestrator: a brain that fanned out work now learns when its workers stop or wait for input — worker lifecycle events are copied to the owning workspace tagged with the task, bypass the owner's `none` wake policy, and are parked as a backlog when the owner has no brain yet.

--- a/changelog.d/orch-f.md
+++ b/changelog.d/orch-f.md
@@ -3,5 +3,8 @@
 
 - MCP: `ledger_update` (every profile) lets a fan-out worker record `review_requested` / `input_required` on its own task; `ledger_list` is a commander-only tool (registered only under `--commander`, never in the full or core profile) that shows the brain the tasks it owns. Fan-out prompts now tell workers to report through the ledger instead of a chat "done".
 
+- Orchestrator: `deck.ledgerGate` (default off, `~/.wmux/deck-ledger-gate.json`) makes the brain's Stop gate hold a turn while the ledger lists open tasks it owns, with the existing consecutive-block cap and hysteresis; while on, `deck_ask_decision` shows the human the open-task list.
+- Every ledger transition is posted to the task's mission channel as `[ledger] <task> <from>→<to> <by> <summary>`.
+
 ### Fixed
 - Orchestrator: a brain that fanned out work now learns when its workers stop or wait for input — worker lifecycle events are copied to the owning workspace tagged with the task, bypass the owner's `none` wake policy, and are parked as a backlog when the owner has no brain yet.

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -289,8 +289,8 @@ Total: **164** methods (`ALL_RPC_METHODS` in
 | `task.mission.list` | `a2a.channel.read` | `a2a` |
 | `task.mission.update` | `a2a.channel.send` | `a2a` |
 | `task.fanout.start` | `a2a.execute` | `a2a` |
-| `ledger.list` | `a2a.channel.read` | `a2a` |
-| `ledger.update` | `a2a.channel.send` | `a2a` |
+| `ledger.list` | `ledger.read` | `a2a` |
+| `ledger.update` | `ledger.write` | `a2a` |
 
 ---
 

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -26,7 +26,7 @@ returns `EPERM`. Wire framing: newline-delimited JSON, one object per line.
 
 ## RPC methods
 
-Total: **162** methods (`ALL_RPC_METHODS` in
+Total: **164** methods (`ALL_RPC_METHODS` in
 `src/shared/rpc.ts`). Capability and risk class are read from
 `src/main/mcp/methodCapabilityMap.ts`:
 
@@ -289,6 +289,8 @@ Total: **162** methods (`ALL_RPC_METHODS` in
 | `task.mission.list` | `a2a.channel.read` | `a2a` |
 | `task.mission.update` | `a2a.channel.send` | `a2a` |
 | `task.fanout.start` | `a2a.execute` | `a2a` |
+| `ledger.list` | `a2a.channel.read` | `a2a` |
+| `ledger.update` | `a2a.channel.send` | `a2a` |
 
 ---
 

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "64e84f5161fc63162ef9115ffd0fe4931711d4b5d97658c876991ba1e981d3bf",
+      "wireResultSha256": "504255f85dcbed53fe00be73c6fd2791fc0def68fd3284e43c1af90c5271ac3b",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",
@@ -84,6 +84,7 @@
         "channel_mission_close",
         "channel_mission_list",
         "fanout_start",
+        "ledger_update",
         "pane_split",
         "pane_close",
         "pane_focus",
@@ -98,7 +99,7 @@
     },
     "core": {
       "maxListBytes": 49000,
-      "wireResultSha256": "de8e90800228d2d47e1ca4c16205e6fd1a22305d1c7f5d4b468a66d3a6cb7ecb",
+      "wireResultSha256": "311894d5db23232d284c67a8126243b354c028150f8289a1dff6af1bc2c4e585",
       "instructionSha256": "0c313d4e88ad9313bb6a51ff00717abbb243ebcdd18f8e226cba2c738e43c95a",
       "toolNames": [
         "terminal_read",
@@ -138,6 +139,7 @@
         "channel_mission_close",
         "channel_mission_list",
         "fanout_start",
+        "ledger_update",
         "pane_split",
         "pane_close",
         "pane_focus",
@@ -152,7 +154,7 @@
     },
     "commander": {
       "maxListBytes": 60000,
-      "wireResultSha256": "de1a64379698f49626012b826d8d03e4a28c43a1fb54028f9dd54a7cfe6c16a5",
+      "wireResultSha256": "5d41335c653c0916a0f2658b991b3daba44b89bc4cf0b60a80c6fffe78f975fb",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",
@@ -195,7 +197,8 @@
         "pane_focus",
         "surface_new",
         "pane_stash",
-        "pane_unstash"
+        "pane_unstash",
+        "ledger_list"
       ]
     }
   }

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -154,7 +154,7 @@
     },
     "commander": {
       "maxListBytes": 60000,
-      "wireResultSha256": "5d41335c653c0916a0f2658b991b3daba44b89bc4cf0b60a80c6fffe78f975fb",
+      "wireResultSha256": "40697b75121ca418727474252ac949975a0242a9b6e613bb97f051eb0f2e0562",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",
@@ -198,7 +198,8 @@
         "surface_new",
         "pane_stash",
         "pane_unstash",
-        "ledger_list"
+        "ledger_list",
+        "ledger_update"
       ]
     }
   }

--- a/scripts/probe-commander-surface.mjs
+++ b/scripts/probe-commander-surface.mjs
@@ -14,6 +14,7 @@ import { copyFileSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
@@ -55,6 +56,12 @@ const packageJson = JSON.parse(readFileSync(PACKAGE_PATH, 'utf8'));
 //   invariant to "commander ⊆ core ∪ COMMANDER_ONLY_TOOLS", at which point
 //   this number is the one that binds.
 const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+// The commander-only SSOT (src/shared/commanderSurface.ts), read from the tsc
+// output the bundle is built from — the same list the MCP entry registers
+// against, never a copy typed into this script.
+const { COMMANDER_ONLY_TOOLS, COMMANDER_ONLY_RESERVED_TOOLS } = createRequire(import.meta.url)(
+  path.join(REPO_ROOT, 'dist', 'mcp', 'shared', 'commanderSurface.js'),
+);
 
 function sha256(value) {
   return createHash('sha256').update(value).digest('hex');
@@ -440,10 +447,13 @@ async function main() {
   const fullOrder = byProfile.get('full');
   const fullNames = new Set(fullOrder);
 
-  // Every narrower profile is a strict, order-preserving subset of full: a
-  // host that cached the full ordering must never see a tool move.
+  // core is a strict, order-preserving subset of full: a host that cached the
+  // full ordering must never see a tool move. commander is the same for the
+  // part of it that comes from full; its commander-ONLY tools (see below) are
+  // appended after that part.
+  const commanderOnly = new Set(COMMANDER_ONLY_TOOLS);
   for (const profile of ['core', 'commander']) {
-    const names = byProfile.get(profile);
+    const names = byProfile.get(profile).filter((name) => !(profile === 'commander' && commanderOnly.has(name)));
     assert.ok(
       names.every((name) => fullNames.has(name)),
       `${profile} surface must be a strict subset of the full surface`,
@@ -460,13 +470,39 @@ async function main() {
     );
   }
 
-  // commander ⊆ core: commander drops browser_/company_ too, so the security
-  // role can never name a tool the optimization profile already removed.
+  // commander ⊆ core ∪ COMMANDER_ONLY_TOOLS: commander drops browser_/company_
+  // too, so the security role can never name a full-profile tool the
+  // optimization profile already removed; what it ADDS is exactly the
+  // commander-only SSOT, appended after the full-derived part.
   const coreNames = new Set(byProfile.get('core'));
+  const commanderNames = byProfile.get('commander');
   assert.ok(
-    byProfile.get('commander').every((name) => coreNames.has(name)),
-    'commander surface must be contained in the core surface',
+    commanderNames.every((name) => coreNames.has(name) || commanderOnly.has(name)),
+    'commander surface must be contained in core ∪ COMMANDER_ONLY_TOOLS',
   );
+  const fromFull = commanderNames.filter((name) => !commanderOnly.has(name));
+  assert.deepEqual(
+    commanderNames.slice(fromFull.length),
+    [...COMMANDER_ONLY_TOOLS],
+    'commander-only tools must be exactly COMMANDER_ONLY_TOOLS, appended after the full-derived part',
+  );
+  // No commander-only name may leak into full or core, and no reserved (not
+  // yet wired) name may appear anywhere.
+  for (const profile of ['full', 'core']) {
+    assert.deepEqual(
+      byProfile.get(profile).filter((name) => commanderOnly.has(name)),
+      [],
+      `${profile} surface must not contain a commander-only tool`,
+    );
+  }
+  const reserved = new Set(COMMANDER_ONLY_RESERVED_TOOLS);
+  for (const [profile, names] of byProfile) {
+    assert.deepEqual(
+      names.filter((name) => reserved.has(name)),
+      [],
+      `${profile} surface must not contain a reserved commander-only name before it is wired`,
+    );
+  }
 
   // The point of the core profile: no browser tools at all.
   assert.deepEqual(

--- a/scripts/probe-commander-surface.mjs
+++ b/scripts/probe-commander-surface.mjs
@@ -59,7 +59,7 @@ const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
 // The commander-only SSOT (src/shared/commanderSurface.ts), read from the tsc
 // output the bundle is built from — the same list the MCP entry registers
 // against, never a copy typed into this script.
-const { COMMANDER_ONLY_TOOLS, COMMANDER_ONLY_RESERVED_TOOLS } = createRequire(import.meta.url)(
+const { COMMANDER_ONLY_TOOLS, COMMANDER_ONLY_RESERVED_TOOLS, COMMANDER_VARIANT_TOOLS } = createRequire(import.meta.url)(
   path.join(REPO_ROOT, 'dist', 'mcp', 'shared', 'commanderSurface.js'),
 );
 
@@ -486,15 +486,28 @@ async function main() {
     [...COMMANDER_ONLY_TOOLS],
     'commander-only tools must be exactly COMMANDER_ONLY_TOOLS, appended after the full-derived part',
   );
-  // No commander-only name may leak into full or core, and no reserved (not
-  // yet wired) name may appear anywhere.
+  // No commander-only name may leak into full or core — except a declared
+  // VARIANT, which re-registers a full/core name under the brain's schema and
+  // must therefore exist in both — and no reserved (not yet wired) name may
+  // appear anywhere.
+  const variants = new Set(COMMANDER_VARIANT_TOOLS);
   for (const profile of ['full', 'core']) {
     assert.deepEqual(
-      byProfile.get(profile).filter((name) => commanderOnly.has(name)),
+      byProfile.get(profile).filter((name) => commanderOnly.has(name) && !variants.has(name)),
       [],
       `${profile} surface must not contain a commander-only tool`,
     );
+    assert.deepEqual(
+      [...variants].filter((name) => !byProfile.get(profile).includes(name)),
+      [],
+      `${profile} surface must contain every commander variant's base tool`,
+    );
   }
+  assert.equal(
+    new Set(commanderNames).size,
+    commanderNames.length,
+    'commander surface must list each name once (a variant replaces the base registration)',
+  );
   const reserved = new Set(COMMANDER_ONLY_RESERVED_TOOLS);
   for (const [profile, names] of byProfile) {
     assert.deepEqual(

--- a/src/daemon/ledger/TaskLedger.ts
+++ b/src/daemon/ledger/TaskLedger.ts
@@ -6,29 +6,36 @@
 //
 // Storage: one JSONL file under the wmux data dir (WMUX_DATA_SUFFIX-scoped
 // through the caller-supplied dir, exactly like the deck-* stores). Every
-// accepted write appends one line through a single writer queue, so two
-// concurrent updates cannot interleave half-lines. Boot replays the file in
-// order; a truncated last line (crash mid-append) is ignored, never fatal.
-// Past LEDGER_ROTATE_BYTES the file is rotated: the old log moves to `.1` and
-// the new one opens with a `snapshot` line carrying every live entry, so a
-// replay of the fresh file alone reconstructs the full state.
+// write — the checks, the append and the in-memory commit — runs inside ONE
+// serialized section, so two concurrent updates cannot both pass the
+// compare-and-swap against the same snapshot, and memory only changes after
+// the line is on disk: a failed append returns `persist_failed`, commits
+// nothing and fires no listener. Boot replays the file in order; a truncated
+// last line (crash mid-append) is ignored, never fatal. Past LEDGER_ROTATE_BYTES
+// the file is rotated: the old log is hard-linked to `.1` and a snapshot line
+// (every live entry + parked orphan) is renamed over the live path, so at no
+// instant is there no ledger; a replay that finds no live file but a `.1`
+// recovers from `.1`.
 //
 // Rules enforced here (the contract lists them; this is the writer):
 //   - transitions: `canTransition`; a same-status resubmit is a no-op.
 //   - authz: `canActorSet` — the ONE predicate, never re-implemented.
+//   - gate results are written by the `system` actor only (`recordGate`,
+//     the gate runner); `update` ignores a caller-supplied gate.
 //   - `completed`: only by a `brain`, only from `review_requested` (table),
-//     only with a recorded gate whose exitCode is exactly 0 — unless
+//     only with a SYSTEM-recorded gate whose exitCode is exactly 0 — unless
 //     `force: true` with a non-empty `reason`, which is logged on the entry.
 //   - CAS: every update names the `expectedRev` it read; a stale one is
-//     refused so two writers cannot both pass the table against one snapshot.
+//     refused.
 //   - WorkTask closed/detached → `closeTask` forces `cancelled` unless the
 //     entry is already `completed`.
 //   - terminal entries older than LEDGER_TERMINAL_RETENTION_MS are pruned
-//     from the live map on load and on list.
+//     from the live map on load and on list (`onPrune` tells the host).
 //
 // Orphaned events (lane F step 1): a worker lifecycle event whose owner
-// workspace has no brain is parked here under `orphaned_event` and handed back
-// as a backlog (`takeOrphanedEvents`) when a brain boots for that workspace.
+// workspace has no brain is parked here under `orphaned_event`, bounded by
+// count and bytes (oldest dropped, logged), peeked as a backlog when a brain
+// boots and acknowledged only once a wake actually delivered it.
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -48,6 +55,14 @@ import {
 export const LEDGER_FILENAME = 'task-ledger.jsonl';
 /** Rotate past this many bytes (spec: 5 MB). */
 export const LEDGER_ROTATE_BYTES = 5 * 1024 * 1024;
+/** Caps on free text the writer stores (a worker/brain summary, the gate
+ *  command line). Bytes, truncated from the end — the head carries the
+ *  meaning. */
+export const LEDGER_SUMMARY_MAX_BYTES = 2 * 1024;
+export const LEDGER_GATE_COMMAND_MAX_BYTES = 512;
+/** Orphan backlog bounds (all owners together): oldest dropped past either. */
+export const LEDGER_ORPHAN_MAX_COUNT = 200;
+export const LEDGER_ORPHAN_MAX_BYTES = 256 * 1024;
 
 export function getTaskLedgerPath(dir: string): string {
   return path.join(dir, LEDGER_FILENAME);
@@ -88,7 +103,6 @@ export interface LedgerUpdateInput {
   actor: LedgerActor;
   expectedRev: number;
   summary?: string;
-  gate?: LedgerGateResult;
   force?: boolean;
   reason?: string;
 }
@@ -100,7 +114,8 @@ export type LedgerUpdateError =
   | 'not_authorized'
   | 'illegal_transition'
   | 'gate_required'
-  | 'force_reason_required';
+  | 'force_reason_required'
+  | 'persist_failed';
 
 export type LedgerUpdateResult =
   | { ok: true; entry: LedgerEntry; noop?: true }
@@ -136,20 +151,44 @@ export interface TaskLedgerOptions {
   now?: () => number;
   rotateBytes?: number;
   retentionMs?: number;
+  orphanMaxCount?: number;
+  orphanMaxBytes?: number;
   log?: (line: string) => void;
+  /** Called with every entry id the retention prune drops, so a host can
+   *  release what it keyed on the id. */
+  onPrune?: (id: string) => void;
 }
 
 const SYSTEM_ACTOR = (workspaceId = 'daemon'): LedgerActor => ({ kind: 'system', workspaceId });
 
-function truncateTail(tail: string): string {
-  const bytes = Buffer.byteLength(tail, 'utf8');
-  if (bytes <= LEDGER_GATE_TAIL_MAX_BYTES) return tail;
-  const buf = Buffer.from(tail, 'utf8');
-  return buf.subarray(buf.length - LEDGER_GATE_TAIL_MAX_BYTES).toString('utf8');
+/** Keep the LAST `maxBytes` of `text` without splitting a UTF-8 sequence:
+ *  after cutting, advance past any continuation bytes (10xxxxxx). */
+export function truncateTail(text: string, maxBytes: number = LEDGER_GATE_TAIL_MAX_BYTES): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+  let start = buf.length - maxBytes;
+  while (start < buf.length && (buf[start] & 0xc0) === 0x80) start += 1;
+  return buf.subarray(start).toString('utf8');
+}
+
+/** Keep the FIRST `maxBytes` of `text` without splitting a UTF-8 sequence:
+ *  back the cut up to the start of the sequence it landed inside. */
+export function truncateHead(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end -= 1;
+  return buf.subarray(0, end).toString('utf8');
 }
 
 function boundGate(gate: LedgerGateResult): LedgerGateResult {
-  return { ...gate, tail: truncateTail(typeof gate.tail === 'string' ? gate.tail : '') };
+  return {
+    exitCode: gate.exitCode === null ? null : typeof gate.exitCode === 'number' ? gate.exitCode : null,
+    tail: truncateTail(typeof gate.tail === 'string' ? gate.tail : ''),
+    at: typeof gate.at === 'number' ? gate.at : Date.now(),
+    command: truncateHead(typeof gate.command === 'string' ? gate.command : '', LEDGER_GATE_COMMAND_MAX_BYTES),
+    recordedBy: 'system',
+  };
 }
 
 function isEntryShape(v: unknown): v is LedgerEntry {
@@ -165,19 +204,35 @@ function isEntryShape(v: unknown): v is LedgerEntry {
   );
 }
 
+function isOrphanShape(v: unknown): v is OrphanedEvent {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.ownerWorkspaceId === 'string' && typeof o.seq === 'number' && 'payload' in o;
+}
+
+function orphanBytes(o: OrphanedEvent): number {
+  return Buffer.byteLength(JSON.stringify(o), 'utf8');
+}
+
 export class TaskLedger {
   private readonly filePath: string;
   private readonly dir: string;
   private readonly now: () => number;
   private readonly rotateBytes: number;
   private readonly retentionMs: number;
+  private readonly orphanMaxCount: number;
+  private readonly orphanMaxBytes: number;
   private readonly log: (line: string) => void;
+  private readonly onPrune: (id: string) => void;
   private readonly entries = new Map<string, LedgerEntry>();
   private orphans: OrphanedEvent[] = [];
   private readonly listeners = new Set<(t: LedgerTransition) => void>();
-  private queue: Promise<void> = Promise.resolve();
+  /** Every write runs inside this chain — checks, append and commit together. */
+  private queue: Promise<unknown> = Promise.resolve();
   /** Lines the last load skipped (torn tail / malformed) — observability. */
   readonly skippedLines: number;
+  /** True when the last load recovered from the rotated `.1` file. */
+  readonly recoveredFromRotated: boolean;
 
   constructor(opts: TaskLedgerOptions) {
     this.dir = opts.dir;
@@ -185,8 +240,13 @@ export class TaskLedger {
     this.now = opts.now ?? Date.now;
     this.rotateBytes = opts.rotateBytes ?? LEDGER_ROTATE_BYTES;
     this.retentionMs = opts.retentionMs ?? LEDGER_TERMINAL_RETENTION_MS;
-    this.log = opts.log ?? (() => {});
-    this.skippedLines = this.replay();
+    this.orphanMaxCount = opts.orphanMaxCount ?? LEDGER_ORPHAN_MAX_COUNT;
+    this.orphanMaxBytes = opts.orphanMaxBytes ?? LEDGER_ORPHAN_MAX_BYTES;
+    this.log = opts.log ?? (() => undefined);
+    this.onPrune = opts.onPrune ?? (() => undefined);
+    const loaded = this.replay();
+    this.skippedLines = loaded.skipped;
+    this.recoveredFromRotated = loaded.recovered;
     this.pruneTerminal();
   }
 
@@ -211,6 +271,13 @@ export class TaskLedger {
     return best;
   }
 
+  /** Same, but only an OPEN entry: a finished task's workspace must not keep
+   *  routing events to the brain. */
+  findOpenByTaskWorkspace(taskWorkspaceId: string): LedgerEntry | null {
+    const e = this.findByTaskWorkspace(taskWorkspaceId);
+    return e && isOpenLedgerStatus(e.status) ? e : null;
+  }
+
   list(filter: LedgerListFilter = {}): LedgerEntry[] {
     this.pruneTerminal();
     const out: LedgerEntry[] = [];
@@ -233,29 +300,36 @@ export class TaskLedger {
   // ── writes ───────────────────────────────────────────────────────────────
 
   /** Mirror an existing WorkTask into the ledger as `working`. Idempotent:
-   *  an already-registered id returns its live entry and writes nothing. */
-  async register(input: LedgerRegisterInput): Promise<LedgerEntry> {
-    const existing = this.entries.get(input.id);
-    if (existing) return existing;
-    const by = input.actor ?? SYSTEM_ACTOR();
-    const entry: LedgerEntry = {
-      schemaVersion: LEDGER_SCHEMA_VERSION,
-      id: input.id,
-      taskWorkspaceId: input.taskWorkspaceId,
-      ownerWorkspaceId: input.ownerWorkspaceId,
-      title: input.title,
-      status: 'working',
-      rev: 1,
-      updatedAt: this.now(),
-      updatedBy: by,
-    };
-    this.entries.set(entry.id, entry);
-    await this.append({ op: 'entry', entry });
-    this.emit({ entry, from: null, to: 'working', by });
-    return entry;
+   *  an already-registered id returns its live entry and writes nothing.
+   *  Rejects when the line could not be persisted (nothing is committed). */
+  register(input: LedgerRegisterInput): Promise<LedgerEntry> {
+    return this.serialize(async () => {
+      const existing = this.entries.get(input.id);
+      if (existing) return existing;
+      const by = input.actor ?? SYSTEM_ACTOR();
+      const entry: LedgerEntry = {
+        schemaVersion: LEDGER_SCHEMA_VERSION,
+        id: input.id,
+        taskWorkspaceId: input.taskWorkspaceId,
+        ownerWorkspaceId: input.ownerWorkspaceId,
+        title: truncateHead(input.title, LEDGER_SUMMARY_MAX_BYTES),
+        status: 'working',
+        rev: 1,
+        updatedAt: this.now(),
+        updatedBy: by,
+      };
+      await this.append({ op: 'entry', entry });
+      this.entries.set(entry.id, entry);
+      this.emit({ entry, from: null, to: 'working', by });
+      return entry;
+    });
   }
 
-  async update(input: LedgerUpdateInput): Promise<LedgerUpdateResult> {
+  update(input: LedgerUpdateInput): Promise<LedgerUpdateResult> {
+    return this.serialize(() => this.updateLocked(input));
+  }
+
+  private async updateLocked(input: LedgerUpdateInput): Promise<LedgerUpdateResult> {
     const entry = this.entries.get(input.id);
     if (!entry) return { ok: false, error: 'not_found', message: `no ledger entry for task ${input.id}` };
     if (!isLedgerStatus(input.status)) {
@@ -297,8 +371,10 @@ export class TaskLedger {
           entry,
         };
       }
-      const gate = input.gate ?? entry.gate;
-      const gatePassed = gate !== undefined && gate.exitCode === 0;
+      // Provenance, not just value: the gate must have been RECORDED by the
+      // gate runner (system). A gate that arrived on the wire never counts.
+      const gate = entry.gate;
+      const gatePassed = gate !== undefined && gate.recordedBy === 'system' && gate.exitCode === 0;
       if (!gatePassed) {
         if (input.force !== true) {
           return {
@@ -319,13 +395,18 @@ export class TaskLedger {
             entry,
           };
         }
-        forcedReason = reason;
+        forcedReason = truncateHead(reason, LEDGER_SUMMARY_MAX_BYTES);
       }
     }
-    const summary =
+    const given =
       typeof input.summary === 'string' && input.summary.trim().length > 0
-        ? input.summary.trim()
-        : entry.summary;
+        ? truncateHead(input.summary.trim(), LEDGER_SUMMARY_MAX_BYTES)
+        : undefined;
+    const base = given ?? entry.summary;
+    const summary =
+      forcedReason !== undefined
+        ? truncateHead(`${base ? `${base} ` : ''}[forced: ${forcedReason}]`, LEDGER_SUMMARY_MAX_BYTES)
+        : base;
     const updated: LedgerEntry = {
       ...entry,
       status: next,
@@ -333,13 +414,13 @@ export class TaskLedger {
       updatedAt: this.now(),
       updatedBy: input.actor,
       ...(summary !== undefined ? { summary } : {}),
-      ...(input.gate ? { gate: boundGate(input.gate) } : {}),
-      ...(forcedReason !== undefined
-        ? { summary: `${summary ? `${summary} ` : ''}[forced: ${forcedReason}]` }
-        : {}),
     };
+    try {
+      await this.append({ op: 'entry', entry: updated });
+    } catch (err) {
+      return { ok: false, error: 'persist_failed', message: `ledger write failed: ${String(err)}`, entry };
+    }
     this.entries.set(updated.id, updated);
-    await this.append({ op: 'entry', entry: updated });
     this.emit({
       entry: updated,
       from: entry.status,
@@ -351,58 +432,118 @@ export class TaskLedger {
     return { ok: true, entry: updated };
   }
 
+  /** The gate runner's write: attach a gate result to an entry. SYSTEM only —
+   *  this is the one provenance `completed` trusts. Bumps the rev (a brain
+   *  holding an older rev re-reads and sees the result). No status change,
+   *  no transition event. */
+  recordGate(id: string, gate: LedgerGateResult, actor: LedgerActor = SYSTEM_ACTOR()): Promise<LedgerUpdateResult> {
+    return this.serialize(async () => {
+      const entry = this.entries.get(id);
+      if (!entry) return { ok: false, error: 'not_found', message: `no ledger entry for task ${id}` };
+      if (actor.kind !== 'system') {
+        return { ok: false, error: 'not_authorized', message: 'only the gate runner (system) may record a gate result', entry };
+      }
+      const updated: LedgerEntry = {
+        ...entry,
+        gate: boundGate(gate),
+        rev: entry.rev + 1,
+        updatedAt: this.now(),
+        updatedBy: actor,
+      };
+      try {
+        await this.append({ op: 'entry', entry: updated });
+      } catch (err) {
+        return { ok: false, error: 'persist_failed', message: `ledger write failed: ${String(err)}`, entry };
+      }
+      this.entries.set(id, updated);
+      return { ok: true, entry: updated };
+    });
+  }
+
   /** WorkTask closed or detached: force-terminate the entry (`cancelled`)
    *  unless it already reached `completed`. Returns the resulting entry, or
-   *  null for an unknown id. */
-  async closeTask(id: string, actor: LedgerActor = SYSTEM_ACTOR(), summary = 'WorkTask closed'): Promise<LedgerEntry | null> {
-    const entry = this.entries.get(id);
-    if (!entry) return null;
-    if (entry.status === 'completed' || entry.status === 'cancelled') return entry;
-    const updated: LedgerEntry = {
-      ...entry,
-      status: 'cancelled',
-      rev: entry.rev + 1,
-      updatedAt: this.now(),
-      updatedBy: actor,
-      summary,
-    };
-    this.entries.set(id, updated);
-    await this.append({ op: 'entry', entry: updated });
-    this.emit({ entry: updated, from: entry.status, to: 'cancelled', by: actor, summary });
-    return updated;
+   *  null for an unknown id; the previous entry when the write failed. */
+  closeTask(id: string, actor: LedgerActor = SYSTEM_ACTOR(), summary = 'WorkTask closed'): Promise<LedgerEntry | null> {
+    return this.serialize(async () => {
+      const entry = this.entries.get(id);
+      if (!entry) return null;
+      if (entry.status === 'completed' || entry.status === 'cancelled') return entry;
+      const updated: LedgerEntry = {
+        ...entry,
+        status: 'cancelled',
+        rev: entry.rev + 1,
+        updatedAt: this.now(),
+        updatedBy: actor,
+        summary: truncateHead(summary, LEDGER_SUMMARY_MAX_BYTES),
+      };
+      try {
+        await this.append({ op: 'entry', entry: updated });
+      } catch (err) {
+        this.log(`[ledger] closeTask ${id} not persisted: ${String(err)}`);
+        return entry;
+      }
+      this.entries.set(id, updated);
+      this.emit({ entry: updated, from: entry.status, to: 'cancelled', by: actor, summary: updated.summary });
+      return updated;
+    });
   }
 
   // ── orphaned events (worker events with no brain to receive them) ────────
 
-  async recordOrphanedEvent(event: OrphanedEvent): Promise<void> {
-    this.orphans.push(event);
-    await this.append({ op: 'orphaned_event', event });
+  /** Park an event. Bounded: past the count or byte cap the OLDEST parked
+   *  events are dropped (and logged) before this one is appended. */
+  recordOrphanedEvent(event: OrphanedEvent): Promise<void> {
+    return this.serialize(async () => {
+      const next = [...this.orphans, event];
+      let bytes = next.reduce((n, o) => n + orphanBytes(o), 0);
+      let dropped = 0;
+      while (next.length > 1 && (next.length > this.orphanMaxCount || bytes > this.orphanMaxBytes)) {
+        const gone = next.shift() as OrphanedEvent;
+        bytes -= orphanBytes(gone);
+        dropped += 1;
+      }
+      if (dropped > 0) {
+        this.log(`[ledger] orphan backlog over cap — dropped ${dropped} oldest parked event(s)`);
+      }
+      await this.append({ op: 'orphaned_event', event });
+      this.orphans = next;
+    });
   }
 
+  /** The backlog for one owner workspace, in seq order. Non-destructive: the
+   *  caller acknowledges what a wake actually delivered (`ackOrphanedEvents`). */
   peekOrphanedEvents(ownerWorkspaceId: string): OrphanedEvent[] {
     return this.orphans
       .filter((o) => o.ownerWorkspaceId === ownerWorkspaceId)
       .sort((a, b) => a.seq - b.seq);
   }
 
-  /** Drain the backlog for one owner workspace, in seq order. */
-  takeOrphanedEvents(ownerWorkspaceId: string): OrphanedEvent[] {
-    const taken = this.peekOrphanedEvents(ownerWorkspaceId);
-    if (taken.length === 0) return taken;
-    const upToSeq = taken[taken.length - 1].seq;
-    this.orphans = this.orphans.filter(
-      (o) => !(o.ownerWorkspaceId === ownerWorkspaceId && o.seq <= upToSeq),
-    );
-    void this.append({ op: 'orphans_drained', ownerWorkspaceId, upToSeq });
-    return taken;
+  /** Drop the parked events of `ownerWorkspaceId` at or below `upToSeq` —
+   *  they reached a brain. */
+  ackOrphanedEvents(ownerWorkspaceId: string, upToSeq: number): Promise<void> {
+    return this.serialize(async () => {
+      const remaining = this.orphans.filter(
+        (o) => !(o.ownerWorkspaceId === ownerWorkspaceId && o.seq <= upToSeq),
+      );
+      if (remaining.length === this.orphans.length) return;
+      await this.append({ op: 'orphans_drained', ownerWorkspaceId, upToSeq });
+      this.orphans = remaining;
+    });
   }
 
-  /** Resolves once every queued append (and any rotation) has hit disk. */
+  /** Resolves once every queued write (and any rotation) has settled. */
   flush(): Promise<void> {
-    return this.queue;
+    return this.queue.then(() => undefined, () => undefined);
   }
 
   // ── internals ────────────────────────────────────────────────────────────
+
+  /** Run `fn` after every earlier write, and before every later one. */
+  private serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.queue.then(fn, fn);
+    this.queue = run.then(() => undefined, () => undefined);
+    return run;
+  }
 
   private emit(t: LedgerTransition): void {
     for (const l of this.listeners) {
@@ -419,53 +560,78 @@ export class TaskLedger {
     for (const [id, e] of this.entries) {
       if ((e.status === 'completed' || e.status === 'cancelled') && e.updatedAt < cutoff) {
         this.entries.delete(id);
+        try {
+          this.onPrune(id);
+        } catch {
+          // a host hook must not break the prune
+        }
       }
     }
   }
 
-  private append(line: LedgerLine): Promise<void> {
+  /** Append one line (caller holds the write section). Rejects on failure;
+   *  the caller then commits nothing. */
+  private async append(line: LedgerLine): Promise<void> {
     const text = `${JSON.stringify(line)}\n`;
-    this.queue = this.queue
-      .then(async () => {
-        await fs.promises.mkdir(this.dir, { recursive: true });
-        await fs.promises.appendFile(this.filePath, text, 'utf8');
-        const stat = await fs.promises.stat(this.filePath);
-        if (stat.size > this.rotateBytes) await this.rotate();
-      })
-      .catch((err) => {
-        this.log(`[ledger] append failed: ${String(err)}`);
-      });
-    return this.queue;
+    await fs.promises.mkdir(this.dir, { recursive: true });
+    await fs.promises.appendFile(this.filePath, text, 'utf8');
+    const stat = await fs.promises.stat(this.filePath);
+    if (stat.size > this.rotateBytes) {
+      try {
+        await this.rotate(line);
+      } catch (err) {
+        // The append itself succeeded; a failed rotation only delays the
+        // next one. Never fail the write for it.
+        this.log(`[ledger] rotation failed: ${String(err)}`);
+      }
+    }
   }
 
-  /** Move the full log aside and open a fresh one with a snapshot line, so
-   *  the new file alone replays to the current state. */
-  private async rotate(): Promise<void> {
-    const snapshot: LedgerLine = {
-      op: 'snapshot',
-      entries: [...this.entries.values()],
-      orphans: [...this.orphans],
-    };
+  /** Keep the old log as `.1` (hard link, so it exists before anything moves)
+   *  and rename a fresh snapshot over the live path — no instant without a
+   *  ledger. Refuses when the snapshot itself would exceed the cap: rotating
+   *  would immediately need rotating again, so the log is left to grow and a
+   *  warning is logged instead. `justAppended` is the line the snapshot must
+   *  already reflect — the caller commits it to memory only after append
+   *  returns, so it is folded in here. */
+  private async rotate(justAppended: LedgerLine): Promise<void> {
+    const entries = new Map(this.entries);
+    let orphans = [...this.orphans];
+    if (justAppended.op === 'entry') entries.set(justAppended.entry.id, justAppended.entry);
+    else if (justAppended.op === 'orphaned_event') orphans.push(justAppended.event);
+    else if (justAppended.op === 'orphans_drained') {
+      orphans = orphans.filter(
+        (o) => !(o.ownerWorkspaceId === justAppended.ownerWorkspaceId && o.seq <= justAppended.upToSeq),
+      );
+    }
+    const snapshot: LedgerLine = { op: 'snapshot', entries: [...entries.values()], orphans };
+    const text = `${JSON.stringify(snapshot)}\n`;
+    if (Buffer.byteLength(text, 'utf8') > this.rotateBytes) {
+      this.log('[ledger] snapshot would exceed the rotation cap — not rotating');
+      return;
+    }
     const rotated = `${this.filePath}.1`;
+    const tmp = `${this.filePath}.tmp-${process.pid}-${Date.now()}`;
+    await fs.promises.writeFile(tmp, text, 'utf8');
     await fs.promises.rm(rotated, { force: true });
-    await fs.promises.rename(this.filePath, rotated);
-    await fs.promises.writeFile(this.filePath, `${JSON.stringify(snapshot)}\n`, 'utf8');
+    await fs.promises.link(this.filePath, rotated);
+    await fs.promises.rename(tmp, this.filePath);
   }
 
-  /** Replay the log into memory. Returns the number of skipped lines. */
-  private replay(): number {
-    let raw: string;
-    try {
-      raw = fs.readFileSync(this.filePath, 'utf8');
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0;
-      this.log(`[ledger] read failed, starting empty: ${String(err)}`);
-      return 0;
+  /** Replay the log into memory. Falls back to the rotated `.1` file when the
+   *  live file is missing (a crash between the two rotation steps). */
+  private replay(): { skipped: number; recovered: boolean } {
+    let raw: string | null = this.readLog(this.filePath);
+    let recovered = false;
+    if (raw === null) {
+      raw = this.readLog(`${this.filePath}.1`);
+      if (raw === null) return { skipped: 0, recovered: false };
+      recovered = true;
+      this.log('[ledger] live log missing — recovering from the rotated .1 file');
     }
     const lines = raw.split('\n');
     let skipped = 0;
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
+    for (const line of lines) {
       if (line.length === 0) continue;
       let parsed: unknown;
       try {
@@ -479,7 +645,18 @@ export class TaskLedger {
       this.apply(parsed);
     }
     if (skipped > 0) this.log(`[ledger] replay skipped ${skipped} unreadable line(s)`);
-    return skipped;
+    return { skipped, recovered };
+  }
+
+  private readLog(p: string): string | null {
+    try {
+      return fs.readFileSync(p, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        this.log(`[ledger] read of ${p} failed: ${String(err)}`);
+      }
+      return null;
+    }
   }
 
   private apply(parsed: unknown): void {
@@ -497,14 +674,12 @@ export class TaskLedger {
         if (Array.isArray(s.entries)) {
           for (const e of s.entries) if (isEntryShape(e)) this.entries.set(e.id, e);
         }
-        this.orphans = Array.isArray(s.orphans) ? (s.orphans as OrphanedEvent[]) : [];
+        this.orphans = Array.isArray(s.orphans) ? s.orphans.filter(isOrphanShape) : [];
         return;
       }
       case 'orphaned_event': {
-        const ev = (line as { event?: unknown }).event as OrphanedEvent | undefined;
-        if (ev && typeof ev.ownerWorkspaceId === 'string' && typeof ev.seq === 'number') {
-          this.orphans.push(ev);
-        }
+        const ev = (line as { event?: unknown }).event;
+        if (isOrphanShape(ev)) this.orphans.push(ev);
         return;
       }
       case 'orphans_drained': {

--- a/src/daemon/ledger/TaskLedger.ts
+++ b/src/daemon/ledger/TaskLedger.ts
@@ -1,0 +1,523 @@
+// ─── Task Ledger — the status log behind src/shared/ledger.ts ───────────────
+//
+// A STATUS LOG keyed by WorkTask id. WorkTask (daemon WorkTaskService) stays
+// the source of identity and ownership: an entry is only ever created by
+// `register`, which mirrors an existing task; the ledger never invents one.
+//
+// Storage: one JSONL file under the wmux data dir (WMUX_DATA_SUFFIX-scoped
+// through the caller-supplied dir, exactly like the deck-* stores). Every
+// accepted write appends one line through a single writer queue, so two
+// concurrent updates cannot interleave half-lines. Boot replays the file in
+// order; a truncated last line (crash mid-append) is ignored, never fatal.
+// Past LEDGER_ROTATE_BYTES the file is rotated: the old log moves to `.1` and
+// the new one opens with a `snapshot` line carrying every live entry, so a
+// replay of the fresh file alone reconstructs the full state.
+//
+// Rules enforced here (the contract lists them; this is the writer):
+//   - transitions: `canTransition`; a same-status resubmit is a no-op.
+//   - authz: `canActorSet` — the ONE predicate, never re-implemented.
+//   - `completed`: only by a `brain`, only from `review_requested` (table),
+//     only with a recorded gate whose exitCode is exactly 0 — unless
+//     `force: true` with a non-empty `reason`, which is logged on the entry.
+//   - CAS: every update names the `expectedRev` it read; a stale one is
+//     refused so two writers cannot both pass the table against one snapshot.
+//   - WorkTask closed/detached → `closeTask` forces `cancelled` unless the
+//     entry is already `completed`.
+//   - terminal entries older than LEDGER_TERMINAL_RETENTION_MS are pruned
+//     from the live map on load and on list.
+//
+// Orphaned events (lane F step 1): a worker lifecycle event whose owner
+// workspace has no brain is parked here under `orphaned_event` and handed back
+// as a backlog (`takeOrphanedEvents`) when a brain boots for that workspace.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  LEDGER_GATE_TAIL_MAX_BYTES,
+  LEDGER_SCHEMA_VERSION,
+  LEDGER_TERMINAL_RETENTION_MS,
+  canActorSet,
+  canTransition,
+  isLedgerStatus,
+  type LedgerActor,
+  type LedgerEntry,
+  type LedgerGateResult,
+  type LedgerStatus,
+} from '../../shared/ledger';
+
+export const LEDGER_FILENAME = 'task-ledger.jsonl';
+/** Rotate past this many bytes (spec: 5 MB). */
+export const LEDGER_ROTATE_BYTES = 5 * 1024 * 1024;
+
+export function getTaskLedgerPath(dir: string): string {
+  return path.join(dir, LEDGER_FILENAME);
+}
+
+/** A worker lifecycle event parked for an owner workspace that had no brain
+ *  when it fired. `payload` is opaque to the ledger (the coalescer input the
+ *  deck handler built); `seq` is the EventBus seq used to drain in order. */
+export interface OrphanedEvent {
+  ownerWorkspaceId: string;
+  seq: number;
+  payload: unknown;
+}
+
+/** One accepted transition, as seen by listeners (mission-channel emitter). */
+export interface LedgerTransition {
+  entry: LedgerEntry;
+  /** null on first registration. */
+  from: LedgerStatus | null;
+  to: LedgerStatus;
+  by: LedgerActor;
+  summary?: string;
+  /** Present when `completed` was forced past a missing/failing gate. */
+  forcedReason?: string;
+}
+
+export interface LedgerRegisterInput {
+  id: string;
+  taskWorkspaceId: string;
+  ownerWorkspaceId: string;
+  title: string;
+  actor?: LedgerActor;
+}
+
+export interface LedgerUpdateInput {
+  id: string;
+  status: string;
+  actor: LedgerActor;
+  expectedRev: number;
+  summary?: string;
+  gate?: LedgerGateResult;
+  force?: boolean;
+  reason?: string;
+}
+
+export type LedgerUpdateError =
+  | 'not_found'
+  | 'invalid_status'
+  | 'stale_rev'
+  | 'not_authorized'
+  | 'illegal_transition'
+  | 'gate_required'
+  | 'force_reason_required';
+
+export type LedgerUpdateResult =
+  | { ok: true; entry: LedgerEntry; noop?: true }
+  | { ok: false; error: LedgerUpdateError; message: string; entry?: LedgerEntry };
+
+export interface LedgerListFilter {
+  ownerWorkspaceId?: string;
+  taskWorkspaceId?: string;
+  id?: string;
+  /** Only working / input_required / review_requested. */
+  openOnly?: boolean;
+}
+
+export const OPEN_LEDGER_STATUSES: readonly LedgerStatus[] = [
+  'working',
+  'input_required',
+  'review_requested',
+];
+
+export function isOpenLedgerStatus(status: LedgerStatus): boolean {
+  return OPEN_LEDGER_STATUSES.includes(status);
+}
+
+type LedgerLine =
+  | { op: 'entry'; entry: LedgerEntry }
+  | { op: 'snapshot'; entries: LedgerEntry[]; orphans: OrphanedEvent[] }
+  | { op: 'orphaned_event'; event: OrphanedEvent }
+  | { op: 'orphans_drained'; ownerWorkspaceId: string; upToSeq: number };
+
+export interface TaskLedgerOptions {
+  /** The wmux data dir (already WMUX_DATA_SUFFIX-scoped by the caller). */
+  dir: string;
+  now?: () => number;
+  rotateBytes?: number;
+  retentionMs?: number;
+  log?: (line: string) => void;
+}
+
+const SYSTEM_ACTOR = (workspaceId = 'daemon'): LedgerActor => ({ kind: 'system', workspaceId });
+
+function truncateTail(tail: string): string {
+  const bytes = Buffer.byteLength(tail, 'utf8');
+  if (bytes <= LEDGER_GATE_TAIL_MAX_BYTES) return tail;
+  const buf = Buffer.from(tail, 'utf8');
+  return buf.subarray(buf.length - LEDGER_GATE_TAIL_MAX_BYTES).toString('utf8');
+}
+
+function boundGate(gate: LedgerGateResult): LedgerGateResult {
+  return { ...gate, tail: truncateTail(typeof gate.tail === 'string' ? gate.tail : '') };
+}
+
+function isEntryShape(v: unknown): v is LedgerEntry {
+  if (!v || typeof v !== 'object') return false;
+  const e = v as Record<string, unknown>;
+  return (
+    typeof e.id === 'string' &&
+    typeof e.taskWorkspaceId === 'string' &&
+    typeof e.ownerWorkspaceId === 'string' &&
+    isLedgerStatus(e.status) &&
+    typeof e.rev === 'number' &&
+    typeof e.updatedAt === 'number'
+  );
+}
+
+export class TaskLedger {
+  private readonly filePath: string;
+  private readonly dir: string;
+  private readonly now: () => number;
+  private readonly rotateBytes: number;
+  private readonly retentionMs: number;
+  private readonly log: (line: string) => void;
+  private readonly entries = new Map<string, LedgerEntry>();
+  private orphans: OrphanedEvent[] = [];
+  private readonly listeners = new Set<(t: LedgerTransition) => void>();
+  private queue: Promise<void> = Promise.resolve();
+  /** Lines the last load skipped (torn tail / malformed) — observability. */
+  readonly skippedLines: number;
+
+  constructor(opts: TaskLedgerOptions) {
+    this.dir = opts.dir;
+    this.filePath = getTaskLedgerPath(opts.dir);
+    this.now = opts.now ?? Date.now;
+    this.rotateBytes = opts.rotateBytes ?? LEDGER_ROTATE_BYTES;
+    this.retentionMs = opts.retentionMs ?? LEDGER_TERMINAL_RETENTION_MS;
+    this.log = opts.log ?? (() => {});
+    this.skippedLines = this.replay();
+    this.pruneTerminal();
+  }
+
+  get path(): string {
+    return this.filePath;
+  }
+
+  // ── reads ────────────────────────────────────────────────────────────────
+
+  get(id: string): LedgerEntry | null {
+    return this.entries.get(id) ?? null;
+  }
+
+  /** The entry whose task workspace is `taskWorkspaceId` (a task has exactly
+   *  one dedicated workspace; a re-used workspace id resolves to the newest). */
+  findByTaskWorkspace(taskWorkspaceId: string): LedgerEntry | null {
+    let best: LedgerEntry | null = null;
+    for (const e of this.entries.values()) {
+      if (e.taskWorkspaceId !== taskWorkspaceId) continue;
+      if (!best || e.updatedAt > best.updatedAt) best = e;
+    }
+    return best;
+  }
+
+  list(filter: LedgerListFilter = {}): LedgerEntry[] {
+    this.pruneTerminal();
+    const out: LedgerEntry[] = [];
+    for (const e of this.entries.values()) {
+      if (filter.id !== undefined && e.id !== filter.id) continue;
+      if (filter.ownerWorkspaceId !== undefined && e.ownerWorkspaceId !== filter.ownerWorkspaceId) continue;
+      if (filter.taskWorkspaceId !== undefined && e.taskWorkspaceId !== filter.taskWorkspaceId) continue;
+      if (filter.openOnly && !isOpenLedgerStatus(e.status)) continue;
+      out.push(e);
+    }
+    out.sort((a, b) => a.updatedAt - b.updatedAt);
+    return out;
+  }
+
+  onTransition(listener: (t: LedgerTransition) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  // ── writes ───────────────────────────────────────────────────────────────
+
+  /** Mirror an existing WorkTask into the ledger as `working`. Idempotent:
+   *  an already-registered id returns its live entry and writes nothing. */
+  async register(input: LedgerRegisterInput): Promise<LedgerEntry> {
+    const existing = this.entries.get(input.id);
+    if (existing) return existing;
+    const by = input.actor ?? SYSTEM_ACTOR();
+    const entry: LedgerEntry = {
+      schemaVersion: LEDGER_SCHEMA_VERSION,
+      id: input.id,
+      taskWorkspaceId: input.taskWorkspaceId,
+      ownerWorkspaceId: input.ownerWorkspaceId,
+      title: input.title,
+      status: 'working',
+      rev: 1,
+      updatedAt: this.now(),
+      updatedBy: by,
+    };
+    this.entries.set(entry.id, entry);
+    await this.append({ op: 'entry', entry });
+    this.emit({ entry, from: null, to: 'working', by });
+    return entry;
+  }
+
+  async update(input: LedgerUpdateInput): Promise<LedgerUpdateResult> {
+    const entry = this.entries.get(input.id);
+    if (!entry) return { ok: false, error: 'not_found', message: `no ledger entry for task ${input.id}` };
+    if (!isLedgerStatus(input.status)) {
+      return { ok: false, error: 'invalid_status', message: `unknown status "${input.status}"`, entry };
+    }
+    const next = input.status;
+    if (input.expectedRev !== entry.rev) {
+      return {
+        ok: false,
+        error: 'stale_rev',
+        message: `expectedRev ${input.expectedRev} but the entry is at rev ${entry.rev} — re-read and retry`,
+        entry,
+      };
+    }
+    if (!canActorSet(input.actor, entry, next)) {
+      return {
+        ok: false,
+        error: 'not_authorized',
+        message: `${input.actor.kind} ${input.actor.workspaceId} may not set ${next} on task ${entry.id}`,
+        entry,
+      };
+    }
+    if (!canTransition(entry.status, next)) {
+      return {
+        ok: false,
+        error: 'illegal_transition',
+        message: `${entry.status} → ${next} is not an allowed transition`,
+        entry,
+      };
+    }
+    if (entry.status === next) return { ok: true, entry, noop: true };
+    let forcedReason: string | undefined;
+    if (next === 'completed') {
+      if (input.actor.kind !== 'brain') {
+        return {
+          ok: false,
+          error: 'not_authorized',
+          message: 'only the owning brain may mark a task completed',
+          entry,
+        };
+      }
+      const gate = input.gate ?? entry.gate;
+      const gatePassed = gate !== undefined && gate.exitCode === 0;
+      if (!gatePassed) {
+        if (input.force !== true) {
+          return {
+            ok: false,
+            error: 'gate_required',
+            message: gate
+              ? `the recorded gate did not pass (exitCode ${String(gate.exitCode)}); run the gate again or force with a reason`
+              : 'no gate result recorded for this task; run the gate first or force with a reason',
+            entry,
+          };
+        }
+        const reason = typeof input.reason === 'string' ? input.reason.trim() : '';
+        if (!reason) {
+          return {
+            ok: false,
+            error: 'force_reason_required',
+            message: 'force: true requires a non-empty reason',
+            entry,
+          };
+        }
+        forcedReason = reason;
+      }
+    }
+    const summary =
+      typeof input.summary === 'string' && input.summary.trim().length > 0
+        ? input.summary.trim()
+        : entry.summary;
+    const updated: LedgerEntry = {
+      ...entry,
+      status: next,
+      rev: entry.rev + 1,
+      updatedAt: this.now(),
+      updatedBy: input.actor,
+      ...(summary !== undefined ? { summary } : {}),
+      ...(input.gate ? { gate: boundGate(input.gate) } : {}),
+      ...(forcedReason !== undefined
+        ? { summary: `${summary ? `${summary} ` : ''}[forced: ${forcedReason}]` }
+        : {}),
+    };
+    this.entries.set(updated.id, updated);
+    await this.append({ op: 'entry', entry: updated });
+    this.emit({
+      entry: updated,
+      from: entry.status,
+      to: next,
+      by: input.actor,
+      ...(updated.summary !== undefined ? { summary: updated.summary } : {}),
+      ...(forcedReason !== undefined ? { forcedReason } : {}),
+    });
+    return { ok: true, entry: updated };
+  }
+
+  /** WorkTask closed or detached: force-terminate the entry (`cancelled`)
+   *  unless it already reached `completed`. Returns the resulting entry, or
+   *  null for an unknown id. */
+  async closeTask(id: string, actor: LedgerActor = SYSTEM_ACTOR(), summary = 'WorkTask closed'): Promise<LedgerEntry | null> {
+    const entry = this.entries.get(id);
+    if (!entry) return null;
+    if (entry.status === 'completed' || entry.status === 'cancelled') return entry;
+    const updated: LedgerEntry = {
+      ...entry,
+      status: 'cancelled',
+      rev: entry.rev + 1,
+      updatedAt: this.now(),
+      updatedBy: actor,
+      summary,
+    };
+    this.entries.set(id, updated);
+    await this.append({ op: 'entry', entry: updated });
+    this.emit({ entry: updated, from: entry.status, to: 'cancelled', by: actor, summary });
+    return updated;
+  }
+
+  // ── orphaned events (worker events with no brain to receive them) ────────
+
+  async recordOrphanedEvent(event: OrphanedEvent): Promise<void> {
+    this.orphans.push(event);
+    await this.append({ op: 'orphaned_event', event });
+  }
+
+  peekOrphanedEvents(ownerWorkspaceId: string): OrphanedEvent[] {
+    return this.orphans
+      .filter((o) => o.ownerWorkspaceId === ownerWorkspaceId)
+      .sort((a, b) => a.seq - b.seq);
+  }
+
+  /** Drain the backlog for one owner workspace, in seq order. */
+  takeOrphanedEvents(ownerWorkspaceId: string): OrphanedEvent[] {
+    const taken = this.peekOrphanedEvents(ownerWorkspaceId);
+    if (taken.length === 0) return taken;
+    const upToSeq = taken[taken.length - 1].seq;
+    this.orphans = this.orphans.filter(
+      (o) => !(o.ownerWorkspaceId === ownerWorkspaceId && o.seq <= upToSeq),
+    );
+    void this.append({ op: 'orphans_drained', ownerWorkspaceId, upToSeq });
+    return taken;
+  }
+
+  /** Resolves once every queued append (and any rotation) has hit disk. */
+  flush(): Promise<void> {
+    return this.queue;
+  }
+
+  // ── internals ────────────────────────────────────────────────────────────
+
+  private emit(t: LedgerTransition): void {
+    for (const l of this.listeners) {
+      try {
+        l(t);
+      } catch (err) {
+        this.log(`[ledger] transition listener threw: ${String(err)}`);
+      }
+    }
+  }
+
+  private pruneTerminal(): void {
+    const cutoff = this.now() - this.retentionMs;
+    for (const [id, e] of this.entries) {
+      if ((e.status === 'completed' || e.status === 'cancelled') && e.updatedAt < cutoff) {
+        this.entries.delete(id);
+      }
+    }
+  }
+
+  private append(line: LedgerLine): Promise<void> {
+    const text = `${JSON.stringify(line)}\n`;
+    this.queue = this.queue
+      .then(async () => {
+        await fs.promises.mkdir(this.dir, { recursive: true });
+        await fs.promises.appendFile(this.filePath, text, 'utf8');
+        const stat = await fs.promises.stat(this.filePath);
+        if (stat.size > this.rotateBytes) await this.rotate();
+      })
+      .catch((err) => {
+        this.log(`[ledger] append failed: ${String(err)}`);
+      });
+    return this.queue;
+  }
+
+  /** Move the full log aside and open a fresh one with a snapshot line, so
+   *  the new file alone replays to the current state. */
+  private async rotate(): Promise<void> {
+    const snapshot: LedgerLine = {
+      op: 'snapshot',
+      entries: [...this.entries.values()],
+      orphans: [...this.orphans],
+    };
+    const rotated = `${this.filePath}.1`;
+    await fs.promises.rm(rotated, { force: true });
+    await fs.promises.rename(this.filePath, rotated);
+    await fs.promises.writeFile(this.filePath, `${JSON.stringify(snapshot)}\n`, 'utf8');
+  }
+
+  /** Replay the log into memory. Returns the number of skipped lines. */
+  private replay(): number {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(this.filePath, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 0;
+      this.log(`[ledger] read failed, starting empty: ${String(err)}`);
+      return 0;
+    }
+    const lines = raw.split('\n');
+    let skipped = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.length === 0) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        // A torn last line is the crash-mid-append case; anything else
+        // malformed is skipped the same way rather than poisoning the boot.
+        skipped += 1;
+        continue;
+      }
+      this.apply(parsed);
+    }
+    if (skipped > 0) this.log(`[ledger] replay skipped ${skipped} unreadable line(s)`);
+    return skipped;
+  }
+
+  private apply(parsed: unknown): void {
+    if (!parsed || typeof parsed !== 'object') return;
+    const line = parsed as Partial<LedgerLine> & { op?: string };
+    switch (line.op) {
+      case 'entry': {
+        const e = (line as { entry?: unknown }).entry;
+        if (isEntryShape(e)) this.entries.set(e.id, e);
+        return;
+      }
+      case 'snapshot': {
+        const s = line as { entries?: unknown; orphans?: unknown };
+        this.entries.clear();
+        if (Array.isArray(s.entries)) {
+          for (const e of s.entries) if (isEntryShape(e)) this.entries.set(e.id, e);
+        }
+        this.orphans = Array.isArray(s.orphans) ? (s.orphans as OrphanedEvent[]) : [];
+        return;
+      }
+      case 'orphaned_event': {
+        const ev = (line as { event?: unknown }).event as OrphanedEvent | undefined;
+        if (ev && typeof ev.ownerWorkspaceId === 'string' && typeof ev.seq === 'number') {
+          this.orphans.push(ev);
+        }
+        return;
+      }
+      case 'orphans_drained': {
+        const d = line as { ownerWorkspaceId?: unknown; upToSeq?: unknown };
+        if (typeof d.ownerWorkspaceId === 'string' && typeof d.upToSeq === 'number') {
+          this.orphans = this.orphans.filter(
+            (o) => !(o.ownerWorkspaceId === d.ownerWorkspaceId && o.seq <= (d.upToSeq as number)),
+          );
+        }
+        return;
+      }
+      default:
+        return;
+    }
+  }
+}

--- a/src/daemon/ledger/__tests__/TaskLedger.test.ts
+++ b/src/daemon/ledger/__tests__/TaskLedger.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TaskLedger, getTaskLedgerPath, type LedgerTransition } from '../TaskLedger';
+import {
+  LEDGER_STATUSES,
+  LEDGER_TRANSITIONS,
+  LEDGER_TERMINAL_RETENTION_MS,
+  LEDGER_GATE_TAIL_MAX_BYTES,
+  type LedgerActor,
+  type LedgerStatus,
+} from '../../../shared/ledger';
+
+let dir: string;
+let clock = 1_000;
+const now = () => clock;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-task-ledger-'));
+  clock = 1_000;
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+const BRAIN: LedgerActor = { kind: 'brain', workspaceId: 'ws-owner' };
+const WORKER: LedgerActor = { kind: 'worker', workspaceId: 'ws-task' };
+const SYSTEM: LedgerActor = { kind: 'system', workspaceId: 'daemon' };
+
+function open(): TaskLedger {
+  return new TaskLedger({ dir, now });
+}
+
+async function seed(ledger: TaskLedger, id = 'wtask-1') {
+  return ledger.register({ id, taskWorkspaceId: 'ws-task', ownerWorkspaceId: 'ws-owner', title: 'lane' });
+}
+
+/** Drive an entry to `status` with system writes (authz-free), for matrix tests. */
+async function driveTo(ledger: TaskLedger, id: string, status: LedgerStatus): Promise<void> {
+  const route: Record<LedgerStatus, LedgerStatus[]> = {
+    working: [],
+    input_required: ['input_required'],
+    review_requested: ['review_requested'],
+    completed: ['review_requested', 'completed'],
+    failed: ['failed'],
+    cancelled: ['cancelled'],
+  };
+  for (const step of route[status]) {
+    const cur = ledger.get(id)!;
+    const actor: LedgerActor = step === 'completed' ? BRAIN : SYSTEM;
+    const res = await ledger.update({
+      id,
+      status: step,
+      actor,
+      expectedRev: cur.rev,
+      ...(step === 'completed' ? { gate: { exitCode: 0, tail: '', at: now(), command: 'gate' } } : {}),
+    });
+    if (!res.ok) throw new Error(`driveTo ${status} failed at ${step}: ${res.message}`);
+  }
+}
+
+describe('TaskLedger — append / replay / truncation', () => {
+  it('registers working, persists, and replays after restart (data-dir scoped)', async () => {
+    const a = open();
+    const entry = await seed(a);
+    expect(entry.status).toBe('working');
+    expect(entry.rev).toBe(1);
+    await a.flush();
+    expect(fs.existsSync(getTaskLedgerPath(dir))).toBe(true);
+
+    const b = open();
+    expect(b.get('wtask-1')).toEqual(entry);
+    // A different data dir sees nothing — WMUX_DATA_SUFFIX isolation.
+    const other = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-task-ledger-other-'));
+    try {
+      expect(new TaskLedger({ dir: other, now }).list()).toEqual([]);
+    } finally {
+      fs.rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it('register is idempotent — a second call returns the live entry and writes nothing', async () => {
+    const a = open();
+    const first = await seed(a);
+    await a.update({ id: 'wtask-1', status: 'input_required', actor: WORKER, expectedRev: 1 });
+    const again = await seed(a);
+    expect(again.status).toBe('input_required');
+    expect(again).not.toEqual(first);
+    await a.flush();
+    const lines = fs.readFileSync(getTaskLedgerPath(dir), 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+  });
+
+  it('ignores a truncated last line on replay and keeps every whole line', async () => {
+    const a = open();
+    await seed(a);
+    await a.update({ id: 'wtask-1', status: 'review_requested', actor: WORKER, expectedRev: 1, summary: 'done' });
+    await a.flush();
+    fs.appendFileSync(getTaskLedgerPath(dir), '{"op":"entry","entry":{"id":"wtask-1","status":"fail', 'utf8');
+    const b = open();
+    expect(b.skippedLines).toBe(1);
+    expect(b.get('wtask-1')?.status).toBe('review_requested');
+    expect(b.get('wtask-1')?.summary).toBe('done');
+  });
+
+  it('rotates past the byte cap with a snapshot line the fresh file replays from', async () => {
+    const a = new TaskLedger({ dir, now, rotateBytes: 600 });
+    await seed(a, 'wtask-1');
+    await seed(a, 'wtask-2');
+    await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-owner', seq: 7, payload: { kind: 'agent.stop' } });
+    await seed(a, 'wtask-3');
+    await a.flush();
+    expect(fs.existsSync(`${getTaskLedgerPath(dir)}.1`)).toBe(true);
+    const fresh = fs.readFileSync(getTaskLedgerPath(dir), 'utf8').trim().split('\n');
+    expect(JSON.parse(fresh[0]).op).toBe('snapshot');
+    const b = open();
+    expect(b.list().map((e) => e.id).sort()).toEqual(['wtask-1', 'wtask-2', 'wtask-3']);
+    expect(b.peekOrphanedEvents('ws-owner')).toHaveLength(1);
+  });
+
+  it('prunes terminal entries past the retention window on load', async () => {
+    const a = open();
+    await seed(a);
+    await driveTo(a, 'wtask-1', 'cancelled');
+    await a.flush();
+    clock += LEDGER_TERMINAL_RETENTION_MS + 1;
+    expect(open().get('wtask-1')).toBeNull();
+  });
+});
+
+describe('TaskLedger — transition matrix', () => {
+  for (const from of LEDGER_STATUSES) {
+    for (const to of LEDGER_STATUSES) {
+      const allowed = from === to || LEDGER_TRANSITIONS[from].includes(to);
+      it(`${from} → ${to} is ${allowed ? 'accepted' : 'refused'} (system actor)`, async () => {
+        const a = open();
+        await seed(a);
+        await driveTo(a, 'wtask-1', from);
+        const cur = a.get('wtask-1')!;
+        const res = await a.update({
+          id: 'wtask-1',
+          status: to,
+          actor: to === 'completed' ? BRAIN : SYSTEM,
+          expectedRev: cur.rev,
+          gate: { exitCode: 0, tail: '', at: now(), command: 'gate' },
+        });
+        expect(res.ok).toBe(allowed);
+        if (!res.ok) expect(res.error).toBe('illegal_transition');
+        if (res.ok && from === to) expect(res.noop).toBe(true);
+      });
+    }
+  }
+
+  it('refuses an unknown status and a stale rev', async () => {
+    const a = open();
+    await seed(a);
+    const bad = await a.update({ id: 'wtask-1', status: 'done', actor: SYSTEM, expectedRev: 1 });
+    expect(bad).toMatchObject({ ok: false, error: 'invalid_status' });
+    const stale = await a.update({ id: 'wtask-1', status: 'failed', actor: SYSTEM, expectedRev: 0 });
+    expect(stale).toMatchObject({ ok: false, error: 'stale_rev' });
+    const missing = await a.update({ id: 'nope', status: 'failed', actor: SYSTEM, expectedRev: 1 });
+    expect(missing).toMatchObject({ ok: false, error: 'not_found' });
+  });
+
+  it('completed needs a passing gate unless forced with a reason, and only a brain may set it', async () => {
+    const a = open();
+    await seed(a);
+    await driveTo(a, 'wtask-1', 'review_requested');
+    const noGate = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2 });
+    expect(noGate).toMatchObject({ ok: false, error: 'gate_required' });
+    const failedGate = await a.update({
+      id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2,
+      gate: { exitCode: 1, tail: 'boom', at: now(), command: 'gate' },
+    });
+    expect(failedGate).toMatchObject({ ok: false, error: 'gate_required' });
+    const nullGate = await a.update({
+      id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2,
+      gate: { exitCode: null, tail: '', at: now(), command: 'gate' },
+    });
+    expect(nullGate).toMatchObject({ ok: false, error: 'gate_required' });
+    const forcedNoReason = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2, force: true });
+    expect(forcedNoReason).toMatchObject({ ok: false, error: 'force_reason_required' });
+    const systemComplete = await a.update({
+      id: 'wtask-1', status: 'completed', actor: SYSTEM, expectedRev: 2,
+      gate: { exitCode: 0, tail: '', at: now(), command: 'gate' },
+    });
+    expect(systemComplete).toMatchObject({ ok: false, error: 'not_authorized' });
+    const forced = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2, force: true, reason: 'owner waived' });
+    expect(forced.ok).toBe(true);
+    expect(a.get('wtask-1')?.summary).toContain('[forced: owner waived]');
+  });
+
+  it('bounds the recorded gate tail to LEDGER_GATE_TAIL_MAX_BYTES, keeping the end', async () => {
+    const a = open();
+    await seed(a);
+    const tail = `${'x'.repeat(LEDGER_GATE_TAIL_MAX_BYTES)}END`;
+    const res = await a.update({
+      id: 'wtask-1', status: 'review_requested', actor: SYSTEM, expectedRev: 1,
+      gate: { exitCode: 0, tail, at: now(), command: 'gate' },
+    });
+    expect(res.ok).toBe(true);
+    const stored = a.get('wtask-1')!.gate!.tail;
+    expect(Buffer.byteLength(stored)).toBe(LEDGER_GATE_TAIL_MAX_BYTES);
+    expect(stored.endsWith('END')).toBe(true);
+  });
+});
+
+describe('TaskLedger — authz matrix', () => {
+  const cases: Array<{ actor: LedgerActor; status: LedgerStatus; ok: boolean; why: string }> = [
+    { actor: WORKER, status: 'review_requested', ok: true, why: 'worker on its own task, worker-settable' },
+    { actor: WORKER, status: 'cancelled', ok: false, why: 'worker may not cancel' },
+    { actor: { kind: 'worker', workspaceId: 'ws-other' }, status: 'failed', ok: false, why: 'worker on someone else\'s task' },
+    { actor: BRAIN, status: 'cancelled', ok: true, why: 'owning brain' },
+    { actor: { kind: 'brain', workspaceId: 'ws-stranger' }, status: 'cancelled', ok: false, why: 'non-owning brain' },
+    { actor: SYSTEM, status: 'failed', ok: true, why: 'daemon' },
+  ];
+  for (const c of cases) {
+    it(`${c.actor.kind}@${c.actor.workspaceId} → ${c.status}: ${c.ok ? 'allowed' : 'refused'} (${c.why})`, async () => {
+      const a = open();
+      await seed(a);
+      const res = await a.update({ id: 'wtask-1', status: c.status, actor: c.actor, expectedRev: 1 });
+      expect(res.ok).toBe(c.ok);
+      if (!res.ok) expect(res.error).toBe('not_authorized');
+    });
+  }
+});
+
+describe('TaskLedger — close, orphans, listeners', () => {
+  it('closeTask forces cancelled unless already completed', async () => {
+    const a = open();
+    await seed(a, 'wtask-1');
+    await seed(a, 'wtask-2');
+    await driveTo(a, 'wtask-2', 'completed');
+    expect((await a.closeTask('wtask-1'))?.status).toBe('cancelled');
+    expect((await a.closeTask('wtask-2'))?.status).toBe('completed');
+    expect(await a.closeTask('wtask-9')).toBeNull();
+  });
+
+  it('parks orphaned events per owner, drains them in seq order once, and survives restart', async () => {
+    const a = open();
+    await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-owner', seq: 12, payload: { kind: 'agent.stop' } });
+    await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-owner', seq: 9, payload: { kind: 'agent.awaiting_input' } });
+    await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-else', seq: 10, payload: {} });
+    await a.flush();
+    const b = open();
+    const drained = b.takeOrphanedEvents('ws-owner');
+    expect(drained.map((o) => o.seq)).toEqual([9, 12]);
+    expect(b.takeOrphanedEvents('ws-owner')).toEqual([]);
+    await b.flush();
+    const c = open();
+    expect(c.peekOrphanedEvents('ws-owner')).toEqual([]);
+    expect(c.peekOrphanedEvents('ws-else')).toHaveLength(1);
+  });
+
+  it('emits one transition per accepted write, none for refusals or no-ops', async () => {
+    const a = open();
+    const seen: LedgerTransition[] = [];
+    a.onTransition((t) => seen.push(t));
+    await seed(a);
+    await a.update({ id: 'wtask-1', status: 'working', actor: WORKER, expectedRev: 1 });
+    await a.update({ id: 'wtask-1', status: 'cancelled', actor: WORKER, expectedRev: 1 });
+    await a.update({ id: 'wtask-1', status: 'review_requested', actor: WORKER, expectedRev: 1, summary: 'gate green' });
+    expect(seen.map((t) => `${t.from}→${t.to}`)).toEqual(['null→working', 'working→review_requested']);
+    expect(seen[1].summary).toBe('gate green');
+    expect(a.list({ ownerWorkspaceId: 'ws-owner', openOnly: true })).toHaveLength(1);
+    expect(a.list({ taskWorkspaceId: 'ws-nope' })).toHaveLength(0);
+    expect(a.findByTaskWorkspace('ws-task')?.id).toBe('wtask-1');
+  });
+});

--- a/src/daemon/ledger/__tests__/TaskLedger.test.ts
+++ b/src/daemon/ledger/__tests__/TaskLedger.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { TaskLedger, getTaskLedgerPath, type LedgerTransition } from '../TaskLedger';
+import {
+  TaskLedger,
+  getTaskLedgerPath,
+  truncateTail,
+  truncateHead,
+  LEDGER_SUMMARY_MAX_BYTES,
+  LEDGER_GATE_COMMAND_MAX_BYTES,
+  type LedgerTransition,
+} from '../TaskLedger';
 import {
   LEDGER_STATUSES,
   LEDGER_TRANSITIONS,
@@ -21,22 +29,25 @@ beforeEach(() => {
   clock = 1_000;
 });
 afterEach(() => {
+  vi.restoreAllMocks();
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
 const BRAIN: LedgerActor = { kind: 'brain', workspaceId: 'ws-owner' };
 const WORKER: LedgerActor = { kind: 'worker', workspaceId: 'ws-task' };
 const SYSTEM: LedgerActor = { kind: 'system', workspaceId: 'daemon' };
+const PASS = { exitCode: 0, tail: 'ok', at: 1, command: 'npm test' };
 
-function open(): TaskLedger {
-  return new TaskLedger({ dir, now });
+function open(extra: Partial<ConstructorParameters<typeof TaskLedger>[0]> = {}): TaskLedger {
+  return new TaskLedger({ dir, now, ...extra });
 }
 
 async function seed(ledger: TaskLedger, id = 'wtask-1') {
   return ledger.register({ id, taskWorkspaceId: 'ws-task', ownerWorkspaceId: 'ws-owner', title: 'lane' });
 }
 
-/** Drive an entry to `status` with system writes (authz-free), for matrix tests. */
+/** Drive an entry to `status` with system writes (authz-free), for matrix tests.
+ *  `completed` goes through a system-recorded gate, as production does. */
 async function driveTo(ledger: TaskLedger, id: string, status: LedgerStatus): Promise<void> {
   const route: Record<LedgerStatus, LedgerStatus[]> = {
     working: [],
@@ -47,16 +58,23 @@ async function driveTo(ledger: TaskLedger, id: string, status: LedgerStatus): Pr
     cancelled: ['cancelled'],
   };
   for (const step of route[status]) {
+    if (step === 'completed') {
+      const g = await ledger.recordGate(id, PASS);
+      if (!g.ok) throw new Error(`recordGate failed: ${g.message}`);
+    }
     const cur = ledger.get(id)!;
-    const actor: LedgerActor = step === 'completed' ? BRAIN : SYSTEM;
-    const res = await ledger.update({
-      id,
-      status: step,
-      actor,
-      expectedRev: cur.rev,
-      ...(step === 'completed' ? { gate: { exitCode: 0, tail: '', at: now(), command: 'gate' } } : {}),
-    });
+    const res = await ledger.update({ id, status: step, actor: step === 'completed' ? BRAIN : SYSTEM, expectedRev: cur.rev });
     if (!res.ok) throw new Error(`driveTo ${status} failed at ${step}: ${res.message}`);
+  }
+}
+
+/** Bounce an entry working ↔ input_required `n` times: the log grows, the
+ *  snapshot does not — the shape that makes rotation worthwhile. */
+async function churn(ledger: TaskLedger, id: string, n: number): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    const cur = ledger.get(id)!;
+    const res = await ledger.update({ id, status: cur.status === 'working' ? 'input_required' : 'working', actor: SYSTEM, expectedRev: cur.rev });
+    if (!res.ok) throw new Error(res.message);
   }
 }
 
@@ -71,7 +89,6 @@ describe('TaskLedger — append / replay / truncation', () => {
 
     const b = open();
     expect(b.get('wtask-1')).toEqual(entry);
-    // A different data dir sees nothing — WMUX_DATA_SUFFIX isolation.
     const other = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-task-ledger-other-'));
     try {
       expect(new TaskLedger({ dir: other, now }).list()).toEqual([]);
@@ -104,28 +121,98 @@ describe('TaskLedger — append / replay / truncation', () => {
     expect(b.get('wtask-1')?.summary).toBe('done');
   });
 
-  it('rotates past the byte cap with a snapshot line the fresh file replays from', async () => {
-    const a = new TaskLedger({ dir, now, rotateBytes: 600 });
+  it('a failed disk write commits nothing: ok:false, memory unchanged, no listener fired', async () => {
+    const a = open();
+    await seed(a);
+    const seen: LedgerTransition[] = [];
+    a.onTransition((t) => seen.push(t));
+    vi.spyOn(fs.promises, 'appendFile').mockRejectedValueOnce(new Error('ENOSPC'));
+    const res = await a.update({ id: 'wtask-1', status: 'review_requested', actor: WORKER, expectedRev: 1 });
+    expect(res).toMatchObject({ ok: false, error: 'persist_failed' });
+    expect(a.get('wtask-1')?.status).toBe('working');
+    expect(a.get('wtask-1')?.rev).toBe(1);
+    expect(seen).toEqual([]);
+    // The ledger keeps working after the failure.
+    const retry = await a.update({ id: 'wtask-1', status: 'review_requested', actor: WORKER, expectedRev: 1 });
+    expect(retry.ok).toBe(true);
+    expect(seen).toHaveLength(1);
+    vi.spyOn(fs.promises, 'appendFile').mockRejectedValueOnce(new Error('ENOSPC'));
+    await expect(a.register({ id: 'wtask-2', taskWorkspaceId: 't', ownerWorkspaceId: 'o', title: 'x' })).rejects.toThrow('ENOSPC');
+    expect(a.get('wtask-2')).toBeNull();
+  });
+
+  it('serializes concurrent updates so only one of two writers with the same rev wins', async () => {
+    const a = open();
+    await seed(a);
+    const [x, y] = await Promise.all([
+      a.update({ id: 'wtask-1', status: 'review_requested', actor: WORKER, expectedRev: 1 }),
+      a.update({ id: 'wtask-1', status: 'failed', actor: WORKER, expectedRev: 1 }),
+    ]);
+    expect([x.ok, y.ok].sort()).toEqual([false, true]);
+    expect(a.get('wtask-1')?.rev).toBe(2);
+  });
+
+  it('rotates past the byte cap: old log linked to .1 first, snapshot renamed over live, fresh file replays', async () => {
+    const a = open({ rotateBytes: 1200 });
     await seed(a, 'wtask-1');
     await seed(a, 'wtask-2');
     await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-owner', seq: 7, payload: { kind: 'agent.stop' } });
     await seed(a, 'wtask-3');
+    await churn(a, 'wtask-1', 6);
     await a.flush();
     expect(fs.existsSync(`${getTaskLedgerPath(dir)}.1`)).toBe(true);
     const fresh = fs.readFileSync(getTaskLedgerPath(dir), 'utf8').trim().split('\n');
     expect(JSON.parse(fresh[0]).op).toBe('snapshot');
+    expect(fs.readdirSync(dir).filter((f) => f.includes('.tmp-'))).toEqual([]);
     const b = open();
+    expect(b.recoveredFromRotated).toBe(false);
     expect(b.list().map((e) => e.id).sort()).toEqual(['wtask-1', 'wtask-2', 'wtask-3']);
     expect(b.peekOrphanedEvents('ws-owner')).toHaveLength(1);
   });
 
-  it('prunes terminal entries past the retention window on load', async () => {
+  it('recovers from .1 when the live file is missing', async () => {
+    const a = open({ rotateBytes: 1200 });
+    await seed(a, 'wtask-1');
+    await seed(a, 'wtask-2');
+    await seed(a, 'wtask-3');
+    await churn(a, 'wtask-1', 6);
+    await a.flush();
+    expect(fs.existsSync(`${getTaskLedgerPath(dir)}.1`)).toBe(true);
+    fs.rmSync(getTaskLedgerPath(dir));
+    const b = open();
+    expect(b.recoveredFromRotated).toBe(true);
+    expect(b.list().map((e) => e.id).sort()).toEqual(['wtask-1', 'wtask-2', 'wtask-3']);
+  });
+
+  it('refuses to rotate when the snapshot itself would exceed the cap (no recursive rotation)', async () => {
+    const logs: string[] = [];
+    const a = open({ rotateBytes: 300, log: (l) => logs.push(l) });
+    await seed(a, 'wtask-1');
+    await seed(a, 'wtask-2');
+    await a.flush();
+    expect(fs.existsSync(`${getTaskLedgerPath(dir)}.1`)).toBe(false);
+    expect(logs.some((l) => l.includes('snapshot would exceed'))).toBe(true);
+    expect(open().list()).toHaveLength(2);
+  });
+
+  it('prunes terminal entries past the retention window on load and tells the host', async () => {
     const a = open();
     await seed(a);
     await driveTo(a, 'wtask-1', 'cancelled');
     await a.flush();
     clock += LEDGER_TERMINAL_RETENTION_MS + 1;
-    expect(open().get('wtask-1')).toBeNull();
+    const pruned: string[] = [];
+    expect(open({ onPrune: (id) => pruned.push(id) }).get('wtask-1')).toBeNull();
+    expect(pruned).toEqual(['wtask-1']);
+  });
+
+  it('validates snapshot orphans on replay like orphaned_event lines', async () => {
+    fs.writeFileSync(
+      getTaskLedgerPath(dir),
+      `${JSON.stringify({ op: 'snapshot', entries: [], orphans: [{ ownerWorkspaceId: 'ws', seq: 1, payload: {} }, { bogus: true }, 'x', null] })}\n`,
+      'utf8',
+    );
+    expect(open().peekOrphanedEvents('ws')).toHaveLength(1);
   });
 });
 
@@ -137,14 +224,9 @@ describe('TaskLedger — transition matrix', () => {
         const a = open();
         await seed(a);
         await driveTo(a, 'wtask-1', from);
+        if (to === 'completed' && allowed && from !== to) await a.recordGate('wtask-1', PASS);
         const cur = a.get('wtask-1')!;
-        const res = await a.update({
-          id: 'wtask-1',
-          status: to,
-          actor: to === 'completed' ? BRAIN : SYSTEM,
-          expectedRev: cur.rev,
-          gate: { exitCode: 0, tail: '', at: now(), command: 'gate' },
-        });
+        const res = await a.update({ id: 'wtask-1', status: to, actor: to === 'completed' ? BRAIN : SYSTEM, expectedRev: cur.rev });
         expect(res.ok).toBe(allowed);
         if (!res.ok) expect(res.error).toBe('illegal_transition');
         if (res.ok && from === to) expect(res.noop).toBe(true);
@@ -155,54 +237,78 @@ describe('TaskLedger — transition matrix', () => {
   it('refuses an unknown status and a stale rev', async () => {
     const a = open();
     await seed(a);
-    const bad = await a.update({ id: 'wtask-1', status: 'done', actor: SYSTEM, expectedRev: 1 });
-    expect(bad).toMatchObject({ ok: false, error: 'invalid_status' });
-    const stale = await a.update({ id: 'wtask-1', status: 'failed', actor: SYSTEM, expectedRev: 0 });
-    expect(stale).toMatchObject({ ok: false, error: 'stale_rev' });
-    const missing = await a.update({ id: 'nope', status: 'failed', actor: SYSTEM, expectedRev: 1 });
-    expect(missing).toMatchObject({ ok: false, error: 'not_found' });
+    expect(await a.update({ id: 'wtask-1', status: 'done', actor: SYSTEM, expectedRev: 1 })).toMatchObject({ ok: false, error: 'invalid_status' });
+    expect(await a.update({ id: 'wtask-1', status: 'failed', actor: SYSTEM, expectedRev: 0 })).toMatchObject({ ok: false, error: 'stale_rev' });
+    expect(await a.update({ id: 'nope', status: 'failed', actor: SYSTEM, expectedRev: 1 })).toMatchObject({ ok: false, error: 'not_found' });
   });
 
-  it('completed needs a passing gate unless forced with a reason, and only a brain may set it', async () => {
+  it('completed needs a SYSTEM-recorded passing gate unless forced with a reason, and only a brain may set it', async () => {
     const a = open();
     await seed(a);
     await driveTo(a, 'wtask-1', 'review_requested');
-    const noGate = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2 });
-    expect(noGate).toMatchObject({ ok: false, error: 'gate_required' });
-    const failedGate = await a.update({
-      id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2,
-      gate: { exitCode: 1, tail: 'boom', at: now(), command: 'gate' },
-    });
-    expect(failedGate).toMatchObject({ ok: false, error: 'gate_required' });
-    const nullGate = await a.update({
-      id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2,
-      gate: { exitCode: null, tail: '', at: now(), command: 'gate' },
-    });
-    expect(nullGate).toMatchObject({ ok: false, error: 'gate_required' });
-    const forcedNoReason = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2, force: true });
-    expect(forcedNoReason).toMatchObject({ ok: false, error: 'force_reason_required' });
-    const systemComplete = await a.update({
-      id: 'wtask-1', status: 'completed', actor: SYSTEM, expectedRev: 2,
-      gate: { exitCode: 0, tail: '', at: now(), command: 'gate' },
-    });
-    expect(systemComplete).toMatchObject({ ok: false, error: 'not_authorized' });
+    expect(await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2 })).toMatchObject({ ok: false, error: 'gate_required' });
+    // Only the gate runner may record a gate.
+    expect(await a.recordGate('wtask-1', PASS, BRAIN)).toMatchObject({ ok: false, error: 'not_authorized' });
+    expect(await a.recordGate('wtask-1', PASS, WORKER)).toMatchObject({ ok: false, error: 'not_authorized' });
+    // A failing / signalled gate does not pass.
+    await a.recordGate('wtask-1', { ...PASS, exitCode: 1 });
+    expect(await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 3 })).toMatchObject({ ok: false, error: 'gate_required' });
+    await a.recordGate('wtask-1', { ...PASS, exitCode: null });
+    expect(await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 4 })).toMatchObject({ ok: false, error: 'gate_required' });
+    expect(await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 4, force: true })).toMatchObject({ ok: false, error: 'force_reason_required' });
+    await a.recordGate('wtask-1', PASS);
+    expect(a.get('wtask-1')?.gate?.recordedBy).toBe('system');
+    expect(await a.update({ id: 'wtask-1', status: 'completed', actor: SYSTEM, expectedRev: 5 })).toMatchObject({ ok: false, error: 'not_authorized' });
+    const done = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 5 });
+    expect(done.ok).toBe(true);
+  });
+
+  it('a gate that was never recorded by the system does not count even if present on a replayed entry', async () => {
+    const a = open();
+    await seed(a);
+    await driveTo(a, 'wtask-1', 'review_requested');
+    await a.flush();
+    // Forge a passing gate line without provenance, as a tampered log would.
+    const forged = { ...a.get('wtask-1')!, rev: 3, gate: { exitCode: 0, tail: '', at: 1, command: 'x' } };
+    fs.appendFileSync(getTaskLedgerPath(dir), `${JSON.stringify({ op: 'entry', entry: forged })}\n`, 'utf8');
+    const b = open();
+    expect(await b.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 3 })).toMatchObject({ ok: false, error: 'gate_required' });
+  });
+
+  it('forced completion logs the reason on the entry', async () => {
+    const a = open();
+    await seed(a);
+    await driveTo(a, 'wtask-1', 'review_requested');
     const forced = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 2, force: true, reason: 'owner waived' });
     expect(forced.ok).toBe(true);
     expect(a.get('wtask-1')?.summary).toContain('[forced: owner waived]');
   });
 
-  it('bounds the recorded gate tail to LEDGER_GATE_TAIL_MAX_BYTES, keeping the end', async () => {
+  it('clamps the gate tail, the gate command and the summary by bytes', async () => {
     const a = open();
     await seed(a);
     const tail = `${'x'.repeat(LEDGER_GATE_TAIL_MAX_BYTES)}END`;
-    const res = await a.update({
-      id: 'wtask-1', status: 'review_requested', actor: SYSTEM, expectedRev: 1,
-      gate: { exitCode: 0, tail, at: now(), command: 'gate' },
-    });
+    await a.recordGate('wtask-1', { ...PASS, tail, command: 'c'.repeat(LEDGER_GATE_COMMAND_MAX_BYTES + 50) });
+    const gate = a.get('wtask-1')!.gate!;
+    expect(Buffer.byteLength(gate.tail)).toBe(LEDGER_GATE_TAIL_MAX_BYTES);
+    expect(gate.tail.endsWith('END')).toBe(true);
+    expect(Buffer.byteLength(gate.command)).toBe(LEDGER_GATE_COMMAND_MAX_BYTES);
+    const res = await a.update({ id: 'wtask-1', status: 'review_requested', actor: SYSTEM, expectedRev: 2, summary: 's'.repeat(LEDGER_SUMMARY_MAX_BYTES * 2) });
     expect(res.ok).toBe(true);
-    const stored = a.get('wtask-1')!.gate!.tail;
-    expect(Buffer.byteLength(stored)).toBe(LEDGER_GATE_TAIL_MAX_BYTES);
-    expect(stored.endsWith('END')).toBe(true);
+    expect(Buffer.byteLength(a.get('wtask-1')!.summary!)).toBe(LEDGER_SUMMARY_MAX_BYTES);
+  });
+});
+
+describe('truncateTail / truncateHead — UTF-8 safe', () => {
+  it('never splits a multibyte sequence', () => {
+    const text = `ab${'한'.repeat(10)}`; // 한 = 3 bytes
+    const tail = truncateTail(text, 10); // 10 bytes lands inside a 한
+    expect(tail).toBe('한한한');
+    expect(Buffer.byteLength(tail)).toBe(9);
+    const head = truncateHead(text, 4); // a b + 2 bytes of 한
+    expect(head).toBe('ab');
+    expect(truncateTail(text, 1000)).toBe(text);
+    expect(truncateHead('😀😀', 5)).toBe('😀');
   });
 });
 
@@ -237,20 +343,40 @@ describe('TaskLedger — close, orphans, listeners', () => {
     expect(await a.closeTask('wtask-9')).toBeNull();
   });
 
-  it('parks orphaned events per owner, drains them in seq order once, and survives restart', async () => {
+  it('findOpenByTaskWorkspace ignores finished tasks', async () => {
+    const a = open();
+    await seed(a);
+    expect(a.findOpenByTaskWorkspace('ws-task')?.id).toBe('wtask-1');
+    await a.closeTask('wtask-1');
+    expect(a.findOpenByTaskWorkspace('ws-task')).toBeNull();
+    expect(a.findByTaskWorkspace('ws-task')?.id).toBe('wtask-1');
+  });
+
+  it('parks orphaned events per owner; peek is non-destructive, ack releases up to a seq, both survive restart', async () => {
     const a = open();
     await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-owner', seq: 12, payload: { kind: 'agent.stop' } });
     await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-owner', seq: 9, payload: { kind: 'agent.awaiting_input' } });
     await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws-else', seq: 10, payload: {} });
-    await a.flush();
     const b = open();
-    const drained = b.takeOrphanedEvents('ws-owner');
-    expect(drained.map((o) => o.seq)).toEqual([9, 12]);
-    expect(b.takeOrphanedEvents('ws-owner')).toEqual([]);
-    await b.flush();
+    expect(b.peekOrphanedEvents('ws-owner').map((o) => o.seq)).toEqual([9, 12]);
+    expect(b.peekOrphanedEvents('ws-owner').map((o) => o.seq)).toEqual([9, 12]);
+    await b.ackOrphanedEvents('ws-owner', 9);
+    expect(b.peekOrphanedEvents('ws-owner').map((o) => o.seq)).toEqual([12]);
     const c = open();
-    expect(c.peekOrphanedEvents('ws-owner')).toEqual([]);
+    expect(c.peekOrphanedEvents('ws-owner').map((o) => o.seq)).toEqual([12]);
     expect(c.peekOrphanedEvents('ws-else')).toHaveLength(1);
+  });
+
+  it('bounds the orphan backlog by count and by bytes, dropping the oldest and logging it', async () => {
+    const logs: string[] = [];
+    const a = open({ orphanMaxCount: 3, log: (l) => logs.push(l) });
+    for (let seq = 1; seq <= 5; seq++) await a.recordOrphanedEvent({ ownerWorkspaceId: 'ws', seq, payload: {} });
+    expect(a.peekOrphanedEvents('ws').map((o) => o.seq)).toEqual([3, 4, 5]);
+    expect(logs.some((l) => l.includes('orphan backlog over cap'))).toBe(true);
+    const b = open({ orphanMaxBytes: 200 });
+    await b.recordOrphanedEvent({ ownerWorkspaceId: 'ws2', seq: 1, payload: { pad: 'x'.repeat(150) } });
+    await b.recordOrphanedEvent({ ownerWorkspaceId: 'ws2', seq: 2, payload: { pad: 'y'.repeat(150) } });
+    expect(b.peekOrphanedEvents('ws2').map((o) => o.seq)).toEqual([2]);
   });
 
   it('emits one transition per accepted write, none for refusals or no-ops', async () => {
@@ -265,6 +391,5 @@ describe('TaskLedger — close, orphans, listeners', () => {
     expect(seen[1].summary).toBe('gate green');
     expect(a.list({ ownerWorkspaceId: 'ws-owner', openOnly: true })).toHaveLength(1);
     expect(a.list({ taskWorkspaceId: 'ws-nope' })).toHaveLength(0);
-    expect(a.findByTaskWorkspace('ws-task')?.id).toBe('wtask-1');
   });
 });

--- a/src/main/deck/ClaudeSdkAdapter.ts
+++ b/src/main/deck/ClaudeSdkAdapter.ts
@@ -299,6 +299,10 @@ export const DEFAULT_ALLOWED_TOOLS: string[] = [
   // Commander-only (never in full/core): the task ledger read. A pure read of
   // the brain's own rows, so it auto-allows like the other observe tools.
   WMUX('ledger_list'),
+  // The brain-scoped ledger_update (commander variant): it can only move the
+  // brain's OWN tasks, and `completed` is refused server-side without a
+  // system-recorded passing gate or a logged force+reason.
+  WMUX('ledger_update'),
 ];
 
 // Built-in CLI tools the orchestrator must NEVER hold. `allowedTools` only

--- a/src/main/deck/ClaudeSdkAdapter.ts
+++ b/src/main/deck/ClaudeSdkAdapter.ts
@@ -30,7 +30,7 @@ import { loadCommanderMemory, getMemoryRootDir } from './commanderMemory';
 import { getAccountStore, VENDOR_ENV_KEYS } from '../account/accountStore';
 import { mintCommanderToken, revokeCommanderToken } from './commanderTrust';
 import { evaluateCommanderToolPermission } from './commanderToolSandbox';
-import { COMMANDER_MODE_ARG, COMMANDER_TOOL_SURFACE } from '../../shared/commanderSurface';
+import { COMMANDER_MODE_ARG, COMMANDER_TOOL_SURFACE, COMMANDER_ONLY_TOOLS } from '../../shared/commanderSurface';
 import {
   type BrainAdapter,
   type BrainEvent,
@@ -232,7 +232,10 @@ const WMUX = (t: string): string => `mcp__wmux__${t}`;
 // auto-allow list and the actually-registered surface cannot drift. The
 // literal list below is retained as documentation + a change-review speed
 // bump: the test suite asserts it equals the derivation.
-export const DEFAULT_ALLOWED_TOOLS_FROM_SURFACE: string[] = COMMANDER_TOOL_SURFACE.map(WMUX);
+export const DEFAULT_ALLOWED_TOOLS_FROM_SURFACE: string[] = [
+  ...COMMANDER_TOOL_SURFACE,
+  ...COMMANDER_ONLY_TOOLS,
+].map(WMUX);
 
 export const DEFAULT_ALLOWED_TOOLS: string[] = [
   // Read / observe — the whole family.
@@ -293,6 +296,9 @@ export const DEFAULT_ALLOWED_TOOLS: string[] = [
   // record — the server RPC (deck.rpc.ts) enforces every precondition (auto
   // mode, TTL elapsed, substance floor), so a disallowed call is refused there.
   WMUX('deck_resolve_decision'),
+  // Commander-only (never in full/core): the task ledger read. A pure read of
+  // the brain's own rows, so it auto-allows like the other observe tools.
+  WMUX('ledger_list'),
 ];
 
 // Built-in CLI tools the orchestrator must NEVER hold. `allowedTools` only

--- a/src/main/deck/CommanderEventCoalescer.ts
+++ b/src/main/deck/CommanderEventCoalescer.ts
@@ -108,6 +108,17 @@ export interface A2aTaskDetail {
   verifiedItemCount?: number;
 }
 
+/** Tag on a lifecycle event that was COPIED from a fan-out task workspace to
+ *  its owning (parent) workspace. Lane F: the event is the parent's own
+ *  delegated work, so the parent's `wakePolicy: 'none'` does not swallow it —
+ *  a brain that fanned out must learn its workers finished. */
+export interface DelegatedTaskTag {
+  /** WorkTask id. */
+  taskId: string;
+  /** The task's dedicated workspace (where the event actually fired). */
+  taskWorkspaceId: string;
+}
+
 /** The minimal slice of an AgentLifecycleEvent the coalescer needs. */
 export interface CoalescerInput {
   workspaceId: string;
@@ -126,6 +137,8 @@ export interface CoalescerInput {
   a2a?: A2aTaskDetail;
   /** Only set for kind === 'agent.stop' from a hook (see AgentLastMessage). */
   lastMessage?: AgentLastMessage;
+  /** Set when this event was routed from a fan-out task workspace to its owner. */
+  task?: DelegatedTaskTag;
 }
 
 /** One buffered event: the last seen per (ptyId, kind). Exported so the pure
@@ -143,6 +156,8 @@ export interface BufferedEvent {
   a2a?: A2aTaskDetail;
   /** Only set for kind === 'agent.stop' from a hook (see AgentLastMessage). */
   lastMessage?: AgentLastMessage;
+  /** Set when this event was routed from a fan-out task workspace to its owner. */
+  task?: DelegatedTaskTag;
 }
 
 /** Internal per-workspace phase — surfaced only for tests/observability. The
@@ -243,6 +258,12 @@ export interface CoalescerDeps {
    *  flush prompt (e.g. "fleet: 3 running, 1 blocked"). Read fresh at flush;
    *  absent/throwing/empty = no line. Unused until WP4 wires it. */
   getFleetTail?: (workspaceId: string) => string | undefined;
+  /** Lane F: drain the worker events parked in the task ledger while this
+   *  workspace had no brain (`orphaned_event`). Called on the human send that
+   *  boots/addresses the brain, and the backlog is replayed through the
+   *  ordinary push path so it lands in the next wake. Absent/throwing = no
+   *  backlog. */
+  takeOrphanBacklog?: (workspaceId: string) => CoalescerInput[];
 }
 
 const DEFAULT_DEBOUNCE_MS = 1_500;
@@ -282,7 +303,7 @@ export class CommanderEventCoalescer {
   /** Ingest one lifecycle event. Drops kinds we don't wake on and events at/below
    *  the workspace watermark (already flushed). Buffers, then either debounces
    *  (idle) or holds (busy) until a flush point. */
-  push(ev: CoalescerInput): void {
+  push(ev: CoalescerInput, opts: { replay?: boolean } = {}): void {
     if (this.disposed) return;
     if (
       ev.kind !== 'agent.stop' &&
@@ -296,7 +317,10 @@ export class CommanderEventCoalescer {
       ev.kind !== 'a2a.canceled'
     ) return;
     const st = this.ensureState(ev.workspaceId);
-    if (ev.seq <= st.watermark) return; // idempotency — already delivered/consumed
+    // Idempotency — already delivered/consumed. A replayed orphan backlog
+    // skips the check: its seqs predate whatever this workspace has flushed
+    // since, yet by construction nobody ever delivered them.
+    if (!opts.replay && ev.seq <= st.watermark) return;
     const byKind = st.buffer.get(ev.ptyId) ?? new Map<CoalescedKind, BufferedEvent>();
     byKind.set(ev.kind, {
       ptyId: ev.ptyId,
@@ -308,6 +332,7 @@ export class CommanderEventCoalescer {
       ...(ev.detail ? { detail: ev.detail } : {}),
       ...(ev.a2a ? { a2a: ev.a2a } : {}),
       ...(ev.lastMessage ? { lastMessage: ev.lastMessage } : {}),
+      ...(ev.task ? { task: ev.task } : {}),
     });
     st.buffer.set(ev.ptyId, byKind);
 
@@ -504,6 +529,19 @@ export class CommanderEventCoalescer {
     st.buffer.clear();
     this.clearDebounce(st);
     st.phase = 'idle';
+    // Lane F: a human send means a brain exists (or is about to) for this
+    // workspace — hand it the worker events that fired while it had none.
+    for (const orphan of this.safeOrphanBacklog(workspaceId)) {
+      this.push({ ...orphan, workspaceId }, { replay: true });
+    }
+  }
+
+  private safeOrphanBacklog(workspaceId: string): CoalescerInput[] {
+    try {
+      return this.deps.takeOrphanBacklog?.(workspaceId) ?? [];
+    } catch {
+      return [];
+    }
   }
 
   /** Test/observability peek. */
@@ -809,17 +847,26 @@ export class CommanderEventCoalescer {
       ? { ...standingAutonomy, summarize: true, continueInstruction: true }
       : standingAutonomy;
     const policy: WakePolicy = loopRunning || workActive ? 'all' : standingAutonomy.wakePolicy;
-    if (policy === 'none') {
-      this.consume(st, events);
-      return;
-    }
     let flushEvents = events;
+    if (policy === 'none') {
+      // Lane F: 'none' swallows FOREIGN noise, not the workspace's own
+      // delegated work. An event tagged with a fan-out task the brain owns
+      // still wakes it; everything else is consumed as before.
+      const delegated = events.filter((e) => e.task !== undefined);
+      if (delegated.length === 0) {
+        this.consume(st, events);
+        return;
+      }
+      flushEvents = delegated;
+    }
     if (policy === 'value-filtered') {
       // assist surfaces the HIGH-VALUE kinds: a pane blocked on input, a PR
       // that just went red, and fresh review feedback. Plain agent.stop is the
-      // summary-spam we drop.
+      // summary-spam we drop. A delegated worker's stop is the parent's own
+      // result, never spam.
       const worthy = events.filter(
         (e) =>
+          e.task !== undefined ||
           e.kind === 'agent.awaiting_input' ||
           e.kind === 'pr.ci_failed' ||
           e.kind === 'pr.review_comment' ||
@@ -1019,7 +1066,9 @@ function renderEventLine(
   const a2a = e.a2a;
   const subjectLabel = a2a
     ? `task=${sanitizeSnippet(a2a.taskId)}(to=${sanitizeSnippet(a2a.to)})`
-    : `pane=${e.ptyId}(${e.agent ?? 'shell'})`;
+    : e.task
+      ? `worker-task=${sanitizeSnippet(e.task.taskId)} ws=${sanitizeSnippet(e.task.taskWorkspaceId)} pane=${e.ptyId}(${e.agent ?? 'shell'})`
+      : `pane=${e.ptyId}(${e.agent ?? 'shell'})`;
   const kindLabel =
     e.kind === 'agent.stop' ? 'stop'
     : e.kind === 'pr.ci_failed' ? 'ci-failed'

--- a/src/main/deck/CommanderEventCoalescer.ts
+++ b/src/main/deck/CommanderEventCoalescer.ts
@@ -158,6 +158,8 @@ export interface BufferedEvent {
   lastMessage?: AgentLastMessage;
   /** Set when this event was routed from a fan-out task workspace to its owner. */
   task?: DelegatedTaskTag;
+  /** Internal: replayed from the orphan backlog — acknowledged on delivery. */
+  replayed?: true;
 }
 
 /** Internal per-workspace phase — surfaced only for tests/observability. The
@@ -258,12 +260,16 @@ export interface CoalescerDeps {
    *  flush prompt (e.g. "fleet: 3 running, 1 blocked"). Read fresh at flush;
    *  absent/throwing/empty = no line. Unused until WP4 wires it. */
   getFleetTail?: (workspaceId: string) => string | undefined;
-  /** Lane F: drain the worker events parked in the task ledger while this
-   *  workspace had no brain (`orphaned_event`). Called on the human send that
-   *  boots/addresses the brain, and the backlog is replayed through the
-   *  ordinary push path so it lands in the next wake. Absent/throwing = no
-   *  backlog. */
-  takeOrphanBacklog?: (workspaceId: string) => CoalescerInput[];
+  /** Lane F: PEEK the worker events parked in the task ledger while this
+   *  workspace had no brain (`orphaned_event`). Read when a brain boots for
+   *  the workspace (manager created, mode turned on, human send) and replayed
+   *  through the ordinary push path; nothing leaves the backlog until
+   *  `ackOrphanBacklog` confirms a wake delivered it, so a flush that is
+   *  consumed instead (pending decision, auto-wake off, a failed turn) leaves
+   *  the events parked for the next boot. Absent/throwing = no backlog. */
+  peekOrphanBacklog?: (workspaceId: string) => CoalescerInput[];
+  /** Lane F: the parked events at or below `upToSeq` reached the brain. */
+  ackOrphanBacklog?: (workspaceId: string, upToSeq: number) => void;
 }
 
 const DEFAULT_DEBOUNCE_MS = 1_500;
@@ -333,6 +339,7 @@ export class CommanderEventCoalescer {
       ...(ev.a2a ? { a2a: ev.a2a } : {}),
       ...(ev.lastMessage ? { lastMessage: ev.lastMessage } : {}),
       ...(ev.task ? { task: ev.task } : {}),
+      ...(opts.replay ? { replayed: true as const } : {}),
     });
     st.buffer.set(ev.ptyId, byKind);
 
@@ -531,16 +538,39 @@ export class CommanderEventCoalescer {
     st.phase = 'idle';
     // Lane F: a human send means a brain exists (or is about to) for this
     // workspace — hand it the worker events that fired while it had none.
-    for (const orphan of this.safeOrphanBacklog(workspaceId)) {
+    this.replayOrphanBacklog(workspaceId);
+  }
+
+  /** Lane F: a brain just came up for this workspace (manager created, or
+   *  the mode left 'off') without a human send. Replay the parked worker
+   *  events so the first wake carries them; budgets are untouched. */
+  notifyBrainBooted(workspaceId: string): void {
+    if (this.disposed) return;
+    this.replayOrphanBacklog(workspaceId);
+  }
+
+  private replayOrphanBacklog(workspaceId: string): void {
+    let backlog: CoalescerInput[];
+    try {
+      backlog = this.deps.peekOrphanBacklog?.(workspaceId) ?? [];
+    } catch {
+      backlog = [];
+    }
+    for (const orphan of backlog) {
       this.push({ ...orphan, workspaceId }, { replay: true });
     }
   }
 
-  private safeOrphanBacklog(workspaceId: string): CoalescerInput[] {
+  /** Delivery confirmed for `events`: acknowledge the replayed ones so the
+   *  backlog releases them (up to the highest replayed seq). */
+  private ackReplayed(workspaceId: string, events: readonly BufferedEvent[]): void {
+    let maxSeq = -Infinity;
+    for (const e of events) if (e.replayed && e.seq > maxSeq) maxSeq = e.seq;
+    if (maxSeq === -Infinity) return;
     try {
-      return this.deps.takeOrphanBacklog?.(workspaceId) ?? [];
+      this.deps.ackOrphanBacklog?.(workspaceId, maxSeq);
     } catch {
-      return [];
+      // best-effort — an un-acked backlog only replays once more
     }
   }
 
@@ -931,6 +961,7 @@ export class CommanderEventCoalescer {
           this.recordWake(st, this.nowFn());
           if (snapshotMaxSeq > st.watermark) st.watermark = snapshotMaxSeq;
           this.pruneBuffer(st, snapshotMaxSeq);
+          this.ackReplayed(workspaceId, flushEvents);
           // Events may have arrived during the send — leave them for the next
           // idle-driven flush.
           st.phase = st.buffer.size > 0 ? 'buffering' : 'idle';

--- a/src/main/deck/__tests__/CommanderEventCoalescer.delegated.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.delegated.test.ts
@@ -1,0 +1,123 @@
+// Lane F: worker events copied from a fan-out task workspace to the owning
+// workspace carry a `task` tag — the parent's 'none' wake policy must let
+// them through, and an orphan backlog replays on the human send that boots
+// the brain.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  CommanderEventCoalescer,
+  buildEventPrompt,
+  type CoalescerInput,
+} from '../CommanderEventCoalescer';
+import { DEFAULT_AUTONOMY, type WorkspaceAutonomy } from '../deckAutonomyStore';
+
+const settle = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function mk(autonomy: WorkspaceAutonomy, backlog: CoalescerInput[] = []) {
+  const prompts: { ws: string; prompt: string }[] = [];
+  const c = new CommanderEventCoalescer({
+    runTurn: async (ws, prompt) => {
+      prompts.push({ ws, prompt });
+      return { ok: true };
+    },
+    isBusy: () => false,
+    getAutonomy: () => autonomy,
+    takeOrphanBacklog: () => backlog.splice(0),
+    debounceMs: 1_000,
+  });
+  return { c, prompts };
+}
+
+function stop(over: Partial<CoalescerInput> = {}): CoalescerInput {
+  return {
+    workspaceId: 'ws-parent',
+    ptyId: 'pty-worker',
+    kind: 'agent.stop',
+    source: 'hook',
+    agent: 'claude',
+    seq: 1,
+    ts: 0,
+    ...over,
+  };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('delegated-task events under wakePolicy none', () => {
+  it('a tagged worker stop wakes the parent even though its policy is none', async () => {
+    const { c, prompts } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' });
+    c.push(stop({ task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].ws).toBe('ws-parent');
+    expect(prompts[0].prompt).toContain('worker-task=wtask-1 ws=ws-task');
+  });
+
+  it('an untagged stop is still consumed under none (unchanged behaviour)', async () => {
+    const { c, prompts } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' });
+    c.push(stop());
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(0);
+    expect(c.getPhase('ws-parent')).toBe('idle');
+  });
+
+  it('under none only the tagged events reach the prompt; foreign ones are consumed alongside', async () => {
+    const { c, prompts } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' });
+    c.push(stop({ ptyId: 'pty-foreign', seq: 1 }));
+    c.push(stop({ ptyId: 'pty-worker', seq: 2, task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].prompt).not.toContain('pty-foreign');
+    // Both seqs are behind the watermark now — neither replays.
+    c.push(stop({ ptyId: 'pty-foreign', seq: 1 }));
+    c.push(stop({ ptyId: 'pty-worker', seq: 2, task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+  });
+
+  it('value-filtered treats a tagged plain stop as worthy', async () => {
+    const { c, prompts } = mk({ ...DEFAULT_AUTONOMY, mode: 'assist', wakePolicy: 'value-filtered' });
+    c.push(stop({ task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+  });
+});
+
+describe('orphan backlog replay', () => {
+  it('a human send drains the backlog and its stale seqs still flush', async () => {
+    const backlog = [stop({ workspaceId: 'ws-parent', seq: 3, task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } })];
+    const { c, prompts } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' }, backlog);
+    // Advance the watermark past the orphan's seq first.
+    c.push(stop({ ptyId: 'pty-x', seq: 10 }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(0);
+    c.notifyHumanSend('ws-parent');
+    c.notifyIdle('ws-parent');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].prompt).toContain('worker-task=wtask-1');
+    expect(backlog).toHaveLength(0);
+  });
+});
+
+describe('buildEventPrompt with a task tag', () => {
+  it('names the worker task and workspace on the line', () => {
+    const prompt = buildEventPrompt(
+      [{ ptyId: 'p', kind: 'agent.stop', source: 'hook', agent: 'claude', seq: 1, ts: 0, task: { taskId: 't1', taskWorkspaceId: 'w1' } }],
+      DEFAULT_AUTONOMY,
+      { remaining: 1, total: 1 },
+    );
+    expect(prompt).toContain('worker-task=t1 ws=w1 pane=p(claude)');
+  });
+});

--- a/src/main/deck/__tests__/CommanderEventCoalescer.delegated.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.delegated.test.ts
@@ -16,19 +16,25 @@ const settle = async () => {
   await Promise.resolve();
 };
 
-function mk(autonomy: WorkspaceAutonomy, backlog: CoalescerInput[] = []) {
+function mk(autonomy: WorkspaceAutonomy, backlog: CoalescerInput[] = [], extra: { pendingDecision?: () => boolean; runOk?: () => boolean } = {}) {
   const prompts: { ws: string; prompt: string }[] = [];
+  const acks: number[] = [];
   const c = new CommanderEventCoalescer({
     runTurn: async (ws, prompt) => {
       prompts.push({ ws, prompt });
-      return { ok: true };
+      return extra.runOk ? { ok: extra.runOk(), code: 'spawn_failed' } : { ok: true };
     },
     isBusy: () => false,
     getAutonomy: () => autonomy,
-    takeOrphanBacklog: () => backlog.splice(0),
+    ...(extra.pendingDecision ? { hasPendingDecision: extra.pendingDecision } : {}),
+    peekOrphanBacklog: () => [...backlog],
+    ackOrphanBacklog: (_ws, upToSeq) => {
+      acks.push(upToSeq);
+      for (let i = backlog.length - 1; i >= 0; i--) if (backlog[i].seq <= upToSeq) backlog.splice(i, 1);
+    },
     debounceMs: 1_000,
   });
-  return { c, prompts };
+  return { c, prompts, acks };
 }
 
 function stop(over: Partial<CoalescerInput> = {}): CoalescerInput {
@@ -92,21 +98,54 @@ describe('delegated-task events under wakePolicy none', () => {
   });
 });
 
-describe('orphan backlog replay', () => {
-  it('a human send drains the backlog and its stale seqs still flush', async () => {
-    const backlog = [stop({ workspaceId: 'ws-parent', seq: 3, task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } })];
-    const { c, prompts } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' }, backlog);
-    // Advance the watermark past the orphan's seq first.
+describe('orphan backlog replay (peek → deliver → ack)', () => {
+  const orphan = () => stop({ workspaceId: 'ws-parent', seq: 3, task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } });
+
+  it('a human send replays the backlog, its stale seq still flushes, and delivery acks it', async () => {
+    const backlog = [orphan()];
+    const { c, prompts, acks } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' }, backlog);
     c.push(stop({ ptyId: 'pty-x', seq: 10 }));
     vi.advanceTimersByTime(1_000);
     await settle();
     expect(prompts).toHaveLength(0);
     c.notifyHumanSend('ws-parent');
+    expect(backlog).toHaveLength(1); // peeked, not taken
     c.notifyIdle('ws-parent');
     vi.advanceTimersByTime(1_000);
     await settle();
     expect(prompts).toHaveLength(1);
     expect(prompts[0].prompt).toContain('worker-task=wtask-1');
+    expect(acks).toEqual([3]);
+    expect(backlog).toHaveLength(0);
+  });
+
+  it('a flush consumed by a pending decision leaves the backlog parked (no ack)', async () => {
+    const backlog = [orphan()];
+    const { c, prompts, acks } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' }, backlog, { pendingDecision: () => true });
+    c.notifyBrainBooted('ws-parent');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(0);
+    expect(acks).toEqual([]);
+    expect(backlog).toHaveLength(1);
+  });
+
+  it('a failed turn leaves the backlog parked; a later boot replays it', async () => {
+    const backlog = [orphan()];
+    let ok = false;
+    const { c, prompts, acks } = mk({ ...DEFAULT_AUTONOMY, wakePolicy: 'none' }, backlog, { runOk: () => ok });
+    c.notifyBrainBooted('ws-parent');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+    expect(acks).toEqual([]);
+    expect(backlog).toHaveLength(1);
+    ok = true;
+    c.notifyBrainBooted('ws-parent');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(2);
+    expect(acks).toEqual([3]);
     expect(backlog).toHaveLength(0);
   });
 });

--- a/src/main/deck/__tests__/deckLedgerGateStore.test.ts
+++ b/src/main/deck/__tests__/deckLedgerGateStore.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  DEFAULT_LEDGER_GATE_ENABLED,
+  loadLedgerGateEnabled,
+  setLedgerGateEnabled,
+  getDeckLedgerGatePath,
+} from '../deckLedgerGateStore';
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-deck-ledger-gate-'));
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('deckLedgerGateStore', () => {
+  it('defaults to OFF on a missing or corrupt file', () => {
+    expect(DEFAULT_LEDGER_GATE_ENABLED).toBe(false);
+    expect(loadLedgerGateEnabled(dir)).toBe(false);
+    fs.writeFileSync(getDeckLedgerGatePath(dir), 'CORRUPT{', 'utf8');
+    expect(loadLedgerGateEnabled(dir)).toBe(false);
+  });
+
+  it('round-trips ON and back OFF', async () => {
+    expect(await setLedgerGateEnabled(true, dir)).toBe(true);
+    expect(loadLedgerGateEnabled(dir)).toBe(true);
+    expect(await setLedgerGateEnabled(false, dir)).toBe(false);
+    expect(loadLedgerGateEnabled(dir)).toBe(false);
+  });
+});

--- a/src/main/deck/__tests__/stopGate.ledger.test.ts
+++ b/src/main/deck/__tests__/stopGate.ledger.test.ts
@@ -1,0 +1,90 @@
+// Lane F step 4 — the Stop gate on the task ledger (`deck.ledgerGate`).
+// Table-driven: flag off unchanged; 0 open; 1 working; 1 input_required;
+// ledger read error; 3 consecutive blocks release with the ledger flag.
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateStopGate,
+  describeOpenLedgerTasksForDecision,
+  type StopGateLedgerInput,
+  type StopGateLedgerTask,
+} from '../stopGate';
+import type { FleetSnapshot } from '../../../shared/workspaceMirror';
+
+const quiet: FleetSnapshot = { workspaceId: 'ws-1', ts: Date.now(), panes: [] };
+const working: StopGateLedgerTask = { id: 'wtask-1', title: 'lane A', status: 'working' };
+const blocked: StopGateLedgerTask = { id: 'wtask-2', title: 'lane B', status: 'input_required' };
+const review: StopGateLedgerTask = { id: 'wtask-3', title: 'lane C', status: 'review_requested' };
+
+const table: Array<{ name: string; ledger: StopGateLedgerInput | undefined; blocks: number; expectBlock: boolean; reason?: RegExp }> = [
+  { name: 'flag off, open tasks present → unchanged (allow)', ledger: { enabled: false, openTasks: [working] }, blocks: 0, expectBlock: false },
+  { name: 'no ledger input at all → unchanged (allow)', ledger: undefined, blocks: 0, expectBlock: false },
+  { name: 'flag on, 0 open → allow', ledger: { enabled: true, openTasks: [] }, blocks: 0, expectBlock: false },
+  { name: 'flag on, 1 working → block naming the task', ledger: { enabled: true, openTasks: [working] }, blocks: 0, expectBlock: true, reason: /wtask-1 "lane A" \(working/ },
+  { name: 'flag on, 1 input_required → block with the blocked hint', ledger: { enabled: true, openTasks: [blocked] }, blocks: 0, expectBlock: true, reason: /wtask-2 .*input_required: the worker is blocked/ },
+  { name: 'flag on, 1 review_requested → block with the gate hint', ledger: { enabled: true, openTasks: [review] }, blocks: 0, expectBlock: true, reason: /review_requested: the worker claims done/ },
+  { name: 'flag on, ledger read error (null) → snapshot inference decides (allow on a quiet fleet)', ledger: { enabled: true, openTasks: null }, blocks: 0, expectBlock: false },
+  { name: 'flag on, 3 consecutive blocks → released', ledger: { enabled: true, openTasks: [working] }, blocks: 3, expectBlock: false },
+];
+
+describe('evaluateStopGate — ledger path', () => {
+  for (const row of table) {
+    it(row.name, () => {
+      const verdict = evaluateStopGate({ snapshot: quiet, ledger: row.ledger, consecutiveBlocks: row.blocks });
+      expect(verdict.block).toBe(row.expectBlock);
+      if (verdict.block && row.reason) expect(verdict.reason).toMatch(row.reason);
+      if (verdict.block) {
+        expect(verdict.reason).toContain('Do NOT close or kill a pane');
+        expect(verdict.reason).toContain('deck_ask_decision');
+        expect(verdict.outstandingPtyIds).toEqual([]);
+      }
+    });
+  }
+
+  it('the cap-out carries ledgerReleased and a fingerprint that suppresses the same open set next turn', () => {
+    const ledger: StopGateLedgerInput = { enabled: true, openTasks: [working, blocked] };
+    const capped = evaluateStopGate({ snapshot: quiet, ledger, consecutiveBlocks: 3 });
+    expect(capped.block).toBe(false);
+    if (capped.block) throw new Error('unreachable');
+    expect(capped.ledgerReleased).toBe(true);
+    expect(capped.cappedOutFingerprint).toContain('wtask-1:working');
+    const again = evaluateStopGate({ snapshot: quiet, ledger, consecutiveBlocks: 0, suppressedFingerprint: capped.cappedOutFingerprint });
+    expect(again.block).toBe(false);
+    // A status change re-arms the gate.
+    const changed = evaluateStopGate({
+      snapshot: quiet,
+      ledger: { enabled: true, openTasks: [working, { ...blocked, status: 'review_requested' }] },
+      consecutiveBlocks: 0,
+      suppressedFingerprint: capped.cappedOutFingerprint,
+    });
+    expect(changed.block).toBe(true);
+  });
+
+  it('a pane cap-out without open tasks is NOT flagged ledgerReleased', () => {
+    const busy: FleetSnapshot = { workspaceId: 'ws-1', ts: Date.now(), panes: [{ ptyId: 'p', agentName: 'c', agentStatus: 'running', isActivePane: false }] };
+    const capped = evaluateStopGate({ snapshot: busy, ledger: { enabled: true, openTasks: [] }, consecutiveBlocks: 3 });
+    expect(capped.block).toBe(false);
+    if (!capped.block) expect(capped.ledgerReleased).toBeUndefined();
+  });
+
+  it('rule 4 is not flipped: a pending decision releases the gate even with open tasks', () => {
+    const verdict = evaluateStopGate({ snapshot: quiet, ledger: { enabled: true, openTasks: [working] }, pendingDecision: true, consecutiveBlocks: 0 });
+    expect(verdict.block).toBe(false);
+  });
+
+  it('a stale snapshot still contributes no panes; open tasks alone hold the turn and name no pane', () => {
+    const stale: FleetSnapshot = { workspaceId: 'ws-1', ts: Date.now() - 120_000, panes: [{ ptyId: 'p', agentName: 'c', agentStatus: 'running', isActivePane: false }] };
+    const verdict = evaluateStopGate({ snapshot: stale, ledger: { enabled: true, openTasks: [working] }, consecutiveBlocks: 0 });
+    expect(verdict.block).toBe(true);
+    if (verdict.block) expect(verdict.outstandingPtyIds).toEqual([]);
+  });
+});
+
+describe('describeOpenLedgerTasksForDecision', () => {
+  it('renders one bracketed line, empty when nothing is open', () => {
+    expect(describeOpenLedgerTasksForDecision([])).toBe('');
+    expect(describeOpenLedgerTasksForDecision([working, blocked])).toBe(
+      '[open tasks in the ledger: wtask-1 "lane A" (working), wtask-2 "lane B" (input_required)]',
+    );
+  });
+});

--- a/src/main/deck/__tests__/taskLedgerHost.test.ts
+++ b/src/main/deck/__tests__/taskLedgerHost.test.ts
@@ -8,8 +8,14 @@ import {
   takeOrphanBacklog,
   createWorkTaskReconciler,
   getMissionChannelId,
+  rememberMissionChannel,
+  readLedgerGateInput,
+  formatLedgerTransition,
+  installLedgerChannelEmitter,
   setTaskLedgerForTests,
 } from '../taskLedgerHost';
+import { overrideLedgerGateForTests } from '../deckLedgerGateStore';
+import { raiseDecision } from '../deckDecisionStore';
 import type { CoalescerInput } from '../CommanderEventCoalescer';
 
 let dir: string;
@@ -23,6 +29,7 @@ beforeEach(async () => {
 });
 afterEach(() => {
   setTaskLedgerForTests(null);
+  overrideLedgerGateForTests(null);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
@@ -100,5 +107,63 @@ describe('createWorkTaskReconciler', () => {
     clock = 2_000;
     await reconcile();
     expect(calls).toBe(4);
+  });
+});
+
+describe('readLedgerGateInput (step 4)', () => {
+  it('reports disabled with no read while the flag is off', () => {
+    overrideLedgerGateForTests(false);
+    expect(readLedgerGateInput('ws-parent')).toEqual({ enabled: false, openTasks: null });
+  });
+
+  it('lists only this owner\'s open tasks when on, and null when the ledger throws', async () => {
+    overrideLedgerGateForTests(true);
+    await ledger.register({ id: 'wtask-2', taskWorkspaceId: 'ws-t2', ownerWorkspaceId: 'ws-other', title: 'not mine' });
+    await ledger.update({ id: 'wtask-1', status: 'input_required', actor: { kind: 'worker', workspaceId: 'ws-task' }, expectedRev: 1 });
+    expect(readLedgerGateInput('ws-parent')).toEqual({
+      enabled: true,
+      openTasks: [{ id: 'wtask-1', title: 'lane', status: 'input_required' }],
+    });
+    const broken = { list: () => { throw new Error('disk'); } } as unknown as TaskLedger;
+    expect(readLedgerGateInput('ws-parent', broken)).toEqual({ enabled: true, openTasks: null });
+  });
+
+  it('deck_ask_decision context is prefixed with the open-task list while the gate is on', async () => {
+    overrideLedgerGateForTests(true);
+    const d = await raiseDecision('ws-parent', { question: 'merge?', context: 'details' }, dir);
+    expect(d?.context).toBe('[open tasks in the ledger: wtask-1 "lane" (working)]\ndetails');
+    expect(d?.question).toBe('merge?');
+    overrideLedgerGateForTests(false);
+    const off = await raiseDecision('ws-parent', { question: 'merge?', context: 'details' }, dir);
+    expect(off?.context).toBe('details');
+  });
+});
+
+describe('ledger → mission channel emitter (step 5)', () => {
+  it('formats one line per transition and posts it to the task\'s mission channel as the owner', async () => {
+    const posts: Array<{ channelId: string; ownerWorkspaceId: string; text: string; clientMsgId: string }> = [];
+    const dispose = installLedgerChannelEmitter({ post: async (p) => { posts.push(p); return { ok: true }; } });
+    rememberMissionChannel('wtask-1', 'ch-1');
+    await ledger.update({ id: 'wtask-1', status: 'review_requested', actor: { kind: 'worker', workspaceId: 'ws-task' }, expectedRev: 1, summary: 'gate  green\nall tests' });
+    // No channel known for this task → skipped, not thrown.
+    await ledger.register({ id: 'wtask-5', taskWorkspaceId: 'ws-t5', ownerWorkspaceId: 'ws-parent', title: 'quiet' });
+    dispose();
+    await ledger.update({ id: 'wtask-1', status: 'working', actor: { kind: 'brain', workspaceId: 'ws-parent' }, expectedRev: 2 });
+    expect(posts).toEqual([{
+      channelId: 'ch-1',
+      ownerWorkspaceId: 'ws-parent',
+      text: '[ledger] wtask-1 working→review_requested worker@ws-task gate green all tests',
+      clientMsgId: 'ledger:wtask-1:2',
+    }]);
+  });
+
+  it('formatLedgerTransition renders a first registration as new→working', () => {
+    const line = formatLedgerTransition({
+      entry: { id: 'wtask-9', rev: 1 } as never,
+      from: null,
+      to: 'working',
+      by: { kind: 'system', workspaceId: 'daemon' },
+    });
+    expect(line).toBe('[ledger] wtask-9 new→working system@daemon');
   });
 });

--- a/src/main/deck/__tests__/taskLedgerHost.test.ts
+++ b/src/main/deck/__tests__/taskLedgerHost.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TaskLedger } from '../../../daemon/ledger/TaskLedger';
+import {
+  routeWorkerEventToOwner,
+  takeOrphanBacklog,
+  createWorkTaskReconciler,
+  getMissionChannelId,
+  setTaskLedgerForTests,
+} from '../taskLedgerHost';
+import type { CoalescerInput } from '../CommanderEventCoalescer';
+
+let dir: string;
+let ledger: TaskLedger;
+
+beforeEach(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-ledger-host-'));
+  ledger = new TaskLedger({ dir });
+  setTaskLedgerForTests(ledger);
+  await ledger.register({ id: 'wtask-1', taskWorkspaceId: 'ws-task', ownerWorkspaceId: 'ws-parent', title: 'lane' });
+});
+afterEach(() => {
+  setTaskLedgerForTests(null);
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function ev(over: Partial<CoalescerInput> = {}): CoalescerInput {
+  return { workspaceId: 'ws-task', ptyId: 'pty-1', kind: 'agent.stop', source: 'hook', agent: 'claude', seq: 5, ts: 0, ...over };
+}
+
+describe('routeWorkerEventToOwner', () => {
+  it('copies a task-workspace event to the owner, tagged, when the owner has a brain', () => {
+    const pushed: CoalescerInput[] = [];
+    routeWorkerEventToOwner(ev(), { hasBrain: () => true, push: (e) => pushed.push(e) });
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].workspaceId).toBe('ws-parent');
+    expect(pushed[0].task).toEqual({ taskId: 'wtask-1', taskWorkspaceId: 'ws-task' });
+    expect(pushed[0].ptyId).toBe('pty-1');
+  });
+
+  it('leaves a non-task workspace event alone', () => {
+    const pushed: CoalescerInput[] = [];
+    routeWorkerEventToOwner(ev({ workspaceId: 'ws-human' }), { hasBrain: () => true, push: (e) => pushed.push(e) });
+    expect(pushed).toHaveLength(0);
+  });
+
+  it('parks the event as an orphan backlog when the owner has no brain, drained later', async () => {
+    const pushed: CoalescerInput[] = [];
+    routeWorkerEventToOwner(ev(), { hasBrain: () => false, push: (e) => pushed.push(e) });
+    await ledger.flush();
+    expect(pushed).toHaveLength(0);
+    const backlog = takeOrphanBacklog('ws-parent');
+    expect(backlog).toHaveLength(1);
+    expect(backlog[0].task?.taskId).toBe('wtask-1');
+    expect(takeOrphanBacklog('ws-parent')).toHaveLength(0);
+  });
+
+  it('reconciles once for an unknown workspace and delivers if the task appears', async () => {
+    const pushed: CoalescerInput[] = [];
+    const reconcile = async () => {
+      await ledger.register({ id: 'wtask-2', taskWorkspaceId: 'ws-task-2', ownerWorkspaceId: 'ws-parent', title: 'late' });
+    };
+    routeWorkerEventToOwner(ev({ workspaceId: 'ws-task-2' }), { hasBrain: () => true, push: (e) => pushed.push(e), reconcile });
+    for (let i = 0; i < 50 && pushed.length === 0; i++) await new Promise((r) => setTimeout(r, 10));
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0].task?.taskId).toBe('wtask-2');
+  });
+});
+
+describe('createWorkTaskReconciler', () => {
+  it('registers open materialized tasks, cancels closed ones, remembers channels, and throttles', async () => {
+    let calls = 0;
+    let clock = 0;
+    const tasks = [
+      { id: 'wtask-1', title: 'lane', status: 'closed', owner: { verifiedWorkspaceId: 'ws-parent' }, paneGroupId: 'ws-task', missionChannelId: 'ch-1' },
+      { id: 'wtask-3', title: 'new', status: 'open', owner: { verifiedWorkspaceId: 'ws-parent' }, paneGroupId: 'ws-task-3', missionChannelId: 'ch-3' },
+      { id: 'wtask-4', title: 'unmaterialized', status: 'open', owner: { verifiedWorkspaceId: 'ws-parent' } },
+    ];
+    const reconcile = createWorkTaskReconciler({
+      candidateOwners: () => ['ws-parent', 'ws-parent', 'ws-other'],
+      listTasks: async (owner) => {
+        calls += 1;
+        if (owner === 'ws-other') throw new Error('daemon down');
+        return { ok: true, tasks };
+      },
+      now: () => clock,
+      minIntervalMs: 1_000,
+    });
+    await reconcile();
+    expect(calls).toBe(2);
+    expect(ledger.get('wtask-1')?.status).toBe('cancelled');
+    expect(ledger.get('wtask-3')?.status).toBe('working');
+    expect(ledger.get('wtask-3')?.ownerWorkspaceId).toBe('ws-parent');
+    expect(ledger.get('wtask-4')).toBeNull();
+    expect(getMissionChannelId('wtask-3')).toBe('ch-3');
+    await reconcile();
+    expect(calls).toBe(2);
+    clock = 2_000;
+    await reconcile();
+    expect(calls).toBe(4);
+  });
+});

--- a/src/main/deck/__tests__/taskLedgerHost.test.ts
+++ b/src/main/deck/__tests__/taskLedgerHost.test.ts
@@ -5,7 +5,9 @@ import path from 'node:path';
 import { TaskLedger } from '../../../daemon/ledger/TaskLedger';
 import {
   routeWorkerEventToOwner,
-  takeOrphanBacklog,
+  peekOrphanBacklog,
+  ackOrphanBacklog,
+  noteWorkTaskClosed,
   createWorkTaskReconciler,
   getMissionChannelId,
   rememberMissionChannel,
@@ -15,7 +17,7 @@ import {
   setTaskLedgerForTests,
 } from '../taskLedgerHost';
 import { overrideLedgerGateForTests } from '../deckLedgerGateStore';
-import { raiseDecision } from '../deckDecisionStore';
+import { raiseDecision, composeDecisionContext, DECISION_LEDGER_PREFIX_MAX_CHARS, DECISION_LIMITS } from '../deckDecisionStore';
 import type { CoalescerInput } from '../CommanderEventCoalescer';
 
 let dir: string;
@@ -53,15 +55,36 @@ describe('routeWorkerEventToOwner', () => {
     expect(pushed).toHaveLength(0);
   });
 
-  it('parks the event as an orphan backlog when the owner has no brain, drained later', async () => {
+  it('parks the event as an orphan backlog when the owner has no brain; peek is non-destructive, ack releases', async () => {
     const pushed: CoalescerInput[] = [];
     routeWorkerEventToOwner(ev(), { hasBrain: () => false, push: (e) => pushed.push(e) });
     await ledger.flush();
     expect(pushed).toHaveLength(0);
-    const backlog = takeOrphanBacklog('ws-parent');
+    const backlog = peekOrphanBacklog('ws-parent');
     expect(backlog).toHaveLength(1);
     expect(backlog[0].task?.taskId).toBe('wtask-1');
-    expect(takeOrphanBacklog('ws-parent')).toHaveLength(0);
+    expect(peekOrphanBacklog('ws-parent')).toHaveLength(1);
+    await ackOrphanBacklog('ws-parent', 5);
+    expect(peekOrphanBacklog('ws-parent')).toHaveLength(0);
+  });
+
+  it('does not route events from a finished task workspace (completed/cancelled entries stop waking the brain)', async () => {
+    await ledger.closeTask('wtask-1');
+    const pushed: CoalescerInput[] = [];
+    let reconciled = 0;
+    routeWorkerEventToOwner(ev(), { hasBrain: () => true, push: (e) => pushed.push(e), reconcile: async () => { reconciled += 1; } });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(pushed).toHaveLength(0);
+    expect(reconciled).toBe(0);
+    expect(peekOrphanBacklog('ws-parent')).toHaveLength(0);
+  });
+
+  it('noteWorkTaskClosed cancels the entry immediately and drops its channel mapping', async () => {
+    rememberMissionChannel('wtask-1', 'ch-1');
+    await noteWorkTaskClosed('wtask-1');
+    expect(ledger.get('wtask-1')?.status).toBe('cancelled');
+    expect(getMissionChannelId('wtask-1')).toBeNull();
+    await noteWorkTaskClosed('wtask-unknown');
   });
 
   it('reconciles once for an unknown workspace and delivers if the task appears', async () => {
@@ -132,6 +155,13 @@ describe('readLedgerGateInput (step 4)', () => {
     overrideLedgerGateForTests(true);
     const d = await raiseDecision('ws-parent', { question: 'merge?', context: 'details' }, dir);
     expect(d?.context).toBe('[open tasks in the ledger: wtask-1 "lane" (working)]\ndetails');
+    // A long open-task list gets its own budget and never evicts the brain's context.
+    const longPrefix = `[open tasks in the ledger: ${'wtask-x "very long title" (working), '.repeat(40)}]\n`;
+    const composed = composeDecisionContext(longPrefix, 'the question context');
+    expect(composed.length).toBeLessThanOrEqual(DECISION_LIMITS.MAX_CONTEXT_CHARS);
+    expect(composed.endsWith('the question context')).toBe(true);
+    expect(composed.indexOf('the question context')).toBeLessThanOrEqual(DECISION_LEDGER_PREFIX_MAX_CHARS);
+    expect(composeDecisionContext('', 'x'.repeat(2000)).length).toBe(DECISION_LIMITS.MAX_CONTEXT_CHARS);
     expect(d?.question).toBe('merge?');
     overrideLedgerGateForTests(false);
     const off = await raiseDecision('ws-parent', { question: 'merge?', context: 'details' }, dir);
@@ -152,7 +182,7 @@ describe('ledger → mission channel emitter (step 5)', () => {
     expect(posts).toEqual([{
       channelId: 'ch-1',
       ownerWorkspaceId: 'ws-parent',
-      text: '[ledger] wtask-1 working→review_requested worker@ws-task gate green all tests',
+      text: '[ledger] wtask-1 working→review_requested worker@ws-task worker: "gate green all tests"',
       clientMsgId: 'ledger:wtask-1:2',
     }]);
   });
@@ -165,5 +195,13 @@ describe('ledger → mission channel emitter (step 5)', () => {
       by: { kind: 'system', workspaceId: 'daemon' },
     });
     expect(line).toBe('[ledger] wtask-9 new→working system@daemon');
+    const quoted = formatLedgerTransition({
+      entry: { id: 'wtask-9', rev: 2 } as never,
+      from: 'working',
+      to: 'input_required',
+      by: { kind: 'worker', workspaceId: 'ws-t' },
+      summary: 'need the "API key"',
+    });
+    expect(quoted).toBe('[ledger] wtask-9 working→input_required worker@ws-t worker: "need the ”API key”"');
   });
 });

--- a/src/main/deck/deckDecisionStore.ts
+++ b/src/main/deck/deckDecisionStore.ts
@@ -195,6 +195,20 @@ function mutate(
 /** Raise (or replace) a workspace's pending decision. Callers should reject a
  *  second raise while one is already pending (RPC layer) so the brain can't
  *  stack decisions; this store itself is last-writer-wins. */
+/** The ledger prefix may take at most this share of the context budget, so a
+ *  long open-task list can never evict the brain's own context. */
+export const DECISION_LEDGER_PREFIX_MAX_CHARS = Math.floor(DECISION_LIMITS.MAX_CONTEXT_CHARS / 4);
+
+/** Prefix first, within ITS budget; then the brain's context in what is left.
+ *  Exported for the unit test. */
+export function composeDecisionContext(prefix: string, context: string): string {
+  const head = prefix.length > DECISION_LEDGER_PREFIX_MAX_CHARS
+    ? `${prefix.slice(0, DECISION_LEDGER_PREFIX_MAX_CHARS - 1)}…`
+    : prefix;
+  const room = DECISION_LIMITS.MAX_CONTEXT_CHARS - head.length;
+  return `${head}${context.slice(0, Math.max(0, room))}`.trim();
+}
+
 /** The open-task line for a decision context (empty when the gate is off,
  *  nothing is open, or the ledger cannot be read). Never throws. */
 function ledgerDecisionPrefix(workspaceId: string): string {
@@ -218,14 +232,14 @@ export async function raiseDecision(
   // sees what the brain still has open — prepended to the context, never to
   // the question (which the brain wrote and the UI keys on).
   const rawContext = typeof args.context === 'string' ? args.context.trim() : '';
-  const context = `${ledgerDecisionPrefix(workspaceId)}${rawContext}`.trim();
+  const context = composeDecisionContext(ledgerDecisionPrefix(workspaceId), rawContext);
   return mutate(
     workspaceId,
     () => ({
       id: randomUUID(),
       question: question.slice(0, DECISION_LIMITS.MAX_QUESTION_CHARS),
       options: sanitizeOptions(args.options),
-      context: context.slice(0, DECISION_LIMITS.MAX_CONTEXT_CHARS),
+      context,
       status: 'pending',
       raisedAt: Date.now(),
     }),

--- a/src/main/deck/deckDecisionStore.ts
+++ b/src/main/deck/deckDecisionStore.ts
@@ -29,6 +29,8 @@ import path from 'node:path';
 import { getWmuxDir } from '../../daemon/config';
 import { atomicReadJSONSync, atomicWriteJSON } from '../../daemon/util/atomicWrite';
 import type { AgentMode } from './deckAutonomyStore';
+import { readLedgerGateInput } from './taskLedgerHost';
+import { describeOpenLedgerTasksForDecision } from './stopGate';
 
 export type DecisionStatus = 'pending' | 'resolved';
 
@@ -193,6 +195,18 @@ function mutate(
 /** Raise (or replace) a workspace's pending decision. Callers should reject a
  *  second raise while one is already pending (RPC layer) so the brain can't
  *  stack decisions; this store itself is last-writer-wins. */
+/** The open-task line for a decision context (empty when the gate is off,
+ *  nothing is open, or the ledger cannot be read). Never throws. */
+function ledgerDecisionPrefix(workspaceId: string): string {
+  try {
+    const gate = readLedgerGateInput(workspaceId);
+    if (!gate.enabled || !gate.openTasks || gate.openTasks.length === 0) return '';
+    return `${describeOpenLedgerTasksForDecision(gate.openTasks)}\n`;
+  } catch {
+    return '';
+  }
+}
+
 export async function raiseDecision(
   workspaceId: string,
   args: { question: string; options?: string[]; context?: string },
@@ -200,16 +214,18 @@ export async function raiseDecision(
 ): Promise<WorkspaceDecision | null> {
   const question = args.question.trim();
   if (!question) return null;
+  // Lane F: while the ledger gate is on, the human answering this decision
+  // sees what the brain still has open — prepended to the context, never to
+  // the question (which the brain wrote and the UI keys on).
+  const rawContext = typeof args.context === 'string' ? args.context.trim() : '';
+  const context = `${ledgerDecisionPrefix(workspaceId)}${rawContext}`.trim();
   return mutate(
     workspaceId,
     () => ({
       id: randomUUID(),
       question: question.slice(0, DECISION_LIMITS.MAX_QUESTION_CHARS),
       options: sanitizeOptions(args.options),
-      context:
-        typeof args.context === 'string'
-          ? args.context.trim().slice(0, DECISION_LIMITS.MAX_CONTEXT_CHARS)
-          : '',
+      context: context.slice(0, DECISION_LIMITS.MAX_CONTEXT_CHARS),
       status: 'pending',
       raisedAt: Date.now(),
     }),

--- a/src/main/deck/deckLedgerGateStore.ts
+++ b/src/main/deck/deckLedgerGateStore.ts
@@ -8,7 +8,14 @@
 // the snapshot-inferred gate (stopGate.ts) stays the shipped behaviour until
 // the ledger has run in dogfood. Same storage shape and never-throw posture as
 // deck-autowake.json.
+//
+// EXPERIMENTAL / JSON-ONLY: nothing in the app calls `setLedgerGateEnabled`
+// yet — there is no Settings toggle. Flip the flag by writing
+// `{"enabled": true}` to deck-ledger-gate.json in the wmux data dir. The
+// loader caches by file mtime, so the read that runs on every Stop and every
+// deck_ask_decision is a stat, not a parse, until the file changes.
 
+import fs from 'node:fs';
 import path from 'node:path';
 import { getWmuxDir } from '../../daemon/config';
 import { atomicReadJSONSync, atomicWriteJSON } from '../../daemon/util/atomicWrite';
@@ -26,15 +33,30 @@ export function getDeckLedgerGatePath(dir: string = getWmuxDir()): string {
   return path.join(dir, 'deck-ledger-gate.json');
 }
 
-/** Read the switch. Anything uncertain resolves to the default (OFF). */
+/** path → { mtimeMs, value }: re-parsed only when the file's mtime moves. */
+const cache = new Map<string, { mtimeMs: number; value: boolean }>();
+
+function parseFlag(p: string): boolean {
+  const raw = atomicReadJSONSync<unknown>(p);
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return DEFAULT_LEDGER_GATE_ENABLED;
+  const enabled = (raw as Record<string, unknown>).enabled;
+  return typeof enabled === 'boolean' ? enabled : DEFAULT_LEDGER_GATE_ENABLED;
+}
+
+/** Read the switch. Anything uncertain resolves to the default (OFF). A
+ *  stat per call; the parse only when the mtime changed. */
 export function loadLedgerGateEnabled(dir?: string): boolean {
   if (testOverride !== null) return testOverride;
+  const p = getDeckLedgerGatePath(dir);
   try {
-    const raw = atomicReadJSONSync<unknown>(getDeckLedgerGatePath(dir));
-    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return DEFAULT_LEDGER_GATE_ENABLED;
-    const enabled = (raw as Record<string, unknown>).enabled;
-    return typeof enabled === 'boolean' ? enabled : DEFAULT_LEDGER_GATE_ENABLED;
+    const mtimeMs = fs.statSync(p).mtimeMs;
+    const hit = cache.get(p);
+    if (hit && hit.mtimeMs === mtimeMs) return hit.value;
+    const value = parseFlag(p);
+    cache.set(p, { mtimeMs, value });
+    return value;
   } catch {
+    cache.delete(p);
     return DEFAULT_LEDGER_GATE_ENABLED;
   }
 }

--- a/src/main/deck/deckLedgerGateStore.ts
+++ b/src/main/deck/deckLedgerGateStore.ts
@@ -1,0 +1,47 @@
+// ─── Command Deck — `deck.ledgerGate` switch (Stop gate on the task ledger) ──
+//
+// When ON, the orchestrator's Stop gate holds a turn open while the task
+// ledger still lists OPEN tasks (working / input_required / review_requested)
+// owned by that brain — the ledger is the one state the brain, the workers and
+// the gate share, so a "delegated, done" turn cannot end while a worker's row
+// says otherwise. Default OFF (owner decision, orchestrator track 2026-09):
+// the snapshot-inferred gate (stopGate.ts) stays the shipped behaviour until
+// the ledger has run in dogfood. Same storage shape and never-throw posture as
+// deck-autowake.json.
+
+import path from 'node:path';
+import { getWmuxDir } from '../../daemon/config';
+import { atomicReadJSONSync, atomicWriteJSON } from '../../daemon/util/atomicWrite';
+
+export const DEFAULT_LEDGER_GATE_ENABLED = false;
+
+let testOverride: boolean | null = null;
+
+/** Tests only: force the switch without touching the data dir (null = off). */
+export function overrideLedgerGateForTests(value: boolean | null): void {
+  testOverride = value;
+}
+
+export function getDeckLedgerGatePath(dir: string = getWmuxDir()): string {
+  return path.join(dir, 'deck-ledger-gate.json');
+}
+
+/** Read the switch. Anything uncertain resolves to the default (OFF). */
+export function loadLedgerGateEnabled(dir?: string): boolean {
+  if (testOverride !== null) return testOverride;
+  try {
+    const raw = atomicReadJSONSync<unknown>(getDeckLedgerGatePath(dir));
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return DEFAULT_LEDGER_GATE_ENABLED;
+    const enabled = (raw as Record<string, unknown>).enabled;
+    return typeof enabled === 'boolean' ? enabled : DEFAULT_LEDGER_GATE_ENABLED;
+  } catch {
+    return DEFAULT_LEDGER_GATE_ENABLED;
+  }
+}
+
+/** Persist the switch. Returns the value now in force. */
+export async function setLedgerGateEnabled(enabled: boolean, dir?: string): Promise<boolean> {
+  const next = enabled === true;
+  await atomicWriteJSON(getDeckLedgerGatePath(dir), { enabled: next });
+  return next;
+}

--- a/src/main/deck/stopGate.ts
+++ b/src/main/deck/stopGate.ts
@@ -44,6 +44,23 @@
 //      it — both the caller's job, see stopGateState).
 
 import type { FleetSnapshot, FleetSnapshotPane } from '../../shared/workspaceMirror';
+import type { LedgerStatus } from '../../shared/ledger';
+
+/** One OPEN ledger row owned by the brain being gated (lane F). */
+export interface StopGateLedgerTask {
+  id: string;
+  title: string;
+  status: LedgerStatus;
+}
+
+/** The ledger's view for one Stop (lane F, `deck.ledgerGate`). `openTasks`
+ *  is null when the ledger could not be read — the gate then falls back to
+ *  today's snapshot inference (fail-open toward the shipped behaviour, never
+ *  toward a wedge). */
+export interface StopGateLedgerInput {
+  enabled: boolean;
+  openTasks: readonly StopGateLedgerTask[] | null;
+}
 
 /** Default ceiling on consecutive refusals for one turn. */
 export const DEFAULT_MAX_CONSECUTIVE_BLOCKS = 3;
@@ -85,6 +102,9 @@ export type StopGateVerdict =
        * of refusals on the next turn. Absent on every other allow.
        */
       cappedOutFingerprint?: string;
+      /** Lane F: this allow ended a run of LEDGER-held refusals at the cap —
+       *  the caller logs `ledger_gate_released`. */
+      ledgerReleased?: true;
     }
   /**
    * `outstandingPtyIds` is the set of panes this refusal is actually about, and
@@ -128,13 +148,47 @@ function describePane(pane: FleetSnapshotPane): string {
 function gateFingerprint(
   activeWork: { id: string; updatedAt?: number } | null,
   outstanding: readonly FleetSnapshotPane[],
+  openTasks: readonly StopGateLedgerTask[] = [],
 ): string {
   const work = activeWork ? `${activeWork.id}@${activeWork.updatedAt ?? 0}` : '';
   const panes = outstanding
     .map((p) => `${p.ptyId}:${p.agentStatus}`)
     .sort()
     .join(',');
-  return `${work}|${panes}`;
+  const tasks = openTasks
+    .map((t) => `${t.id}:${t.status}`)
+    .sort()
+    .join(',');
+  return tasks.length > 0 ? `${work}|${panes}|${tasks}` : `${work}|${panes}`;
+}
+
+/** Lane F: the ledger's refusal text. One line per open task with the action
+ *  that clears it, plus the same no-kill / no-repeat rules as the pane branch. */
+function describeLedgerHold(openTasks: readonly StopGateLedgerTask[]): string {
+  const lines = openTasks.map((t) => {
+    const hint =
+      t.status === 'review_requested'
+        ? 'the worker claims done — run the gate and complete it, or bounce it back'
+        : t.status === 'input_required'
+          ? 'the worker is blocked — answer it (ledger_list shows its summary) or decide'
+          : 'the worker is still working — check its pane or wait for its report';
+    return `${t.id} "${t.title}" (${t.status}: ${hint})`;
+  });
+  const noun = openTasks.length === 1 ? 'task' : 'tasks';
+  return (
+    `Do not end this turn yet: the task ledger still lists ${openTasks.length} open ${noun} you own — ${lines.join('; ')}. ` +
+    'Read ledger_list for their current rev and summary and drive each one to completed, failed or cancelled. '
+  );
+}
+
+/** The ledger portion of a decision prompt (lane F): prepended to the context
+ *  of deck_ask_decision while the ledger gate is on, so the human sees what
+ *  is still open when the brain asks. Empty when nothing is open. */
+export function describeOpenLedgerTasksForDecision(openTasks: readonly StopGateLedgerTask[]): string {
+  if (openTasks.length === 0) return '';
+  return (
+    `[open tasks in the ledger: ${openTasks.map((t) => `${t.id} "${t.title}" (${t.status})`).join(', ')}]`
+  );
 }
 
 /**
@@ -161,6 +215,9 @@ export function evaluateStopGate(input: {
    *  5). Matching the current state means the gate already gave up on exactly
    *  this hold — stay quiet instead of re-buying the same refusal run. */
   suppressedFingerprint?: string | null;
+  /** Lane F: the task ledger's view (see StopGateLedgerInput). Absent or
+   *  `enabled: false` = the shipped snapshot-inferred gate, unchanged. */
+  ledger?: StopGateLedgerInput;
   /** How many times in a row this turn's Stop has already been refused. */
   consecutiveBlocks: number;
   maxConsecutiveBlocks?: number;
@@ -187,23 +244,55 @@ export function evaluateStopGate(input: {
       ? snapshot.panes.filter((p) => isOutstanding(p.agentStatus))
       : [];
 
-  // Nothing held — no active work, no outstanding panes. The common allow.
-  if (!activeWork && outstanding.length === 0) return { block: false };
+  // Lane F — the ledger path (`deck.ledgerGate`). Open tasks owned by this
+  // brain hold the turn exactly like outstanding panes do, through the SAME
+  // cap (rule 3) and hysteresis (rule 5). A ledger that could not be read
+  // (openTasks null) contributes nothing: that is rule 2 applied to the
+  // ledger — a missing signal cannot prove work, so the snapshot inference
+  // above decides, never a wedge.
+  const openTasks: readonly StopGateLedgerTask[] =
+    input.ledger?.enabled && input.ledger.openTasks ? input.ledger.openTasks : [];
+
+  // Nothing held — no active work, no outstanding panes, no open tasks. The
+  // common allow.
+  if (!activeWork && outstanding.length === 0 && openTasks.length === 0) return { block: false };
 
   // Rule 5: the gate already capped out on exactly this state. Stay quiet
   // until the state changes; the caller's TTL and the next human turn bound
   // how long "quiet" can last.
-  const fingerprint = gateFingerprint(activeWork ?? null, outstanding);
+  const fingerprint = gateFingerprint(activeWork ?? null, outstanding, openTasks);
   if (input.suppressedFingerprint != null && input.suppressedFingerprint === fingerprint) {
     return { block: false };
   }
 
   // Rule 3: the refusal-run cap. The fingerprint travels with this allow so
   // the caller can record what was held on — an allow for exhaustion, not for
-  // completion.
+  // completion. A ledger-held run that caps out is flagged so the caller can
+  // log `ledger_gate_released`.
   const max = input.maxConsecutiveBlocks ?? DEFAULT_MAX_CONSECUTIVE_BLOCKS;
   if (input.consecutiveBlocks >= max) {
-    return { block: false, cappedOutFingerprint: fingerprint };
+    return {
+      block: false,
+      cappedOutFingerprint: fingerprint,
+      ...(openTasks.length > 0 ? { ledgerReleased: true as const } : {}),
+    };
+  }
+
+  // Ledger hold: refuse, naming the open tasks. Outstanding panes (if any)
+  // ride along so input.rpc keeps protecting them (#733); the reason leads
+  // with the ledger because that is the state the brain can actually change.
+  if (openTasks.length > 0) {
+    return {
+      block: true,
+      outstandingPtyIds: outstanding.map((p) => p.ptyId),
+      fingerprint,
+      reason:
+        `${describeLedgerHold(openTasks)}` +
+        (outstanding.length > 0
+          ? `Panes still needing you: ${outstanding.map(describePane).join(', ')}. `
+          : '') +
+        `${NO_KILL_SENTENCE} ${NO_REPEAT_SENTENCE}`,
+    };
   }
 
   // A durable active-work record is stronger than the renderer-derived pane

--- a/src/main/deck/taskLedgerHost.ts
+++ b/src/main/deck/taskLedgerHost.ts
@@ -1,0 +1,196 @@
+// ─── Task ledger — main-process host + worker→owner event routing ───────────
+//
+// The TaskLedger (src/daemon/ledger) is a plain fs-backed class; every consumer
+// that needs it lives in the main process (the event coalescer, the Stop gate,
+// the pipe RPC, the fan-out service), so main hosts the single instance here.
+// The data dir is the WMUX_DATA_SUFFIX-scoped wmux dir, same as the deck-*
+// stores.
+//
+// Lane F step 1 — why the routing exists: a worker's agent.stop /
+// agent.awaiting_input is pushed only to the EMITTING workspace, and a fan-out
+// task workspace has no brain of its own (wakePolicy 'none'), so the parent
+// brain that fanned out never learned its workers finished. `WorkTask.owner`
+// is the missing link: resolve it through the ledger (which mirrors WorkTask —
+// see the reconciler) and push a tagged COPY to the owner's coalescer. An
+// owner with no brain gets the event parked as `orphaned_event` and replayed
+// when a brain boots for it.
+
+import { getWmuxDir } from '../../daemon/config';
+import { TaskLedger } from '../../daemon/ledger/TaskLedger';
+import type { CoalescerInput } from './CommanderEventCoalescer';
+
+let ledger: TaskLedger | null = null;
+
+export function getTaskLedger(): TaskLedger {
+  if (!ledger) {
+    ledger = new TaskLedger({ dir: getWmuxDir(), log: (line) => console.warn(line) });
+  }
+  return ledger;
+}
+
+/** Tests only: swap the hosted instance (null = re-create lazily). */
+export function setTaskLedgerForTests(instance: TaskLedger | null): void {
+  ledger = instance;
+}
+
+// ── worker event → owner ────────────────────────────────────────────────────
+
+export interface WorkerEventRoutingPorts {
+  /** True when the owner workspace has (or will boot) a brain: a live manager
+   *  or a resting mode other than 'off'. False parks the event instead. */
+  hasBrain: (ownerWorkspaceId: string) => boolean;
+  push: (ev: CoalescerInput) => void;
+  /** Bring the ledger up to date with WorkTask when the emitting workspace is
+   *  unknown (a task materialized without a register call). Throttled by the
+   *  caller; absent = no second look. */
+  reconcile?: () => Promise<void>;
+  ledger?: TaskLedger;
+}
+
+/**
+ * If `ev.workspaceId` is a fan-out task workspace, deliver a copy of the event
+ * to the owning workspace tagged `{taskId, taskWorkspaceId}`. Non-task
+ * workspaces are left alone; the caller keeps its existing push regardless.
+ */
+export function routeWorkerEventToOwner(ev: CoalescerInput, ports: WorkerEventRoutingPorts): void {
+  const l = ports.ledger ?? getTaskLedger();
+  const deliver = (entry: { id: string; ownerWorkspaceId: string }): void => {
+    if (entry.ownerWorkspaceId === ev.workspaceId) return;
+    const tagged: CoalescerInput = {
+      ...ev,
+      workspaceId: entry.ownerWorkspaceId,
+      task: { taskId: entry.id, taskWorkspaceId: ev.workspaceId },
+    };
+    if (ports.hasBrain(entry.ownerWorkspaceId)) {
+      ports.push(tagged);
+      return;
+    }
+    void l.recordOrphanedEvent({ ownerWorkspaceId: entry.ownerWorkspaceId, seq: ev.seq, payload: tagged });
+  };
+  const entry = l.findByTaskWorkspace(ev.workspaceId);
+  if (entry) {
+    deliver(entry);
+    return;
+  }
+  if (!ports.reconcile) return;
+  void ports
+    .reconcile()
+    .then(() => {
+      const late = l.findByTaskWorkspace(ev.workspaceId);
+      if (late) deliver(late);
+    })
+    .catch(() => undefined);
+}
+
+function isCoalescerInput(v: unknown): v is CoalescerInput {
+  if (!v || typeof v !== 'object') return false;
+  const e = v as Record<string, unknown>;
+  return typeof e.workspaceId === 'string' && typeof e.ptyId === 'string' && typeof e.kind === 'string' && typeof e.seq === 'number';
+}
+
+/** Drain the parked worker events for a workspace whose brain just booted. */
+export function takeOrphanBacklog(workspaceId: string, instance?: TaskLedger): CoalescerInput[] {
+  const l = instance ?? getTaskLedger();
+  const out: CoalescerInput[] = [];
+  for (const o of l.takeOrphanedEvents(workspaceId)) {
+    if (isCoalescerInput(o.payload)) out.push(o.payload);
+  }
+  return out;
+}
+
+// ── reconcile with WorkTask (the identity source) ───────────────────────────
+
+/** The slice of the daemon's `task.mission.list` projection the ledger needs. */
+export interface WorkTaskProjectionLike {
+  id: string;
+  title: string;
+  status: 'open' | 'closed';
+  owner: { verifiedWorkspaceId: string };
+  paneGroupId?: string;
+  missionChannelId?: string;
+}
+
+export interface WorkTaskReconcilerPorts {
+  /** Workspaces that may own tasks (every workspace the mirror knows). */
+  candidateOwners: () => string[];
+  /** `task.mission.list` for one owner — the daemon's owner-scoped read. */
+  listTasks: (ownerWorkspaceId: string) => Promise<unknown>;
+  ledger?: TaskLedger;
+  /** Minimum spacing between two full passes (default 10s). */
+  minIntervalMs?: number;
+  now?: () => number;
+}
+
+/** taskId → mission channel id, learned from the projection (step 5 posts
+ *  transitions there). */
+const missionChannels = new Map<string, string>();
+
+export function getMissionChannelId(taskId: string): string | null {
+  return missionChannels.get(taskId) ?? null;
+}
+
+export function rememberMissionChannel(taskId: string, channelId: string): void {
+  missionChannels.set(taskId, channelId);
+}
+
+function projectTasks(res: unknown): WorkTaskProjectionLike[] {
+  const r = res as { ok?: boolean; tasks?: unknown } | null;
+  if (!r || r.ok !== true || !Array.isArray(r.tasks)) return [];
+  return r.tasks.filter((t): t is WorkTaskProjectionLike => {
+    if (!t || typeof t !== 'object') return false;
+    const x = t as Record<string, unknown>;
+    return (
+      typeof x.id === 'string' &&
+      (x.status === 'open' || x.status === 'closed') &&
+      !!x.owner &&
+      typeof (x.owner as Record<string, unknown>).verifiedWorkspaceId === 'string'
+    );
+  });
+}
+
+/**
+ * Build a throttled "mirror WorkTask into the ledger" pass: every open,
+ * materialized task (paneGroupId = its workspace) gets a `working` entry if it
+ * has none; every closed task with a live entry is force-cancelled. The ledger
+ * never invents a task — every entry here is a WorkTask the daemon returned.
+ */
+export function createWorkTaskReconciler(ports: WorkTaskReconcilerPorts): () => Promise<void> {
+  const now = ports.now ?? Date.now;
+  const minInterval = ports.minIntervalMs ?? 10_000;
+  let lastRun = -Infinity;
+  let inFlight: Promise<void> | null = null;
+  return () => {
+    if (inFlight) return inFlight;
+    if (now() - lastRun < minInterval) return Promise.resolve();
+    const l = ports.ledger ?? getTaskLedger();
+    inFlight = (async () => {
+      lastRun = now();
+      const owners = [...new Set(ports.candidateOwners())];
+      for (const owner of owners) {
+        let tasks: WorkTaskProjectionLike[];
+        try {
+          tasks = projectTasks(await ports.listTasks(owner));
+        } catch {
+          continue;
+        }
+        for (const t of tasks) {
+          if (typeof t.missionChannelId === 'string') missionChannels.set(t.id, t.missionChannelId);
+          if (t.status === 'closed') {
+            if (l.get(t.id)) await l.closeTask(t.id);
+            continue;
+          }
+          if (!t.paneGroupId || l.get(t.id)) continue;
+          await l.register({
+            id: t.id,
+            taskWorkspaceId: t.paneGroupId,
+            ownerWorkspaceId: t.owner.verifiedWorkspaceId,
+            title: typeof t.title === 'string' ? t.title : t.id,
+          });
+        }
+      }
+    })().finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  };
+}

--- a/src/main/deck/taskLedgerHost.ts
+++ b/src/main/deck/taskLedgerHost.ts
@@ -12,8 +12,8 @@
 // brain that fanned out never learned its workers finished. `WorkTask.owner`
 // is the missing link: resolve it through the ledger (which mirrors WorkTask —
 // see the reconciler) and push a tagged COPY to the owner's coalescer. An
-// owner with no brain gets the event parked as `orphaned_event` and replayed
-// when a brain boots for it.
+// owner with no brain gets the event parked as `orphaned_event`, replayed when
+// a brain boots for it and acknowledged only once a wake delivered it.
 
 import { getWmuxDir } from '../../daemon/config';
 import { TaskLedger, type LedgerTransition } from '../../daemon/ledger/TaskLedger';
@@ -23,9 +23,17 @@ import type { StopGateLedgerInput } from './stopGate';
 
 let ledger: TaskLedger | null = null;
 
+/** taskId → mission channel id, learned from the projection / fan-out (step
+ *  5 posts transitions there). Released when the entry leaves the ledger. */
+const missionChannels = new Map<string, string>();
+
 export function getTaskLedger(): TaskLedger {
   if (!ledger) {
-    ledger = new TaskLedger({ dir: getWmuxDir(), log: (line) => console.warn(line) });
+    ledger = new TaskLedger({
+      dir: getWmuxDir(),
+      log: (line) => console.warn(line),
+      onPrune: (id) => missionChannels.delete(id),
+    });
   }
   return ledger;
 }
@@ -33,6 +41,7 @@ export function getTaskLedger(): TaskLedger {
 /** Tests only: swap the hosted instance (null = re-create lazily). */
 export function setTaskLedgerForTests(instance: TaskLedger | null): void {
   ledger = instance;
+  missionChannels.clear();
 }
 
 // ── worker event → owner ────────────────────────────────────────────────────
@@ -50,9 +59,10 @@ export interface WorkerEventRoutingPorts {
 }
 
 /**
- * If `ev.workspaceId` is a fan-out task workspace, deliver a copy of the event
- * to the owning workspace tagged `{taskId, taskWorkspaceId}`. Non-task
- * workspaces are left alone; the caller keeps its existing push regardless.
+ * If `ev.workspaceId` is the workspace of an OPEN fan-out task, deliver a copy
+ * of the event to the owning workspace tagged `{taskId, taskWorkspaceId}`. A
+ * finished task's workspace and non-task workspaces are left alone; the
+ * caller keeps its existing push regardless.
  */
 export function routeWorkerEventToOwner(ev: CoalescerInput, ports: WorkerEventRoutingPorts): void {
   const l = ports.ledger ?? getTaskLedger();
@@ -67,18 +77,22 @@ export function routeWorkerEventToOwner(ev: CoalescerInput, ports: WorkerEventRo
       ports.push(tagged);
       return;
     }
-    void l.recordOrphanedEvent({ ownerWorkspaceId: entry.ownerWorkspaceId, seq: ev.seq, payload: tagged });
+    l.recordOrphanedEvent({ ownerWorkspaceId: entry.ownerWorkspaceId, seq: ev.seq, payload: tagged }).catch(
+      (err) => console.warn(`[deck] could not park a worker event for ${entry.ownerWorkspaceId}: ${String(err)}`),
+    );
   };
-  const entry = l.findByTaskWorkspace(ev.workspaceId);
+  const entry = l.findOpenByTaskWorkspace(ev.workspaceId);
   if (entry) {
     deliver(entry);
     return;
   }
-  if (!ports.reconcile) return;
+  // Unknown workspace: it may be a task that materialized before the ledger
+  // heard of it. Only a task that is still open after the reconcile routes.
+  if (!ports.reconcile || l.findByTaskWorkspace(ev.workspaceId)) return;
   void ports
     .reconcile()
     .then(() => {
-      const late = l.findByTaskWorkspace(ev.workspaceId);
+      const late = l.findOpenByTaskWorkspace(ev.workspaceId);
       if (late) deliver(late);
     })
     .catch(() => undefined);
@@ -90,14 +104,22 @@ function isCoalescerInput(v: unknown): v is CoalescerInput {
   return typeof e.workspaceId === 'string' && typeof e.ptyId === 'string' && typeof e.kind === 'string' && typeof e.seq === 'number';
 }
 
-/** Drain the parked worker events for a workspace whose brain just booted. */
-export function takeOrphanBacklog(workspaceId: string, instance?: TaskLedger): CoalescerInput[] {
+/** The parked worker events for a workspace whose brain is booting — a PEEK:
+ *  nothing leaves the backlog until `ackOrphanBacklog` confirms a wake
+ *  delivered it. */
+export function peekOrphanBacklog(workspaceId: string, instance?: TaskLedger): CoalescerInput[] {
   const l = instance ?? getTaskLedger();
   const out: CoalescerInput[] = [];
-  for (const o of l.takeOrphanedEvents(workspaceId)) {
+  for (const o of l.peekOrphanedEvents(workspaceId)) {
     if (isCoalescerInput(o.payload)) out.push(o.payload);
   }
   return out;
+}
+
+/** Acknowledge parked events at or below `upToSeq` — they reached the brain. */
+export function ackOrphanBacklog(workspaceId: string, upToSeq: number, instance?: TaskLedger): Promise<void> {
+  const l = instance ?? getTaskLedger();
+  return l.ackOrphanedEvents(workspaceId, upToSeq);
 }
 
 // ── Stop gate + decision prompt inputs (lane F step 4) ──────────────────────
@@ -128,10 +150,15 @@ export function readLedgerGateInput(workspaceId: string, instance?: TaskLedger):
 
 // ── mission-channel emitter (lane F step 5) ─────────────────────────────────
 
-/** `[ledger] <taskId> <from>→<to> <by> <summary?>` — one line per transition. */
+/** `[ledger] <taskId> <from>→<to> <by> worker: "<summary>"` — one line per
+ *  transition. The summary is text the ACTOR wrote (a worker, usually) and
+ *  the post goes out under the owner's authorship, so it is quoted and
+ *  labelled with its author kind: provenance stays visible in the transcript. */
 export function formatLedgerTransition(t: LedgerTransition): string {
   const by = `${t.by.kind}@${t.by.workspaceId}`;
-  const summary = t.summary ? ` ${t.summary.replace(/\s+/g, ' ').trim().slice(0, 500)}` : '';
+  const summary = t.summary
+    ? ` ${t.by.kind}: "${t.summary.replace(/\s+/g, ' ').replace(/"/g, '”').trim().slice(0, 500)}"`
+    : '';
   return `[ledger] ${t.entry.id} ${t.from ?? 'new'}→${t.to} ${by}${summary}`;
 }
 
@@ -183,16 +210,25 @@ export interface WorkTaskReconcilerPorts {
   now?: () => number;
 }
 
-/** taskId → mission channel id, learned from the projection (step 5 posts
- *  transitions there). */
-const missionChannels = new Map<string, string>();
-
 export function getMissionChannelId(taskId: string): string | null {
   return missionChannels.get(taskId) ?? null;
 }
 
 export function rememberMissionChannel(taskId: string, channelId: string): void {
   missionChannels.set(taskId, channelId);
+}
+
+/** A WorkTask was closed (task.mission.close succeeded, or the task was
+ *  detached): force its ledger entry to `cancelled` NOW rather than on the
+ *  next reconcile pass, and release its channel mapping. Never throws. */
+export async function noteWorkTaskClosed(taskId: string, instance?: TaskLedger): Promise<void> {
+  const l = instance ?? getTaskLedger();
+  try {
+    if (l.get(taskId)) await l.closeTask(taskId);
+  } catch (err) {
+    console.warn(`[deck] ledger close for ${taskId} failed: ${String(err)}`);
+  }
+  missionChannels.delete(taskId);
 }
 
 function projectTasks(res: unknown): WorkTaskProjectionLike[] {
@@ -215,6 +251,8 @@ function projectTasks(res: unknown): WorkTaskProjectionLike[] {
  * materialized task (paneGroupId = its workspace) gets a `working` entry if it
  * has none; every closed task with a live entry is force-cancelled. The ledger
  * never invents a task — every entry here is a WorkTask the daemon returned.
+ * Runs from the periodic timer, before a Stop-gate evaluation and on an
+ * unknown-workspace event; the throttle makes all three cheap.
  */
 export function createWorkTaskReconciler(ports: WorkTaskReconcilerPorts): () => Promise<void> {
   const now = ports.now ?? Date.now;
@@ -236,18 +274,23 @@ export function createWorkTaskReconciler(ports: WorkTaskReconcilerPorts): () => 
           continue;
         }
         for (const t of tasks) {
-          if (typeof t.missionChannelId === 'string') missionChannels.set(t.id, t.missionChannelId);
           if (t.status === 'closed') {
             if (l.get(t.id)) await l.closeTask(t.id);
+            missionChannels.delete(t.id);
             continue;
           }
+          if (typeof t.missionChannelId === 'string') missionChannels.set(t.id, t.missionChannelId);
           if (!t.paneGroupId || l.get(t.id)) continue;
-          await l.register({
-            id: t.id,
-            taskWorkspaceId: t.paneGroupId,
-            ownerWorkspaceId: t.owner.verifiedWorkspaceId,
-            title: typeof t.title === 'string' ? t.title : t.id,
-          });
+          try {
+            await l.register({
+              id: t.id,
+              taskWorkspaceId: t.paneGroupId,
+              ownerWorkspaceId: t.owner.verifiedWorkspaceId,
+              title: typeof t.title === 'string' ? t.title : t.id,
+            });
+          } catch (err) {
+            console.warn(`[deck] ledger register for ${t.id} failed: ${String(err)}`);
+          }
         }
       }
     })().finally(() => {

--- a/src/main/deck/taskLedgerHost.ts
+++ b/src/main/deck/taskLedgerHost.ts
@@ -16,8 +16,10 @@
 // when a brain boots for it.
 
 import { getWmuxDir } from '../../daemon/config';
-import { TaskLedger } from '../../daemon/ledger/TaskLedger';
+import { TaskLedger, type LedgerTransition } from '../../daemon/ledger/TaskLedger';
 import type { CoalescerInput } from './CommanderEventCoalescer';
+import { loadLedgerGateEnabled } from './deckLedgerGateStore';
+import type { StopGateLedgerInput } from './stopGate';
 
 let ledger: TaskLedger | null = null;
 
@@ -96,6 +98,66 @@ export function takeOrphanBacklog(workspaceId: string, instance?: TaskLedger): C
     if (isCoalescerInput(o.payload)) out.push(o.payload);
   }
   return out;
+}
+
+// ── Stop gate + decision prompt inputs (lane F step 4) ──────────────────────
+
+/** The ledger's view for one Stop of `workspaceId`'s brain. `openTasks` is
+ *  null when the ledger threw — the gate then falls back to the snapshot
+ *  inference. Never throws. */
+export function readLedgerGateInput(workspaceId: string, instance?: TaskLedger): StopGateLedgerInput {
+  let enabled = false;
+  try {
+    enabled = loadLedgerGateEnabled();
+  } catch {
+    enabled = false;
+  }
+  if (!enabled) return { enabled: false, openTasks: null };
+  try {
+    const l = instance ?? getTaskLedger();
+    return {
+      enabled: true,
+      openTasks: l
+        .list({ ownerWorkspaceId: workspaceId, openOnly: true })
+        .map((e) => ({ id: e.id, title: e.title, status: e.status })),
+    };
+  } catch {
+    return { enabled: true, openTasks: null };
+  }
+}
+
+// ── mission-channel emitter (lane F step 5) ─────────────────────────────────
+
+/** `[ledger] <taskId> <from>→<to> <by> <summary?>` — one line per transition. */
+export function formatLedgerTransition(t: LedgerTransition): string {
+  const by = `${t.by.kind}@${t.by.workspaceId}`;
+  const summary = t.summary ? ` ${t.summary.replace(/\s+/g, ' ').trim().slice(0, 500)}` : '';
+  return `[ledger] ${t.entry.id} ${t.from ?? 'new'}→${t.to} ${by}${summary}`;
+}
+
+export interface LedgerChannelPort {
+  /** Post `text` to `channelId` as the owner workspace (the mission channel's
+   *  creator). Resolves to the daemon's envelope; rejections are swallowed. */
+  post: (input: { channelId: string; ownerWorkspaceId: string; text: string; clientMsgId: string }) => Promise<unknown>;
+}
+
+/** Subscribe the hosted ledger to a mission-channel poster. Every transition
+ *  whose task has a known mission channel is posted there; a task with no
+ *  channel yet (not reconciled) is skipped. Returns the unsubscribe. */
+export function installLedgerChannelEmitter(port: LedgerChannelPort, instance?: TaskLedger): () => void {
+  const l = instance ?? getTaskLedger();
+  return l.onTransition((t) => {
+    const channelId = getMissionChannelId(t.entry.id);
+    if (!channelId) return;
+    void port
+      .post({
+        channelId,
+        ownerWorkspaceId: t.entry.ownerWorkspaceId,
+        text: formatLedgerTransition(t),
+        clientMsgId: `ledger:${t.entry.id}:${t.entry.rev}`,
+      })
+      .catch(() => undefined);
+  });
 }
 
 // ── reconcile with WorkTask (the identity source) ───────────────────────────

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -78,6 +78,7 @@ import { RemoteAttachmentsStore } from './remote/RemoteAttachmentsStore';
 import { registerFanOutHandler } from './ipc/handlers/fanout.handler';
 import { createFanOutService } from './worktask/createFanOutService';
 import { registerFanOutRpc } from './pipe/handlers/fanout.rpc';
+import { registerLedgerRpc } from './pipe/handlers/ledger.rpc';
 import { registerWorktaskHandlers } from './ipc/handlers/worktask.handler';
 import { registerDeckHandler } from './ipc/handlers/deck.handler';
 import { registerWorkspaceMirrorHandler } from './ipc/handlers/workspaceMirror.handler';
@@ -858,6 +859,7 @@ registerRemoteHandlers({
 const fanOutService = createFanOutService(() => daemonClient, () => mainWindow);
 registerFanOutHandler(fanOutService);
 registerFanOutRpc(rpcRouter, fanOutService, () => mainWindow);
+registerLedgerRpc(rpcRouter, () => mainWindow);
 // J3 태스크 수명주기 — close(remove→close 순서)·1클릭 PR(gh 4중 게이트)·정리 스캔
 // (디스크 정본)·미발사 재발사(prompt.md 읽기). 물질화 필드는 데몬 projection에서
 // 역참조하므로 렌더러는 taskId만 싣는다(단일 정본). 파이프 미노출(renderer-trusted).

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -54,7 +54,8 @@ import { DeckHeartbeat } from '../../deck/DeckHeartbeat';
 import { CommanderEventCoalescer } from '../../deck/CommanderEventCoalescer';
 import {
   routeWorkerEventToOwner,
-  takeOrphanBacklog,
+  peekOrphanBacklog,
+  ackOrphanBacklog,
   createWorkTaskReconciler,
   readLedgerGateInput,
   installLedgerChannelEmitter,
@@ -349,6 +350,10 @@ export function registerDeckHandler(
                 // back to the snapshot inference above.
                 ledger: readLedgerGateInput(workspaceId),
               });
+              // Keep the ledger honest against WorkTask right around the gate:
+              // a task closed elsewhere must not hold the next Stop. Throttled
+              // inside; the pass lands for the next evaluation.
+              void reconcileTaskLedger().catch(() => undefined);
               if (!verdict.block && verdict.ledgerReleased) {
                 console.warn(`[deck] ledger_gate_released workspace=${workspaceId} after ${consecutiveBlocks} consecutive blocks`);
               }
@@ -790,6 +795,9 @@ export function registerDeckHandler(
     });
     managerRef = manager;
     managers.set(workspaceId, { manager, model, fullPower, vendor });
+    // Lane F: a brain now exists for this workspace — replay the worker
+    // events parked while it had none (the manager's first idle flushes them).
+    coalescer?.notifyBrainBooted(workspaceId);
     return manager;
   };
 
@@ -1460,6 +1468,13 @@ export function registerDeckHandler(
       return client.rpc('task.mission.list', { verifiedWorkspaceId: owner });
     },
   });
+  // Periodic pass (lane F): fan-out registration and the unknown-workspace
+  // path both feed the ledger, but a task closed or detached elsewhere only
+  // shows up by re-reading WorkTask — so the reconciler also runs on a timer.
+  const ledgerReconcileTimer = setInterval(() => {
+    void reconcileTaskLedger().catch(() => undefined);
+  }, 60_000);
+  ledgerReconcileTimer.unref?.();
   // Lane F step 5: every ledger transition is posted to the task's mission
   // channel as the owner workspace, so the channel transcript and the ledger
   // never disagree about what happened.
@@ -1478,8 +1493,12 @@ export function registerDeckHandler(
   });
   coalescer = new CommanderEventCoalescer({
     runTurn: (workspaceId, prompt) => runTurnForWorkspace(prompt, workspaceId),
-    // Lane F: worker events parked while this workspace had no brain.
-    takeOrphanBacklog: (workspaceId) => takeOrphanBacklog(workspaceId),
+    // Lane F: worker events parked while this workspace had no brain —
+    // peeked at boot, acknowledged only once a wake delivered them.
+    peekOrphanBacklog: (workspaceId) => peekOrphanBacklog(workspaceId),
+    ackOrphanBacklog: (workspaceId, upToSeq) => {
+      void ackOrphanBacklog(workspaceId, upToSeq).catch(() => undefined);
+    },
     isBusy: (workspaceId) =>
       managers.get(workspaceId)?.manager.getStatus().status === 'busy',
     // Fail-closed autonomy caps (summarize on, dangerous caps off by default).
@@ -2217,6 +2236,9 @@ export function registerDeckHandler(
         }
       }
       const next = await setWorkspaceMode(workspaceId, mode as AgentMode);
+      // Lane F: leaving 'off' means wakes may boot a brain here again — replay
+      // the worker events parked while the workspace was off.
+      if (mode !== 'off') coalescer?.notifyBrainBooted(workspaceId);
       // setWorkspaceMode reset caps to the pure mode ceiling. If a loop is still
       // running, re-narrow that new ceiling by the loop tier — otherwise raising
       // the mode mid-loop would silently grant a `report` mission drive/press
@@ -2543,6 +2565,7 @@ export function registerDeckHandler(
   return () => {
     app.removeListener('before-quit', disposeAll);
     clearTimeout(reconcileTimer);
+    clearInterval(ledgerReconcileTimer);
     offBus();
     coalescer?.dispose();
     disposeLedgerEmitter();

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -52,6 +52,11 @@ import { loadCommanderSession, saveCommanderSession, clearCommanderSession } fro
 import { DeckScheduler } from '../../deck/DeckScheduler';
 import { DeckHeartbeat } from '../../deck/DeckHeartbeat';
 import { CommanderEventCoalescer } from '../../deck/CommanderEventCoalescer';
+import {
+  routeWorkerEventToOwner,
+  takeOrphanBacklog,
+  createWorkTaskReconciler,
+} from '../../deck/taskLedgerHost';
 import { createGlobalTurnGate, type GlobalTurnGate } from '../../deck/globalTurnGate';
 import { loadDeckHeartbeat } from '../../deck/deckHeartbeatStore';
 import { getWorkspaceMirror, type FleetSnapshot } from '../../workspace/WorkspaceMirror';
@@ -1435,8 +1440,21 @@ export function registerDeckHandler(
   // The main-process EventBus already carries agent.stop / agent.awaiting_input
   // (hook + detector sourced). Subscribe, coalesce per workspace, and wake the
   // owning orchestrator so it observes fleet lifecycle changes WITHOUT polling.
+  // Lane F: the ledger mirrors WorkTask (the identity source) on demand —
+  // every workspace the mirror knows is a candidate owner, listed through the
+  // daemon's owner-scoped `task.mission.list`. Throttled inside.
+  const reconcileTaskLedger = createWorkTaskReconciler({
+    candidateOwners: () => (getWorkspaceMirror().getEntries() ?? []).map((e) => e.id),
+    listTasks: async (owner) => {
+      const client = opts.getDaemonClient?.() ?? null;
+      if (!client) return null;
+      return client.rpc('task.mission.list', { verifiedWorkspaceId: owner });
+    },
+  });
   coalescer = new CommanderEventCoalescer({
     runTurn: (workspaceId, prompt) => runTurnForWorkspace(prompt, workspaceId),
+    // Lane F: worker events parked while this workspace had no brain.
+    takeOrphanBacklog: (workspaceId) => takeOrphanBacklog(workspaceId),
     isBusy: (workspaceId) =>
       managers.get(workspaceId)?.manager.getStatus().status === 'busy',
     // Fail-closed autonomy caps (summarize on, dangerous caps off by default).
@@ -1584,7 +1602,7 @@ export function registerDeckHandler(
     // Waking the deck brain on one would announce work that never ended —
     // same class of false "finished" the alarm exists to suppress.
     if (ev.decision === 'internal') return;
-    coalescer?.push({
+    const lifecycleInput = {
       workspaceId: ev.workspaceId,
       ptyId: ev.ptyId,
       kind: ev.kind,
@@ -1595,6 +1613,16 @@ export function registerDeckHandler(
       // Carries the pane's closing words on a hook-sourced stop so the wake
       // prompt can say whether the pane is blocked on a question.
       ...(ev.lastMessage ? { lastMessage: ev.lastMessage } : {}),
+    };
+    coalescer?.push(lifecycleInput);
+    // Lane F: a fan-out task workspace has no brain of its own, so ALSO copy
+    // the event to the owning (parent) workspace's coalescer, tagged with the
+    // task. The parent's 'none' wake policy lets tagged events through; an
+    // owner with no brain gets it parked in the ledger as an orphan backlog.
+    routeWorkerEventToOwner(lifecycleInput, {
+      hasBrain: (owner) => managers.has(owner) || loadWorkspaceMode(owner) !== 'off',
+      push: (copy) => coalescer?.push(copy),
+      reconcile: reconcileTaskLedger,
     });
   });
 

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -56,6 +56,8 @@ import {
   routeWorkerEventToOwner,
   takeOrphanBacklog,
   createWorkTaskReconciler,
+  readLedgerGateInput,
+  installLedgerChannelEmitter,
 } from '../../deck/taskLedgerHost';
 import { createGlobalTurnGate, type GlobalTurnGate } from '../../deck/globalTurnGate';
 import { loadDeckHeartbeat } from '../../deck/deckHeartbeatStore';
@@ -342,7 +344,14 @@ export function registerDeckHandler(
                 // this exact state, re-blocking on it next turn only re-buys
                 // the same refusal run.
                 suppressedFingerprint: suppressedGateFingerprint(workspaceId),
+                // Lane F: open ledger tasks hold the turn while
+                // deck.ledgerGate is on (default off); a read failure falls
+                // back to the snapshot inference above.
+                ledger: readLedgerGateInput(workspaceId),
               });
+              if (!verdict.block && verdict.ledgerReleased) {
+                console.warn(`[deck] ledger_gate_released workspace=${workspaceId} after ${consecutiveBlocks} consecutive blocks`);
+              }
               // Record which panes are holding the gate so input.rpc can refuse
               // session-terminating input aimed at them (#733). The list comes
               // off the verdict, never off the snapshot: an active-work hold on
@@ -1451,6 +1460,22 @@ export function registerDeckHandler(
       return client.rpc('task.mission.list', { verifiedWorkspaceId: owner });
     },
   });
+  // Lane F step 5: every ledger transition is posted to the task's mission
+  // channel as the owner workspace, so the channel transcript and the ledger
+  // never disagree about what happened.
+  const disposeLedgerEmitter = installLedgerChannelEmitter({
+    post: async ({ channelId, ownerWorkspaceId, text, clientMsgId }) => {
+      const client = opts.getDaemonClient?.() ?? null;
+      if (!client) return null;
+      return client.rpc('a2a.channel.post', {
+        channelId,
+        sender: { workspaceId: ownerWorkspaceId, memberId: ownerWorkspaceId },
+        text,
+        verifiedWorkspaceId: ownerWorkspaceId,
+        clientMsgId,
+      });
+    },
+  });
   coalescer = new CommanderEventCoalescer({
     runTurn: (workspaceId, prompt) => runTurnForWorkspace(prompt, workspaceId),
     // Lane F: worker events parked while this workspace had no brain.
@@ -2520,6 +2545,7 @@ export function registerDeckHandler(
     clearTimeout(reconcileTimer);
     offBus();
     coalescer?.dispose();
+    disposeLedgerEmitter();
     globalTurnGate.dispose();
     scheduler.stop();
     heartbeat.stop();

--- a/src/main/mcp/firstParty.ts
+++ b/src/main/mcp/firstParty.ts
@@ -296,6 +296,10 @@ export const FIRST_PARTY_METHODS: ReadonlySet<RpcMethod> = new Set<RpcMethod>([
   // server-derived in the handler and the spawn is approval-gated, so the grant
   // is to ATTEMPT the call; an unverifiable caller still fails closed.
   'task.fanout.start',
+  // Task ledger — ledger_update (every profile, worker-scoped by the ledger's
+  // authz) and ledger_list (commander-only tool, also in the commander lane).
+  'ledger.list',
+  'ledger.update',
   // `company.a2a.*` used to be granted here for the six company_a2a_* tools.
   // Those tools are gone, so the grants went with them (least privilege — a
   // reserved wmux.internal method must not stay reachable by a clientName

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -466,6 +466,11 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
   // decides whether a plugin may reach the surface at all.
   'task.fanout.start': { capability: 'a2a.execute', riskClass: 'a2a' },
 
+  // --- Task ledger (pipe/handlers/ledger.rpc.ts) --- same read/mutation
+  // split as task.mission.*; actor/transition authz is enforced in the ledger.
+  'ledger.list':   { capability: 'a2a.channel.read', riskClass: 'a2a' },
+  'ledger.update': { capability: 'a2a.channel.send', riskClass: 'a2a' },
+
   // --- Company subsystem (substrate-internal team/orchestration). All
   //     internal for v3.0; can be re-classified once spec covers a2a teams.
   'company.create':         { capability: 'wmux.internal' },

--- a/src/main/mcp/methodCapabilityMap.ts
+++ b/src/main/mcp/methodCapabilityMap.ts
@@ -468,8 +468,8 @@ export const METHOD_CAPABILITY: Record<RpcMethod, RequiredCapability> = {
 
   // --- Task ledger (pipe/handlers/ledger.rpc.ts) --- same read/mutation
   // split as task.mission.*; actor/transition authz is enforced in the ledger.
-  'ledger.list':   { capability: 'a2a.channel.read', riskClass: 'a2a' },
-  'ledger.update': { capability: 'a2a.channel.send', riskClass: 'a2a' },
+  'ledger.list':   { capability: 'ledger.read',  riskClass: 'a2a' },
+  'ledger.update': { capability: 'ledger.write', riskClass: 'a2a' },
 
   // --- Company subsystem (substrate-internal team/orchestration). All
   //     internal for v3.0; can be re-classified once spec covers a2a teams.
@@ -554,6 +554,10 @@ export const CAPABILITY_RISK_CLASS: Record<string, RiskClass> = {
   // capability-level fence, not a UX differentiation.
   'a2a.channel.read': 'a2a',
   'a2a.channel.send': 'a2a',
+  // Task ledger — the orchestration ledger is agent-to-agent state, so the
+  // dialog wording is the a2a one; the capability ids stay distinct.
+  'ledger.read':  'a2a',
+  'ledger.write': 'a2a',
   // Plugin host UI contribution points (B-1) — enforced at mount time by
   // the renderer host, not per-RPC; classed here so the approval dialog
   // renders real copy instead of fallback text.
@@ -631,6 +635,9 @@ export const CAPABILITY_EFFECT: Record<string, 'read' | 'write'> = {
   'a2a.read':    'read',
   'a2a.channel.read': 'read',
   'a2a.channel.send': 'write',
+  // Task ledger: list observes, update changes task status.
+  'ledger.read':  'read',
+  'ledger.write': 'write',
   // Plugin host UI contribution points — enforced at mount time, never a
   // per-RPC gate, so the classification is nominal. Listed so the
   // completeness test covers the whole vocabulary.

--- a/src/main/mcp/permissionGrammar.ts
+++ b/src/main/mcp/permissionGrammar.ts
@@ -59,6 +59,11 @@ const KNOWN_CAPABILITIES = new Set<string>([
   // of risk.
   'a2a.channel.read',
   'a2a.channel.send',
+  // Task ledger (ledger.list / ledger.update). Its own pair rather than a
+  // ride on a2a.channel.*: a channel-send approval must not silently cover
+  // rewriting task status, and a ledger grant must not open channel posts.
+  'ledger.read',
+  'ledger.write',
   // Plugin host UI contribution points (B-1). Enforced at contribution
   // registration time — the host refuses to mount the iframe/widget when
   // the capability is missing or the plugin isn't trusted; per-RPC

--- a/src/main/pipe/handlers/__tests__/ledger.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/ledger.rpc.test.ts
@@ -57,7 +57,7 @@ describe('ledger.update', () => {
     expect(stale.error.code).toBe('STALE_REV');
   });
 
-  it('a worker cannot complete or touch a stranger task; the brain completes with a passing gate', async () => {
+  it('a worker cannot complete or touch a stranger task; the brain completes only after the gate runner recorded a pass', async () => {
     const notMine = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-9', status: 'failed', expectedRev: 1 })) as { error: { code: string } };
     expect(notMine.error.code).toBe('NOT_AUTHORIZED');
     await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'review_requested', expectedRev: 1 });
@@ -65,9 +65,22 @@ describe('ledger.update', () => {
     expect(selfCertify.error.code).toBe('NOT_AUTHORIZED');
     const noGate = (await call('ledger.update', { taskId: 'wtask-1', status: 'completed', expectedRev: 2 }, brainCtx)) as { error: { code: string } };
     expect(noGate.error.code).toBe('GATE_REQUIRED');
-    const done = (await call('ledger.update', { taskId: 'wtask-1', status: 'completed', expectedRev: 2, gate: { exitCode: 0, tail: 'ok', at: 1, command: 'npm test' } }, brainCtx)) as { ok: boolean; entry: { status: string } };
+    // A caller-supplied gate is refused outright — for the brain AND the worker.
+    const wireGate = (await call('ledger.update', { taskId: 'wtask-1', status: 'completed', expectedRev: 2, gate: { exitCode: 0, tail: 'ok', at: 1, command: 'npm test' } }, brainCtx)) as { error: { code: string } };
+    expect(wireGate.error.code).toBe('INVALID_ARGUMENT');
+    const workerGate = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'working', expectedRev: 2, gate: { exitCode: 0 } })) as { error: { code: string } };
+    expect(workerGate.error.code).toBe('INVALID_ARGUMENT');
+    expect(ledger.get('wtask-1')?.gate).toBeUndefined();
+    await ledger.recordGate('wtask-1', { exitCode: 0, tail: 'ok', at: 1, command: 'npm test' });
+    const done = (await call('ledger.update', { taskId: 'wtask-1', status: 'completed', expectedRev: 3 }, brainCtx)) as { ok: boolean; entry: { status: string } };
     expect(done.ok).toBe(true);
     expect(done.entry.status).toBe('completed');
+  });
+
+  it('clamps summary and reason bytes on the wire path', async () => {
+    const res = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'input_required', expectedRev: 1, summary: 'x'.repeat(10_000) })) as { ok: boolean; entry: { summary: string } };
+    expect(res.ok).toBe(true);
+    expect(Buffer.byteLength(res.entry.summary)).toBe(2048);
   });
 
   it('validates the wire shape', async () => {

--- a/src/main/pipe/handlers/__tests__/ledger.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/ledger.rpc.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TaskLedger } from '../../../../daemon/ledger/TaskLedger';
+import { registerLedgerRpc } from '../ledger.rpc';
+import type { RpcContext } from '../../../../shared/rpc';
+
+type Handler = (params: Record<string, unknown>, ctx?: RpcContext) => Promise<unknown>;
+
+let dir: string;
+let ledger: TaskLedger;
+let handlers: Map<string, Handler>;
+
+beforeEach(async () => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-ledger-rpc-'));
+  ledger = new TaskLedger({ dir });
+  await ledger.register({ id: 'wtask-1', taskWorkspaceId: 'ws-task', ownerWorkspaceId: 'ws-brain', title: 'lane' });
+  await ledger.register({ id: 'wtask-9', taskWorkspaceId: 'ws-task-9', ownerWorkspaceId: 'ws-stranger', title: 'other' });
+  handlers = new Map();
+  const router = { register: (m: string, h: Handler) => handlers.set(m, h) };
+  registerLedgerRpc(router as never, () => null, {
+    getLedger: () => ledger,
+    resolveCallerWorkspace: async (pty) => (pty === 'pty-task' ? 'ws-task' : null),
+  });
+});
+afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const call = (m: string, p: Record<string, unknown>, ctx?: RpcContext) => handlers.get(m)!(p, ctx);
+const brainCtx = { commanderWorkspace: 'ws-brain' } as RpcContext;
+
+describe('ledger.list', () => {
+  it('a commander lists only the tasks its workspace owns', async () => {
+    const res = (await call('ledger.list', {}, brainCtx)) as { ok: boolean; actor: unknown; entries: { id: string }[] };
+    expect(res.ok).toBe(true);
+    expect(res.actor).toEqual({ kind: 'brain', workspaceId: 'ws-brain' });
+    expect(res.entries.map((e) => e.id)).toEqual(['wtask-1']);
+  });
+
+  it('a worker lists its own task by resolved senderPtyId; an unresolvable caller is refused', async () => {
+    const res = (await call('ledger.list', { senderPtyId: 'pty-task' })) as { entries: { id: string }[] };
+    expect(res.entries.map((e) => e.id)).toEqual(['wtask-1']);
+    const denied = (await call('ledger.list', { senderPtyId: 'pty-nope' })) as { ok: boolean; error: { code: string } };
+    expect(denied.ok).toBe(false);
+    expect(denied.error.code).toBe('NOT_AUTHORIZED');
+  });
+});
+
+describe('ledger.update', () => {
+  it('a worker hands its task to review with the rev it read; a stale rev is refused', async () => {
+    const ok = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'review_requested', expectedRev: 1, summary: 'gate green' })) as { ok: boolean; entry: { status: string; rev: number } };
+    expect(ok.ok).toBe(true);
+    expect(ok.entry.status).toBe('review_requested');
+    expect(ok.entry.rev).toBe(2);
+    const stale = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'working', expectedRev: 1 })) as { ok: boolean; error: { code: string } };
+    expect(stale.ok).toBe(false);
+    expect(stale.error.code).toBe('STALE_REV');
+  });
+
+  it('a worker cannot complete or touch a stranger task; the brain completes with a passing gate', async () => {
+    const notMine = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-9', status: 'failed', expectedRev: 1 })) as { error: { code: string } };
+    expect(notMine.error.code).toBe('NOT_AUTHORIZED');
+    await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'review_requested', expectedRev: 1 });
+    const selfCertify = (await call('ledger.update', { senderPtyId: 'pty-task', taskId: 'wtask-1', status: 'completed', expectedRev: 2 })) as { error: { code: string } };
+    expect(selfCertify.error.code).toBe('NOT_AUTHORIZED');
+    const noGate = (await call('ledger.update', { taskId: 'wtask-1', status: 'completed', expectedRev: 2 }, brainCtx)) as { error: { code: string } };
+    expect(noGate.error.code).toBe('GATE_REQUIRED');
+    const done = (await call('ledger.update', { taskId: 'wtask-1', status: 'completed', expectedRev: 2, gate: { exitCode: 0, tail: 'ok', at: 1, command: 'npm test' } }, brainCtx)) as { ok: boolean; entry: { status: string } };
+    expect(done.ok).toBe(true);
+    expect(done.entry.status).toBe('completed');
+  });
+
+  it('validates the wire shape', async () => {
+    const noStatus = (await call('ledger.update', { taskId: 'wtask-1', status: 'done', expectedRev: 1 }, brainCtx)) as { error: { code: string } };
+    expect(noStatus.error.code).toBe('INVALID_ARGUMENT');
+    const noRev = (await call('ledger.update', { taskId: 'wtask-1', status: 'failed' }, brainCtx)) as { error: { code: string } };
+    expect(noRev.error.code).toBe('INVALID_ARGUMENT');
+  });
+});

--- a/src/main/pipe/handlers/ledger.rpc.ts
+++ b/src/main/pipe/handlers/ledger.rpc.ts
@@ -1,0 +1,120 @@
+// ─── ledger.list / ledger.update — the task ledger on the pipe surface ───────
+//
+// Two methods over the main-hosted TaskLedger (deck/taskLedgerHost.ts).
+// Identity is server-resolved, never taken from params:
+//   - a VALIDATED commander token (ctx.commanderWorkspace, set by RpcRouter)
+//     makes the caller a `brain` actor for that workspace;
+//   - otherwise the caller's senderPtyId resolves to its workspace through the
+//     mirror/renderer (the same D5 anchor a2a.channel.* uses) and the caller
+//     is a `worker` actor for that workspace.
+// Authorization and transition legality live in the ledger (canActorSet /
+// canTransition); this handler only shapes the wire and refuses an
+// unresolvable caller. Reads are scoped to the caller's own rows: the tasks a
+// workspace owns plus the task whose workspace it is.
+
+import type { BrowserWindow } from 'electron';
+import type { RpcRouter } from '../RpcRouter';
+import type { RpcContext } from '../../../shared/rpc';
+import { isLedgerStatus, type LedgerActor, type LedgerGateResult } from '../../../shared/ledger';
+import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
+import { getTaskLedger } from '../../deck/taskLedgerHost';
+import type { TaskLedger } from '../../../daemon/ledger/TaskLedger';
+
+type GetWindow = () => BrowserWindow | null;
+
+export interface LedgerRpcDeps {
+  /** Injected in tests; defaults to the hosted instance. */
+  getLedger?: () => TaskLedger;
+  /** Injected in tests; defaults to the mirror/renderer resolution. */
+  resolveCallerWorkspace?: (senderPtyId: string) => Promise<string | null>;
+}
+
+function deny(code: string, message: string): { ok: false; error: { code: string; message: string } } {
+  return { ok: false, error: { code, message } };
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function readGate(v: unknown): LedgerGateResult | undefined {
+  if (!v || typeof v !== 'object') return undefined;
+  const g = v as Record<string, unknown>;
+  const exitCode = g.exitCode === null ? null : typeof g.exitCode === 'number' ? g.exitCode : undefined;
+  if (exitCode === undefined) return undefined;
+  return {
+    exitCode,
+    tail: typeof g.tail === 'string' ? g.tail : '',
+    at: typeof g.at === 'number' ? g.at : Date.now(),
+    command: typeof g.command === 'string' ? g.command : '',
+  };
+}
+
+export function registerLedgerRpc(router: RpcRouter, getWindow: GetWindow, deps: LedgerRpcDeps = {}): void {
+  const ledgerOf = deps.getLedger ?? getTaskLedger;
+  const resolveCaller =
+    deps.resolveCallerWorkspace ??
+    (async (senderPtyId: string) => {
+      try {
+        return await resolvePtyOwnerWorkspace(getWindow, senderPtyId);
+      } catch {
+        return null;
+      }
+    });
+
+  /** Who is calling: the validated commander (brain) or a pane (worker). */
+  const resolveActor = async (
+    params: Record<string, unknown>,
+    ctx?: RpcContext,
+  ): Promise<LedgerActor | null> => {
+    if (ctx?.commanderWorkspace) return { kind: 'brain', workspaceId: ctx.commanderWorkspace };
+    const senderPtyId = str(params.senderPtyId);
+    if (!senderPtyId) return null;
+    const ws = await resolveCaller(senderPtyId);
+    return ws ? { kind: 'worker', workspaceId: ws } : null;
+  };
+
+  router.register('ledger.list', async (params, ctx) => {
+    const actor = await resolveActor(params, ctx);
+    if (!actor) {
+      return deny('NOT_AUTHORIZED', 'ledger.list: caller identity could not be resolved (no commander token, no resolvable senderPtyId)');
+    }
+    const ledger = ledgerOf();
+    const taskId = str(params.taskId);
+    const openOnly = params.openOnly === true;
+    const mine = ledger
+      .list({ ...(taskId ? { id: taskId } : {}), ...(openOnly ? { openOnly: true } : {}) })
+      .filter((e) => e.ownerWorkspaceId === actor.workspaceId || e.taskWorkspaceId === actor.workspaceId);
+    return { ok: true, actor, entries: mine };
+  });
+
+  router.register('ledger.update', async (params, ctx) => {
+    const actor = await resolveActor(params, ctx);
+    if (!actor) {
+      return deny('NOT_AUTHORIZED', 'ledger.update: caller identity could not be resolved (no commander token, no resolvable senderPtyId)');
+    }
+    const taskId = str(params.taskId);
+    if (!taskId) return deny('INVALID_ARGUMENT', 'ledger.update: taskId is required');
+    const status = str(params.status);
+    if (!isLedgerStatus(status)) {
+      return deny('INVALID_ARGUMENT', `ledger.update: status must be one of working, input_required, review_requested, completed, failed, cancelled (got "${status}")`);
+    }
+    if (typeof params.expectedRev !== 'number' || !Number.isInteger(params.expectedRev)) {
+      return deny('INVALID_ARGUMENT', 'ledger.update: expectedRev (the rev you read from ledger_list) is required');
+    }
+    const res = await ledgerOf().update({
+      id: taskId,
+      status,
+      actor,
+      expectedRev: params.expectedRev,
+      ...(str(params.summary) ? { summary: str(params.summary) } : {}),
+      ...(readGate(params.gate) ? { gate: readGate(params.gate) } : {}),
+      ...(params.force === true ? { force: true } : {}),
+      ...(str(params.reason) ? { reason: str(params.reason) } : {}),
+    });
+    if (!res.ok) {
+      return { ...deny(res.error.toUpperCase(), `ledger.update: ${res.message}`), ...(res.entry ? { entry: res.entry } : {}) };
+    }
+    return { ok: true, entry: res.entry, ...(res.noop ? { noop: true } : {}) };
+  });
+}

--- a/src/main/pipe/handlers/ledger.rpc.ts
+++ b/src/main/pipe/handlers/ledger.rpc.ts
@@ -15,10 +15,10 @@
 import type { BrowserWindow } from 'electron';
 import type { RpcRouter } from '../RpcRouter';
 import type { RpcContext } from '../../../shared/rpc';
-import { isLedgerStatus, type LedgerActor, type LedgerGateResult } from '../../../shared/ledger';
+import { isLedgerStatus, type LedgerActor } from '../../../shared/ledger';
 import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 import { getTaskLedger } from '../../deck/taskLedgerHost';
-import type { TaskLedger } from '../../../daemon/ledger/TaskLedger';
+import { LEDGER_SUMMARY_MAX_BYTES, truncateHead, type TaskLedger } from '../../../daemon/ledger/TaskLedger';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -37,17 +37,9 @@ function str(v: unknown): string {
   return typeof v === 'string' ? v.trim() : '';
 }
 
-function readGate(v: unknown): LedgerGateResult | undefined {
-  if (!v || typeof v !== 'object') return undefined;
-  const g = v as Record<string, unknown>;
-  const exitCode = g.exitCode === null ? null : typeof g.exitCode === 'number' ? g.exitCode : undefined;
-  if (exitCode === undefined) return undefined;
-  return {
-    exitCode,
-    tail: typeof g.tail === 'string' ? g.tail : '',
-    at: typeof g.at === 'number' ? g.at : Date.now(),
-    command: typeof g.command === 'string' ? g.command : '',
-  };
+/** Free text off the wire, clamped to the ledger's byte cap. */
+function text(v: unknown): string {
+  return truncateHead(str(v), LEDGER_SUMMARY_MAX_BYTES);
 }
 
 export function registerLedgerRpc(router: RpcRouter, getWindow: GetWindow, deps: LedgerRpcDeps = {}): void {
@@ -102,15 +94,21 @@ export function registerLedgerRpc(router: RpcRouter, getWindow: GetWindow, deps:
     if (typeof params.expectedRev !== 'number' || !Number.isInteger(params.expectedRev)) {
       return deny('INVALID_ARGUMENT', 'ledger.update: expectedRev (the rev you read from ledger_list) is required');
     }
+    // A gate result is the gate runner's write (system actor, TaskLedger.
+    // recordGate). No wire caller — worker or brain — may supply one: a
+    // caller-written "exitCode: 0" is exactly the self-certification the
+    // ledger exists to refuse.
+    if (params.gate !== undefined) {
+      return deny('INVALID_ARGUMENT', 'ledger.update: gate results are recorded by the gate runner, not by callers; omit "gate" (use force + reason to complete without one)');
+    }
     const res = await ledgerOf().update({
       id: taskId,
       status,
       actor,
       expectedRev: params.expectedRev,
-      ...(str(params.summary) ? { summary: str(params.summary) } : {}),
-      ...(readGate(params.gate) ? { gate: readGate(params.gate) } : {}),
+      ...(text(params.summary) ? { summary: text(params.summary) } : {}),
       ...(params.force === true ? { force: true } : {}),
-      ...(str(params.reason) ? { reason: str(params.reason) } : {}),
+      ...(text(params.reason) ? { reason: text(params.reason) } : {}),
     });
     if (!res.ok) {
       return { ...deny(res.error.toUpperCase(), `ledger.update: ${res.message}`), ...(res.entry ? { entry: res.entry } : {}) };

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -37,7 +37,7 @@ import {
 import { TaskWorktreeManager } from './TaskWorktreeManager';
 import type { TaskWorktreePlan } from './TaskWorktreeManager';
 import type { ProjectConfigState } from '../../shared/wmuxProjectConfig';
-import { getTaskLedger, rememberMissionChannel } from '../deck/taskLedgerHost';
+import { getTaskLedger, rememberMissionChannel, noteWorkTaskClosed } from '../deck/taskLedgerHost';
 import {
   FANOUT_TASK_PORT_ENV,
   assignFanoutPorts,
@@ -650,7 +650,9 @@ export class FanOutService {
     _plan?: TaskWorktreePlan,
   ): Promise<void> {
     try {
-      await this.daemon.rpc('task.mission.close', { taskId, verifiedWorkspaceId });
+      const closed = (await this.daemon.rpc('task.mission.close', { taskId, verifiedWorkspaceId })) as { ok?: boolean } | undefined;
+      // Lane F: a closed task leaves the ledger `cancelled` right away.
+      if (closed?.ok) await noteWorkTaskClosed(taskId);
     } catch {
       // best-effort 보상 — 실패해도 fan-out은 계속한다.
     }

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -37,6 +37,7 @@ import {
 import { TaskWorktreeManager } from './TaskWorktreeManager';
 import type { TaskWorktreePlan } from './TaskWorktreeManager';
 import type { ProjectConfigState } from '../../shared/wmuxProjectConfig';
+import { getTaskLedger, rememberMissionChannel } from '../deck/taskLedgerHost';
 import {
   FANOUT_TASK_PORT_ENV,
   assignFanoutPorts,
@@ -597,6 +598,21 @@ export class FanOutService {
       }
     } catch (err) {
       return { ...base, unmaterialized: true, error: `task.update threw: ${(err as Error).message}` };
+    }
+    // Lane F: the materialized task enters the ledger as `working` right here,
+    // so the owner's brain, the Stop gate and the workers read one state from
+    // the first second. Best-effort: a ledger write failure never fails the
+    // fan-out (the reconciler mirrors it on the next look).
+    try {
+      rememberMissionChannel(taskId, channelId);
+      await getTaskLedger().register({
+        id: taskId,
+        taskWorkspaceId: workspaceId,
+        ownerWorkspaceId: ctx.verifiedWorkspaceId,
+        title: ctx.title,
+      });
+    } catch {
+      // best-effort — see above.
     }
 
     // ⑤ 채널 invite — 태스크 워크스페이스를 미션 채널 멤버로(실패 비치명 §2 C3).

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -71,6 +71,14 @@ You are running in a wmux pane. When this task is done and you go idle:
 - A channel post that mentions only your *workspace* — or that mentions nobody — is **not** pasted. It raises an unread badge and nothing else.
 
 So going idle is not "waiting for the next message": nothing wakes you for the third case. If you are expecting follow-up work, check \`channel_unread\` / \`a2a_task_query\` yourself before you stop. And report completion in your mission channel (\`channel_post\`) — an idle worker and a hung worker look identical from the outside, and the only difference the sender can see is what you said.
+
+## How completion is recorded (task ledger)
+
+Your task has a row in the task ledger; the brain reads that row, not your prose. A natural-language "done" is **not** completion.
+
+- When the task is done **and your own gate passed** (tsc / lint / tests for what you touched): \`ledger_update({task_id, status: "review_requested", expected_rev, summary})\` — the summary says what landed and what you verified.
+- On a blocker you cannot clear yourself: \`ledger_update({task_id, status: "input_required", expected_rev, summary})\` — the summary names what you need.
+- \`expected_rev\` is the rev you last read (1 right after fan-out); a stale rev is refused, so re-read and retry. Only the brain can mark \`completed\`.
 `;
 
 /** 데몬 RPC 최소 표면(테스트 주입 가능). daemonClient.rpc의 부분집합. */

--- a/src/main/worktask/TaskCloseService.ts
+++ b/src/main/worktask/TaskCloseService.ts
@@ -24,6 +24,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 import type { TaskWorktreeManager } from './TaskWorktreeManager';
+import { noteWorkTaskClosed } from '../deck/taskLedgerHost';
 import { getExecEnv } from '../../shared/execEnv';
 
 const execFileAsync = promisify(execFile);
@@ -153,6 +154,9 @@ export class TaskCloseService {
         verifiedWorkspaceId,
       })) as { ok?: boolean; archivePending?: boolean; error?: { message?: string } };
       if (res && res.ok === true) {
+        // Lane F: the task ledger learns about the close now, not on the
+        // next reconcile pass (an open row would hold the brain's Stop gate).
+        await noteWorkTaskClosed(taskId);
         return { ok: true, archivePending: res.archivePending === true };
       }
       return { ok: false, error: res?.error?.message ?? 'task.mission.close failed' };

--- a/src/mcp/__tests__/ledger.test.ts
+++ b/src/mcp/__tests__/ledger.test.ts
@@ -1,0 +1,78 @@
+// Tests for the ledger_update (worker, every profile) and ledger_list
+// (commander-only) MCP tools: wire mapping, identity attachment, and the
+// reserved commander-only names staying unregistered.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../wmux-client', () => ({
+  sendRpc: vi.fn(),
+  setClientIdentity: vi.fn(),
+  clearClientIdentity: vi.fn(),
+}));
+
+import { sendRpc } from '../wmux-client';
+import { registerLedgerUpdateTool, registerLedgerListTool } from '../ledger';
+import { FIRST_PARTY_METHODS } from '../../main/mcp/firstParty';
+import { COMMANDER_ONLY_TOOLS, COMMANDER_RPC_METHODS } from '../../shared/commanderSurface';
+import { CORE_TOOL_SURFACE } from '../../shared/coreSurface';
+
+const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }>;
+
+function collect(): { tools: Map<string, ToolHandler>; shapes: Map<string, Record<string, unknown>> } {
+  const tools = new Map<string, ToolHandler>();
+  const shapes = new Map<string, Record<string, unknown>>();
+  const tool = (name: string, _d: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+    tools.set(name, handler);
+    shapes.set(name, schema);
+  };
+  registerLedgerUpdateTool({ tool } as never, { getSenderPtyId: () => 'pty-mine', resolveWorkspaceId: async () => 'ws-mine' });
+  registerLedgerListTool(tool as never);
+  return { tools, shapes };
+}
+
+beforeEach(() => mockSendRpc.mockReset());
+
+describe('ledger_update', () => {
+  it('maps snake_case args to the wire and attaches the verified senderPtyId', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, entry: { id: 'wtask-1', status: 'review_requested', rev: 2 } });
+    const { tools } = collect();
+    const res = await tools.get('ledger_update')!({ task_id: 'wtask-1', status: 'review_requested', expected_rev: 1, summary: 'gate green' });
+    expect(mockSendRpc).toHaveBeenCalledWith('ledger.update', {
+      taskId: 'wtask-1', status: 'review_requested', expectedRev: 1, summary: 'gate green', senderPtyId: 'pty-mine',
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0].text).toContain('review_requested');
+  });
+
+  it('flags a refused update as an error result and exposes no completed/cancelled status', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, error: { code: 'STALE_REV', message: 'stale' } });
+    const { tools, shapes } = collect();
+    const res = await tools.get('ledger_update')!({ task_id: 'wtask-1', status: 'failed', expected_rev: 0 });
+    expect(res.isError).toBe(true);
+    const status = shapes.get('ledger_update')!['status'] as { options: string[] };
+    expect(status.options).not.toContain('completed');
+    expect(status.options).not.toContain('cancelled');
+  });
+
+  it('is on the core surface and its RPC is first-party', () => {
+    expect(CORE_TOOL_SURFACE).toContain('ledger_update');
+    expect(FIRST_PARTY_METHODS.has('ledger.update' as never)).toBe(true);
+  });
+});
+
+describe('ledger_list (commander-only)', () => {
+  it('forwards the filters and sends no workspace — the commander token is the identity', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, entries: [] });
+    const { tools } = collect();
+    await tools.get('ledger_list')!({ open_only: true, task_id: 'wtask-1' });
+    expect(mockSendRpc).toHaveBeenCalledWith('ledger.list', { taskId: 'wtask-1', openOnly: true });
+  });
+
+  it('is listed commander-only, outside core, with its RPC in the commander lane', () => {
+    expect(COMMANDER_ONLY_TOOLS).toContain('ledger_list');
+    expect(CORE_TOOL_SURFACE).not.toContain('ledger_list');
+    expect(COMMANDER_RPC_METHODS.has('ledger.list')).toBe(true);
+  });
+});

--- a/src/mcp/__tests__/ledger.test.ts
+++ b/src/mcp/__tests__/ledger.test.ts
@@ -11,7 +11,7 @@ vi.mock('../wmux-client', () => ({
 }));
 
 import { sendRpc } from '../wmux-client';
-import { registerLedgerUpdateTool, registerLedgerListTool } from '../ledger';
+import { registerLedgerUpdateTool, registerLedgerListTool, registerLedgerBrainUpdateTool } from '../ledger';
 import { FIRST_PARTY_METHODS } from '../../main/mcp/firstParty';
 import { COMMANDER_ONLY_TOOLS, COMMANDER_RPC_METHODS } from '../../shared/commanderSurface';
 import { CORE_TOOL_SURFACE } from '../../shared/coreSurface';
@@ -29,6 +29,16 @@ function collect(): { tools: Map<string, ToolHandler>; shapes: Map<string, Recor
   };
   registerLedgerUpdateTool({ tool } as never, { getSenderPtyId: () => 'pty-mine', resolveWorkspaceId: async () => 'ws-mine' });
   registerLedgerListTool(tool as never);
+  return { tools, shapes };
+}
+
+function collectBrain(): { tools: Map<string, ToolHandler>; shapes: Map<string, Record<string, unknown>> } {
+  const tools = new Map<string, ToolHandler>();
+  const shapes = new Map<string, Record<string, unknown>>();
+  registerLedgerBrainUpdateTool(((name: string, _d: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+    tools.set(name, handler);
+    shapes.set(name, schema);
+  }) as never);
   return { tools, shapes };
 }
 
@@ -59,6 +69,25 @@ describe('ledger_update', () => {
   it('is on the core surface and its RPC is first-party', () => {
     expect(CORE_TOOL_SURFACE).toContain('ledger_update');
     expect(FIRST_PARTY_METHODS.has('ledger.update' as never)).toBe(true);
+  });
+});
+
+describe('ledger_update — brain variant (commander-only)', () => {
+  it('registers under the same name with the full status enum and force/reason, sending no identity', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, entry: { id: 'wtask-1', status: 'completed', rev: 4 } });
+    const { tools, shapes } = collectBrain();
+    const status = shapes.get('ledger_update')!['status'] as { options: string[] };
+    expect(status.options).toEqual(expect.arrayContaining(['completed', 'failed', 'cancelled', 'input_required', 'working']));
+    await tools.get('ledger_update')!({ task_id: 'wtask-1', status: 'completed', expected_rev: 3, summary: 'gate green', force: true, reason: 'owner waived' });
+    expect(mockSendRpc).toHaveBeenCalledWith('ledger.update', {
+      taskId: 'wtask-1', status: 'completed', expectedRev: 3, summary: 'gate green', force: true, reason: 'owner waived',
+    });
+    expect(Object.keys(shapes.get('ledger_update')!)).not.toContain('gate');
+  });
+
+  it('is on the commander lane with its RPC in the commander allow lane', () => {
+    expect(COMMANDER_ONLY_TOOLS).toContain('ledger_update');
+    expect(COMMANDER_RPC_METHODS.has('ledger.update')).toBe(true);
   });
 });
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -28,7 +28,7 @@ import { registerUtilityTools } from './playwright/tools/utility';
 import { registerExtractionTools } from './playwright/tools/extraction';
 import { registerChannelTools } from './channels';
 import { registerFanOutTools } from './fanout';
-import { registerLedgerUpdateTool, registerLedgerListTool } from './ledger';
+import { registerLedgerUpdateTool, registerLedgerListTool, registerLedgerBrainUpdateTool } from './ledger';
 import { registerPaneLifecycleTools } from './paneLifecycle';
 import { registerReplTools } from './repl/tools';
 import { getWmuxMcpServerInstructions, resolveMcpServerVersion } from './serverMetadata';
@@ -1620,6 +1620,10 @@ if (COMMANDER_MODE) {
     return (registerToolUnfiltered as (...a: unknown[]) => ReturnType<typeof server.tool>)(name, ...rest);
   }) as typeof server.tool;
   registerLedgerListTool(registerCommanderOnly);
+  // The brain's ledger_update: the worker registration of that name was
+  // filtered out above (not in COMMANDER_TOOL_SURFACE), so this is the only
+  // ledger_update a commander sees.
+  registerLedgerBrainUpdateTool(registerCommanderOnly);
 }
 
 // Hook the MCP initialize handshake so wmux substrate learns the declared

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,7 +2,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { sendRpc, setClientIdentity, setCommanderRole, setWorkspaceToken } from './wmux-client';
-import { COMMANDER_TOOL_SURFACE } from '../shared/commanderSurface';
+import { COMMANDER_TOOL_SURFACE, COMMANDER_ONLY_TOOLS } from '../shared/commanderSurface';
 import { CORE_TOOL_SURFACE } from '../shared/coreSurface';
 import type { RpcMethod } from '../shared/rpc';
 import {
@@ -28,6 +28,7 @@ import { registerUtilityTools } from './playwright/tools/utility';
 import { registerExtractionTools } from './playwright/tools/extraction';
 import { registerChannelTools } from './channels';
 import { registerFanOutTools } from './fanout';
+import { registerLedgerUpdateTool, registerLedgerListTool } from './ledger';
 import { registerPaneLifecycleTools } from './paneLifecycle';
 import { registerReplTools } from './repl/tools';
 import { getWmuxMcpServerInstructions, resolveMcpServerVersion } from './serverMetadata';
@@ -480,6 +481,11 @@ if (COMMANDER_MODE) {
 // Legacy (non-catalog) registration sites are filtered by an explicit manifest
 // for every profile that is narrower than `full`. `full` registers everything
 // and needs no patch at all.
+// Lane F: the UNFILTERED registration binding, captured BEFORE the manifest
+// patch below so the commander-only lane (end of this function) can register a
+// tool that is deliberately absent from COMMANDER_TOOL_SURFACE (which is a
+// filter of the full surface) — see COMMANDER_ONLY_TOOLS.
+const registerToolUnfiltered = server.tool.bind(server);
 const LEGACY_SURFACE: readonly string[] | null =
   SURFACE_PROFILE === 'commander'
     ? COMMANDER_TOOL_SURFACE
@@ -1558,6 +1564,14 @@ registerFanOutTools(server, {
   resolveWorkspaceId: requireWorkspaceId,
 });
 
+// === Task ledger — worker side (full + core) ===
+// Same walk-hit-only provenance as fan-out: the handler resolves the caller's
+// workspace from this ptyId and the ledger scopes the write to that task.
+registerLedgerUpdateTool(server, {
+  getSenderPtyId: () => MY_PTY_ID,
+  resolveWorkspaceId: requireWorkspaceId,
+});
+
 // === Pane + surface lifecycle tools (issue #285) ===
 // Five MCP tools (pane_split / pane_close / pane_focus, surface_new /
 // surface_close) that mirror the workspace-scoped pane/surface lifecycle RPCs
@@ -1585,6 +1599,28 @@ registerPaneLifecycleTools(
 // authorize. The authority ceiling is unchanged — a caller holding
 // `terminal_send` already drives an arbitrary shell in its own pane as the user.
 registerReplTools(server, MCP_CATALOG_OPTIONS);
+
+// === Commander-only registration lane ===
+// Tools that exist ONLY under --commander. They bypass the manifest filter on
+// purpose (registerToolUnfiltered) and are appended AFTER every full-profile
+// tool so the full ordering the probe pins is untouched. Every name here MUST
+// be in COMMANDER_ONLY_TOOLS (shared/commanderSurface.ts) — the invariant
+// tests and the probe read that list; a name outside it is a bug.
+//
+// Reserved, NOT yet wired (lane O2 — task_gate_run, task_adopt, task_close,
+// task_pr, git_status, git_log, gh_pr_view): register them here, through
+// registerCommanderOnly, and move each name from COMMANDER_ONLY_RESERVED_TOOLS
+// to COMMANDER_ONLY_TOOLS in the same commit.
+if (COMMANDER_MODE) {
+  const commanderOnly = new Set(COMMANDER_ONLY_TOOLS);
+  const registerCommanderOnly: typeof server.tool = ((name: string, ...rest: unknown[]) => {
+    if (!commanderOnly.has(name)) {
+      throw new Error(`[wmux-mcp] ${name} is not listed in COMMANDER_ONLY_TOOLS`);
+    }
+    return (registerToolUnfiltered as (...a: unknown[]) => ReturnType<typeof server.tool>)(name, ...rest);
+  }) as typeof server.tool;
+  registerLedgerListTool(registerCommanderOnly);
+}
 
 // Hook the MCP initialize handshake so wmux substrate learns the declared
 // plugin identity (clientInfo.name + version). Fire `mcp.identify` once so

--- a/src/mcp/ledger.ts
+++ b/src/mcp/ledger.ts
@@ -1,0 +1,102 @@
+// ─── Task ledger tools for the bundled MCP server ───────────────────────────
+//
+// Two tools over the `ledger.*` pipe RPCs (src/main/pipe/handlers/ledger.rpc.ts):
+//
+//   ledger_update — every profile (full + core). A WORKER reports its own
+//     task: identity is the server-resolved senderPtyId (same provenance rule
+//     as the channel tools — walk-hit only, never the env hint), and the
+//     ledger refuses anything but the worker-settable statuses on the task
+//     whose workspace is the caller's. This is how "done" becomes a fact:
+//     `review_requested` after the worker's own gate passed, `input_required`
+//     on a blocker. A natural-language "done" in a channel is not completion.
+//
+//   ledger_list — COMMANDER-ONLY (registered through the commander-only lane
+//     in src/mcp/index.ts, never in full/core). The brain reads the tasks its
+//     workspace owns; the validated commander token on every outbound RPC is
+//     the identity, so the tool sends no workspace at all.
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { sendRpc } from './wmux-client';
+import type { RpcMethod } from '../shared/rpc';
+import { WORKER_SETTABLE_STATUSES, LEDGER_STATUSES } from '../shared/ledger';
+
+export interface LedgerToolDeps {
+  /** The server's OWN verified senderPtyId (PID-map walk hit, '' on miss). */
+  getSenderPtyId?: () => string;
+  /** Warms the walk that populates the ptyId above (see fanout.ts). */
+  resolveWorkspaceId?: () => Promise<string>;
+}
+
+const LEDGER_UPDATE_SHAPE = {
+  task_id: z.string().min(1).describe('Your WorkTask id (wtask-…), from your fan-out prompt or mission channel.'),
+  status: z
+    .enum(WORKER_SETTABLE_STATUSES as [string, ...string[]])
+    .describe('review_requested = done AND your own gate passed; input_required = blocked, say on what; failed = cannot finish; working = resumed.'),
+  expected_rev: z.number().int().describe('The rev you last read (1 right after fan-out). A stale rev is refused: re-read and retry.'),
+  summary: z.string().max(2000).optional().describe('One or two lines: what landed / what blocks you.'),
+};
+
+const LEDGER_LIST_SHAPE = {
+  task_id: z.string().optional().describe('Only this task.'),
+  open_only: z.boolean().optional().describe('Only working / input_required / review_requested.'),
+};
+
+function toResult(result: unknown): { content: { type: 'text'; text: string }[]; isError?: true } {
+  const r = result as { ok?: boolean } | undefined;
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) }],
+    ...(r && r.ok === false ? { isError: true as const } : {}),
+  };
+}
+
+/** Register `ledger_update` (worker-scoped; full + core). */
+export function registerLedgerUpdateTool(server: McpServer, deps: LedgerToolDeps): void {
+  const resolveSenderPtyId = deps.getSenderPtyId ?? (() => '');
+  server.tool(
+    'ledger_update',
+    'Record the state of YOUR fan-out task in the task ledger. Call it with status "review_requested" when the task is done and your own gate (tsc/lint/tests) passed, or "input_required" when you are blocked — a natural-language "done" is not completion. Only your own task, only these statuses; the brain marks completed.',
+    LEDGER_UPDATE_SHAPE,
+    async ({ task_id, status, expected_rev, summary }) => {
+      if (deps.resolveWorkspaceId) {
+        try {
+          await deps.resolveWorkspaceId();
+        } catch {
+          // The handler refuses an unresolvable caller with its own message.
+        }
+      }
+      const params: Record<string, unknown> = { taskId: task_id, status, expectedRev: expected_rev };
+      if (summary !== undefined) params['summary'] = summary;
+      const pty = resolveSenderPtyId();
+      if (pty) params['senderPtyId'] = pty;
+      try {
+        return toResult(await sendRpc('ledger.update' as RpcMethod, params));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+      }
+    },
+  );
+}
+
+/** Register `ledger_list` (commander-only). `register` is the UNFILTERED
+ *  server.tool binding — the commander manifest filter would drop a name it
+ *  does not list, and this one is deliberately outside that list. */
+export function registerLedgerListTool(register: McpServer['tool']): void {
+  register(
+    'ledger_list',
+    `List the task ledger for the tasks YOUR workspace owns: id, title, status (${LEDGER_STATUSES.join(' | ')}), rev, summary, gate, worker workspace. Read it before deciding a worker is done: review_requested with a summary is the worker's claim, completed is yours after the gate.`,
+    LEDGER_LIST_SHAPE,
+    async ({ task_id, open_only }) => {
+      const params: Record<string, unknown> = {};
+      if (task_id !== undefined) params['taskId'] = task_id;
+      if (open_only !== undefined) params['openOnly'] = open_only;
+      try {
+        return toResult(await sendRpc('ledger.list' as RpcMethod, params));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+      }
+    },
+  );
+}

--- a/src/mcp/ledger.ts
+++ b/src/mcp/ledger.ts
@@ -21,6 +21,11 @@ import { sendRpc } from './wmux-client';
 import type { RpcMethod } from '../shared/rpc';
 import { WORKER_SETTABLE_STATUSES, LEDGER_STATUSES } from '../shared/ledger';
 
+/** Statuses the BRAIN variant of ledger_update offers: everything the table
+ *  allows an owner to set. `completed` is still refused server-side without a
+ *  system-recorded passing gate or force + reason. */
+const BRAIN_SETTABLE_STATUSES = LEDGER_STATUSES;
+
 export interface LedgerToolDeps {
   /** The server's OWN verified senderPtyId (PID-map walk hit, '' on miss). */
   getSenderPtyId?: () => string;
@@ -35,6 +40,17 @@ const LEDGER_UPDATE_SHAPE = {
     .describe('review_requested = done AND your own gate passed; input_required = blocked, say on what; failed = cannot finish; working = resumed.'),
   expected_rev: z.number().int().describe('The rev you last read (1 right after fan-out). A stale rev is refused: re-read and retry.'),
   summary: z.string().max(2000).optional().describe('One or two lines: what landed / what blocks you.'),
+};
+
+const LEDGER_BRAIN_UPDATE_SHAPE = {
+  task_id: z.string().min(1).describe('A task you own (from ledger_list).'),
+  status: z
+    .enum(BRAIN_SETTABLE_STATUSES as unknown as [string, ...string[]])
+    .describe('completed = review_requested + a passing gate the gate runner recorded (or force + reason); input_required = bounce back with a question; working = resumed; failed / cancelled = closed without completion.'),
+  expected_rev: z.number().int().describe('The rev from ledger_list. A stale rev is refused: re-read and retry.'),
+  summary: z.string().max(2000).optional().describe('What you verified / why.'),
+  force: z.boolean().optional().describe('completed without a passing recorded gate. Requires reason; the reason is logged on the entry.'),
+  reason: z.string().max(500).optional().describe('Why force is justified.'),
 };
 
 const LEDGER_LIST_SHAPE = {
@@ -69,6 +85,29 @@ export function registerLedgerUpdateTool(server: McpServer, deps: LedgerToolDeps
       if (summary !== undefined) params['summary'] = summary;
       const pty = resolveSenderPtyId();
       if (pty) params['senderPtyId'] = pty;
+      try {
+        return toResult(await sendRpc('ledger.update' as RpcMethod, params));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text' as const, text: `Error: ${message}` }], isError: true };
+      }
+    },
+  );
+}
+
+/** Register the BRAIN variant of `ledger_update` (commander-only). Same
+ *  name as the worker tool, wider status enum, force override; identity is
+ *  the commander token on the RPC and authz is the ledger's (owner rows). */
+export function registerLedgerBrainUpdateTool(register: McpServer['tool']): void {
+  register(
+    'ledger_update',
+    'Move one of YOUR tasks in the task ledger. Mark completed only after review_requested AND a passing gate recorded by the gate runner (task_gate_run) — the server refuses otherwise; force + reason is the logged exception. Bounce a review back with input_required, or close a task as failed / cancelled. Carry the rev you read.',
+    LEDGER_BRAIN_UPDATE_SHAPE,
+    async ({ task_id, status, expected_rev, summary, force, reason }) => {
+      const params: Record<string, unknown> = { taskId: task_id, status, expectedRev: expected_rev };
+      if (summary !== undefined) params['summary'] = summary;
+      if (force === true) params['force'] = true;
+      if (reason !== undefined) params['reason'] = reason;
       try {
         return toResult(await sendRpc('ledger.update' as RpcMethod, params));
       } catch (err) {

--- a/src/shared/__tests__/commanderSurface.test.ts
+++ b/src/shared/__tests__/commanderSurface.test.ts
@@ -7,6 +7,7 @@ import {
   COMMANDER_TEARDOWN_DENY,
   COMMANDER_ONLY_TOOLS,
   COMMANDER_ONLY_RESERVED_TOOLS,
+  COMMANDER_VARIANT_TOOLS,
 } from '../commanderSurface';
 import { CORE_TOOL_SURFACE } from '../coreSurface';
 import {
@@ -86,14 +87,34 @@ function walkSources(dir: string, out: string[] = []): string[] {
 }
 
 describe('commander-only lane invariants (COMMANDER_ONLY_TOOLS)', () => {
-  it('is disjoint from the filtered commander surface, core and full', () => {
+  it('is disjoint from the filtered commander surface, core and full — except the declared variants', () => {
     const full = new Set(baseline.profiles.full.toolNames);
+    const variants = new Set(COMMANDER_VARIANT_TOOLS);
     for (const name of COMMANDER_ONLY_TOOLS) {
       expect(COMMANDER_TOOL_SURFACE).not.toContain(name);
+      if (variants.has(name)) {
+        // A variant re-registers a full/core name under the brain's schema;
+        // the worker registration must exist in full and core for it to be
+        // a variant at all.
+        expect(full.has(name), `${name} is declared a variant but is not in full`).toBe(true);
+        expect(CORE_TOOL_SURFACE).toContain(name);
+        continue;
+      }
       expect(CORE_TOOL_SURFACE).not.toContain(name);
       expect(full.has(name), `${name} leaked into the full profile`).toBe(false);
       expect(baseline.profiles.core.toolNames).not.toContain(name);
     }
+    for (const name of COMMANDER_VARIANT_TOOLS) expect(COMMANDER_ONLY_TOOLS).toContain(name);
+  });
+
+  it('the commander profile lists each name exactly once (a variant replaces, never duplicates)', () => {
+    const names = baseline.profiles.commander.toolNames;
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('the brain has a ledger write path: ledger_update on the commander lane and ledger.update in the RPC lane', () => {
+    expect(COMMANDER_ONLY_TOOLS).toContain('ledger_update');
+    expect(COMMANDER_RPC_METHODS.has('ledger.update')).toBe(true);
   });
 
   it('the published commander baseline === COMMANDER_TOOL_SURFACE (full order) + COMMANDER_ONLY_TOOLS', () => {
@@ -123,6 +144,5 @@ describe('commander-only lane invariants (COMMANDER_ONLY_TOOLS)', () => {
 
   it('the commander RPC lane carries the ledger read the commander-only tool calls', () => {
     expect(COMMANDER_RPC_METHODS.has('ledger.list')).toBe(true);
-    expect(COMMANDER_RPC_METHODS.has('ledger.update')).toBe(false);
   });
 });

--- a/src/shared/__tests__/commanderSurface.test.ts
+++ b/src/shared/__tests__/commanderSurface.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
 import {
   COMMANDER_TOOL_SURFACE,
   COMMANDER_RPC_METHODS,
   COMMANDER_TEARDOWN_DENY,
+  COMMANDER_ONLY_TOOLS,
+  COMMANDER_ONLY_RESERVED_TOOLS,
 } from '../commanderSurface';
+import { CORE_TOOL_SURFACE } from '../coreSurface';
 import {
   DEFAULT_ALLOWED_TOOLS,
   DEFAULT_ALLOWED_TOOLS_FROM_SURFACE,
@@ -58,5 +63,66 @@ describe('commander surface manifest invariants', () => {
     ]) {
       expect(COMMANDER_TEARDOWN_DENY.has(required)).toBe(true);
     }
+  });
+});
+
+// Lane F: the commander-only lane (src/mcp/index.ts) ADDS tools to the
+// commander profile that no other profile registers. Every enforcement layer
+// must agree on that second list too.
+const baseline = JSON.parse(
+  readFileSync(path.join(__dirname, '..', '..', '..', 'scripts', 'mcp-protocol-baseline.json'), 'utf8'),
+) as { profiles: Record<string, { toolNames: string[] }> };
+
+function walkSources(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name);
+    if (statSync(p).isDirectory()) {
+      if (name !== '__tests__') walkSources(p, out);
+    } else if (p.endsWith('.ts')) {
+      out.push(readFileSync(p, 'utf8'));
+    }
+  }
+  return out;
+}
+
+describe('commander-only lane invariants (COMMANDER_ONLY_TOOLS)', () => {
+  it('is disjoint from the filtered commander surface, core and full', () => {
+    const full = new Set(baseline.profiles.full.toolNames);
+    for (const name of COMMANDER_ONLY_TOOLS) {
+      expect(COMMANDER_TOOL_SURFACE).not.toContain(name);
+      expect(CORE_TOOL_SURFACE).not.toContain(name);
+      expect(full.has(name), `${name} leaked into the full profile`).toBe(false);
+      expect(baseline.profiles.core.toolNames).not.toContain(name);
+    }
+  });
+
+  it('the published commander baseline === COMMANDER_TOOL_SURFACE (full order) + COMMANDER_ONLY_TOOLS', () => {
+    const fullOrder = baseline.profiles.full.toolNames;
+    const filtered = new Set(COMMANDER_TOOL_SURFACE);
+    expect(baseline.profiles.commander.toolNames).toEqual([
+      ...fullOrder.filter((n) => filtered.has(n)),
+      ...COMMANDER_ONLY_TOOLS,
+    ]);
+  });
+
+  it('SDK auto-allow list covers the commander-only tools too (invariant ①, extended)', () => {
+    for (const name of COMMANDER_ONLY_TOOLS) {
+      expect(DEFAULT_ALLOWED_TOOLS).toContain(`mcp__wmux__${name}`);
+    }
+  });
+
+  it('reserved lane-O2 names are absent from every profile and from every src/mcp registration', () => {
+    const sources = walkSources(path.join(__dirname, '..', '..', 'mcp')).join('\n');
+    for (const name of COMMANDER_ONLY_RESERVED_TOOLS) {
+      expect(COMMANDER_ONLY_TOOLS).not.toContain(name);
+      expect(COMMANDER_TOOL_SURFACE).not.toContain(name);
+      for (const profile of Object.values(baseline.profiles)) expect(profile.toolNames).not.toContain(name);
+      expect(sources.includes(`'${name}'`), `${name} is registered in src/mcp before being wired`).toBe(false);
+    }
+  });
+
+  it('the commander RPC lane carries the ledger read the commander-only tool calls', () => {
+    expect(COMMANDER_RPC_METHODS.has('ledger.list')).toBe(true);
+    expect(COMMANDER_RPC_METHODS.has('ledger.update')).toBe(false);
   });
 });

--- a/src/shared/commanderSurface.ts
+++ b/src/shared/commanderSurface.ts
@@ -110,6 +110,33 @@ export const COMMANDER_TOOL_SURFACE: readonly string[] = [
   'deck_resolve_decision',
 ];
 
+/** Tools registered ONLY under `--commander` — never in the full or core
+ *  profile (the full tools/list sits a few hundred bytes under its budget, and
+ *  these are brain-only anyway: a pane agent has no ledger to read). A second
+ *  SSOT list beside COMMANDER_TOOL_SURFACE, which is a FILTER of the full
+ *  registration; this one is an ADDITION. The probe's subset invariant reads
+ *  `commander ⊆ core ∪ COMMANDER_ONLY_TOOLS`, and the SDK auto-allow list
+ *  derives from both lists. */
+export const COMMANDER_ONLY_TOOLS: readonly string[] = [
+  // Task ledger read: every task this brain owns, with rev/status/summary.
+  'ledger_list',
+];
+
+/** Commander-only names RESERVED for the gate/adopt/close/PR and git read
+ *  tools (orchestrator track, lane O2). Listed so the registration point in
+ *  src/mcp/index.ts and the invariant tests agree on the names before the
+ *  tools exist: a test asserts each stays ABSENT from every profile until it
+ *  is wired, then moves it into COMMANDER_ONLY_TOOLS. */
+export const COMMANDER_ONLY_RESERVED_TOOLS: readonly string[] = [
+  'task_gate_run',
+  'task_adopt',
+  'task_close',
+  'task_pr',
+  'git_status',
+  'git_log',
+  'gh_pr_view',
+];
+
 /** Pipe RPC methods the commander tool surface actually invokes — the
  *  PermissionEnforcer allow lane for a VALIDATED commander token. Least
  *  privilege: derived from what the tools above call (see the invariant test
@@ -173,6 +200,8 @@ export const COMMANDER_RPC_METHODS: ReadonlySet<string> = new Set<string>([
   // workspace from the validated commander binding, and every spawn still
   // passes the approval prompt).
   'task.fanout.start',
+  // task ledger (commander-only ledger_list; the brain's own rows)
+  'ledger.list',
 ]);
 
 /** Teardown-EFFECT methods a validated commander is refused server-side

--- a/src/shared/commanderSurface.ts
+++ b/src/shared/commanderSurface.ts
@@ -120,7 +120,19 @@ export const COMMANDER_TOOL_SURFACE: readonly string[] = [
 export const COMMANDER_ONLY_TOOLS: readonly string[] = [
   // Task ledger read: every task this brain owns, with rev/status/summary.
   'ledger_list',
+  // The BRAIN-scoped variant of ledger_update (see COMMANDER_VARIANT_TOOLS):
+  // the full/core registration of the same name is the worker's, filtered
+  // out of the commander profile; this one carries the brain's statuses
+  // (completed / failed / cancelled) and the force+reason override.
+  'ledger_update',
 ];
+
+/** Names in COMMANDER_ONLY_TOOLS that ALSO exist in full/core under a
+ *  different (narrower) schema. The commander lane registers the brain
+ *  variant after the manifest filter dropped the worker one, so the commander
+ *  profile still lists each name exactly once. Everything else in
+ *  COMMANDER_ONLY_TOOLS must be absent from full and core. */
+export const COMMANDER_VARIANT_TOOLS: readonly string[] = ['ledger_update'];
 
 /** Commander-only names RESERVED for the gate/adopt/close/PR and git read
  *  tools (orchestrator track, lane O2). Listed so the registration point in
@@ -200,8 +212,10 @@ export const COMMANDER_RPC_METHODS: ReadonlySet<string> = new Set<string>([
   // workspace from the validated commander binding, and every spawn still
   // passes the approval prompt).
   'task.fanout.start',
-  // task ledger (commander-only ledger_list; the brain's own rows)
+  // task ledger (commander-only ledger_list / brain-scoped ledger_update;
+  // the brain's own rows — authz is the ledger's canActorSet)
   'ledger.list',
+  'ledger.update',
 ]);
 
 /** Teardown-EFFECT methods a validated commander is refused server-side

--- a/src/shared/coreSurface.ts
+++ b/src/shared/coreSurface.ts
@@ -72,6 +72,7 @@ export const CORE_TOOL_SURFACE: readonly string[] = [
   'channel_mission_close',
   'channel_mission_list',
   'fanout_start',
+  'ledger_update',
   'pane_split',
   'pane_close',
   'pane_focus',

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -56,6 +56,10 @@ export interface LedgerGateResult {
   /** Epoch ms. */
   at: number;
   command: string;
+  /** Provenance. The writer stamps `'system'` on a gate it recorded itself
+   *  (the gate runner); `completed` trusts ONLY such a gate. Absent on a
+   *  result that did not come through the writer's own recordGate path. */
+  recordedBy?: LedgerActorKind;
 }
 
 export interface LedgerEntry {

--- a/src/shared/rpc.ts
+++ b/src/shared/rpc.ts
@@ -514,7 +514,12 @@ export type RpcMethod =
   // fixed. Identity rides the same senderPtyId→verifiedWorkspaceId stamp as
   // `task.mission.*`, the spawn is approval-gated, and the call is
   // accept-then-poll (re-send the key to read the state).
-  | 'task.fanout.start';
+  | 'task.fanout.start'
+  // Task ledger (pipe/handlers/ledger.rpc.ts) — the status log behind
+  // src/shared/ledger.ts. Reads are scoped to the caller's own rows (owner or
+  // task workspace); updates are authorized by the ledger's canActorSet.
+  | 'ledger.list'
+  | 'ledger.update';
 
 // All available methods as array (for system.capabilities)
 export const ALL_RPC_METHODS = [
@@ -682,6 +687,8 @@ export const ALL_RPC_METHODS = [
   'task.mission.list',
   'task.mission.update',
   'task.fanout.start',
+  'ledger.list',
+  'ledger.update',
 ] as const satisfies readonly RpcMethod[];
 
 // === RPC Parameter Types ===


### PR DESCRIPTION
## Why

A brain that fans out never learns its workers finished: a task workspace's `agent.stop` / `awaiting_input` is pushed only to that workspace, whose `wakePolicy` defaults to `none`, so the coalescer consumes it and the parent stays idle. "Delegate and forget" is not the model being lazy — the signal never arrives. This is lane F of the orchestrator track (wave 1).

## What

- **Worker event → owner brain.** The deck handler copies a task workspace's stop/awaiting_input event to the `WorkTask.owner` workspace tagged `{taskId, taskWorkspaceId}`; the coalescer lets tagged events through `wakePolicy: 'none'` and names the worker task in the wake prompt. An owner with no brain yet gets the event parked as `orphaned_event` and replayed on the human send that boots it.
- **Task ledger** (`src/daemon/ledger/TaskLedger.ts`): a status log keyed by WorkTask id — JSONL under the wmux data dir, single writer, torn-tail-tolerant replay, 5 MB rotation with snapshot, compare-and-swap on `rev`, `canActorSet` authorization, `completed` only by a brain with a passing gate (or `force` + reason), `closeTask` → `cancelled`, terminal-entry retention. Pipe RPC `ledger.list` / `ledger.update` (commander token = brain, senderPtyId = worker). Fan-out registers `working` and remembers the mission channel.
- **Commander-only registration lane** in the MCP entry (`COMMANDER_ONLY_TOOLS` SSOT next to `COMMANDER_TOOL_SURFACE`): `ledger_list` is commander-only; `ledger_update` (worker-scoped) is in full and core. Reserved names for lane O2's tools with a test that they are absent until wired. The probe's subset invariant is relaxed to `core ⊆ full`, `commander ⊆ core ∪ COMMANDER_ONLY_TOOLS`, with a leak assertion. Budgets after: full 76,714 / 78,000, core 47,895 / 49,000, commander 43,973 / 60,000.
- **Ledger-backed Stop gate**, behind `deck.ledgerGate` (default OFF, `deck-ledger-gate.json`): open tasks owned by the brain block Stop; stale fallback and the consecutive-block cap are kept; the pending-decision release is NOT flipped; after 3 consecutive ledger blocks the gate releases and logs `ledger_gate_released`; a ledger read failure falls back to today's inference. While on, `deck_ask_decision` prompts carry the open-task list.
- **Ledger → mission channel**: every transition posts `[ledger] <taskId> <from>→<to> <by> <summary>` to the task's mission channel.
- Worker preamble gains the ledger contract (`review_requested` on done, `input_required` on a blocker; a natural-language "done" is not completion).

## Tests

53 ledger, 6 coalescer delegated-event, 10 ledger host, 13 ledger Stop gate (table-driven), 2 gate store, 5 ledger RPC, 5 ledger MCP tool, +5 commander-only surface invariants. Full `npm test`: 14,108 passing. `probe:mcp` green on all three profiles; baseline refreshed in the same commit. `docs/api/reference.md` regenerated.

## Notes

- Changelog fragment: `changelog.d/orch-f.md`.
- `deck.ledgerGate` has no Settings toggle yet (renderer out of lane scope); flip it via the JSON store. The orphan backlog replays on the next human send only.
- The ledger service is hosted in the main process (all consumers live there); the daemon supplies WorkTask identity.
- Lane O2's tools (#1197) get wired into `COMMANDER_ONLY_TOOLS` + `RpcMethod` in a small integration PR after both land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a task ledger for tracking delegated task status, ownership, authorization, revisions, and completion requirements.
  * Added `ledger_update` and commander-only `ledger_list` tools for reporting and viewing task progress.
  * Orchestrator stop decisions now account for open ledger tasks when the ledger gate is enabled.
  * Worker lifecycle events are routed to owning workspaces, with backlog recovery when owners reconnect.
  * Ledger transitions can be reported through mission channels.

* **Documentation**
  * Updated API references and protocol profiles with the new ledger methods and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->