### PR TITLE
feat(input): a real submit receipt, a verified brain sender, scoped approval presses and an honest channel nudge

### DIFF
--- a/changelog.d/orch-o1.md
+++ b/changelog.d/orch-o1.md
@@ -7,3 +7,12 @@
   Enter is re-sent once before giving up. Previously `submitted: true` meant
   only "a carriage return was written", so an orchestrator reported progress on
   panes whose prompt was still sitting uncommitted in the composer.
+
+- An orchestrator brain can finally reach the agents in its own workspace. A
+  brain owns no pane, so every same-workspace A2A reply it sent was suppressed
+  as an "unverified sender" and merely stored — the brain was told the message
+  landed while the worker sat waiting. A caller carrying the daemon-validated
+  commander binding now satisfies that guard and the missing-anchor one, while
+  the self-loop protection for pane callers is unchanged. A reply addressed at
+  a brain is refused outright with `target_is_brain`: there is no pane behind
+  it to write into.

--- a/changelog.d/orch-o1.md
+++ b/changelog.d/orch-o1.md
@@ -9,28 +9,37 @@
   panes whose prompt was still sitting uncommitted in the composer.
 
 - An orchestrator brain can finally reach the agents in its own workspace. A
-  brain owns no pane, so every same-workspace A2A reply it sent was suppressed
-  as an "unverified sender" and merely stored — the brain was told the message
-  landed while the worker sat waiting. A caller carrying the daemon-validated
-  commander binding now satisfies that guard and the missing-anchor one, while
-  the self-loop protection for pane callers is unchanged. A reply addressed at
-  a brain is refused outright with `target_is_brain`: there is no pane behind
-  it to write into.
+  brain owns no pane, so every same-workspace A2A reply it sent to an ADDRESSED
+  pane was suppressed as an "unverified sender" and merely stored — the brain
+  was told the message landed while the worker sat waiting. A caller carrying
+  the daemon-validated commander binding, for the workspace that binding names,
+  now satisfies that one guard. An anchorless reply is still suppressed (it
+  would fall back to whichever pane happens to be focused), and the self-loop
+  protection for pane callers is unchanged.
 
 - An automated approval press is now scoped to panes that were actually
   delegated: the target's workspace must be a task workspace with autonomy on,
   the prompt must have come from a hook rather than the screen-regex detector,
   and a re-read must still show it. A fact the daemon cannot establish counts
   as a refusal, and a refusal leaves the request live for a human to answer.
+  People are not subject to any of this — approving or denying from the phone
+  or the web works exactly as before — and a DENY is always allowed, from any
+  caller, because refusing one would keep a pane blocked in the name of safety.
 
 - A channel wake nudge now carries the first line of the message it is waking
   you for, so an agent no longer has to spend a turn reading just to find out
-  whether the nudge mattered. A nudge that never landed (the pane died mid-race)
-  marks that recipient `target_gone` instead of leaving the message looking
-  pending forever; a nudge that DID land is still not a delivery receipt.
+  whether the nudge mattered. It rides only into panes wmux can name as an
+  agent TUI, with shell metacharacters stripped: the text comes from another
+  workspace and is committed with an Enter, so a pane that is really a shell
+  would run it. A nudge that never landed (the pane died mid-race) marks that
+  member's own rows, over the message range it announced, `target_gone` instead
+  of leaving them looking pending forever — and a later ack promotes them back
+  to `delivered`. A nudge that DID land is still not a delivery receipt.
 
 - `wmux channel unread` and the `channel_unread` tool now answer from the same
   daemon call and report the same set. The CLI no longer takes the member from
   `$WMUX_MEMBER_ID` (only an explicit `--member`, matching the tool) and no
   longer hides caught-up rows, so the two surfaces can no longer contradict
-  each other about what you owe.
+  each other about what you owe. Each row names its member, and a workspace
+  holding several says so, since without `--member` the rows shown are the
+  whole workspace's and not only yours.

--- a/changelog.d/orch-o1.md
+++ b/changelog.d/orch-o1.md
@@ -16,3 +16,21 @@
   the self-loop protection for pane callers is unchanged. A reply addressed at
   a brain is refused outright with `target_is_brain`: there is no pane behind
   it to write into.
+
+- An automated approval press is now scoped to panes that were actually
+  delegated: the target's workspace must be a task workspace with autonomy on,
+  the prompt must have come from a hook rather than the screen-regex detector,
+  and a re-read must still show it. A fact the daemon cannot establish counts
+  as a refusal, and a refusal leaves the request live for a human to answer.
+
+- A channel wake nudge now carries the first line of the message it is waking
+  you for, so an agent no longer has to spend a turn reading just to find out
+  whether the nudge mattered. A nudge that never landed (the pane died mid-race)
+  marks that recipient `target_gone` instead of leaving the message looking
+  pending forever; a nudge that DID land is still not a delivery receipt.
+
+- `wmux channel unread` and the `channel_unread` tool now answer from the same
+  daemon call and report the same set. The CLI no longer takes the member from
+  `$WMUX_MEMBER_ID` (only an explicit `--member`, matching the tool) and no
+  longer hides caught-up rows, so the two surfaces can no longer contradict
+  each other about what you owe.

--- a/changelog.d/orch-o1.md
+++ b/changelog.d/orch-o1.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `terminal_send({ submit: true })` now reports whether the prompt was actually
+  committed. The result carries `accepted` — true only when the pane was
+  observed to move (its turn started, or the input line cleared) — plus
+  `agentStatusAfter`, and the pane's last screen lines when it did not. The
+  Enter is re-sent once before giving up. Previously `submitted: true` meant
+  only "a carriage return was written", so an orchestrator reported progress on
+  panes whose prompt was still sitting uncommitted in the composer.

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "504255f85dcbed53fe00be73c6fd2791fc0def68fd3284e43c1af90c5271ac3b",
+      "wireResultSha256": "e775c78adeedca5fff3b29890adc9166e898c817b60fdc1b171081a74369f6c2",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",
@@ -99,7 +99,7 @@
     },
     "core": {
       "maxListBytes": 49000,
-      "wireResultSha256": "311894d5db23232d284c67a8126243b354c028150f8289a1dff6af1bc2c4e585",
+      "wireResultSha256": "4036aa08b52701b5ecda81d9e264d2859fdc76e193c48af55dd9301469d745be",
       "instructionSha256": "0c313d4e88ad9313bb6a51ff00717abbb243ebcdd18f8e226cba2c738e43c95a",
       "toolNames": [
         "terminal_read",
@@ -154,7 +154,7 @@
     },
     "commander": {
       "maxListBytes": 60000,
-      "wireResultSha256": "40697b75121ca418727474252ac949975a0242a9b6e613bb97f051eb0f2e0562",
+      "wireResultSha256": "93d7ccefee4849988de46713463a93a1d6803de488fdebb8e0d26d55ce4a5535",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",

--- a/src/cli/commands/__tests__/channel.test.ts
+++ b/src/cli/commands/__tests__/channel.test.ts
@@ -83,14 +83,44 @@ describe('wmux channel — transport + identity', () => {
     });
   });
 
-  it('unread honors $WMUX_MEMBER_ID like post/ack (GLM review — consistent member filtering)', async () => {
+  // PARITY WITH MCP `channel_unread` (canonical). The tool takes ONLY an
+  // explicit member_id, so the CLI reading $WMUX_MEMBER_ID meant the two
+  // surfaces answered the same question from different daemon calls — a pane
+  // could be told "no unread" by one and shown rows by the other.
+  it('unread ignores $WMUX_MEMBER_ID — only an explicit --member narrows the set', async () => {
     process.env.WMUX_MEMBER_ID = 'codex';
     daemonRpc.mockResolvedValue(okEnvelope({ ok: true, entries: [] }));
     await handleChannel('unread', [], false);
     expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.unread', {
+      senderPtyId: 'pty-self',
+    });
+
+    daemonRpc.mockClear();
+    await handleChannel('unread', ['--member', 'codex'], false);
+    expect(daemonRpc).toHaveBeenCalledWith('a2a.channel.unread', {
       memberId: 'codex',
       senderPtyId: 'pty-self',
     });
+  });
+
+  it('unread prints every row the daemon returned, caught-up ones included', async () => {
+    daemonRpc.mockResolvedValue(
+      okEnvelope({
+        ok: true,
+        entries: [
+          { channelId: 'ch-1', name: 'general', memberId: 'codex', lastReadSeq: 9, headSeq: 9, unread: 0, mentionUnread: 0, trimmedBeforeCursor: 0 },
+          { channelId: 'ch-2', name: 'build', memberId: 'codex', lastReadSeq: 2, headSeq: 5, unread: 3, mentionUnread: 1, trimmedBeforeCursor: 0 },
+        ],
+      }),
+    );
+    await handleChannel('unread', [], false);
+    const printed = logSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+    // The zero-unread row is REPORTED, not hidden: an agent has to be able to
+    // reconcile this output against what channel_unread returns.
+    expect(printed).toContain('#general (ch-1)');
+    expect(printed).toContain('up to date');
+    expect(printed).toContain('#build (ch-2) member=codex: 3 unread (1 mention you)');
+    expect(printed).not.toContain('No unread channel messages.');
   });
 
   it('post sends sender WITHOUT workspaceId (daemon backfills from its own stamp)', async () => {

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -35,7 +35,8 @@ wmux channel — durable agent messaging (Channels v2)
   unread mentions you will be re-nudged — ack is what makes it stop.
 
   wmux channel unread [--member <id>]
-      Your per-channel unread + mention counts. Cheap; call when nudged.
+      Your per-channel unread + mention counts, one line per member row —
+      the same set the channel_unread tool returns. Cheap; call when nudged.
   wmux channel read <channel> [--since <seq>] [--limit <n>]
       Print messages, oldest first, paging forward. Without --since it
       starts from YOUR unread cursor (when you have one member row here).
@@ -270,11 +271,13 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
   const positionals = positionalsOf(args).concat(verbatim);
   switch (sub) {
     case 'unread': {
-      // Same identity ladder as post/ack (GLM review): explicit --member, then
-      // $WMUX_MEMBER_ID — so a multi-agent workspace that pins its member id in
-      // the env gets a filtered summary here too, not the whole workspace's rows.
-      // Absent both = every row (the daemon's default).
-      const memberId = parseFlag(args, '--member') ?? (process.env['WMUX_MEMBER_ID'] || undefined);
+      // PARITY WITH MCP `channel_unread` (canonical). The two surfaces answer
+      // the same question and used to disagree twice over: this command also
+      // took the member from $WMUX_MEMBER_ID (MCP takes only an explicit
+      // member_id), and it then PRINTED only the rows that owed something. So a
+      // pane could be told "no unread" by the CLI while the tool it was about
+      // to call reported rows, and vice versa. One request shape, one set.
+      const memberId = parseFlag(args, '--member');
       const result = await callChannel(
         'a2a.channel.unread' as RpcMethod,
         { ...(memberId !== undefined ? { memberId } : {}) },
@@ -295,15 +298,22 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.log(JSON.stringify(entries, null, 2));
         return;
       }
-      const owed = entries.filter((e) => e.unread > 0 || e.trimmedBeforeCursor > 0);
-      if (owed.length === 0) {
-        console.log('No unread channel messages.');
+      if (entries.length === 0) {
+        console.log('No channel member rows for this workspace.');
         return;
       }
-      for (const e of owed) {
+      // Every row the daemon returned, caught-up ones included — the same set
+      // channel_unread hands an agent. A row hidden here is a row the agent
+      // cannot reconcile against the tool's answer.
+      for (const e of entries) {
         const trimmed = e.trimmedBeforeCursor > 0 ? `  [WARNING: ${e.trimmedBeforeCursor} message(s) trimmed before you read them]` : '';
+        const head = `#${e.name} (${e.channelId}) member=${e.memberId}:`;
+        if (e.unread === 0 && e.trimmedBeforeCursor === 0) {
+          console.log(`${head} up to date (cursor ${e.lastReadSeq}, head ${e.headSeq})`);
+          continue;
+        }
         console.log(
-          `#${e.name} (${e.channelId}) member=${e.memberId}: ${e.unread} unread` +
+          `${head} ${e.unread} unread` +
             (e.mentionUnread > 0 ? ` (${e.mentionUnread} mention you)` : '') +
             ` — read: wmux channel read ${e.channelId} --since ${e.lastReadSeq + 1}${trimmed}`,
         );

--- a/src/cli/commands/channel.ts
+++ b/src/cli/commands/channel.ts
@@ -302,6 +302,18 @@ export async function handleChannel(sub: string | undefined, args: string[], jso
         console.log('No channel member rows for this workspace.');
         return;
       }
+      // Without --member the daemon returns EVERY member row this workspace
+      // holds, not just yours — say so, because a multi-agent workspace
+      // otherwise reads someone else's backlog as its own.
+      if (memberId === undefined) {
+        const members = new Set(entries.map((e) => e.memberId));
+        if (members.size > 1) {
+          console.log(
+            `Showing all ${members.size} member rows in this workspace (${[...members].join(', ')}) — ` +
+              'pass --member <id> for just one.',
+          );
+        }
+      }
       // Every row the daemon returned, caught-up ones included — the same set
       // channel_unread hands an agent. A row hidden here is a row the agent
       // cannot reconcile against the tool's answer.

--- a/src/daemon/approvals/ApprovalRegistry.ts
+++ b/src/daemon/approvals/ApprovalRegistry.ts
@@ -508,16 +508,33 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
 
       // ── Press scope ───────────────────────────────────────────────────────
       // "Can these bytes be pressed" and "may this pane be pressed at all" are
-      // different questions. `decideApprovalPress` answers the second, and it
-      // FAILS CLOSED on a fact nobody established: a pane whose workspace we
-      // cannot classify, or whose autonomy setting we cannot read, is refused
-      // rather than assumed delegated. The workspace-shaped facts come from the
-      // main process; `pressScope` is the seam that supplies them, and until it
-      // is installed this refuses every press by design.
-      const scope = record.workspaceId
-        ? this.deps.pressScope?.(record.workspaceId) ?? {}
-        : {};
+      // different questions. `decideApprovalPress` answers the second — for an
+      // AUTOMATED approve only.
+      //
+      // A human answering from the phone or the web is looking at the prompt;
+      // gating them behind a workspace classification would just be a broken
+      // button, and a refused DENY (from anyone) would keep a pane blocked in
+      // the name of safety. Both bypass, inside the decision, so the reasoning
+      // lives in one place. `resolver` therefore defaults to 'human': every
+      // caller that exists today is a person tapping, and an automated presser
+      // has to say so — at which point it faces the full check.
+      //
+      // For that automated caller the check FAILS CLOSED: a pane whose
+      // workspace we cannot classify, or whose autonomy setting we cannot read,
+      // is refused rather than assumed delegated. Those facts live in main;
+      // `pressScope` is the seam that supplies them, and its ABSENCE reports
+      // `scope-unavailable` — distinct from a workspace that answered "no", so
+      // the missing integration wiring is visible instead of looking like
+      // policy.
+      const scopeAvailable = !!this.deps.pressScope && !!record.workspaceId;
+      const scope =
+        this.deps.pressScope && record.workspaceId
+          ? this.deps.pressScope(record.workspaceId)
+          : {};
       const pressDecision = decideApprovalPress({
+        resolver: params.resolver ?? 'human',
+        decision: params.decision,
+        scopeAvailable,
         ...scope,
         // Only hook-sourced requests are ever created (see the header), so the
         // record's own existence is the origin evidence.
@@ -528,8 +545,12 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
         // NOT an expiry: the request is live and a human at the desktop can
         // still answer it. We simply may not press on their behalf.
         this.deps.log?.(
-          'info',
-          `[approvals] refused ${record.id} on ${record.sessionId}: out of press scope (${pressDecision.reason})`,
+          pressDecision.reason === 'scope-unavailable' ? 'warn' : 'info',
+          pressDecision.reason === 'scope-unavailable'
+            ? `[approvals] refused ${record.id} on ${record.sessionId}: automated press has no ` +
+              'workspace scope source (ApprovalRegistryDeps.pressScope is not wired) — ' +
+              'a human can still answer this request'
+            : `[approvals] refused ${record.id} on ${record.sessionId}: out of press scope (${pressDecision.reason})`,
         );
         return {
           result: {

--- a/src/daemon/approvals/ApprovalRegistry.ts
+++ b/src/daemon/approvals/ApprovalRegistry.ts
@@ -44,7 +44,13 @@
 
 import crypto from 'node:crypto';
 import { hasCriticalRisk } from '../../shared/criticalPatterns';
-import { keystrokesForAgent, looksLikeApprovalPrompt, looksLikeChoiceOnScreen } from './approvalKeystrokes';
+import {
+  decideApprovalPress,
+  keystrokesForAgent,
+  looksLikeApprovalPrompt,
+  looksLikeChoiceOnScreen,
+  type ApprovalPressFacts,
+} from './approvalKeystrokes';
 import {
   formatScreenTail,
   loadApprovalState,
@@ -97,6 +103,14 @@ export interface ApprovalRegistryDeps {
    * delivery it did not make.
    */
   writeToSession: (sessionId: string, data: string) => boolean;
+  /**
+   * The workspace-shaped half of the press scope (see `decideApprovalPress`):
+   * is this workspace a WorkTask task workspace, and what is its deck autonomy
+   * mode. Both facts live in the MAIN process, so the daemon can only be told
+   * them. Absent, or answering `{}`, means "not established" — and unknown is a
+   * refusal, so a press never happens on an assumption.
+   */
+  pressScope?: (workspaceId: string) => Pick<ApprovalPressFacts, 'isTaskWorkspace' | 'autonomyMode'>;
   log?: (level: 'info' | 'warn' | 'error', message: string) => void;
   /** Injected for test determinism. */
   now?: () => number;
@@ -491,6 +505,41 @@ export class ApprovalRegistry implements ApprovalRegistryApi, ApprovalHookSink {
       }
 
       const rows = await this.safeReadScreen(record.sessionId);
+
+      // ── Press scope ───────────────────────────────────────────────────────
+      // "Can these bytes be pressed" and "may this pane be pressed at all" are
+      // different questions. `decideApprovalPress` answers the second, and it
+      // FAILS CLOSED on a fact nobody established: a pane whose workspace we
+      // cannot classify, or whose autonomy setting we cannot read, is refused
+      // rather than assumed delegated. The workspace-shaped facts come from the
+      // main process; `pressScope` is the seam that supplies them, and until it
+      // is installed this refuses every press by design.
+      const scope = record.workspaceId
+        ? this.deps.pressScope?.(record.workspaceId) ?? {}
+        : {};
+      const pressDecision = decideApprovalPress({
+        ...scope,
+        // Only hook-sourced requests are ever created (see the header), so the
+        // record's own existence is the origin evidence.
+        origin: 'hook',
+        stillOnScreen: !!rows && rows.length > 0 && looksLikeApprovalPrompt(rows),
+      });
+      if (!pressDecision.press && pressDecision.reason !== 'prompt-gone') {
+        // NOT an expiry: the request is live and a human at the desktop can
+        // still answer it. We simply may not press on their behalf.
+        this.deps.log?.(
+          'info',
+          `[approvals] refused ${record.id} on ${record.sessionId}: out of press scope (${pressDecision.reason})`,
+        );
+        return {
+          result: {
+            ok: false,
+            reason: 'out-of-scope',
+            request: copyRequest(record),
+          } as ApprovalResolveResult,
+        };
+      }
+
       if (!rows || rows.length === 0 || !looksLikeApprovalPrompt(rows)) {
         // Refusal expires the request: whatever the pane is showing now, it is
         // not the prompt this record was minted for, so leaving it pending would

--- a/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
+++ b/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
@@ -14,7 +14,12 @@ import {
   SCREEN_TAIL_ROWS,
   SCREEN_TAIL_ROW_CHARS,
 } from '../approvalStore';
-import { keystrokesForAgent, looksLikeApprovalPrompt, looksLikeChoiceOnScreen } from '../approvalKeystrokes';
+import {
+  decideApprovalPress,
+  keystrokesForAgent,
+  looksLikeApprovalPrompt,
+  looksLikeChoiceOnScreen,
+} from '../approvalKeystrokes';
 import { MAX_OPTIONS, MAX_OPTION_LABEL_CHARS, MAX_QUESTION_CHARS } from '../askUserQuestion';
 import type { ApprovalEvent } from '../types';
 
@@ -71,6 +76,11 @@ function makeRegistry(overrides: Partial<ApprovalRegistryDeps> = {}): Harness {
       writes.push({ sessionId, data });
       return true;
     },
+    // The workspace-shaped press scope main will supply in production. The
+    // default here is the IN-scope answer (a delegated task workspace with
+    // autonomy on) so each test below exercises its own subject; the scope
+    // itself is pinned by its own describe block.
+    pressScope: () => ({ isTaskWorkspace: true, autonomyMode: 'manual' }),
     now: () => clock++,
     newId: () => `req-${ids.next++}`,
     ...overrides,
@@ -764,7 +774,9 @@ describe('resolvedBy sanitation', () => {
 
   it('applies at the chokepoint, so no caller can bypass it', async () => {
     const { registry: reg } = makeRegistry();
-    await reg.noteHookAwaitingInput({ sessionId: 'p1', agent: 'claude' });
+    // A workspaceId is required for a press: the scope check cannot classify a
+    // pane it cannot name, and unknown is a refusal.
+    await reg.noteHookAwaitingInput({ sessionId: 'p1', agent: 'claude', workspaceId: 'ws-1' });
     const id = reg.list().pending[0].id;
 
     const out = await reg.resolve({
@@ -788,7 +800,9 @@ it('logs the SANITIZED label, not the raw parameter', async () => {
     const { registry: reg } = makeRegistry({
       log: (_level: string, message: string) => { lines.push(message); },
     });
-    await reg.noteHookAwaitingInput({ sessionId: 'p1', agent: 'claude' });
+    // A workspaceId is required for a press: the scope check cannot classify a
+    // pane it cannot name, and unknown is a refusal.
+    await reg.noteHookAwaitingInput({ sessionId: 'p1', agent: 'claude', workspaceId: 'ws-1' });
     const id = reg.list().pending[0].id;
 
     const LF = String.fromCharCode(0x0a);
@@ -1092,5 +1106,98 @@ describe('looksLikeChoiceOnScreen', () => {
 
   it('returns false for empty rows', () => {
     expect(looksLikeChoiceOnScreen([], '1', 'anything')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Press scope — WHICH panes may be pressed at all
+// ---------------------------------------------------------------------------
+// The screen check answers "can these bytes be pressed". This answers the prior
+// question, and it fails closed: a fact nobody established is a refusal, not a
+// permission. A refusal here is NOT an expiry — the request stays live so a
+// human at the desktop can still answer it themselves.
+describe('decideApprovalPress — the four conditions', () => {
+  const inScope = {
+    isTaskWorkspace: true,
+    autonomyMode: 'manual',
+    origin: 'hook' as const,
+    stillOnScreen: true,
+  };
+
+  it('presses when all four hold', () => {
+    expect(decideApprovalPress(inScope)).toEqual({ press: true });
+  });
+
+  it('refuses a hand-opened pane (its workspace is not a task workspace)', () => {
+    expect(decideApprovalPress({ ...inScope, isTaskWorkspace: false })).toEqual({
+      press: false,
+      reason: 'not-a-task-workspace',
+    });
+  });
+
+  it('refuses the parent workspace a fan-out was launched from', () => {
+    // Same shape as a hand-opened pane: the parent was never delegated.
+    expect(decideApprovalPress({ ...inScope, isTaskWorkspace: false }).press).toBe(false);
+  });
+
+  it('refuses when autonomy is off — the human answers their own prompts', () => {
+    expect(decideApprovalPress({ ...inScope, autonomyMode: 'off' })).toEqual({
+      press: false,
+      reason: 'autonomy-off',
+    });
+  });
+
+  it('refuses a detector-only prompt (a numbered list in a diff is not a select)', () => {
+    expect(decideApprovalPress({ ...inScope, origin: 'detector' })).toEqual({
+      press: false,
+      reason: 'detector-only',
+    });
+  });
+
+  it('refuses when the verify-then-press re-read no longer shows the prompt', () => {
+    expect(decideApprovalPress({ ...inScope, stillOnScreen: false })).toEqual({
+      press: false,
+      reason: 'prompt-gone',
+    });
+  });
+
+  it('an UNESTABLISHED fact is a refusal, never an assumption', () => {
+    expect(decideApprovalPress({}).press).toBe(false);
+    expect(decideApprovalPress({ ...inScope, isTaskWorkspace: undefined })).toEqual({
+      press: false,
+      reason: 'workspace-unknown',
+    });
+    expect(decideApprovalPress({ ...inScope, autonomyMode: undefined })).toEqual({
+      press: false,
+      reason: 'autonomy-unknown',
+    });
+  });
+});
+
+describe('ApprovalRegistry — press scope is enforced at resolve', () => {
+  it('refuses an out-of-scope pane WITHOUT expiring the request', async () => {
+    const h = makeRegistry({ pressScope: () => ({ isTaskWorkspace: false, autonomyMode: 'manual' }) });
+    await awaitingInput(h.registry);
+    await settle();
+
+    const res = await h.registry.resolve({ id: 'req-1', decision: 'approve', resolvedBy: 'web' });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected a refusal');
+    expect(res.reason).toBe('out-of-scope');
+    // No bytes, and the request is still answerable by a human.
+    expect(h.writes).toHaveLength(0);
+    expect(h.registry.list().pending).toHaveLength(1);
+  });
+
+  it('refuses when the scope facts are unavailable at all', async () => {
+    const h = makeRegistry({ pressScope: undefined });
+    await awaitingInput(h.registry);
+    await settle();
+
+    const res = await h.registry.resolve({ id: 'req-1', decision: 'approve', resolvedBy: 'web' });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected a refusal');
+    expect(res.reason).toBe('out-of-scope');
+    expect(h.writes).toHaveLength(0);
   });
 });

--- a/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
+++ b/src/daemon/approvals/__tests__/ApprovalRegistry.test.ts
@@ -1118,6 +1118,9 @@ describe('looksLikeChoiceOnScreen', () => {
 // human at the desktop can still answer it themselves.
 describe('decideApprovalPress — the four conditions', () => {
   const inScope = {
+    resolver: 'automated' as const,
+    decision: 'approve' as const,
+    scopeAvailable: true,
     isTaskWorkspace: true,
     autonomyMode: 'manual',
     origin: 'hook' as const,
@@ -1126,6 +1129,45 @@ describe('decideApprovalPress — the four conditions', () => {
 
   it('presses when all four hold', () => {
     expect(decideApprovalPress(inScope)).toEqual({ press: true });
+  });
+
+  // A person tapping Approve is LOOKING at the prompt. Gating them behind a
+  // workspace classification is not safety, it is a broken button.
+  it('never applies to a human, whatever the scope says', () => {
+    expect(
+      decideApprovalPress({ ...inScope, resolver: 'human', isTaskWorkspace: false }),
+    ).toEqual({ press: true });
+    expect(decideApprovalPress({ resolver: 'human' })).toEqual({ press: true });
+  });
+
+  // Denying cancels the tool call and hands the turn back — the safe direction.
+  // Refusing it would keep a pane blocked in the name of protecting it.
+  it('never blocks a deny, from any caller', () => {
+    expect(decideApprovalPress({ ...inScope, decision: 'deny', isTaskWorkspace: false })).toEqual({
+      press: true,
+    });
+    expect(decideApprovalPress({ resolver: 'automated', decision: 'deny' })).toEqual({
+      press: true,
+    });
+  });
+
+  // "Nobody wired the lookup" and "the workspace said no" are different
+  // problems, and only one of them is fixed by an integration commit.
+  it('names a missing scope source distinctly from a workspace that said no', () => {
+    expect(decideApprovalPress({ ...inScope, scopeAvailable: false })).toEqual({
+      press: false,
+      reason: 'scope-unavailable',
+    });
+  });
+
+  it('refuses an autonomy mode it does not recognise (a whitelist, not a blacklist)', () => {
+    // Matching only the literal 'off' meant a typo in the store, or a newer
+    // main writing a name we predate, read as permission.
+    expect(decideApprovalPress({ ...inScope, autonomyMode: 'supervised' })).toEqual({
+      press: false,
+      reason: 'unknown-autonomy-mode',
+    });
+    expect(decideApprovalPress({ ...inScope, autonomyMode: 'assist' })).toEqual({ press: true });
   });
 
   it('refuses a hand-opened pane (its workspace is not a task workspace)', () => {
@@ -1175,12 +1217,14 @@ describe('decideApprovalPress — the four conditions', () => {
 });
 
 describe('ApprovalRegistry — press scope is enforced at resolve', () => {
-  it('refuses an out-of-scope pane WITHOUT expiring the request', async () => {
+  const automatedApprove = { decision: 'approve' as const, resolvedBy: 'deck', resolver: 'automated' as const };
+
+  it('refuses an out-of-scope AUTOMATED press WITHOUT expiring the request', async () => {
     const h = makeRegistry({ pressScope: () => ({ isTaskWorkspace: false, autonomyMode: 'manual' }) });
     await awaitingInput(h.registry);
     await settle();
 
-    const res = await h.registry.resolve({ id: 'req-1', decision: 'approve', resolvedBy: 'web' });
+    const res = await h.registry.resolve({ id: 'req-1', ...automatedApprove });
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('expected a refusal');
     expect(res.reason).toBe('out-of-scope');
@@ -1189,15 +1233,60 @@ describe('ApprovalRegistry — press scope is enforced at resolve', () => {
     expect(h.registry.list().pending).toHaveLength(1);
   });
 
-  it('refuses when the scope facts are unavailable at all', async () => {
+  // The regression this round caught: with the scope source unwired, EVERY
+  // resolve was refused — including the person tapping Approve on their phone.
+  it('lets a human approve even with no scope source wired at all', async () => {
     const h = makeRegistry({ pressScope: undefined });
     await awaitingInput(h.registry);
     await settle();
 
     const res = await h.registry.resolve({ id: 'req-1', decision: 'approve', resolvedBy: 'web' });
+    expect(res.ok).toBe(true);
+    expect(h.writes).toHaveLength(1);
+  });
+
+  it('lets a human deny in a workspace an automated press could not touch', async () => {
+    const h = makeRegistry({ pressScope: () => ({ isTaskWorkspace: false, autonomyMode: 'off' }) });
+    await awaitingInput(h.registry);
+    await settle();
+
+    const res = await h.registry.resolve({ id: 'req-1', decision: 'deny', resolvedBy: 'web' });
+    expect(res.ok).toBe(true);
+    expect(h.writes).toHaveLength(1);
+  });
+
+  // A refused deny would leave the record alive to be re-tapped forever, which
+  // is how "safety" turns into a pane nobody can unblock.
+  it('lets an AUTOMATED deny through regardless of scope', async () => {
+    const h = makeRegistry({ pressScope: () => ({ isTaskWorkspace: false, autonomyMode: 'off' }) });
+    await awaitingInput(h.registry);
+    await settle();
+
+    const res = await h.registry.resolve({
+      id: 'req-1',
+      decision: 'deny',
+      resolvedBy: 'deck',
+      resolver: 'automated',
+    });
+    expect(res.ok).toBe(true);
+    expect(h.writes).toHaveLength(1);
+  });
+
+  it('refuses an automated press with no scope source, and says so in the log', async () => {
+    const logs: string[] = [];
+    const h = makeRegistry({
+      pressScope: undefined,
+      log: (_level, message) => logs.push(message),
+    });
+    await awaitingInput(h.registry);
+    await settle();
+
+    const res = await h.registry.resolve({ id: 'req-1', ...automatedApprove });
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('expected a refusal');
     expect(res.reason).toBe('out-of-scope');
     expect(h.writes).toHaveLength(0);
+    // The missing integration wiring must be visible, not look like policy.
+    expect(logs.join('\n')).toContain('pressScope');
   });
 });

--- a/src/daemon/approvals/approvalKeystrokes.ts
+++ b/src/daemon/approvals/approvalKeystrokes.ts
@@ -165,10 +165,18 @@ function escapeDigit(d: string): string {
 //
 // The checks above answer "can these bytes be pressed". This one answers the
 // prior question: "may this pane be pressed AT ALL". They are different, and
-// conflating them is how an automated approve reaches a pane a human opened
+// conflating them is how an AUTOMATED approve reaches a pane a human opened
 // for themselves — a keystroke into a session nobody delegated.
 //
-// Four conditions, all required:
+// WHAT THIS DOES NOT GOVERN, and must not:
+//   - a HUMAN answering from the phone or the web UI. They are looking at the
+//     prompt; a scope check that refuses them is just a broken button, and a
+//     refused deny would leave the record alive to be re-tapped forever.
+//   - a DENY, from any caller. Denying is the safe direction: it cancels the
+//     tool call and hands the turn back. Refusing a deny keeps a pane blocked
+//     to protect it from being unblocked.
+//
+// Four conditions, all required (for an automated APPROVE):
 //   1. the target pane's workspace is a WorkTask TASK workspace. A pane the
 //      human opened by hand, and the PARENT workspace a fan-out was launched
 //      from, are both refused: neither was delegated to an agent;
@@ -195,6 +203,20 @@ export type ApprovalPromptOrigin = 'hook' | 'detector';
  * means "not established" — never "fine". See the fail-closed note above.
  */
 export interface ApprovalPressFacts {
+  /**
+   * Who is answering. A human at the phone or the web UI is looking at the
+   * prompt and is not subject to any of this; only an automated resolver is.
+   */
+  resolver?: ApprovalResolverKind;
+  /** approve or deny. A deny is always permitted — see the header. */
+  decision?: 'approve' | 'deny';
+  /**
+   * Whether the workspace-shaped facts could be looked up at all. False means
+   * the lookup itself is missing (main never wired it), which is a different
+   * problem from a workspace that answered "no" — and it must be visible, not
+   * silently indistinguishable.
+   */
+  scopeAvailable?: boolean;
   /** The target pane's workspace is a WorkTask task workspace. */
   isTaskWorkspace?: boolean;
   /** The target workspace's deck autonomy mode ('off' | 'manual' | …). */
@@ -205,11 +227,16 @@ export interface ApprovalPressFacts {
   stillOnScreen?: boolean;
 }
 
+/** Who is answering the prompt. */
+export type ApprovalResolverKind = 'human' | 'automated';
+
 export type ApprovalPressRefusal =
+  | 'scope-unavailable'
   | 'workspace-unknown'
   | 'not-a-task-workspace'
   | 'autonomy-unknown'
   | 'autonomy-off'
+  | 'unknown-autonomy-mode'
   | 'origin-unknown'
   | 'detector-only'
   | 'prompt-gone';
@@ -219,15 +246,32 @@ export type ApprovalPressDecision =
   | { press: false; reason: ApprovalPressRefusal };
 
 /**
+ * Deck autonomy modes that mean "an agent may act here". Whitelisted, not
+ * blacklisted: matching only the literal 'off' meant a mode this daemon has
+ * never heard of — a typo in the store, a newer main writing a name we predate
+ * — read as permission. An unrecognised setting is not consent.
+ */
+const AUTONOMY_ON_MODES: ReadonlySet<string> = new Set(['manual', 'assist', 'danger']);
+
+/**
  * May an approval be pressed into this pane? Pure — the caller gathers the
  * facts, this decides. Order is narrowest-blame-first so the reported reason
  * names the condition an operator can actually act on.
  */
 export function decideApprovalPress(facts: ApprovalPressFacts): ApprovalPressDecision {
+  // A human is looking at the prompt they are answering. Nothing below applies.
+  if (facts.resolver === 'human') return { press: true };
+  // Denying is the safe direction — it cancels the tool call and gives the turn
+  // back. A refused deny would keep a pane blocked in the name of safety.
+  if (facts.decision === 'deny') return { press: true };
+  if (facts.scopeAvailable === false) return { press: false, reason: 'scope-unavailable' };
   if (facts.isTaskWorkspace === undefined) return { press: false, reason: 'workspace-unknown' };
   if (!facts.isTaskWorkspace) return { press: false, reason: 'not-a-task-workspace' };
   if (facts.autonomyMode === undefined) return { press: false, reason: 'autonomy-unknown' };
   if (facts.autonomyMode === 'off') return { press: false, reason: 'autonomy-off' };
+  if (!AUTONOMY_ON_MODES.has(facts.autonomyMode)) {
+    return { press: false, reason: 'unknown-autonomy-mode' };
+  }
   if (facts.origin === undefined) return { press: false, reason: 'origin-unknown' };
   if (facts.origin !== 'hook') return { press: false, reason: 'detector-only' };
   if (facts.stillOnScreen !== true) return { press: false, reason: 'prompt-gone' };

--- a/src/daemon/approvals/approvalKeystrokes.ts
+++ b/src/daemon/approvals/approvalKeystrokes.ts
@@ -158,3 +158,78 @@ function escapeDigit(d: string): string {
   // Digits are regex-safe, but be explicit for safety.
   return d.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+// ---------------------------------------------------------------------------
+// Press scope (orchestrator track, 2026-09-04)
+// ---------------------------------------------------------------------------
+//
+// The checks above answer "can these bytes be pressed". This one answers the
+// prior question: "may this pane be pressed AT ALL". They are different, and
+// conflating them is how an automated approve reaches a pane a human opened
+// for themselves — a keystroke into a session nobody delegated.
+//
+// Four conditions, all required:
+//   1. the target pane's workspace is a WorkTask TASK workspace. A pane the
+//      human opened by hand, and the PARENT workspace a fan-out was launched
+//      from, are both refused: neither was delegated to an agent;
+//   2. that workspace has autonomy enabled (mode ≠ 'off'). Autonomy off means
+//      the human answers their own prompts;
+//   3. the pending approval came from a HOOK. The screen-regex detector is a
+//      suspicion — it fires on a numbered list in a diff — and this surface
+//      writes bytes;
+//   4. a re-read taken NOW still shows the prompt (looksLikeApprovalPrompt).
+//      Everything upstream is a fact about when the hook fired, which is not
+//      a fact about the screen a press is about to land on.
+//
+// UNKNOWN IS A REFUSAL. Each fact is optional in the input because the daemon
+// cannot see all of them yet (task-workspace membership and autonomy mode live
+// in the main process), and a fact we cannot establish must never be assumed
+// favourable: the cost of a wrong refusal is a human walking to the desktop,
+// the cost of a wrong press is a keystroke in someone else's terminal.
+
+/** Where the pending approval came from. */
+export type ApprovalPromptOrigin = 'hook' | 'detector';
+
+/**
+ * The facts a press decision needs. Every field is optional and `undefined`
+ * means "not established" — never "fine". See the fail-closed note above.
+ */
+export interface ApprovalPressFacts {
+  /** The target pane's workspace is a WorkTask task workspace. */
+  isTaskWorkspace?: boolean;
+  /** The target workspace's deck autonomy mode ('off' | 'manual' | …). */
+  autonomyMode?: string;
+  /** Which signal created the pending approval. */
+  origin?: ApprovalPromptOrigin;
+  /** A re-read taken now still shows an answerable prompt. */
+  stillOnScreen?: boolean;
+}
+
+export type ApprovalPressRefusal =
+  | 'workspace-unknown'
+  | 'not-a-task-workspace'
+  | 'autonomy-unknown'
+  | 'autonomy-off'
+  | 'origin-unknown'
+  | 'detector-only'
+  | 'prompt-gone';
+
+export type ApprovalPressDecision =
+  | { press: true }
+  | { press: false; reason: ApprovalPressRefusal };
+
+/**
+ * May an approval be pressed into this pane? Pure — the caller gathers the
+ * facts, this decides. Order is narrowest-blame-first so the reported reason
+ * names the condition an operator can actually act on.
+ */
+export function decideApprovalPress(facts: ApprovalPressFacts): ApprovalPressDecision {
+  if (facts.isTaskWorkspace === undefined) return { press: false, reason: 'workspace-unknown' };
+  if (!facts.isTaskWorkspace) return { press: false, reason: 'not-a-task-workspace' };
+  if (facts.autonomyMode === undefined) return { press: false, reason: 'autonomy-unknown' };
+  if (facts.autonomyMode === 'off') return { press: false, reason: 'autonomy-off' };
+  if (facts.origin === undefined) return { press: false, reason: 'origin-unknown' };
+  if (facts.origin !== 'hook') return { press: false, reason: 'detector-only' };
+  if (facts.stillOnScreen !== true) return { press: false, reason: 'prompt-gone' };
+  return { press: true };
+}

--- a/src/daemon/approvals/types.ts
+++ b/src/daemon/approvals/types.ts
@@ -287,6 +287,14 @@ export interface ApprovalResolveParams {
    * sends '1', deny sends ESC.
    */
   choiceKey?: string;
+  /**
+   * Who is answering. Defaults to `'human'`, because every caller that exists
+   * today is a person tapping Approve on the phone or the web UI, and they are
+   * looking at the prompt they are answering. An AUTOMATED resolver must
+   * declare itself — that is what subjects it to the press scope
+   * (`decideApprovalPress`), which a human is deliberately not subject to.
+   */
+  resolver?: 'human' | 'automated';
 }
 
 /**

--- a/src/daemon/approvals/types.ts
+++ b/src/daemon/approvals/types.ts
@@ -168,7 +168,12 @@ export type ApprovalResolveFailure =
   | 'expired'
   | 'unsupported-agent'
   | 'prompt-gone'
-  | 'invalid-choice-key';
+  | 'invalid-choice-key'
+  // The pane is outside the press scope (`decideApprovalPress`): not a
+  // delegated task workspace, autonomy off, or a fact the daemon could not
+  // establish — unknown is a refusal. NOT an expiry: the request stays live and
+  // a human at the desktop can still answer it themselves.
+  | 'out-of-scope';
 
 export type ApprovalResolveResult =
   | {

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -3122,6 +3122,7 @@ export class ChannelService {
     unread: number;
     mentionUnread: number;
     trimmedBeforeCursor: number;
+    latestBody?: string;
   }> {
     const out: Array<{
       channelId: string;
@@ -3133,6 +3134,7 @@ export class ChannelService {
       unread: number;
       mentionUnread: number;
       trimmedBeforeCursor: number;
+      latestBody?: string;
     }> = [];
     for (const channel of this.state.channels) {
       if (channel.status === 'archived') continue;
@@ -3147,6 +3149,13 @@ export class ChannelService {
         const visibleFloor = row.historyFromSeq;
         let unread = 0;
         let mentionUnread = 0;
+        // The oldest owed message's text. The wake nudge carries its first line
+        // so a woken agent knows what it is being woken FOR; without it every
+        // nudge reads identically and the agent must spend a turn reading to
+        // find out. Prefer a MENTION when one is owed — that is the message the
+        // nudge budget is actually being spent on.
+        let firstBody: string | undefined;
+        let firstMentionBody: string | undefined;
         for (const m of msgs) {
           if (m.seq <= cursor || m.seq < visibleFloor) continue;
           // Self-authored messages are never owed (Codex review): a reply
@@ -3162,12 +3171,16 @@ export class ChannelService {
           // consensus). deliveryStatus/recipientSnapshot play no role here.
           if (m.systemKind) continue;
           unread += 1;
+          firstBody ??= m.text;
           const mentioned = (m.mentions ?? []).some(
             (men) =>
               men.workspaceId === verifiedWorkspaceId &&
               (men.memberId === undefined || men.memberId === row.memberId),
           );
-          if (mentioned) mentionUnread += 1;
+          if (mentioned) {
+            mentionUnread += 1;
+            firstMentionBody ??= m.text;
+          }
         }
         // Retained-log gap: messages between the cursor and the first retained
         // seq were trimmed before this member read them.
@@ -3185,10 +3198,55 @@ export class ChannelService {
           unread,
           mentionUnread,
           trimmedBeforeCursor,
+          ...(firstMentionBody ?? firstBody
+            ? { latestBody: firstMentionBody ?? firstBody }
+            : {}),
         });
       }
     }
     return out;
+  }
+
+  /**
+   * Record what happened at the PTY for one wake nudge (channelWakeWorker).
+   *
+   * The push half was write-only: a nudge into a pane that died mid-race was
+   * logged and dropped, and the message it announced stayed `pending` — a
+   * receipt for a delivery nobody made. A failed nudge now flips THAT
+   * recipient's frozen snapshot entry to `target_gone`, and the message's own
+   * status follows only when no recipient is left pending or delivered (the
+   * "at least one delivered" rule the ack path uses, read the other way).
+   *
+   * A SUCCESS is deliberately not a delivery: the hint reached the pane, which
+   * is not the same as the agent having received the message. Only the ack
+   * path (read === received) may write `delivered`. So success stamps the
+   * attempt time and nothing else — the exact false-receipt this method exists
+   * to stop reproducing.
+   */
+  noteNudgeOutcome(params: {
+    channelId: string;
+    workspaceId: string;
+    memberId: string;
+    ok: boolean;
+  }): void {
+    const msgs = this.state.messages[params.channelId] ?? [];
+    let changed = false;
+    for (const m of msgs) {
+      for (const entry of m.recipientSnapshot ?? []) {
+        if (entry.workspaceId !== params.workspaceId) continue;
+        if (entry.status !== 'pending') continue;
+        entry.lastAttemptAt = Date.now();
+        changed = true;
+        if (params.ok) continue;
+        entry.status = 'target_gone';
+        const anyLive = (m.recipientSnapshot ?? []).some((e) => e.status !== 'target_gone');
+        if (!anyLive && m.deliveryStatus === 'pending') m.deliveryStatus = 'target_gone';
+      }
+    }
+    // Bookkeeping only, so it rides the DEBOUNCED cache write: the wake loop
+    // ticks every 15s and must never be held up by a disk write, and the pull
+    // path (cursor + unread) remains the source of truth either way.
+    if (changed) this.scheduleCacheWrites();
   }
 
   // ── Internals ──────────────────────────────────────────────────────

--- a/src/daemon/channels/ChannelService.ts
+++ b/src/daemon/channels/ChannelService.ts
@@ -2910,7 +2910,11 @@ export class ChannelService {
         // would leave the siblings permanently 'pending', and a repeat ack would
         // keep re-finding the first, already-delivered row (Codex review).
         for (const entry of m.recipientSnapshot ?? []) {
-          if (entry.workspaceId === params.verifiedWorkspaceId && entry.status === 'pending') {
+          // Anything not already `delivered` — `target_gone` included. A failed
+          // wake nudge records one moment's dead pane; an ack is the receiver
+          // saying it read the thing. Leaving target_gone alone would let one
+          // dead pane pin a message as undelivered forever.
+          if (entry.workspaceId === params.verifiedWorkspaceId && entry.status !== 'delivered') {
             flips.push({
               entry,
               prevEntryStatus: entry.status,
@@ -2962,9 +2966,9 @@ export class ChannelService {
       if (flips.length > 0 || cursorFlips.length > 0) {
         if (this.eventLog) {
           // G1 append-then-apply: 수집(collect)은 위에서 읽기 전용으로 끝났고,
-          // 적용은 배리어 성공 후 적용기가 수행한다 — 적용기의 재수집(pending
-          // 전용 플립·advance-only 커서)은 뮤텍스 하에서 위 수집과 결정론적으로
-          // 동일하다. 실패 = 무적용(롤백 없음).
+          // 적용은 배리어 성공 후 적용기가 수행한다 — 적용기의 재수집(delivered가
+          // 아닌 행만 플립·advance-only 커서)은 뮤텍스 하에서 위 수집과 결정론적
+          // 으로 동일하다. 실패 = 무적용(롤백 없음).
           if (
             !(await this.commitAndApply(
               {
@@ -3122,7 +3126,7 @@ export class ChannelService {
     unread: number;
     mentionUnread: number;
     trimmedBeforeCursor: number;
-    latestBody?: string;
+    oldestUnreadBody?: string;
   }> {
     const out: Array<{
       channelId: string;
@@ -3134,7 +3138,7 @@ export class ChannelService {
       unread: number;
       mentionUnread: number;
       trimmedBeforeCursor: number;
-      latestBody?: string;
+      oldestUnreadBody?: string;
     }> = [];
     for (const channel of this.state.channels) {
       if (channel.status === 'archived') continue;
@@ -3199,7 +3203,7 @@ export class ChannelService {
           mentionUnread,
           trimmedBeforeCursor,
           ...(firstMentionBody ?? firstBody
-            ? { latestBody: firstMentionBody ?? firstBody }
+            ? { oldestUnreadBody: firstMentionBody ?? firstBody }
             : {}),
         });
       }
@@ -3212,41 +3216,76 @@ export class ChannelService {
    *
    * The push half was write-only: a nudge into a pane that died mid-race was
    * logged and dropped, and the message it announced stayed `pending` — a
-   * receipt for a delivery nobody made. A failed nudge now flips THAT
-   * recipient's frozen snapshot entry to `target_gone`, and the message's own
-   * status follows only when no recipient is left pending or delivered (the
-   * "at least one delivered" rule the ack path uses, read the other way).
+   * promise that something is still being delivered when nothing is. A FAILED
+   * nudge now flips that recipient's frozen snapshot entry to `target_gone`,
+   * and the message's own status follows only when no recipient is left alive
+   * (the ack path's "at least one delivered" rule, read the other way).
    *
-   * A SUCCESS is deliberately not a delivery: the hint reached the pane, which
-   * is not the same as the agent having received the message. Only the ack
-   * path (read === received) may write `delivered`. So success stamps the
-   * attempt time and nothing else — the exact false-receipt this method exists
-   * to stop reproducing.
+   * Scoped on both axes, because a nudge's evidence is narrow: it concerns ONE
+   * member row (a sibling member of the same workspace has its own pane and its
+   * own cursor) and only the seq range the nudge announced (the member had
+   * already read everything at or below its cursor; anything past the head was
+   * posted afterwards). Matching on workspace alone flipped every pending row
+   * in the channel, and since `ack` used to promote only `pending`, nothing
+   * ever recovered.
+   *
+   * A SUCCESS is deliberately NOT recorded. The hint reaching a pane is not the
+   * agent having received the message — only the ack path (read === received)
+   * may write `delivered` — so a success has nothing durable to say, and
+   * writing one would append to the event log on every wake tick.
+   *
+   * Runs under the channel lock and through the same commit/apply path as every
+   * other mutation, so a replay from the event log reconstructs it.
    */
-  noteNudgeOutcome(params: {
+  async noteNudgeOutcome(params: {
     channelId: string;
     workspaceId: string;
     memberId: string;
+    fromSeqExclusive: number;
+    toSeqInclusive: number;
     ok: boolean;
-  }): void {
-    const msgs = this.state.messages[params.channelId] ?? [];
-    let changed = false;
-    for (const m of msgs) {
-      for (const entry of m.recipientSnapshot ?? []) {
-        if (entry.workspaceId !== params.workspaceId) continue;
-        if (entry.status !== 'pending') continue;
-        entry.lastAttemptAt = Date.now();
-        changed = true;
-        if (params.ok) continue;
-        entry.status = 'target_gone';
-        const anyLive = (m.recipientSnapshot ?? []).some((e) => e.status !== 'target_gone');
-        if (!anyLive && m.deliveryStatus === 'pending') m.deliveryStatus = 'target_gone';
+  }): Promise<void> {
+    if (params.ok) return;
+    await this.withChannelLock(params.channelId, async () => {
+      const channel = this.state.channels.find((c) => c.id === params.channelId);
+      if (!channel) return;
+      const msgs = this.state.messages[params.channelId] ?? [];
+      const affects = msgs.some(
+        (m) =>
+          m.seq > params.fromSeqExclusive &&
+          m.seq <= params.toSeqInclusive &&
+          (m.recipientSnapshot ?? []).some(
+            (e) =>
+              e.workspaceId === params.workspaceId &&
+              e.memberId === params.memberId &&
+              e.status === 'pending',
+          ),
+      );
+      if (!affects) return;
+
+      const failedAt = this.now();
+      const event = {
+        kind: 'nudge-failed' as const,
+        channelId: params.channelId,
+        workspaceId: params.workspaceId,
+        memberId: params.memberId,
+        fromSeqExclusive: params.fromSeqExclusive,
+        toSeqInclusive: params.toSeqInclusive,
+        failedAt,
+      };
+      if (this.eventLog) {
+        await this.commitAndApply(event, {
+          verifiedWorkspaceId: params.workspaceId,
+          principalId: params.memberId,
+        });
+        return;
       }
-    }
-    // Bookkeeping only, so it rides the DEBOUNCED cache write: the wake loop
-    // ticks every 15s and must never be held up by a disk write, and the pull
-    // path (cursor + unread) remains the source of truth either way.
-    if (changed) this.scheduleCacheWrites();
+      // Legacy mode (no event log): apply in place, then persist. A persist
+      // failure is tolerated — this is bookkeeping, and the pull path (cursor +
+      // unread) remains the source of truth either way.
+      applyChannelEvent(this.state, event);
+      this.scheduleCacheWrites();
+    });
   }
 
   // ── Internals ──────────────────────────────────────────────────────

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -2590,29 +2590,118 @@ describe('ChannelService — wake nudge support', () => {
     expect(row?.unread).toBe(2);
     // Oldest first — the nudge announces what the agent has not seen yet, not
     // whatever happened to arrive last.
-    expect(row?.latestBody).toBe('first thing');
+    expect(row?.oldestUnreadBody).toBe('first thing');
   });
 
-  it('a failed nudge marks that recipient target_gone; a successful one is NOT a delivery', async () => {
-    const { svc, channelId } = await twoMemberChannel();
-    const posted = await svc.post({
-      channelId,
-      sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
-      text: 'anyone there?',
-      verifiedWorkspaceId: 'ws-1',
+  describe('noteNudgeOutcome', () => {
+    /** Two agents from ws-2 in one channel, plus N posts from ws-1. */
+    async function twoAgentsAnd(posts: string[]) {
+      const h = makeService();
+      const created = await h.svc.create({
+        name: 'general',
+        visibility: 'public',
+        createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+        verifiedWorkspaceId: 'ws-1',
+      });
+      if (!created.ok) throw new Error('create failed');
+      const channelId = created.channel.id;
+      for (const member of ['codex', 'claude']) {
+        await h.svc.join({
+          channelId,
+          member: { workspaceId: 'ws-2', memberId: member, memberName: member },
+          verifiedWorkspaceId: 'ws-2',
+        });
+      }
+      for (const text of posts) {
+        await h.svc.post({
+          channelId,
+          sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+          text,
+          verifiedWorkspaceId: 'ws-1',
+        });
+      }
+      const statusOf = (seq: number, member: string): string | undefined => {
+        const msg = h.svc.getMessages(channelId, undefined, 'ws-1').find((m) => m.seq === seq);
+        return msg?.recipientSnapshot?.find(
+          (e) => e.workspaceId === 'ws-2' && e.memberId === member,
+        )?.status;
+      };
+      const seqs = h.svc
+        .getMessages(channelId, undefined, 'ws-1')
+        .map((m) => m.seq)
+        .sort((a, b) => a - b);
+      return { ...h, channelId, statusOf, seqs };
+    }
+
+    it('a landed nudge records nothing — it is not a delivery', async () => {
+      const { svc, channelId, statusOf, seqs } = await twoAgentsAnd(['anyone there?']);
+      await svc.noteNudgeOutcome({
+        channelId,
+        workspaceId: 'ws-2',
+        memberId: 'codex',
+        fromSeqExclusive: seqs[0]! - 1,
+        toSeqInclusive: seqs[0]!,
+        ok: true,
+      });
+      expect(statusOf(seqs[0]!, 'codex')).toBe('pending');
     });
-    expect(posted.ok).toBe(true);
 
-    const statusFor = (ws: string): string | undefined => {
-      const msg = svc.getMessages(channelId, undefined, 'ws-1')[0];
-      return msg?.recipientSnapshot?.find((e) => e.workspaceId === ws)?.status;
-    };
+    it('a failed nudge touches ONLY that member row', async () => {
+      const { svc, channelId, statusOf, seqs } = await twoAgentsAnd(['anyone there?']);
+      await svc.noteNudgeOutcome({
+        channelId,
+        workspaceId: 'ws-2',
+        memberId: 'codex',
+        fromSeqExclusive: seqs[0]! - 1,
+        toSeqInclusive: seqs[0]!,
+        ok: false,
+      });
+      expect(statusOf(seqs[0]!, 'codex')).toBe('target_gone');
+      // A sibling agent in the same workspace has its own pane and its own
+      // cursor — one dead pane says nothing about it.
+      expect(statusOf(seqs[0]!, 'claude')).toBe('pending');
+    });
 
-    // A nudge that landed is not a receipt — only an ack (read === received) is.
-    svc.noteNudgeOutcome({ channelId, workspaceId: 'ws-2', memberId: 'codex', ok: true });
-    expect(statusFor('ws-2')).toBe('pending');
+    it('a failed nudge touches ONLY the seq range it announced', async () => {
+      const { svc, channelId, statusOf, seqs } = await twoAgentsAnd(['old', 'announced', 'later']);
+      const [alreadyRead, announced, postedAfter] = seqs;
+      await svc.noteNudgeOutcome({
+        channelId,
+        workspaceId: 'ws-2',
+        memberId: 'codex',
+        fromSeqExclusive: alreadyRead!,
+        toSeqInclusive: announced!,
+        ok: false,
+      });
+      // Below the cursor: the member had already read it.
+      expect(statusOf(alreadyRead!, 'codex')).toBe('pending');
+      expect(statusOf(announced!, 'codex')).toBe('target_gone');
+      // Past the head: posted after the nudge went out.
+      expect(statusOf(postedAfter!, 'codex')).toBe('pending');
+    });
 
-    svc.noteNudgeOutcome({ channelId, workspaceId: 'ws-2', memberId: 'codex', ok: false });
-    expect(statusFor('ws-2')).toBe('target_gone');
+    it('an ack recovers a row a failed nudge marked target_gone', async () => {
+      const { svc, channelId, statusOf, seqs } = await twoAgentsAnd(['anyone there?']);
+      await svc.noteNudgeOutcome({
+        channelId,
+        workspaceId: 'ws-2',
+        memberId: 'codex',
+        fromSeqExclusive: seqs[0]! - 1,
+        toSeqInclusive: seqs[0]!,
+        ok: false,
+      });
+      expect(statusOf(seqs[0]!, 'codex')).toBe('target_gone');
+
+      // The agent came back and read it. A dead pane at one moment must not
+      // pin the message as undelivered forever.
+      const acked = await svc.ack({
+        channelId,
+        verifiedWorkspaceId: 'ws-2',
+        uptoSeq: seqs[0]!,
+        memberId: 'codex',
+      });
+      expect(acked.ok).toBe(true);
+      expect(statusOf(seqs[0]!, 'codex')).toBe('delivered');
+    });
   });
 });

--- a/src/daemon/channels/__tests__/ChannelService.test.ts
+++ b/src/daemon/channels/__tests__/ChannelService.test.ts
@@ -2549,3 +2549,70 @@ describe('ChannelService.create — P5 reserved human workspace guard (ship revi
     expect(retry.ok).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// What the wake nudge says, and what a failed nudge records.
+// ---------------------------------------------------------------------------
+describe('ChannelService — wake nudge support', () => {
+  async function twoMemberChannel() {
+    const h = makeService();
+    const created = await h.svc.create({
+      name: 'general',
+      visibility: 'public',
+      createdBy: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+      verifiedWorkspaceId: 'ws-1',
+    });
+    if (!created.ok) throw new Error('create failed');
+    await h.svc.join({
+      channelId: created.channel.id,
+      member: { workspaceId: 'ws-2', memberId: 'codex', memberName: 'Codex' },
+      verifiedWorkspaceId: 'ws-2',
+    });
+    return { ...h, channelId: created.channel.id };
+  }
+
+  it('unreadFor hands the wake worker the OLDEST owed message body', async () => {
+    const { svc, channelId } = await twoMemberChannel();
+    await svc.post({
+      channelId,
+      sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+      text: 'first thing',
+      verifiedWorkspaceId: 'ws-1',
+    });
+    await svc.post({
+      channelId,
+      sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+      text: 'second thing',
+      verifiedWorkspaceId: 'ws-1',
+    });
+
+    const row = svc.unreadFor('ws-2').find((e) => e.channelId === channelId);
+    expect(row?.unread).toBe(2);
+    // Oldest first — the nudge announces what the agent has not seen yet, not
+    // whatever happened to arrive last.
+    expect(row?.latestBody).toBe('first thing');
+  });
+
+  it('a failed nudge marks that recipient target_gone; a successful one is NOT a delivery', async () => {
+    const { svc, channelId } = await twoMemberChannel();
+    const posted = await svc.post({
+      channelId,
+      sender: { workspaceId: 'ws-1', memberId: 'm-1', memberName: 'Alice' },
+      text: 'anyone there?',
+      verifiedWorkspaceId: 'ws-1',
+    });
+    expect(posted.ok).toBe(true);
+
+    const statusFor = (ws: string): string | undefined => {
+      const msg = svc.getMessages(channelId, undefined, 'ws-1')[0];
+      return msg?.recipientSnapshot?.find((e) => e.workspaceId === ws)?.status;
+    };
+
+    // A nudge that landed is not a receipt — only an ack (read === received) is.
+    svc.noteNudgeOutcome({ channelId, workspaceId: 'ws-2', memberId: 'codex', ok: true });
+    expect(statusFor('ws-2')).toBe('pending');
+
+    svc.noteNudgeOutcome({ channelId, workspaceId: 'ws-2', memberId: 'codex', ok: false });
+    expect(statusFor('ws-2')).toBe('target_gone');
+  });
+});

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -15,6 +15,7 @@ import {
   EXHAUSTED_REANNOUNCE_MS,
   BODY_PREVIEW_MAX_LEN,
   bodyPreview,
+  mayCarryBody,
   type WakeUnreadEntry,
   type WakeSessionView,
   type WakeNudgeOutcome,
@@ -670,7 +671,7 @@ describe('recordExternalNudge — membership validation (unbounded-growth guard)
 describe('ChannelWakeWorker — body preview + inject outcome', () => {
   it('carries the first line of the body after the existing hint', () => {
     const h = makeHarness();
-    h.setEntries([entry({ latestBody: 'deploy is red on main\nstack trace follows' })]);
+    h.setEntries([entry({ oldestUnreadBody: 'deploy is red on main\nstack trace follows' })]);
     h.setSessions([session({})]);
     h.worker.tickOnce();
 
@@ -688,7 +689,7 @@ describe('ChannelWakeWorker — body preview + inject outcome', () => {
     const h = makeHarness();
     // ChannelService picks WHICH body to hand over; this pins that the worker
     // renders it unmodified apart from the safety pass.
-    h.setEntries([entry({ mentionUnread: 1, latestBody: '@codex can you take this?' })]);
+    h.setEntries([entry({ mentionUnread: 1, oldestUnreadBody: '@codex can you take this?' })]);
     h.setSessions([session({})]);
     h.worker.tickOnce();
 
@@ -701,9 +702,66 @@ describe('ChannelWakeWorker — body preview + inject outcome', () => {
     h.setEntries([entry({})]);
     h.setSessions([session({})]);
     h.worker.tickOnce();
-    // No dangling separator / empty quotes.
-    expect(h.writes[0]!.data).not.toContain('""');
+    // No dangling separator.
     expect(h.writes[0]!.data.endsWith('--since 3')).toBe(true);
+  });
+
+  // The body is another workspace's text, TYPED into a live pane and committed
+  // with an Enter. `lastDetectedAgent` can be stale — the agent exits and the
+  // shell stays — and a shell would RUN it.
+  describe('the body is an injection surface', () => {
+    const HOSTILE = 'ship it $(rm -rf ~) `id` "quoted" \'also\' \\escaped';
+
+    it('drops shell metacharacters from the preview', () => {
+      const h = makeHarness();
+      h.setEntries([entry({ oldestUnreadBody: HOSTILE })]);
+      h.setSessions([session({ lastDetectedAgent: 'codex' })]);
+      h.worker.tickOnce();
+
+      const text = h.writes[0]!.data;
+      expect(text).toContain('ship it');
+      for (const ch of ['$', '`', '\\', '"', "'"]) {
+        expect(text).not.toContain(ch);
+      }
+    });
+
+    it('omits the body entirely when the pane is a bare shell', () => {
+      const h = makeHarness();
+      h.setEntries([entry({ oldestUnreadBody: 'deploy is red on main' })]);
+      // A pane with no detected agent is exactly the case where the text would
+      // be run rather than composed.
+      h.setSessions([
+        session({ id: 'pty-1', lastDetectedAgent: 'codex' }),
+        session({ id: 'pty-2', lastDetectedAgent: undefined }),
+      ]);
+      // Force the single-eligible-agent path onto the shell by removing the
+      // agent pane: an agent-less pane is never targeted at all...
+      h.setSessions([session({ lastDetectedAgent: 'zsh' })]);
+      h.worker.tickOnce();
+
+      expect(h.writes).toHaveLength(1);
+      expect(h.writes[0]!.data).not.toContain('deploy is red on main');
+      expect(h.writes[0]!.data).toContain('run: wmux channel read');
+    });
+
+    it('caps the FINAL assembled line, not the pieces', () => {
+      const h = makeHarness();
+      h.setEntries([entry({ oldestUnreadBody: 'x'.repeat(500) })]);
+      h.setSessions([session({})]);
+      h.worker.tickOnce();
+
+      // Concatenation is exactly where a bounded hint and a bounded preview
+      // stop being bounded.
+      expect(h.writes[0]!.data.length).toBeLessThanOrEqual(220);
+    });
+
+    it('mayCarryBody names agent TUIs only', () => {
+      expect(mayCarryBody('claude')).toBe(true);
+      expect(mayCarryBody('codex')).toBe(true);
+      expect(mayCarryBody('zsh')).toBe(false);
+      expect(mayCarryBody('')).toBe(false);
+      expect(mayCarryBody(undefined)).toBe(false);
+    });
   });
 
   it('reports success only after the Enter lands, never on the text write alone', () => {
@@ -716,7 +774,15 @@ describe('ChannelWakeWorker — body preview + inject outcome', () => {
     expect(h.outcomes).toEqual([]);
     flushEnter();
     expect(h.outcomes).toEqual([
-      { workspaceId: 'ws-b', channelId: 'ch-1', memberId: 'codex', sessionId: 'pty-1', ok: true },
+      {
+        workspaceId: 'ws-b',
+        channelId: 'ch-1',
+        memberId: 'codex',
+        sessionId: 'pty-1',
+        fromSeqExclusive: 2,
+        toSeqInclusive: 4,
+        ok: true,
+      },
     ]);
   });
 
@@ -728,7 +794,15 @@ describe('ChannelWakeWorker — body preview + inject outcome', () => {
     h.worker.tickOnce();
 
     expect(h.outcomes).toEqual([
-      { workspaceId: 'ws-b', channelId: 'ch-1', memberId: 'codex', sessionId: 'pty-1', ok: false },
+      {
+        workspaceId: 'ws-b',
+        channelId: 'ch-1',
+        memberId: 'codex',
+        sessionId: 'pty-1',
+        fromSeqExclusive: 2,
+        toSeqInclusive: 4,
+        ok: false,
+      },
     ]);
   });
 
@@ -742,7 +816,15 @@ describe('ChannelWakeWorker — body preview + inject outcome', () => {
     flushEnter();
 
     expect(h.outcomes).toEqual([
-      { workspaceId: 'ws-b', channelId: 'ch-1', memberId: 'codex', sessionId: 'pty-1', ok: false },
+      {
+        workspaceId: 'ws-b',
+        channelId: 'ch-1',
+        memberId: 'codex',
+        sessionId: 'pty-1',
+        fromSeqExclusive: 2,
+        toSeqInclusive: 4,
+        ok: false,
+      },
     ]);
   });
 

--- a/src/daemon/channels/__tests__/channelWakeWorker.test.ts
+++ b/src/daemon/channels/__tests__/channelWakeWorker.test.ts
@@ -13,8 +13,11 @@ import {
   WAKE_QUIET_MS,
   WAKE_TICK_MS,
   EXHAUSTED_REANNOUNCE_MS,
+  BODY_PREVIEW_MAX_LEN,
+  bodyPreview,
   type WakeUnreadEntry,
   type WakeSessionView,
+  type WakeNudgeOutcome,
 } from '../channelWakeWorker';
 import {
   PrincipalService,
@@ -53,6 +56,7 @@ interface Harness {
   worker: ChannelWakeWorker;
   writes: Array<{ sessionId: string; data: string }>;
   broadcasts: Array<Record<string, unknown>>;
+  outcomes: WakeNudgeOutcome[];
   logs: string[];
   setEntries(e: WakeUnreadEntry[]): void;
   setSessions(s: WakeSessionView[]): void;
@@ -70,6 +74,7 @@ function makeHarness(
   let writeError: Error | null = null;
   const writes: Array<{ sessionId: string; data: string }> = [];
   const broadcasts: Array<Record<string, unknown>> = [];
+  const outcomes: WakeNudgeOutcome[] = [];
   const logs: string[] = [];
   const worker = new ChannelWakeWorker({
     memberWorkspaces: () => ['ws-b'],
@@ -81,6 +86,7 @@ function makeHarness(
       writes.push({ sessionId, data });
     },
     broadcast: (event) => broadcasts.push(event),
+    onNudgeOutcome: (outcome) => outcomes.push(outcome),
     log: (_level, message) => logs.push(message),
     now: () => nowMs,
     enterDelayMs: 1,
@@ -89,6 +95,7 @@ function makeHarness(
     worker,
     writes,
     broadcasts,
+    outcomes,
     logs,
     setEntries: (e) => (entries = e),
     setSessions: (s) => (sessions = s),
@@ -649,5 +656,105 @@ describe('recordExternalNudge — membership validation (unbounded-growth guard)
     h.setNow(1_000_000);
     h.worker.tickOnce();
     expect(h.writes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The nudge says WHAT you are being woken for, and reports whether it landed.
+// ---------------------------------------------------------------------------
+// Every nudge used to read identically ("2 unread — run: wmux channel read …"),
+// so an agent mid-task had to spend a turn on the read just to learn whether it
+// mattered. And the push half was write-only: a nudge into a pane that died
+// mid-race was logged and dropped while the message it announced stayed
+// 'pending' — a receipt for a delivery nobody made.
+describe('ChannelWakeWorker — body preview + inject outcome', () => {
+  it('carries the first line of the body after the existing hint', () => {
+    const h = makeHarness();
+    h.setEntries([entry({ latestBody: 'deploy is red on main\nstack trace follows' })]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+
+    const text = h.writes[0]!.data;
+    // The hint is unchanged and still comes first.
+    expect(text).toContain('run: wmux channel read ch-1 --since 3');
+    expect(text).toContain('deploy is red on main');
+    // Only the FIRST line — a multi-line body must never turn into several
+    // submits in the target's composer.
+    expect(text).not.toContain('stack trace');
+    expect(text).not.toContain('\n');
+  });
+
+  it('renders the body it is given for a mention', () => {
+    const h = makeHarness();
+    // ChannelService picks WHICH body to hand over; this pins that the worker
+    // renders it unmodified apart from the safety pass.
+    h.setEntries([entry({ mentionUnread: 1, latestBody: '@codex can you take this?' })]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+
+    expect(h.writes[0]!.data).toContain('@codex can you take this?');
+    expect(h.writes[0]!.data).toContain('(1 mention you)');
+  });
+
+  it('falls back to the hint alone when no body is supplied', () => {
+    const h = makeHarness();
+    h.setEntries([entry({})]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+    // No dangling separator / empty quotes.
+    expect(h.writes[0]!.data).not.toContain('""');
+    expect(h.writes[0]!.data.endsWith('--since 3')).toBe(true);
+  });
+
+  it('reports success only after the Enter lands, never on the text write alone', () => {
+    const h = makeHarness();
+    h.setEntries([entry({})]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+
+    // Text is out but the nudge is still sitting uncommitted — not a delivery.
+    expect(h.outcomes).toEqual([]);
+    flushEnter();
+    expect(h.outcomes).toEqual([
+      { workspaceId: 'ws-b', channelId: 'ch-1', memberId: 'codex', sessionId: 'pty-1', ok: true },
+    ]);
+  });
+
+  it('reports failure when the pane dies before the text write', () => {
+    const h = makeHarness();
+    h.setEntries([entry({})]);
+    h.setSessions([session({})]);
+    h.setWriteError(new Error('write EPIPE'));
+    h.worker.tickOnce();
+
+    expect(h.outcomes).toEqual([
+      { workspaceId: 'ws-b', channelId: 'ch-1', memberId: 'codex', sessionId: 'pty-1', ok: false },
+    ]);
+  });
+
+  it('reports failure when the pane dies between the text and the Enter', () => {
+    const h = makeHarness();
+    h.setEntries([entry({})]);
+    h.setSessions([session({})]);
+    h.worker.tickOnce();
+    // The hint landed; the pane dies before the commit.
+    h.setWriteError(new Error('write EPIPE'));
+    flushEnter();
+
+    expect(h.outcomes).toEqual([
+      { workspaceId: 'ws-b', channelId: 'ch-1', memberId: 'codex', sessionId: 'pty-1', ok: false },
+    ]);
+  });
+
+  it('bodyPreview strips control characters and caps the length', () => {
+    expect(bodyPreview('abc')).toBe('a b c');
+    expect(bodyPreview(undefined)).toBe('');
+    expect(bodyPreview('   ')).toBe('');
+    // Only the first line — the rest would submit as separate lines.
+    expect(bodyPreview('first\r\nsecond')).toBe('first');
+    const long = 'x'.repeat(BODY_PREVIEW_MAX_LEN + 50);
+    const out = bodyPreview(long);
+    expect(out.length).toBe(BODY_PREVIEW_MAX_LEN);
+    expect(out.endsWith('…')).toBe(true);
   });
 });

--- a/src/daemon/channels/channelEvents.ts
+++ b/src/daemon/channels/channelEvents.ts
@@ -133,6 +133,35 @@ export type ChannelEventPayload =
     }
   | {
       /**
+       * A wake nudge failed to reach its pane (channelWakeWorker). Recorded so
+       * the messages it was announcing stop looking `pending` forever — a
+       * pending row is a promise that something is still being delivered, and
+       * after the pane died nothing is.
+       *
+       * Scoped on BOTH axes on purpose. One member's dead pane says nothing
+       * about a sibling member in the same workspace, and a nudge says nothing
+       * about messages outside the range it announced — the member had already
+       * read everything at or below its cursor, and anything past the head was
+       * posted after the nudge went out.
+       *
+       * Only FAILURES are recorded. A nudge that landed is not a delivery (the
+       * hint reaching a pane is not the agent having read the message), so a
+       * success has nothing durable to say and recording one would append to
+       * the log on every wake tick.
+       */
+      kind: 'nudge-failed';
+      channelId: string;
+      workspaceId: string;
+      memberId: string;
+      /** The member's cursor when the nudge went out — exclusive lower bound. */
+      fromSeqExclusive: number;
+      /** The channel head when the nudge went out — inclusive upper bound. */
+      toSeqInclusive: number;
+      /** 라이브의 now() — lastAttemptAt 스탬프의 결정론 재현용. */
+      failedAt: number;
+    }
+  | {
+      /**
        * operator-join (설계 §2.1.1) — 오퍼레이터(사람) 좌석 push + 서버-발행 시스템
        * 메시지 append를 **하나의 envelope**로 묶는다. 두 효과를 한 커밋에 실어
        * 원자성을 보장한다: append-only 로그에서는 좌석만 커밋되고 메시지가 실패하는
@@ -331,11 +360,14 @@ export function applyChannelEvent(state: ChannelState, payload: unknown): void {
     case 'ack': {
       const ch = state.channels.find((c) => c.id === p.channelId);
       if (!ch) return;
-      // 수신확인 플립 — pending → delivered만 건드리므로 재적용 no-op(멱등).
+      // 수신확인 플립 — delivered로만 단조 전진하므로 재적용 no-op(멱등).
+      // `target_gone`도 승격 대상이다: 실패한 nudge는 그 시점의 배달 시도에 대한
+      // 기록일 뿐이고, ack는 수신자가 실제로 읽었다는 더 강한 증거다. 승격하지
+      // 않으면 한 번 죽은 pane이 그 메시지를 영구히 미배달로 못박는다.
       for (const m of state.messages[p.channelId] ?? []) {
         if (m.seq > p.uptoSeq) continue;
         for (const entry of m.recipientSnapshot ?? []) {
-          if (entry.workspaceId === p.workspaceId && entry.status === 'pending') {
+          if (entry.workspaceId === p.workspaceId && entry.status !== 'delivered') {
             entry.status = 'delivered';
             entry.lastAttemptAt = p.ackedAt;
             if (m.deliveryStatus !== 'delivered') m.deliveryStatus = 'delivered';
@@ -350,6 +382,29 @@ export function applyChannelEvent(state: ChannelState, payload: unknown): void {
           const current = typeof row.lastReadSeq === 'number' ? row.lastReadSeq : -1;
           if (cursorTarget > current) row.lastReadSeq = cursorTarget;
         }
+      }
+      return;
+    }
+    case 'nudge-failed': {
+      const ch = state.channels.find((c) => c.id === p.channelId);
+      if (!ch) return;
+      // pending → target_gone만 건드린다: 이미 delivered면 ack가 더 강한 증거이고,
+      // 이미 target_gone이면 재적용 no-op(멱등).
+      for (const m of state.messages[p.channelId] ?? []) {
+        if (m.seq <= p.fromSeqExclusive || m.seq > p.toSeqInclusive) continue;
+        let touched = false;
+        for (const entry of m.recipientSnapshot ?? []) {
+          if (entry.workspaceId !== p.workspaceId || entry.memberId !== p.memberId) continue;
+          if (entry.status !== 'pending') continue;
+          entry.status = 'target_gone';
+          entry.lastAttemptAt = p.failedAt;
+          touched = true;
+        }
+        if (!touched) continue;
+        // 메시지 자체는 살아 있는 수신자가 하나도 없을 때만 따라 내려간다
+        // (ack의 "적어도 하나 delivered" 규칙을 뒤집어 읽은 것).
+        const anyLive = (m.recipientSnapshot ?? []).some((e) => e.status !== 'target_gone');
+        if (!anyLive && m.deliveryStatus === 'pending') m.deliveryStatus = 'target_gone';
       }
       return;
     }

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -55,6 +55,27 @@ export interface WakeUnreadEntry {
   unread: number;
   mentionUnread: number;
   trimmedBeforeCursor: number;
+  /**
+   * The oldest unread message's body, supplied by ChannelService. The nudge
+   * carries its first line so the woken agent knows WHAT it is being woken
+   * for — a bare "2 unread, run wmux channel read …" makes every nudge look
+   * identical, and an agent mid-task cannot tell an urgent mention from
+   * routine chatter without spending a turn on the read. Optional: an older
+   * producer that does not supply it still gets the hint-only nudge.
+   */
+  latestBody?: string;
+}
+
+/** Outcome of one nudge attempt, reported back to the producer so a message's
+ *  delivery bookkeeping reflects what actually happened at the PTY. */
+export interface WakeNudgeOutcome {
+  workspaceId: string;
+  channelId: string;
+  memberId: string;
+  sessionId: string;
+  /** False when the write threw — the pane died between target selection and
+   *  the write, so nothing was delivered. */
+  ok: boolean;
 }
 
 export interface WakeSessionView {
@@ -98,6 +119,14 @@ export interface ChannelWakeWorkerDeps {
   /** Broadcast a daemon event (nudge exhaustion → human attention). */
   broadcast(event: Record<string, unknown>): void;
   log(level: 'debug' | 'info' | 'warn', message: string): void;
+  /**
+   * Report what happened at the PTY for one nudge. The push half used to be
+   * write-only: a nudge into a pane that died mid-race was logged and dropped,
+   * and the message it was announcing stayed `pending` forever — a receipt for
+   * a delivery nobody made. Wired to ChannelService, a failure marks that
+   * recipient `target_gone` instead. Optional (test / legacy compatible).
+   */
+  onNudgeOutcome?(outcome: WakeNudgeOutcome): void;
   now(): number;
   /** Test seam: ms between the text write and the Enter write. */
   enterDelayMs?: number;
@@ -154,6 +183,28 @@ const freshTrackerState = (): NudgeTrackerEntry => ({
 const sanitizeLine = (s: string): string =>
   // eslint-disable-next-line no-control-regex
   s.replace(/[\x00-\x1f\x7f]/g, ' ').slice(0, NUDGE_MAX_LEN);
+
+/** Longest body excerpt carried in a nudge. */
+export const BODY_PREVIEW_MAX_LEN = 200;
+
+/**
+ * The first line of a message body, safe to type into a TUI: control
+ * characters (including the newlines that would submit early) become spaces,
+ * runs of whitespace collapse, and the result is capped. Empty for an absent
+ * or blank body, so the caller can drop the segment entirely rather than
+ * appending a dangling separator.
+ */
+export function bodyPreview(body: string | undefined): string {
+  if (!body) return '';
+  const firstLine = body.split(/\r?\n/, 1)[0] ?? '';
+  const clean = firstLine
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f\x7f]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (clean.length <= BODY_PREVIEW_MAX_LEN) return clean;
+  return `${clean.slice(0, BODY_PREVIEW_MAX_LEN - 1)}…`;
+}
 
 export class ChannelWakeWorker {
   private readonly deps: ChannelWakeWorkerDeps;
@@ -316,7 +367,7 @@ export class ChannelWakeWorker {
 
         // A failed write must not burn the nudge budget (G5 spirit: never
         // spend nudges into a void) — retry on a later tick instead.
-        if (!this.inject(target.id, entry)) continue;
+        if (!this.inject(target.id, ws, entry)) continue;
 
         if (wantMention) {
           state.mentionNudges += 1;
@@ -335,16 +386,31 @@ export class ChannelWakeWorker {
    * target selection and the write — a PTY write to a destroyed stream
    * throws synchronously); the caller then keeps the nudge budget intact.
    */
-  private inject(sessionId: string, entry: WakeUnreadEntry): boolean {
+  private inject(sessionId: string, workspaceId: string, entry: WakeUnreadEntry): boolean {
     const mention = entry.mentionUnread > 0 ? ` (${entry.mentionUnread} mention you)` : '';
-    const line = sanitizeLine(
+    const hint = sanitizeLine(
       `[wmux] #${entry.name}: ${entry.unread} unread${mention} — run: wmux channel read ${entry.channelId} --since ${entry.lastReadSeq + 1}`,
     );
+    // The body's first line rides AFTER the hint. Every nudge used to read the
+    // same, so an agent mid-task had to spend a turn on the read just to learn
+    // whether it mattered.
+    const preview = bodyPreview(entry.latestBody);
+    const line = preview ? `${hint} — "${preview}"` : hint;
+    const report = (ok: boolean): void => {
+      this.deps.onNudgeOutcome?.({
+        workspaceId,
+        channelId: entry.channelId,
+        memberId: entry.memberId,
+        sessionId,
+        ok,
+      });
+    };
     this.deps.log('info', `[wake] nudging ${sessionId} for ${entry.channelId}#${entry.memberId} (${entry.unread} unread)`);
     try {
       this.deps.write(sessionId, line);
     } catch (err) {
       this.deps.log('warn', `[wake] nudge write to ${sessionId} failed (session died mid-race?): ${String(err)}`);
+      report(false);
       return false;
     }
     const t = setTimeout(() => {
@@ -352,9 +418,15 @@ export class ChannelWakeWorker {
       try {
         this.deps.write(sessionId, '\r');
       } catch {
-        // session died between the two writes — the pull path still owns
-        // correctness; drop silently.
+        // The session died between the two writes: the hint is stranded
+        // uncommitted in a pane nobody is reading. The pull path still owns
+        // correctness, but the attempt must not be recorded as a delivery.
+        report(false);
+        return;
       }
+      // Committed. This is the only point at which the nudge actually reached
+      // the agent, so it is the only point that may report success.
+      report(true);
     }, this.deps.enterDelayMs ?? ENTER_DELAY_MS);
     t.unref?.();
     this.pendingEnter.add(t);

--- a/src/daemon/channels/channelWakeWorker.ts
+++ b/src/daemon/channels/channelWakeWorker.ts
@@ -56,14 +56,14 @@ export interface WakeUnreadEntry {
   mentionUnread: number;
   trimmedBeforeCursor: number;
   /**
-   * The oldest unread message's body, supplied by ChannelService. The nudge
+   * The OLDEST owed message's body, supplied by ChannelService. The nudge
    * carries its first line so the woken agent knows WHAT it is being woken
    * for — a bare "2 unread, run wmux channel read …" makes every nudge look
    * identical, and an agent mid-task cannot tell an urgent mention from
    * routine chatter without spending a turn on the read. Optional: an older
    * producer that does not supply it still gets the hint-only nudge.
    */
-  latestBody?: string;
+  oldestUnreadBody?: string;
 }
 
 /** Outcome of one nudge attempt, reported back to the producer so a message's
@@ -73,6 +73,14 @@ export interface WakeNudgeOutcome {
   channelId: string;
   memberId: string;
   sessionId: string;
+  /**
+   * The seq range this nudge was announcing: the member's cursor at nudge time
+   * (exclusive) through the channel head (inclusive). Bookkeeping must not
+   * spill outside it — a nudge says nothing about messages the member had
+   * already read, or about ones posted after it went out.
+   */
+  fromSeqExclusive: number;
+  toSeqInclusive: number;
   /** False when the write threw — the pane died between target selection and
    *  the write, so nothing was delivered. */
   ok: boolean;
@@ -188,11 +196,18 @@ const sanitizeLine = (s: string): string =>
 export const BODY_PREVIEW_MAX_LEN = 200;
 
 /**
- * The first line of a message body, safe to type into a TUI: control
- * characters (including the newlines that would submit early) become spaces,
- * runs of whitespace collapse, and the result is capped. Empty for an absent
- * or blank body, so the caller can drop the segment entirely rather than
- * appending a dangling separator.
+ * The first line of a message body, safe to TYPE INTO A LIVE PANE and commit
+ * with an Enter.
+ *
+ * That last clause is the whole problem. This text is written by another
+ * workspace, and it is submitted, not merely displayed. Two escapes matter:
+ * `lastDetectedAgent` can be stale, so the pane may really be a shell, where
+ * `$(…)` and backticks EXECUTE; and a quote can close the agent's own framing.
+ * So the preview keeps letters and punctuation and drops the characters that
+ * change how the line is interpreted — control characters (the newlines that
+ * would submit early included), `$`, backtick, backslash, and both quote
+ * marks. Blank in, blank out, so the caller can drop the segment entirely
+ * instead of appending a dangling separator.
  */
 export function bodyPreview(body: string | undefined): string {
   if (!body) return '';
@@ -200,10 +215,34 @@ export function bodyPreview(body: string | undefined): string {
   const clean = firstLine
     // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x1f\x7f]/g, ' ')
+    // Shell/agent metacharacters. Dropped rather than escaped: an escape is
+    // only correct for the interpreter you assumed, and the point here is that
+    // we do not reliably know which one is on the other end.
+    .replace(/[$`\\"']/g, ' ')
     .replace(/\s+/g, ' ')
     .trim();
   if (clean.length <= BODY_PREVIEW_MAX_LEN) return clean;
   return `${clean.slice(0, BODY_PREVIEW_MAX_LEN - 1)}…`;
+}
+
+/**
+ * Agents whose pane is a TUI chat box, where a pasted line lands in a composer
+ * rather than a command interpreter. The body preview rides only into these:
+ * an unknown or absent agent means the pane may be a bare shell, and a bare
+ * shell would RUN the other workspace's text.
+ */
+const BODY_PREVIEW_AGENTS: ReadonlySet<string> = new Set([
+  'claude',
+  'codex',
+  'gemini',
+  'aider',
+  'opencode',
+  'copilot',
+]);
+
+/** Whether a nudge into this pane may carry the message body at all. */
+export function mayCarryBody(detectedAgent: string | undefined): boolean {
+  return !!detectedAgent && BODY_PREVIEW_AGENTS.has(detectedAgent);
 }
 
 export class ChannelWakeWorker {
@@ -367,7 +406,7 @@ export class ChannelWakeWorker {
 
         // A failed write must not burn the nudge budget (G5 spirit: never
         // spend nudges into a void) — retry on a later tick instead.
-        if (!this.inject(target.id, ws, entry)) continue;
+        if (!this.inject(target.id, ws, entry, target)) continue;
 
         if (wantMention) {
           state.mentionNudges += 1;
@@ -386,22 +425,30 @@ export class ChannelWakeWorker {
    * target selection and the write — a PTY write to a destroyed stream
    * throws synchronously); the caller then keeps the nudge budget intact.
    */
-  private inject(sessionId: string, workspaceId: string, entry: WakeUnreadEntry): boolean {
+  private inject(sessionId: string, workspaceId: string, entry: WakeUnreadEntry, target: WakeSessionView): boolean {
     const mention = entry.mentionUnread > 0 ? ` (${entry.mentionUnread} mention you)` : '';
-    const hint = sanitizeLine(
-      `[wmux] #${entry.name}: ${entry.unread} unread${mention} — run: wmux channel read ${entry.channelId} --since ${entry.lastReadSeq + 1}`,
-    );
+    const hint = `[wmux] #${entry.name}: ${entry.unread} unread${mention} — run: wmux channel read ${entry.channelId} --since ${entry.lastReadSeq + 1}`;
     // The body's first line rides AFTER the hint. Every nudge used to read the
     // same, so an agent mid-task had to spend a turn on the read just to learn
     // whether it mattered.
-    const preview = bodyPreview(entry.latestBody);
-    const line = preview ? `${hint} — "${preview}"` : hint;
+    //
+    // But ONLY into a pane we can name as an agent TUI. `lastDetectedAgent` can
+    // be stale — the agent exits and the shell stays — and this text comes from
+    // another workspace and is committed with an Enter, so a bare shell would
+    // run it. The hint is ours and always safe; the body is not.
+    const preview = mayCarryBody(target.lastDetectedAgent) ? bodyPreview(entry.oldestUnreadBody) : '';
+    // sanitize + cap the FINAL line, not its pieces: the cap has to bound what
+    // actually reaches the PTY, and concatenation is exactly where a bounded
+    // hint and a bounded preview stop being bounded.
+    const line = sanitizeLine(preview ? `${hint} — ${preview}` : hint);
     const report = (ok: boolean): void => {
       this.deps.onNudgeOutcome?.({
         workspaceId,
         channelId: entry.channelId,
         memberId: entry.memberId,
         sessionId,
+        fromSeqExclusive: entry.lastReadSeq,
+        toSeqInclusive: entry.headSeq,
         ok,
       });
     };

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -5679,6 +5679,15 @@ async function main(): Promise<void> {
   channelWakeWorkerRef = new ChannelWakeWorker({
     memberWorkspaces: () => channelService.memberWorkspaces(),
     unreadFor: (ws) => channelService.unreadFor(ws),
+    // A nudge that never landed must not leave the message it announced sitting
+    // at 'pending' forever — the push half used to drop that outcome on the floor.
+    onNudgeOutcome: (outcome) =>
+      channelService.noteNudgeOutcome({
+        channelId: outcome.channelId,
+        workspaceId: outcome.workspaceId,
+        memberId: outcome.memberId,
+        ok: outcome.ok,
+      }),
     // R2: the registry supplies the member's last PTY coordinate even after
     // restart backfill marks it stale. listLiveSessions below is the daemon-
     // owned liveness authority: only attached/detached sessions enter the

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -5680,14 +5680,21 @@ async function main(): Promise<void> {
     memberWorkspaces: () => channelService.memberWorkspaces(),
     unreadFor: (ws) => channelService.unreadFor(ws),
     // A nudge that never landed must not leave the message it announced sitting
-    // at 'pending' forever — the push half used to drop that outcome on the floor.
-    onNudgeOutcome: (outcome) =>
-      channelService.noteNudgeOutcome({
-        channelId: outcome.channelId,
-        workspaceId: outcome.workspaceId,
-        memberId: outcome.memberId,
-        ok: outcome.ok,
-      }),
+    // at 'pending' forever — the push half used to drop that outcome on the
+    // floor. Fire-and-forget by contract: the wake tick must not wait on a
+    // channel lock, and a failure here is bookkeeping, never delivery.
+    onNudgeOutcome: (outcome) => {
+      void channelService
+        .noteNudgeOutcome({
+          channelId: outcome.channelId,
+          workspaceId: outcome.workspaceId,
+          memberId: outcome.memberId,
+          fromSeqExclusive: outcome.fromSeqExclusive,
+          toSeqInclusive: outcome.toSeqInclusive,
+          ok: outcome.ok,
+        })
+        .catch(() => undefined);
+    },
     // R2: the registry supplies the member's last PTY coordinate even after
     // restart backfill marks it stale. listLiveSessions below is the daemon-
     // owned liveness authority: only attached/detached sessions enter the

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
@@ -349,6 +349,36 @@ describe('a2a.task.send — commander binding is stamped, never trusted from the
     );
   });
 
+  // The relaxation is keyed on the binding naming the caller's OWN workspace,
+  // so a brain that could still name a different `workspaceId` on the wire
+  // would carry its privilege into someone else's.
+  it('pins workspaceId to the validated binding, overriding what the caller named', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true });
+    const send = captureTaskSend(makeWorker());
+
+    await send(
+      { workspaceId: 'ws-victim', to: 'ws-victim', message: 'do this' },
+      { origin: 'local', commanderWorkspace: 'ws-brain' } as unknown as RpcContext,
+    );
+
+    const forwarded = sendToRendererMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(forwarded.workspaceId).toBe('ws-brain');
+    expect(forwarded.commanderWorkspaceId).toBe('ws-brain');
+  });
+
+  it('leaves workspaceId alone for an ordinary caller', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true });
+    const send = captureTaskSend(makeWorker());
+
+    await send(
+      { workspaceId: 'ws-a', to: 'ws-b', message: 'hi' },
+      { origin: 'local' } as unknown as RpcContext,
+    );
+
+    const forwarded = sendToRendererMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(forwarded.workspaceId).toBe('ws-a');
+  });
+
   it('drops a caller-supplied commanderWorkspaceId when there is no validated token', async () => {
     sendToRendererMock.mockResolvedValueOnce({ ok: true });
     const send = captureTaskSend(makeWorker());

--- a/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/a2a.rpc.test.ts
@@ -325,3 +325,53 @@ describe('a2a.task.cancel 델타: terminal no-op은 거짓 cancelled 이벤트�
     expect((cancelSends[0][2] as { daemonCommitted?: boolean }).daemonCommitted).toBe(true);
   });
 });
+
+// The brain owns no pane, so the renderer's reply-delivery guards suppressed
+// every brain→worker nudge as an unverifiable sender. Main is the only place
+// that knows the caller is a validated commander, so it must forward that
+// binding — and only ever its own, never one the caller typed.
+describe('a2a.task.send — commander binding is stamped, never trusted from the wire', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('forwards the validated commander workspace to the renderer', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true });
+    const send = captureTaskSend(makeWorker());
+
+    await send(
+      { workspaceId: 'ws-brain', to: 'ws-brain', message: 'status?' },
+      { origin: 'local', commanderWorkspace: 'ws-brain' } as unknown as RpcContext,
+    );
+
+    expect(sendToRendererMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'a2a.task.send',
+      expect.objectContaining({ commanderWorkspaceId: 'ws-brain' }),
+    );
+  });
+
+  it('drops a caller-supplied commanderWorkspaceId when there is no validated token', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true });
+    const send = captureTaskSend(makeWorker());
+
+    await send(
+      { workspaceId: 'ws-a', to: 'ws-b', message: 'hi', commanderWorkspaceId: 'ws-victim' },
+      { origin: 'local' } as unknown as RpcContext,
+    );
+
+    const forwarded = sendToRendererMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(forwarded).not.toHaveProperty('commanderWorkspaceId');
+  });
+
+  it('a validated token overrides a forged claim rather than merging with it', async () => {
+    sendToRendererMock.mockResolvedValueOnce({ ok: true });
+    const send = captureTaskSend(makeWorker());
+
+    await send(
+      { workspaceId: 'ws-brain', to: 'ws-b', message: 'hi', commanderWorkspaceId: 'ws-victim' },
+      { origin: 'local', commanderWorkspace: 'ws-brain' } as unknown as RpcContext,
+    );
+
+    const forwarded = sendToRendererMock.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(forwarded.commanderWorkspaceId).toBe('ws-brain');
+  });
+});

--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -8,7 +8,8 @@ import {
   decideTerminalOmittedTarget,
   isSessionTerminatingInput,
   awaitSubmitReceipt,
-  composerAdvanced,
+  composerCleared,
+  needleInComposer,
   isTurnStart,
   rowFromBottom,
   submitNeedle,
@@ -475,14 +476,20 @@ describe('input.send — submit sends text and Enter as two separate writes', ()
     }
   });
 
-  it('submits only once when the text already ends in \\r', async () => {
+  // A trailing \r IS the submit, so it is stripped and the normal split write
+  // runs — exactly one Enter, and the receipt path still applies. Passing the
+  // fused chunk straight through was the shape that skipped the receipt.
+  it('splits a text that already ends in \\r rather than passing it through fused', async () => {
     const { router, writeMock } = setupWithWrite();
     await router.dispatch({
       id: '3',
       method: 'input.send',
       params: { text: 'already\r', ptyId: 'pty-a', workspaceId: 'ws-self', submit: true },
     });
-    expect(writeMock.mock.calls).toEqual([['pty-a', 'already\r']]);
+    expect(writeMock.mock.calls).toEqual([
+      ['pty-a', 'already'],
+      ['pty-a', '\r'],
+    ]);
   });
 
   it('writes a single chunk with no \\r when submit is not set', async () => {
@@ -784,50 +791,87 @@ describe('input.send refuses to end a gate-held pane (#733)', () => {
 // the two signals that DO prove the pane moved, and — the point of the whole
 // change — pin that raw byte activity does NOT.
 describe('input.send — submit receipt', () => {
-  // A fake PTY screen the test drives frame by frame. Frames are consumed in
-  // order; the last one repeats, so a test can say "moves at poll 3".
-  function fakeProbe(frames: string[], statuses: Array<string | null>): {
-    probe: SubmitProbe;
-    reads: number;
-  } {
-    const state = { reads: 0 };
-    const at = <T,>(arr: T[], i: number): T => arr[Math.min(i, arr.length - 1)]!;
+  const NEEDLE = submitNeedle('write me a haiku');
+
+  /** A clock the wait drives itself: every sleep advances it, so the wall-clock
+   *  budget is exercised deterministically and the suite stays instant. */
+  function fakeClock(startMs = 1_000) {
+    let t = startMs;
     return {
-      probe: {
-        readScreen: () => Promise.resolve(at(frames, state.reads)),
-        readAgentStatus: () => {
-          const s = at(statuses, state.reads);
-          state.reads++;
-          return Promise.resolve(s);
-        },
+      now: (): number => t,
+      sleep: (ms: number): Promise<void> => {
+        t += ms;
+        return Promise.resolve();
       },
-      reads: state.reads,
     };
   }
 
-  const noSleep = (): Promise<void> => Promise.resolve();
+  /**
+   * A fake PTY the test drives frame by frame. Frames are consumed in order and
+   * the last one repeats, so a test can say "moves at poll 3". Statuses carry
+   * the snapshot timestamp the real mirror supplies — `stale` marks a reading
+   * from BEFORE the Enter, which must never count.
+   */
+  function fakeProbe(
+    frames: string[],
+    statuses: Array<{ status: string; ts: number } | null>,
+  ): { probe: SubmitProbe; screenReads: () => number } {
+    const state = { polls: 0, screens: 0 };
+    const at = <T,>(arr: T[], i: number): T => arr[Math.min(i, arr.length - 1)]!;
+    return {
+      probe: {
+        readScreen: () => {
+          const frame = at(frames, state.screens);
+          state.screens++;
+          return Promise.resolve(frame);
+        },
+        readAgentStatus: () => {
+          const s = at(statuses, state.polls);
+          state.polls++;
+          return Promise.resolve(s);
+        },
+      },
+      screenReads: () => state.screens,
+    };
+  }
+
+  const ENTER_AT = 5_000;
+  /** A reading the mirror pushed AFTER our Enter — the only kind that counts. */
+  const fresh = (status: string) => ({ status, ts: ENTER_AT + 10 });
+  /** A reading from before the Enter: our own echo, byte-promoted (#935). */
+  const stale = (status: string) => ({ status, ts: ENTER_AT - 10 });
+
+  const waitOpts = (over: Record<string, unknown> = {}) => {
+    const clock = fakeClock(ENTER_AT);
+    return { windowMs: 200, pollMs: 50, enterAt: ENTER_AT, ...clock, ...over };
+  };
 
   // The composer holds the prompt at the bottom; the pane's footer sits below.
   const COMPOSER = ['claude> ready', '', '│ > write me a haiku │', '  ? for shortcuts'].join('\n');
   // After the submit Claude Code re-renders the prompt into the TRANSCRIPT and
-  // empties the composer — the text is STILL on screen, three rows higher.
+  // empties the composer. The text is STILL on screen — but well ABOVE the
+  // composer area, which is the only thing that counts as cleared.
   const SUBMITTED = [
     '> write me a haiku',
     '  thinking...',
+    '  · reading files',
+    '  · writing',
+    '',
+    '',
     '',
     '│ >                  │',
     '  ? for shortcuts',
   ].join('\n');
 
-  it('accepts on a turn start reported for the pty', async () => {
-    const { probe } = fakeProbe([COMPOSER], ['idle', 'running']);
+  it('accepts on a turn start reported AFTER the Enter', async () => {
+    const { probe } = fakeProbe([COMPOSER], [fresh('running')]);
     const resend = vi.fn();
     const receipt = await awaitSubmitReceipt(
       probe,
-      submitNeedle('write me a haiku'),
+      NEEDLE,
       { screen: COMPOSER, agentStatus: 'idle' },
       resend,
-      { windowMs: 200, pollMs: 50, sleep: noSleep },
+      waitOpts(),
     );
     expect(receipt.accepted).toBe(true);
     expect(receipt.signal).toBe('turn_start');
@@ -835,14 +879,42 @@ describe('input.send — submit receipt', () => {
     expect(resend).not.toHaveBeenCalled();
   });
 
-  it('accepts when the composer line clears even with no status signal', async () => {
-    const { probe } = fakeProbe([COMPOSER, SUBMITTED], [null]);
+  // #935 — agentStatus is byte-promoted, so the pane echoing our own text can
+  // flip it to running. A snapshot from before the \r must not sign for it.
+  it('ignores a running status whose snapshot predates the Enter', async () => {
+    const { probe } = fakeProbe([COMPOSER], [stale('running')]);
     const receipt = await awaitSubmitReceipt(
       probe,
-      submitNeedle('write me a haiku'),
+      NEEDLE,
+      { screen: COMPOSER, agentStatus: 'idle' },
+      vi.fn(),
+      waitOpts(),
+    );
+    expect(receipt.accepted).toBe(false);
+    expect(receipt.signal).toBe('none');
+  });
+
+  it('checks the status BEFORE the first screen poll (a hook-fast turn costs no IPC)', async () => {
+    const p = fakeProbe([COMPOSER], [fresh('running')]);
+    const receipt = await awaitSubmitReceipt(
+      p.probe,
+      NEEDLE,
+      { screen: COMPOSER, agentStatus: 'idle' },
+      vi.fn(),
+      waitOpts(),
+    );
+    expect(receipt.accepted).toBe(true);
+    expect(p.screenReads()).toBe(0);
+  });
+
+  it('accepts when the text LEAVES the composer area, with no status signal', async () => {
+    const { probe } = fakeProbe([SUBMITTED], [null]);
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      NEEDLE,
       { screen: COMPOSER, agentStatus: null },
       vi.fn(),
-      { windowMs: 200, pollMs: 50, sleep: noSleep },
+      waitOpts(),
     );
     expect(receipt.accepted).toBe(true);
     expect(receipt.signal).toBe('composer_cleared');
@@ -853,14 +925,14 @@ describe('input.send — submit receipt', () => {
   it('does NOT accept on echo-only byte activity, and retries the Enter once', async () => {
     const echo1 = ['claude> ready', '', '│ > write me a haiku│', '  ? for shortcuts'].join('\n');
     const echo2 = ['claude> ready', '', '│ > write me a haiku ▌│', '  ? for shortcuts'].join('\n');
-    const { probe } = fakeProbe([echo1, echo2], ['idle']);
+    const { probe } = fakeProbe([echo1, echo2], [fresh('idle')]);
     const resend = vi.fn();
     const receipt = await awaitSubmitReceipt(
       probe,
-      submitNeedle('write me a haiku'),
+      NEEDLE,
       { screen: COMPOSER, agentStatus: 'idle' },
       resend,
-      { windowMs: 100, pollMs: 50, sleep: noSleep },
+      waitOpts({ windowMs: 100 }),
     );
     expect(receipt.accepted).toBe(false);
     expect(receipt.signal).toBe('none');
@@ -869,17 +941,38 @@ describe('input.send — submit receipt', () => {
     expect(receipt.screenTail).toContain('write me a haiku');
   });
 
+  // A soft newline pushed the text up one row and it is STILL uncommitted —
+  // the precise failure the receipt exists to catch, so "moved" is not enough.
+  it('does NOT accept when the needle merely moves up inside the composer', async () => {
+    const grown = [
+      'claude> ready',
+      '',
+      '│ > write me a haiku │',
+      '│                    │',
+      '  ? for shortcuts',
+    ].join('\n');
+    const { probe } = fakeProbe([grown], [fresh('idle')]);
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      NEEDLE,
+      { screen: COMPOSER, agentStatus: 'idle' },
+      vi.fn(),
+      waitOpts({ windowMs: 100 }),
+    );
+    expect(receipt.accepted).toBe(false);
+  });
+
   it('accepts on the retry when the turn starts late', async () => {
-    // idle for the whole first window (4 polls at 50ms), running after.
-    const statuses = ['idle', 'idle', 'idle', 'idle', 'running'];
+    // Nothing for the whole first window, running only after the re-send.
+    const statuses = [null, null, null, null, null, fresh('running')];
     const { probe } = fakeProbe([COMPOSER], statuses);
     const resend = vi.fn();
     const receipt = await awaitSubmitReceipt(
       probe,
-      submitNeedle('write me a haiku'),
+      NEEDLE,
       { screen: COMPOSER, agentStatus: 'idle' },
       resend,
-      { windowMs: 200, pollMs: 50, sleep: noSleep },
+      waitOpts(),
     );
     expect(receipt.accepted).toBe(true);
     expect(receipt.retried).toBe(true);
@@ -889,9 +982,13 @@ describe('input.send — submit receipt', () => {
   it('reports unobservable instead of guessing when the pane cannot be read', async () => {
     const { probe } = fakeProbe([''], [null]);
     const resend = vi.fn();
-    const receipt = await awaitSubmitReceipt(probe, 'x', { screen: '', agentStatus: null }, resend, {
-      sleep: noSleep,
-    });
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      'x',
+      { screen: '', agentStatus: null },
+      resend,
+      waitOpts(),
+    );
     expect(receipt).toEqual({
       accepted: false,
       agentStatusAfter: null,
@@ -901,51 +998,141 @@ describe('input.send — submit receipt', () => {
     expect(resend).not.toHaveBeenCalled();
   });
 
+  // A blind second Enter presses whatever the pane is showing — a confirmation
+  // dialog's default, say. If we never saw our text in the composer we have no
+  // idea what is down there, so we do not press again.
+  it('never re-sends the Enter when the needle was not in the composer', async () => {
+    const dialog = ['Overwrite existing file?', '  [Y] yes   [n] no'].join('\n');
+    const { probe } = fakeProbe([dialog], [fresh('idle')]);
+    const resend = vi.fn();
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      NEEDLE,
+      { screen: dialog, agentStatus: 'idle' },
+      resend,
+      waitOpts({ windowMs: 100 }),
+    );
+    expect(resend).not.toHaveBeenCalled();
+    expect(receipt.retried).toBe(false);
+    expect(receipt.signal).toBe('unobservable');
+  });
+
+  it('a PTY that dies before the retry yields accepted:false, not a thrown RPC', async () => {
+    const { probe } = fakeProbe([COMPOSER], [fresh('idle')]);
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      NEEDLE,
+      { screen: COMPOSER, agentStatus: 'idle' },
+      () => {
+        throw new Error('write EPIPE');
+      },
+      waitOpts({ windowMs: 100 }),
+    );
+    expect(receipt.accepted).toBe(false);
+    expect(receipt.retried).toBe(true);
+  });
+
+  it('stops at the total ceiling even when every window would allow more', async () => {
+    const { probe } = fakeProbe([COMPOSER], [fresh('idle')]);
+    const clock = fakeClock(ENTER_AT);
+    await awaitSubmitReceipt(probe, NEEDLE, { screen: COMPOSER, agentStatus: 'idle' }, vi.fn(), {
+      windowMs: 5_000,
+      pollMs: 50,
+      maxTotalMs: 200,
+      enterAt: ENTER_AT,
+      ...clock,
+    });
+    // The ceiling, not the window, decided when to stop.
+    expect(clock.now() - ENTER_AT).toBeLessThanOrEqual(250);
+  });
+
   it('rowFromBottom finds the LAST occurrence and measures from the bottom', () => {
-    expect(rowFromBottom(COMPOSER, submitNeedle('write me a haiku'))).toBe(1);
-    expect(rowFromBottom(SUBMITTED, submitNeedle('write me a haiku'))).toBe(4);
+    expect(rowFromBottom(COMPOSER, NEEDLE)).toBe(1);
+    expect(rowFromBottom(SUBMITTED, NEEDLE)).toBe(8);
     expect(rowFromBottom(COMPOSER, 'nowhere')).toBe(-1);
   });
 
-  it('composerAdvanced refuses to guess when the text was never on the input line', () => {
+  it('needleInComposer is the bottom region only', () => {
+    expect(needleInComposer(COMPOSER, NEEDLE)).toBe(true);
+    // On screen, but up in the transcript — not the input line.
+    expect(needleInComposer(SUBMITTED, NEEDLE)).toBe(false);
+    expect(needleInComposer(COMPOSER, 'nowhere')).toBe(false);
+  });
+
+  it('composerCleared refuses to guess when the text was never on the input line', () => {
     // Not visible before → we have no idea where the composer is; not a receipt.
-    expect(composerAdvanced('unrelated', 'still unrelated', 'ghost')).toBe(false);
+    expect(composerCleared('unrelated', 'still unrelated', 'ghost')).toBe(false);
   });
 
   it('isTurnStart only fires on a move INTO a turn', () => {
     expect(isTurnStart('idle', 'running')).toBe(true);
-    expect(isTurnStart('idle', 'awaiting_input')).toBe(true);
+    expect(isTurnStart('waiting', 'running')).toBe(true);
+    expect(isTurnStart(null, 'running')).toBe(true);
+    // A PREVIOUS turn ending inside our window, not ours beginning.
+    expect(isTurnStart('running', 'awaiting_input')).toBe(false);
+    expect(isTurnStart('idle', 'awaiting_input')).toBe(false);
     expect(isTurnStart('running', 'running')).toBe(false);
     // decay, not a turn start
     expect(isTurnStart('running', 'idle')).toBe(false);
     expect(isTurnStart('idle', null)).toBe(false);
   });
 
-  it('the RPC result carries accepted + agentStatusAfter, and submit:false is never accepted', async () => {
-    const pty = { get: vi.fn(() => ({ id: 'x' })), write: vi.fn() } as unknown as PTYManager;
-    const router = new RpcRouter();
-    registerInputRpc(router, pty, () => fakeWindow);
-    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
-      if (method === 'input.findOwnerWorkspace') return Promise.resolve({ workspaceId: 'ws-self' });
-      return Promise.resolve(null);
+  describe('the RPC result', () => {
+    function rpcSetup() {
+      const writeMock = vi.fn();
+      const pty = { get: vi.fn(() => ({ id: 'x' })), write: writeMock } as unknown as PTYManager;
+      const router = new RpcRouter();
+      registerInputRpc(router, pty, () => fakeWindow);
+      sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+        if (method === 'input.findOwnerWorkspace') return Promise.resolve({ workspaceId: 'ws-self' });
+        return Promise.resolve(null);
+      });
+      return { router, writeMock };
+    }
+
+    it('omits accepted entirely when no receipt was attempted (submit:false)', async () => {
+      const { router } = rpcSetup();
+      const res = await router.dispatch({
+        id: 'r1',
+        method: 'input.send',
+        params: { text: 'hello', ptyId: 'pty-a', workspaceId: 'ws-self' },
+      });
+      if (!res.ok) throw new Error(res.error);
+      // Absent, not false: "we did not look" is a different claim from "we
+      // looked and it did not land".
+      expect(res.result).toMatchObject({ submitted: false });
+      expect(res.result).not.toHaveProperty('accepted');
     });
 
-    const noSubmit = await router.dispatch({
-      id: 'r1',
-      method: 'input.send',
-      params: { text: 'hello', ptyId: 'pty-a', workspaceId: 'ws-self' },
+    it('carries accepted + the receipt signal when a submit was attempted', async () => {
+      const { router } = rpcSetup();
+      const res = await router.dispatch({
+        id: 'r2',
+        method: 'input.send',
+        params: { text: 'hello', ptyId: 'pty-a', workspaceId: 'ws-self', submit: true },
+      });
+      if (!res.ok) throw new Error(res.error);
+      // `submitted` says an Enter was written; `accepted` stays false because
+      // nothing observable confirmed it — the two are no longer the same claim.
+      expect(res.result).toMatchObject({ submitted: true, accepted: false });
     });
-    if (!noSubmit.ok) throw new Error(noSubmit.error);
-    expect(noSubmit.result).toMatchObject({ submitted: false, accepted: false, agentStatusAfter: null });
 
-    const submitted = await router.dispatch({
-      id: 'r2',
-      method: 'input.send',
-      params: { text: 'hello', ptyId: 'pty-a', workspaceId: 'ws-self', submit: true },
+    // The trailing-\r shape used to skip the split write AND the receipt, then
+    // report submitted:true with a hard accepted:false — the same false receipt
+    // in a different hat.
+    it('treats a trailing \\r as the submit: split write, and a receipt is attempted', async () => {
+      const { router, writeMock } = rpcSetup();
+      const res = await router.dispatch({
+        id: 'r3',
+        method: 'input.send',
+        params: { text: 'already\r', ptyId: 'pty-a', workspaceId: 'ws-self', submit: true },
+      });
+      if (!res.ok) throw new Error(res.error);
+      expect(writeMock.mock.calls).toEqual([
+        ['pty-a', 'already'],
+        ['pty-a', '\r'],
+      ]);
+      expect(res.result).toHaveProperty('receiptSignal');
     });
-    if (!submitted.ok) throw new Error(submitted.error);
-    // `submitted` says an Enter was written; `accepted` stays false because
-    // nothing observable confirmed it — the two are no longer the same claim.
-    expect(submitted.result).toMatchObject({ submitted: true, accepted: false });
   });
 });

--- a/src/main/pipe/handlers/__tests__/input.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/input.rpc.test.ts
@@ -3,9 +3,19 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { BrowserWindow } from 'electron';
 import { RpcRouter } from '../../RpcRouter';
-import { registerInputRpc, decideTerminalOmittedTarget, isSessionTerminatingInput } from '../input.rpc';
+import {
+  registerInputRpc,
+  decideTerminalOmittedTarget,
+  isSessionTerminatingInput,
+  awaitSubmitReceipt,
+  composerAdvanced,
+  isTurnStart,
+  rowFromBottom,
+  submitNeedle,
+  type SubmitProbe,
+  type RoleBindingResolver,
+} from '../input.rpc';
 import { noteGateVerdict, resetGateVerdicts } from '../../../deck/stopGateState';
-import type { RoleBindingResolver } from '../input.rpc';
 import type { PTYManager } from '../../../pty/PTYManager';
 import type { RoleBinding } from '../../../../shared/orchestratorRole';
 
@@ -762,5 +772,180 @@ describe('input.send refuses to end a gate-held pane (#733)', () => {
     const res = await send(router, 'exit', 'pty-held');
     expect(res.ok).toBe(true);
     expect(writeMock).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Submit receipt (orchestrator track) — `submitted` was never a receipt.
+// ---------------------------------------------------------------------------
+// The handler used to write text, wait 20ms, write \r and report
+// `submitted:true`. Nothing verified the \r landed, so an orchestrator read a
+// prompt that was still sitting in the composer as "delivered". These tests pin
+// the two signals that DO prove the pane moved, and — the point of the whole
+// change — pin that raw byte activity does NOT.
+describe('input.send — submit receipt', () => {
+  // A fake PTY screen the test drives frame by frame. Frames are consumed in
+  // order; the last one repeats, so a test can say "moves at poll 3".
+  function fakeProbe(frames: string[], statuses: Array<string | null>): {
+    probe: SubmitProbe;
+    reads: number;
+  } {
+    const state = { reads: 0 };
+    const at = <T,>(arr: T[], i: number): T => arr[Math.min(i, arr.length - 1)]!;
+    return {
+      probe: {
+        readScreen: () => Promise.resolve(at(frames, state.reads)),
+        readAgentStatus: () => {
+          const s = at(statuses, state.reads);
+          state.reads++;
+          return Promise.resolve(s);
+        },
+      },
+      reads: state.reads,
+    };
+  }
+
+  const noSleep = (): Promise<void> => Promise.resolve();
+
+  // The composer holds the prompt at the bottom; the pane's footer sits below.
+  const COMPOSER = ['claude> ready', '', '│ > write me a haiku │', '  ? for shortcuts'].join('\n');
+  // After the submit Claude Code re-renders the prompt into the TRANSCRIPT and
+  // empties the composer — the text is STILL on screen, three rows higher.
+  const SUBMITTED = [
+    '> write me a haiku',
+    '  thinking...',
+    '',
+    '│ >                  │',
+    '  ? for shortcuts',
+  ].join('\n');
+
+  it('accepts on a turn start reported for the pty', async () => {
+    const { probe } = fakeProbe([COMPOSER], ['idle', 'running']);
+    const resend = vi.fn();
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      submitNeedle('write me a haiku'),
+      { screen: COMPOSER, agentStatus: 'idle' },
+      resend,
+      { windowMs: 200, pollMs: 50, sleep: noSleep },
+    );
+    expect(receipt.accepted).toBe(true);
+    expect(receipt.signal).toBe('turn_start');
+    expect(receipt.agentStatusAfter).toBe('running');
+    expect(resend).not.toHaveBeenCalled();
+  });
+
+  it('accepts when the composer line clears even with no status signal', async () => {
+    const { probe } = fakeProbe([COMPOSER, SUBMITTED], [null]);
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      submitNeedle('write me a haiku'),
+      { screen: COMPOSER, agentStatus: null },
+      vi.fn(),
+      { windowMs: 200, pollMs: 50, sleep: noSleep },
+    );
+    expect(receipt.accepted).toBe(true);
+    expect(receipt.signal).toBe('composer_cleared');
+  });
+
+  // THE regression this change exists for: bytes arrived (the TUI repainted its
+  // box and cursor) but nothing was committed. Byte activity is not a receipt.
+  it('does NOT accept on echo-only byte activity, and retries the Enter once', async () => {
+    const echo1 = ['claude> ready', '', '│ > write me a haiku│', '  ? for shortcuts'].join('\n');
+    const echo2 = ['claude> ready', '', '│ > write me a haiku ▌│', '  ? for shortcuts'].join('\n');
+    const { probe } = fakeProbe([echo1, echo2], ['idle']);
+    const resend = vi.fn();
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      submitNeedle('write me a haiku'),
+      { screen: COMPOSER, agentStatus: 'idle' },
+      resend,
+      { windowMs: 100, pollMs: 50, sleep: noSleep },
+    );
+    expect(receipt.accepted).toBe(false);
+    expect(receipt.signal).toBe('none');
+    expect(resend).toHaveBeenCalledTimes(1);
+    // The caller gets the pane's own words back instead of a bare false.
+    expect(receipt.screenTail).toContain('write me a haiku');
+  });
+
+  it('accepts on the retry when the turn starts late', async () => {
+    // idle for the whole first window (4 polls at 50ms), running after.
+    const statuses = ['idle', 'idle', 'idle', 'idle', 'running'];
+    const { probe } = fakeProbe([COMPOSER], statuses);
+    const resend = vi.fn();
+    const receipt = await awaitSubmitReceipt(
+      probe,
+      submitNeedle('write me a haiku'),
+      { screen: COMPOSER, agentStatus: 'idle' },
+      resend,
+      { windowMs: 200, pollMs: 50, sleep: noSleep },
+    );
+    expect(receipt.accepted).toBe(true);
+    expect(receipt.retried).toBe(true);
+    expect(resend).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports unobservable instead of guessing when the pane cannot be read', async () => {
+    const { probe } = fakeProbe([''], [null]);
+    const resend = vi.fn();
+    const receipt = await awaitSubmitReceipt(probe, 'x', { screen: '', agentStatus: null }, resend, {
+      sleep: noSleep,
+    });
+    expect(receipt).toEqual({
+      accepted: false,
+      agentStatusAfter: null,
+      retried: false,
+      signal: 'unobservable',
+    });
+    expect(resend).not.toHaveBeenCalled();
+  });
+
+  it('rowFromBottom finds the LAST occurrence and measures from the bottom', () => {
+    expect(rowFromBottom(COMPOSER, submitNeedle('write me a haiku'))).toBe(1);
+    expect(rowFromBottom(SUBMITTED, submitNeedle('write me a haiku'))).toBe(4);
+    expect(rowFromBottom(COMPOSER, 'nowhere')).toBe(-1);
+  });
+
+  it('composerAdvanced refuses to guess when the text was never on the input line', () => {
+    // Not visible before → we have no idea where the composer is; not a receipt.
+    expect(composerAdvanced('unrelated', 'still unrelated', 'ghost')).toBe(false);
+  });
+
+  it('isTurnStart only fires on a move INTO a turn', () => {
+    expect(isTurnStart('idle', 'running')).toBe(true);
+    expect(isTurnStart('idle', 'awaiting_input')).toBe(true);
+    expect(isTurnStart('running', 'running')).toBe(false);
+    // decay, not a turn start
+    expect(isTurnStart('running', 'idle')).toBe(false);
+    expect(isTurnStart('idle', null)).toBe(false);
+  });
+
+  it('the RPC result carries accepted + agentStatusAfter, and submit:false is never accepted', async () => {
+    const pty = { get: vi.fn(() => ({ id: 'x' })), write: vi.fn() } as unknown as PTYManager;
+    const router = new RpcRouter();
+    registerInputRpc(router, pty, () => fakeWindow);
+    sendToRendererMock.mockImplementation((_w: unknown, method: string) => {
+      if (method === 'input.findOwnerWorkspace') return Promise.resolve({ workspaceId: 'ws-self' });
+      return Promise.resolve(null);
+    });
+
+    const noSubmit = await router.dispatch({
+      id: 'r1',
+      method: 'input.send',
+      params: { text: 'hello', ptyId: 'pty-a', workspaceId: 'ws-self' },
+    });
+    if (!noSubmit.ok) throw new Error(noSubmit.error);
+    expect(noSubmit.result).toMatchObject({ submitted: false, accepted: false, agentStatusAfter: null });
+
+    const submitted = await router.dispatch({
+      id: 'r2',
+      method: 'input.send',
+      params: { text: 'hello', ptyId: 'pty-a', workspaceId: 'ws-self', submit: true },
+    });
+    if (!submitted.ok) throw new Error(submitted.error);
+    // `submitted` says an Enter was written; `accepted` stays false because
+    // nothing observable confirmed it — the two are no longer the same claim.
+    expect(submitted.result).toMatchObject({ submitted: true, accepted: false });
   });
 });

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -407,7 +407,15 @@ export function registerA2aRpc(
   // 해석·승인 게이트 등 렌더러 UI 반응성 로직은 그대로). 워커 spawn **전에**
   // await — 이후 전이(working/completed)가 데몬 게이트에서 태스크를 찾도록.
   router.register('a2a.task.send', async (params, ctx) => {
-    const result = await sendToRenderer(getWindow, 'a2a.task.send', params);
+    // Forward the VALIDATED commander binding (RpcRouter set it from the
+    // per-spawn token; never read from the wire, so any caller-supplied value
+    // is dropped first). The renderer's reply-delivery guards need it: an
+    // orchestrator brain owns no pane, so without this every brain→worker nudge
+    // in its own workspace is suppressed as an unverifiable sender.
+    const sendParams: Record<string, unknown> = { ...params };
+    delete sendParams.commanderWorkspaceId;
+    if (ctx?.commanderWorkspace) sendParams.commanderWorkspaceId = ctx.commanderWorkspace;
+    const result = await sendToRenderer(getWindow, 'a2a.task.send', sendParams);
 
     // 데몬 정본 미러-생성(신규 태스크 브랜치에서만 — 렌더러가 task 스냅샷 동반).
     // 실패는 soft-degrade: 이후 전이가 'task not found'로 렌더러 폴백을 탄다.

--- a/src/main/pipe/handlers/a2a.rpc.ts
+++ b/src/main/pipe/handlers/a2a.rpc.ts
@@ -412,9 +412,17 @@ export function registerA2aRpc(
     // is dropped first). The renderer's reply-delivery guards need it: an
     // orchestrator brain owns no pane, so without this every brain→worker nudge
     // in its own workspace is suppressed as an unverifiable sender.
+    //
+    // `workspaceId` is PINNED to the same binding, exactly as pane.rpc does for
+    // its confinement: the relaxation is keyed on the binding naming the
+    // caller's own workspace, so a brain that could still name a different
+    // `workspaceId` on the wire would carry its privilege into someone else's.
     const sendParams: Record<string, unknown> = { ...params };
     delete sendParams.commanderWorkspaceId;
-    if (ctx?.commanderWorkspace) sendParams.commanderWorkspaceId = ctx.commanderWorkspace;
+    if (ctx?.commanderWorkspace) {
+      sendParams.commanderWorkspaceId = ctx.commanderWorkspace;
+      sendParams.workspaceId = ctx.commanderWorkspace;
+    }
     const result = await sendToRenderer(getWindow, 'a2a.task.send', sendParams);
 
     // 데몬 정본 미러-생성(신규 태스크 브랜치에서만 — 렌더러가 task 스냅샷 동반).

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -22,6 +22,13 @@ type GetWindow = () => BrowserWindow | null;
  * fused `text\r` chunk is read as a multi-line PASTE by TUI editors (Claude
  * Code / ink) and lands the \r as a soft newline instead of submitting.
  * Live-tunable if a TUI still coalesces at 20ms on a slow host.
+ *
+ * The value has not been re-measured against a live Claude pane in this
+ * change, and it no longer needs to be tuned blind: a delay too short for the
+ * host now shows up as `accepted:false` and re-sends the Enter (see the submit
+ * receipt below), instead of silently stranding the prompt in the composer.
+ * The number to raise, if a host is found where the retry keeps firing, is
+ * this one.
  */
 const SUBMIT_ENTER_DELAY_MS = 20;
 

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -46,12 +46,23 @@ const delay = (ms: number): Promise<void> =>
 // cursor, so bytes flow whether or not anything was committed.
 //
 // Two signals are accepted, both of which require the pane to have MOVED:
-//   (a) turn start — the pane's agentStatus goes to running/awaiting_input,
-//       i.e. the agent detector / hook lane saw a turn begin for this pty.
-//   (b) composer cleared — the text we just typed is no longer sitting on the
-//       input line. Detected positionally (see `rowFromBottom`), because a TUI
-//       like Claude Code re-renders the submitted prompt into its transcript:
-//       the string is still on screen, just no longer at the bottom.
+//   (a) turn start — the pane's agentStatus goes to `running`, from a status
+//       that was not a turn, reported by a mirror snapshot taken AFTER our \r.
+//   (b) composer cleared — the text we just typed has LEFT the composer area
+//       at the bottom of the screen. Positional (see `rowFromBottom`), because
+//       a TUI like Claude Code re-renders the submitted prompt into its
+//       transcript: the string is still on screen, just no longer down there.
+//
+// Both are narrower than they look, and deliberately:
+//   - `running → awaiting_input` is NOT a turn start. It is what a PREVIOUS
+//     turn ending inside our window looks like.
+//   - agentStatus is byte-promoted (#935), so the pane's own echo of our text
+//     can flip it to running before anything was submitted. That is why the
+//     snapshot has to be newer than the \r, not merely different.
+//   - "the needle moved up one row" is NOT acceptance. That is precisely the
+//     soft-newline failure this whole change exists to catch (the composer
+//     grew a line and pushed our text up), and background output does it too.
+//     Only leaving the composer area counts.
 
 /** How long a submit waits for a receipt before retrying the Enter. */
 const SUBMIT_RECEIPT_WINDOW_MS = 400;
@@ -59,13 +70,41 @@ const SUBMIT_RECEIPT_WINDOW_MS = 400;
 /** Poll interval while waiting for a receipt. */
 const SUBMIT_RECEIPT_POLL_MS = 50;
 
+/**
+ * Hard ceiling on the whole receipt wait, retry included. An MCP client gives
+ * a tool call ~10s; a submit that spent most of that budget waiting would turn
+ * a working send into a client-side timeout, which is a worse answer than an
+ * honest `accepted:false`.
+ */
+const SUBMIT_RECEIPT_MAX_TOTAL_MS = 2_000;
+
+/** Per-poll viewport read budget. Short on purpose: a screen we cannot get
+ *  quickly is a poll we skip, not a submit we stall. */
+const SUBMIT_RECEIPT_READ_TIMEOUT_MS = 300;
+
+/** Viewport rows pulled per poll. The composer and its framing live in the
+ *  last handful of rows; the scrollback is irrelevant here. */
+const SUBMIT_RECEIPT_READ_LINES = 20;
+
 /** Screen lines handed back when no receipt arrived, so the caller can see
  *  what the pane is actually showing instead of guessing. */
 const SUBMIT_RECEIPT_TAIL_LINES = 10;
 
-/** Statuses that mean a turn has begun for this pane. A change to any other
- *  status (e.g. running → idle) is decay, not a receipt. */
-const TURN_START_STATUSES: ReadonlySet<string> = new Set(['running', 'awaiting_input']);
+/**
+ * How far up from the bottom the input line can be. A TUI frames its composer
+ * (border, hint row, mode line), so the typed text sits a few rows above the
+ * true bottom; anything further up is transcript, not composer.
+ */
+export const COMPOSER_AREA_ROWS = 6;
+
+/** Statuses that are NOT a turn — a move from one of these into `running` is a
+ *  turn starting. `running → awaiting_input` is the previous turn ending. */
+const NON_TURN_STATUSES: ReadonlySet<string> = new Set([
+  'idle',
+  'waiting',
+  'complete',
+  'error',
+]);
 
 /** Length of the trailing slice of the submitted text used to locate the
  *  composer line. Long enough to be unique in a viewport, short enough that a
@@ -100,26 +139,42 @@ export function rowFromBottom(screen: string, needle: string): number {
 }
 
 /**
- * True when the typed text left the input line between `before` and `after`.
+ * Was the typed text sitting in the composer area when we pressed Enter?
  *
- * Gone from the screen entirely, or moved further from the bottom, both mean
- * the composer committed it. Same row means it is still pending — which is
- * exactly what an echo-only repaint looks like, so echo alone never accepts.
- * A needle that was never visible before the Enter tells us nothing (the pane
- * may not render an input line at all), so we refuse to guess.
+ * Only then is the composer signal usable at all: a needle we never saw down
+ * there (empty text, a prompt so wrapped the tail is off-grid, a dialog over
+ * the pane) tells us nothing about what an Enter did, and a receipt built on
+ * "we could not see it" is a guess.
  */
-export function composerAdvanced(before: string, after: string, needle: string): boolean {
-  const beforeRow = rowFromBottom(before, needle);
-  if (beforeRow < 0) return false;
-  const afterRow = rowFromBottom(after, needle);
-  if (afterRow < 0) return true;
-  return afterRow > beforeRow;
+export function needleInComposer(screen: string, needle: string): boolean {
+  const row = rowFromBottom(screen, needle);
+  return row >= 0 && row < COMPOSER_AREA_ROWS;
 }
 
-/** True when the pane's agent status moved INTO a turn between the two reads. */
+/**
+ * True when the typed text LEFT the composer area between `before` and `after`.
+ *
+ * Not "moved up": a composer that grew a soft newline pushes the text up one
+ * row while still holding it uncommitted — the exact failure this change
+ * exists to catch — and background output shifts rows too. Gone from the
+ * bottom region (or off screen entirely) is the only thing a submit does.
+ */
+export function composerCleared(before: string, after: string, needle: string): boolean {
+  if (!needleInComposer(before, needle)) return false;
+  return !needleInComposer(after, needle);
+}
+
+/**
+ * True when the pane's agent status moved INTO a turn.
+ *
+ * Narrow on purpose. `running → awaiting_input` is a PREVIOUS turn ending
+ * inside our window, not ours beginning, so only `running` is an arrival, and
+ * only from a status that was not already a turn.
+ */
 export function isTurnStart(before: string | null, after: string | null): boolean {
-  if (!after || after === before) return false;
-  return TURN_START_STATUSES.has(after);
+  if (after !== 'running') return false;
+  if (before === null) return true;
+  return NON_TURN_STATUSES.has(before);
 }
 
 /** Last `count` non-empty-trailing lines of a screen capture. */
@@ -129,11 +184,19 @@ export function screenTail(screen: string, count = SUBMIT_RECEIPT_TAIL_LINES): s
   return lines.slice(-count).join('\n');
 }
 
+/** One agent-status observation: the value, and WHEN the snapshot carrying it
+ *  was taken. The timestamp is load-bearing — see `awaitSubmitReceipt`. */
+export interface AgentStatusReading {
+  status: string;
+  /** Epoch ms the snapshot was built (renderer push time). */
+  ts: number;
+}
+
 /** What `awaitSubmitReceipt` needs to observe a pane. Injected so the wait is
  *  testable against a fake PTY with no renderer and no mirror. */
 export interface SubmitProbe {
   readScreen: () => Promise<string>;
-  readAgentStatus: () => Promise<string | null>;
+  readAgentStatus: () => Promise<AgentStatusReading | null>;
 }
 
 export interface SubmitReceipt {
@@ -151,53 +214,102 @@ export interface SubmitReceipt {
 /**
  * Wait for one of the two receipts after an Enter, retrying the Enter once.
  *
- * Budget: `windowMs` for the first attempt, then the Enter is re-sent and we
- * wait 2× as long (a TUI that missed the first \r was busy, so give it more
- * room). Still nothing ⇒ `accepted: false` with the screen tail attached.
+ * Budget is WALL CLOCK, not poll count: each poll costs a viewport read whose
+ * latency varies with the pane, so counting iterations meant the real wait
+ * drifted with load. `windowMs` for the first attempt; if the needle was
+ * observably in the composer we re-send the Enter and watch 2× as long, all
+ * clamped by `maxTotalMs` so a submit can never eat an MCP client's timeout.
+ *
+ * Two things that look like over-caution and are not:
+ *
+ *   - A status reading is only evidence when its snapshot was taken AFTER the
+ *     \r. agentStatus is byte-promoted (#935), so the pane echoing our own
+ *     text flips it to `running` — a snapshot from before the Enter would let
+ *     our own keystrokes sign for their own delivery.
+ *   - We re-send the Enter ONLY when the needle was in the composer to begin
+ *     with. Otherwise the pane might be showing a confirmation dialog, and a
+ *     blind second Enter presses its default.
  */
 export async function awaitSubmitReceipt(
   probe: SubmitProbe,
   needle: string,
   before: { screen: string; agentStatus: string | null },
   resendEnter: () => void,
-  opts: { windowMs?: number; pollMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+  opts: {
+    windowMs?: number;
+    pollMs?: number;
+    maxTotalMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+    /** Epoch ms the \r was written. A status snapshot older than this is our
+     *  own echo, not a turn. */
+    enterAt?: number;
+    now?: () => number;
+  } = {},
 ): Promise<SubmitReceipt> {
   const windowMs = opts.windowMs ?? SUBMIT_RECEIPT_WINDOW_MS;
   const pollMs = opts.pollMs ?? SUBMIT_RECEIPT_POLL_MS;
+  const maxTotalMs = opts.maxTotalMs ?? SUBMIT_RECEIPT_MAX_TOTAL_MS;
   const sleep = opts.sleep ?? delay;
+  const now = opts.now ?? Date.now;
+  const enterAt = opts.enterAt ?? now();
 
-  // Neither signal is available: no viewport came back AND no status is known
-  // for this pty (no renderer, or a pane the mirror has never carried). Waiting
-  // 1.2s to learn nothing helps no one, and re-sending an Enter into a pane we
-  // cannot see is worse than not sending it — so say plainly that we could not
-  // observe rather than manufacturing a verdict.
-  if (before.screen === '' && before.agentStatus === null) {
+  const composerUsable = needleInComposer(before.screen, needle);
+  const statusUsable = before.agentStatus !== null || before.screen !== '';
+
+  // Nothing to watch: no viewport came back AND no status is known for this pty
+  // (no renderer, or a pane the mirror has never carried). Waiting to learn
+  // nothing helps no one, and a second Enter into a pane we cannot see is worse
+  // than no second Enter — so say plainly that we could not observe.
+  if (!composerUsable && !statusUsable) {
     return { accepted: false, agentStatusAfter: null, retried: false, signal: 'unobservable' };
   }
 
   let status = before.agentStatus;
   let screen = before.screen;
   let retried = false;
+  const hardDeadline = enterAt + maxTotalMs;
 
-  for (let attempt = 0; attempt < 2; attempt++) {
-    const budget = windowMs * (attempt === 0 ? 1 : 2);
-    for (let waited = 0; waited < budget; waited += pollMs) {
+  /** Read the status and decide; separated so it can run BEFORE the first
+   *  (expensive) screen read — a hook-fast turn start should not wait on IPC. */
+  const pollStatus = async (): Promise<boolean> => {
+    const reading = await probe.readAgentStatus();
+    if (!reading || reading.ts < enterAt) return false;
+    const started = isTurnStart(status, reading.status);
+    status = reading.status;
+    return started;
+  };
+
+  if (await pollStatus()) {
+    return { accepted: true, agentStatusAfter: status, retried, signal: 'turn_start' };
+  }
+
+  // One attempt when the composer is not observable — there is no second Enter
+  // to send, so a longer wait buys only latency.
+  const attempts = composerUsable ? 2 : 1;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const windowDeadline = Math.min(now() + windowMs * (attempt === 0 ? 1 : 2), hardDeadline);
+    while (now() < windowDeadline) {
       await sleep(pollMs);
-      screen = await probe.readScreen();
-      const next = await probe.readAgentStatus();
-      if (next !== null) {
-        if (isTurnStart(status, next)) {
-          return { accepted: true, agentStatusAfter: next, retried, signal: 'turn_start' };
-        }
-        status = next;
+      if (await pollStatus()) {
+        return { accepted: true, agentStatusAfter: status, retried, signal: 'turn_start' };
       }
-      if (composerAdvanced(before.screen, screen, needle)) {
-        return { accepted: true, agentStatusAfter: status, retried, signal: 'composer_cleared' };
+      if (composerUsable) {
+        screen = await probe.readScreen();
+        if (composerCleared(before.screen, screen, needle)) {
+          return { accepted: true, agentStatusAfter: status, retried, signal: 'composer_cleared' };
+        }
       }
     }
-    if (attempt === 0) {
+    if (attempt === 0 && attempts === 2 && now() < hardDeadline) {
       retried = true;
-      resendEnter();
+      try {
+        resendEnter();
+      } catch {
+        // The pane died between the first Enter and the retry. That is an
+        // unaccepted submit, not a failed RPC — the caller gets `false` and the
+        // screen tail, exactly as it would for a pane that ignored us.
+        break;
+      }
     }
   }
 
@@ -205,8 +317,8 @@ export async function awaitSubmitReceipt(
     accepted: false,
     agentStatusAfter: status,
     retried,
-    signal: 'none',
-    screenTail: screenTail(screen),
+    signal: composerUsable ? 'none' : 'unobservable',
+    ...(screen ? { screenTail: screenTail(screen) } : {}),
   };
 }
 
@@ -313,7 +425,14 @@ function makeSubmitProbe(
   return {
     readScreen: async (): Promise<string> => {
       try {
-        const result = await sendToRenderer(getWindow, 'input.readScreen', { ptyId });
+        const result = await sendToRenderer(getWindow, 'input.readScreen', {
+          ptyId,
+          // Bounded on both axes: the composer lives in the last handful of
+          // rows, and a viewport we cannot get in 300ms is a poll to skip, not
+          // a submit to stall.
+          tail_lines: SUBMIT_RECEIPT_READ_LINES,
+          timeoutMs: SUBMIT_RECEIPT_READ_TIMEOUT_MS,
+        });
         if (result !== null && typeof result === 'object') {
           const text = (result as Record<string, unknown>)['text'];
           if (typeof text === 'string') return text;
@@ -323,11 +442,14 @@ function makeSubmitProbe(
       }
       return '';
     },
-    readAgentStatus: (): Promise<string | null> => {
+    readAgentStatus: (): Promise<AgentStatusReading | null> => {
       if (!workspaceId) return Promise.resolve(null);
       const snapshot = getWorkspaceMirror().getFleetSnapshot(workspaceId);
       const pane = snapshot?.panes.find((p) => p.ptyId === ptyId);
-      return Promise.resolve(pane?.agentStatus ?? null);
+      if (!snapshot || !pane?.agentStatus) return Promise.resolve(null);
+      // The snapshot's own build time rides along: a status from BEFORE our \r
+      // cannot testify about it (byte promotion means our echo moves it).
+      return Promise.resolve({ status: pane.agentStatus, ts: snapshot.ts });
     },
   };
 }
@@ -488,28 +610,40 @@ export function registerInputRpc(
     // submit — the \r becomes a soft newline in the composer. A lone \r
     // arriving in its own read cycle is an unambiguous Enter keypress. This is
     // exactly why the two-step terminal_send + terminal_send_key('enter')
-    // workaround succeeded where submit:true did not. We skip the extra write
-    // when the text already ends in \r (avoids a stray empty submit).
-    const wantsSubmit = params['submit'] === true && !safeText.endsWith('\r');
+    // workaround succeeded where submit:true did not.
+    //
+    // A text that ALREADY ends in \r used to skip the split write and the
+    // receipt entirely, and then reported `submitted:true, accepted:false` —
+    // the very false receipt this handler exists to remove, wearing a
+    // different hat. The trailing \r IS the submit, so it is stripped and the
+    // normal path runs: one text write, one Enter, one receipt.
+    const submitRequested = params['submit'] === true;
+    const bodyText = submitRequested && safeText.endsWith('\r') ? safeText.slice(0, -1) : safeText;
     let receipt: SubmitReceipt | undefined;
-    if (wantsSubmit) {
+    if (submitRequested) {
       // Resolve the receipt workspace BEFORE the first write so its round-trip
       // never lands inside the text→Enter gap the delay above protects.
       const receiptWs =
         callerWs ?? (await resolvePtyOwnerWorkspace(getWindow, ptyId).catch(() => null)) ?? undefined;
       const probe = makeSubmitProbe(getWindow, ptyId, receiptWs);
 
-      writeChunk(safeText);
+      if (bodyText) writeChunk(bodyText);
       await delay(SUBMIT_ENTER_DELAY_MS);
       // Snapshot the pane while the text sits UNCOMMITTED on the input line —
       // this is the "before" the composer diff is measured against.
+      const beforeReading = await probe.readAgentStatus();
       const before = {
         screen: await probe.readScreen(),
-        agentStatus: await probe.readAgentStatus(),
+        agentStatus: beforeReading?.status ?? null,
       };
       writeChunk('\r');
-      receipt = await awaitSubmitReceipt(probe, submitNeedle(safeText), before, () =>
-        writeChunk('\r'),
+      const enterAt = Date.now();
+      receipt = await awaitSubmitReceipt(
+        probe,
+        submitNeedle(bodyText),
+        before,
+        () => writeChunk('\r'),
+        { enterAt },
       );
     } else {
       writeChunk(safeText);
@@ -520,11 +654,18 @@ export function registerInputRpc(
       ptyId,
       // `submitted` reports only that an Enter was WRITTEN. `accepted` is the
       // receipt: whether the pane was observed to move. A caller that needs to
-      // know the agent got the prompt must read `accepted`.
-      submitted: params['submit'] === true,
-      accepted: receipt?.accepted ?? false,
-      agentStatusAfter: receipt?.agentStatusAfter ?? null,
-      ...(receipt ? { receiptSignal: receipt.signal, enterRetried: receipt.retried } : {}),
+      // know the agent got the prompt must read `accepted` — and when no
+      // receipt was attempted at all (submit:false) the field is ABSENT rather
+      // than a hard false, which would read as "we looked and it did not land".
+      submitted: submitRequested,
+      ...(receipt
+        ? {
+            accepted: receipt.accepted,
+            agentStatusAfter: receipt.agentStatusAfter,
+            receiptSignal: receipt.signal,
+            enterRetried: receipt.retried,
+          }
+        : {}),
       ...(receipt?.screenTail ? { screenTail: receipt.screenTail } : {}),
       // D2 — surface enforcement on the payload (callRpc stringifies it into the
       // tool result, so the orchestrator sees which model was pinned). The pane

--- a/src/main/pipe/handlers/input.rpc.ts
+++ b/src/main/pipe/handlers/input.rpc.ts
@@ -8,8 +8,10 @@ import { applyRoleBinding, type RoleBinding } from '../../../shared/orchestrator
 import { isGateHeldOn } from '../../deck/stopGateState';
 import {
   assertWorkspaceOwnsPty,
+  resolvePtyOwnerWorkspace,
   resolveRoleBindingForPty,
 } from '../../workspace/ptyOwnership';
+import { getWorkspaceMirror } from '../../workspace/WorkspaceMirror';
 
 type GetWindow = () => BrowserWindow | null;
 
@@ -25,6 +27,181 @@ const SUBMIT_ENTER_DELAY_MS = 20;
 
 const delay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---------------------------------------------------------------------------
+// Submit receipt (orchestrator track, 2026-09-04)
+// ---------------------------------------------------------------------------
+//
+// `submitted: true` used to mean "we wrote a \r", which is not a receipt: the
+// orchestrator read it as "the agent got my prompt" and reported progress on
+// panes that were still sitting on an uncommitted line. Raw PTY byte activity
+// is not a receipt either — a TUI echoes every keystroke and repaints its
+// cursor, so bytes flow whether or not anything was committed.
+//
+// Two signals are accepted, both of which require the pane to have MOVED:
+//   (a) turn start — the pane's agentStatus goes to running/awaiting_input,
+//       i.e. the agent detector / hook lane saw a turn begin for this pty.
+//   (b) composer cleared — the text we just typed is no longer sitting on the
+//       input line. Detected positionally (see `rowFromBottom`), because a TUI
+//       like Claude Code re-renders the submitted prompt into its transcript:
+//       the string is still on screen, just no longer at the bottom.
+
+/** How long a submit waits for a receipt before retrying the Enter. */
+const SUBMIT_RECEIPT_WINDOW_MS = 400;
+
+/** Poll interval while waiting for a receipt. */
+const SUBMIT_RECEIPT_POLL_MS = 50;
+
+/** Screen lines handed back when no receipt arrived, so the caller can see
+ *  what the pane is actually showing instead of guessing. */
+const SUBMIT_RECEIPT_TAIL_LINES = 10;
+
+/** Statuses that mean a turn has begun for this pane. A change to any other
+ *  status (e.g. running → idle) is decay, not a receipt. */
+const TURN_START_STATUSES: ReadonlySet<string> = new Set(['running', 'awaiting_input']);
+
+/** Length of the trailing slice of the submitted text used to locate the
+ *  composer line. Long enough to be unique in a viewport, short enough that a
+ *  wrapped prompt still has the whole needle on its LAST visual row. */
+const SUBMIT_NEEDLE_CHARS = 24;
+
+/**
+ * The fragment of the submitted text we look for on screen. The TAIL, not the
+ * head: a prompt long enough to wrap puts its head on an earlier visual row,
+ * and only the tail is guaranteed to sit on the composer's last row. Collapsed
+ * whitespace, because a TUI re-flows the line it renders.
+ */
+export function submitNeedle(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > SUBMIT_NEEDLE_CHARS ? flat.slice(-SUBMIT_NEEDLE_CHARS) : flat;
+}
+
+/**
+ * How many lines up from the last non-empty line of the screen the needle last
+ * appears; -1 when it is not on screen at all. This is the whole trick behind
+ * "did the composer clear": the input line is the bottom-most place the text
+ * can be, so a submitted prompt can only move UP.
+ */
+export function rowFromBottom(screen: string, needle: string): number {
+  if (!needle) return -1;
+  const lines = screen.replace(/\r/g, '').split('\n');
+  while (lines.length > 0 && lines[lines.length - 1]!.trim() === '') lines.pop();
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i]!.replace(/\s+/g, ' ').includes(needle)) return lines.length - 1 - i;
+  }
+  return -1;
+}
+
+/**
+ * True when the typed text left the input line between `before` and `after`.
+ *
+ * Gone from the screen entirely, or moved further from the bottom, both mean
+ * the composer committed it. Same row means it is still pending — which is
+ * exactly what an echo-only repaint looks like, so echo alone never accepts.
+ * A needle that was never visible before the Enter tells us nothing (the pane
+ * may not render an input line at all), so we refuse to guess.
+ */
+export function composerAdvanced(before: string, after: string, needle: string): boolean {
+  const beforeRow = rowFromBottom(before, needle);
+  if (beforeRow < 0) return false;
+  const afterRow = rowFromBottom(after, needle);
+  if (afterRow < 0) return true;
+  return afterRow > beforeRow;
+}
+
+/** True when the pane's agent status moved INTO a turn between the two reads. */
+export function isTurnStart(before: string | null, after: string | null): boolean {
+  if (!after || after === before) return false;
+  return TURN_START_STATUSES.has(after);
+}
+
+/** Last `count` non-empty-trailing lines of a screen capture. */
+export function screenTail(screen: string, count = SUBMIT_RECEIPT_TAIL_LINES): string {
+  const lines = screen.replace(/\r/g, '').split('\n');
+  while (lines.length > 0 && lines[lines.length - 1]!.trim() === '') lines.pop();
+  return lines.slice(-count).join('\n');
+}
+
+/** What `awaitSubmitReceipt` needs to observe a pane. Injected so the wait is
+ *  testable against a fake PTY with no renderer and no mirror. */
+export interface SubmitProbe {
+  readScreen: () => Promise<string>;
+  readAgentStatus: () => Promise<string | null>;
+}
+
+export interface SubmitReceipt {
+  accepted: boolean;
+  agentStatusAfter: string | null;
+  /** The Enter was sent a second time because the first produced no receipt. */
+  retried: boolean;
+  /** Why we accepted; 'none' when we watched and nothing moved, 'unobservable'
+   *  when neither signal was available to watch in the first place. */
+  signal: 'turn_start' | 'composer_cleared' | 'none' | 'unobservable';
+  /** Present only when `accepted` is false. */
+  screenTail?: string;
+}
+
+/**
+ * Wait for one of the two receipts after an Enter, retrying the Enter once.
+ *
+ * Budget: `windowMs` for the first attempt, then the Enter is re-sent and we
+ * wait 2× as long (a TUI that missed the first \r was busy, so give it more
+ * room). Still nothing ⇒ `accepted: false` with the screen tail attached.
+ */
+export async function awaitSubmitReceipt(
+  probe: SubmitProbe,
+  needle: string,
+  before: { screen: string; agentStatus: string | null },
+  resendEnter: () => void,
+  opts: { windowMs?: number; pollMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<SubmitReceipt> {
+  const windowMs = opts.windowMs ?? SUBMIT_RECEIPT_WINDOW_MS;
+  const pollMs = opts.pollMs ?? SUBMIT_RECEIPT_POLL_MS;
+  const sleep = opts.sleep ?? delay;
+
+  // Neither signal is available: no viewport came back AND no status is known
+  // for this pty (no renderer, or a pane the mirror has never carried). Waiting
+  // 1.2s to learn nothing helps no one, and re-sending an Enter into a pane we
+  // cannot see is worse than not sending it — so say plainly that we could not
+  // observe rather than manufacturing a verdict.
+  if (before.screen === '' && before.agentStatus === null) {
+    return { accepted: false, agentStatusAfter: null, retried: false, signal: 'unobservable' };
+  }
+
+  let status = before.agentStatus;
+  let screen = before.screen;
+  let retried = false;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const budget = windowMs * (attempt === 0 ? 1 : 2);
+    for (let waited = 0; waited < budget; waited += pollMs) {
+      await sleep(pollMs);
+      screen = await probe.readScreen();
+      const next = await probe.readAgentStatus();
+      if (next !== null) {
+        if (isTurnStart(status, next)) {
+          return { accepted: true, agentStatusAfter: next, retried, signal: 'turn_start' };
+        }
+        status = next;
+      }
+      if (composerAdvanced(before.screen, screen, needle)) {
+        return { accepted: true, agentStatusAfter: status, retried, signal: 'composer_cleared' };
+      }
+    }
+    if (attempt === 0) {
+      retried = true;
+      resendEnter();
+    }
+  }
+
+  return {
+    accepted: false,
+    agentStatusAfter: status,
+    retried,
+    signal: 'none',
+    screenTail: screenTail(screen),
+  };
+}
 
 /**
  * Key sequence mapping table for input.sendKey
@@ -110,6 +287,42 @@ export type RoleBindingResolver = (ptyId: string) => Promise<RoleBinding | undef
 export function makeRoleBindingResolver(getWindow: GetWindow): RoleBindingResolver {
   return (ptyId: string): Promise<RoleBinding | undefined> =>
     resolveRoleBindingForPty(getWindow, ptyId);
+}
+
+/**
+ * The live submit probe: viewport from the renderer, agent status from the
+ * main-side WorkspaceMirror (the renderer pushes it, so no extra IPC per poll).
+ *
+ * Both reads FAIL SOFT — an empty screen or an unknown status simply means that
+ * signal cannot accept, never that the send errors. The mirror needs the owning
+ * workspace to key its fleet snapshot; with none resolvable we degrade to the
+ * composer signal alone.
+ */
+function makeSubmitProbe(
+  getWindow: GetWindow,
+  ptyId: string,
+  workspaceId: string | undefined,
+): SubmitProbe {
+  return {
+    readScreen: async (): Promise<string> => {
+      try {
+        const result = await sendToRenderer(getWindow, 'input.readScreen', { ptyId });
+        if (result !== null && typeof result === 'object') {
+          const text = (result as Record<string, unknown>)['text'];
+          if (typeof text === 'string') return text;
+        }
+      } catch {
+        // fail soft — a viewport we cannot read is "no signal", not an error.
+      }
+      return '';
+    },
+    readAgentStatus: (): Promise<string | null> => {
+      if (!workspaceId) return Promise.resolve(null);
+      const snapshot = getWorkspaceMirror().getFleetSnapshot(workspaceId);
+      const pane = snapshot?.panes.find((p) => p.ptyId === ptyId);
+      return Promise.resolve(pane?.agentStatus ?? null);
+    },
+  };
 }
 
 /**
@@ -271,10 +484,26 @@ export function registerInputRpc(
     // workaround succeeded where submit:true did not. We skip the extra write
     // when the text already ends in \r (avoids a stray empty submit).
     const wantsSubmit = params['submit'] === true && !safeText.endsWith('\r');
+    let receipt: SubmitReceipt | undefined;
     if (wantsSubmit) {
+      // Resolve the receipt workspace BEFORE the first write so its round-trip
+      // never lands inside the text→Enter gap the delay above protects.
+      const receiptWs =
+        callerWs ?? (await resolvePtyOwnerWorkspace(getWindow, ptyId).catch(() => null)) ?? undefined;
+      const probe = makeSubmitProbe(getWindow, ptyId, receiptWs);
+
       writeChunk(safeText);
       await delay(SUBMIT_ENTER_DELAY_MS);
+      // Snapshot the pane while the text sits UNCOMMITTED on the input line —
+      // this is the "before" the composer diff is measured against.
+      const before = {
+        screen: await probe.readScreen(),
+        agentStatus: await probe.readAgentStatus(),
+      };
       writeChunk('\r');
+      receipt = await awaitSubmitReceipt(probe, submitNeedle(safeText), before, () =>
+        writeChunk('\r'),
+      );
     } else {
       writeChunk(safeText);
     }
@@ -282,7 +511,14 @@ export function registerInputRpc(
     return {
       ok: true,
       ptyId,
+      // `submitted` reports only that an Enter was WRITTEN. `accepted` is the
+      // receipt: whether the pane was observed to move. A caller that needs to
+      // know the agent got the prompt must read `accepted`.
       submitted: params['submit'] === true,
+      accepted: receipt?.accepted ?? false,
+      agentStatusAfter: receipt?.agentStatusAfter ?? null,
+      ...(receipt ? { receiptSignal: receipt.signal, enterRetried: receipt.retried } : {}),
+      ...(receipt?.screenTail ? { screenTail: receipt.screenTail } : {}),
       // D2 — surface enforcement on the payload (callRpc stringifies it into the
       // tool result, so the orchestrator sees which model was pinned). The pane
       // also shows the rewritten command directly — the primary indication.

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1066,7 +1066,7 @@ server.tool(
 
 server.tool(
   'terminal_send',
-  'Send text to a terminal. By default it is written as-is with no Enter, so a shell command or TUI chat prompt sits on the input line uncommitted — pass `submit: true` to commit it. Omit ptyId for the active terminal. To message OTHER workspaces use a2a_task_send or a2a_broadcast instead.',
+  'Send text to a terminal. By default it is written as-is with no Enter, so a shell command or TUI chat prompt sits on the input line uncommitted — pass `submit: true` to commit it. `ok` means the bytes were WRITTEN, never that anything was submitted: with `submit`, read `accepted` — true only when the pane was observed to move (its turn started, or the input line cleared). `accepted:false` (with `agentStatusAfter` and the pane\'s last screen lines) means the prompt is probably still sitting uncommitted; do not report progress on it. Omit ptyId for the active terminal. To message OTHER workspaces use a2a_task_send or a2a_broadcast instead.',
   TERMINAL_SEND_SHAPE,
   async ({ text, ptyId, submit }) => {
     const route = await resolveTerminalRouteBound(ptyId);
@@ -1088,7 +1088,7 @@ server.tool(
 
 server.tool(
   'terminal_send_key',
-  'Send a named key to a terminal. Omit ptyId for the active terminal. NOT A SUBMIT MECHANISM: `key:"enter"` presses Enter on whatever the input box holds, which is usually NOTHING — a question an agent PRINTED is rendered text, not pending input, so Enter submits nothing and the pane stays blocked. ok means the key was delivered, never that anything was submitted or that the agent resumed. To answer a waiting agent, send the answer with terminal_send({ text, submit: true }) and confirm the pane moved (agentStatus, or a fresh terminal_read) before reporting progress. Reserve this tool for real key presses: ctrl+c, escape, arrow keys, and y/N prompts the agent genuinely rendered.',
+  'Send a named key to a terminal. Omit ptyId for the active terminal. NOT A SUBMIT MECHANISM: `key:"enter"` presses Enter on whatever the input box holds, which is usually NOTHING — a question an agent PRINTED is rendered text, not pending input, so Enter submits nothing and the pane stays blocked. ok means the key was delivered, never that anything was submitted or that the agent resumed. To answer a waiting agent, send the answer with terminal_send({ text, submit: true }) and check its `accepted` field — that is the only receipt that the pane moved. Reserve this tool for real key presses: ctrl+c, escape, arrow keys, and y/N prompts the agent genuinely rendered.',
   TERMINAL_SEND_KEY_SHAPE,
   async ({ key, ptyId }) => {
     const route = await resolveTerminalRouteBound(ptyId);
@@ -1112,7 +1112,8 @@ server.tool(
         'Enter was delivered. This does NOT confirm anything was submitted: if the pane was '
         + 'showing a question the agent printed (rather than text typed into its input box), '
         + 'nothing happened and it is still waiting. Verify with terminal_read or pane_list '
-        + 'before reporting progress; to answer an agent, use terminal_send({text, submit:true}).',
+        + 'before reporting progress; to answer an agent, use terminal_send({text, submit:true}) '
+        + 'and read its `accepted` field.',
       );
     }
     return result;

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { PaneLeaf, Surface } from '../../../shared/types';
-import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, countRoundTrips, maxSideMessages, REPLY_ROUND_CAP, REPLY_SUPPRESS_HINTS, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, type PaneAddress } from '../a2aAddressing';
+import { resolvePaneAddress, activePaneTerminalPty, decideSameWsSend, decideReplyDelivery, isCommanderForWorkspace, countRoundTrips, maxSideMessages, REPLY_ROUND_CAP, REPLY_SUPPRESS_HINTS, isTerminalPtyInLeaves, resolveSelfPaneIdentity, resolveSenderPaneAddress, resolvePaneRole, type PaneAddress } from '../a2aAddressing';
 
 function surface(id: string, ptyId: string, surfaceType: Surface['surfaceType'] = 'terminal'): Surface {
   return { id, ptyId, title: id, shell: '', cwd: '', surfaceType } as Surface;
@@ -261,16 +261,38 @@ describe('decideReplyDelivery', () => {
   // callerPtyId arrives empty and BOTH pane-keyed guards fired — every
   // brain→worker reply in its own workspace was stored and never delivered.
   describe('commander-verified caller (the brain)', () => {
-    const BRAIN = { commanderWorkspaceId: 'ws-brain' };
+    const BRAIN = { commanderWorkspaceId: 'ws-brain', callerWorkspaceId: 'ws-brain' };
 
     it('brain → sibling pane in its own workspace delivers', () => {
       const d = decideReplyDelivery(true, true, false, 'pty-worker', '', BRAIN);
       expect(d).toEqual({ kind: 'deliver', sameWs: true, explicitPtyId: 'pty-worker' });
     });
 
-    it('brain → same-ws target with no anchor delivers (fallback cannot loop into a paneless caller)', () => {
+    // The exemption is for `unverified_sender` ONLY. With no anchor the
+    // delivery helpers fall back to the target workspace's ACTIVE pane (#239),
+    // so relaxing this one would hand the reply to whichever pane is focused.
+    it('brain → same-ws target with NO anchor is still suppressed', () => {
       const d = decideReplyDelivery(true, false, false, undefined, '', BRAIN);
-      expect(d).toEqual({ kind: 'deliver', sameWs: true });
+      expect(d).toEqual({ kind: 'suppress', reason: 'same_ws_no_anchor' });
+    });
+
+    // A token bound to workspace A says nothing about workspace B.
+    it('a commander binding for ANOTHER workspace relaxes nothing', () => {
+      const d = decideReplyDelivery(true, true, false, 'pty-worker', '', {
+        commanderWorkspaceId: 'ws-other',
+        callerWorkspaceId: 'ws-brain',
+      });
+      expect(d).toEqual({ kind: 'suppress', reason: 'unverified_sender' });
+    });
+
+    it('isCommanderForWorkspace requires the binding to name the caller workspace', () => {
+      expect(isCommanderForWorkspace(BRAIN)).toBe(true);
+      expect(
+        isCommanderForWorkspace({ commanderWorkspaceId: 'ws-a', callerWorkspaceId: 'ws-b' }),
+      ).toBe(false);
+      // A binding with nothing to compare against is not a match either.
+      expect(isCommanderForWorkspace({ commanderWorkspaceId: 'ws-a' })).toBe(false);
+      expect(isCommanderForWorkspace({})).toBe(false);
     });
 
     it('brain → brain is refused: there is no pane behind a brain pty', () => {

--- a/src/renderer/hooks/__tests__/a2aAddressing.test.ts
+++ b/src/renderer/hooks/__tests__/a2aAddressing.test.ts
@@ -256,6 +256,56 @@ describe('decideReplyDelivery', () => {
       expect(hint).toMatch(/a2a_task_query|pane_id/);
     }
   });
+
+  // The brain exception. An orchestrator brain has no pane in the tree, so its
+  // callerPtyId arrives empty and BOTH pane-keyed guards fired — every
+  // brain→worker reply in its own workspace was stored and never delivered.
+  describe('commander-verified caller (the brain)', () => {
+    const BRAIN = { commanderWorkspaceId: 'ws-brain' };
+
+    it('brain → sibling pane in its own workspace delivers', () => {
+      const d = decideReplyDelivery(true, true, false, 'pty-worker', '', BRAIN);
+      expect(d).toEqual({ kind: 'deliver', sameWs: true, explicitPtyId: 'pty-worker' });
+    });
+
+    it('brain → same-ws target with no anchor delivers (fallback cannot loop into a paneless caller)', () => {
+      const d = decideReplyDelivery(true, false, false, undefined, '', BRAIN);
+      expect(d).toEqual({ kind: 'deliver', sameWs: true });
+    });
+
+    it('brain → brain is refused: there is no pane behind a brain pty', () => {
+      const d = decideReplyDelivery(true, true, false, 'brain-ws-brain', '', BRAIN);
+      expect(d).toEqual({ kind: 'suppress', reason: 'target_is_brain' });
+    });
+
+    it('a brain target is refused even for an ordinary pane caller', () => {
+      const d = decideReplyDelivery(false, true, false, 'brain-ws-other', 'pty-A');
+      expect(d).toEqual({ kind: 'suppress', reason: 'target_is_brain' });
+    });
+
+    it('an unverified NON-brain caller is still suppressed exactly as before', () => {
+      // Same arguments as the unverified_sender case above, with an empty
+      // identity: no commander binding means nothing changes for it.
+      expect(decideReplyDelivery(true, true, false, 'pty-B', '', {})).toEqual({
+        kind: 'suppress',
+        reason: 'unverified_sender',
+      });
+      expect(decideReplyDelivery(true, false, false, undefined, 'pty-caller', {})).toEqual({
+        kind: 'suppress',
+        reason: 'same_ws_no_anchor',
+      });
+    });
+
+    it('self_loop still protects a pane caller, commander binding or not', () => {
+      const d = decideReplyDelivery(false, true, false, 'pty-A', 'pty-A', BRAIN);
+      expect(d).toEqual({ kind: 'suppress', reason: 'self_loop' });
+    });
+
+    it('a lost pin still fails closed for the brain', () => {
+      const d = decideReplyDelivery(true, true, true, undefined, '', BRAIN);
+      expect(d).toEqual({ kind: 'suppress', reason: 'pin_lost' });
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.a2aPaneIdentity.test.ts
@@ -122,13 +122,17 @@ describe('useRpcBridge — pane-level A2A identity wiring', () => {
     // S-C2: the same-ws reply is no longer blanket-suppressed — it pins to the
     // SYMMETRIC from/to anchor and suppresses ONLY per the four guards, which
     // now live in decideReplyDelivery (a2aAddressing.ts, unit-tested there):
-    // pin_lost / same_ws_no_anchor / self_loop / unverified_sender. The reply
-    // branch must route through that single decision point AND surface its
-    // outcome in the response (delivery.reason + hint) instead of skipping
-    // silently — the silent skip is what the 2026-08-13 dogfood hit.
+    // pin_lost / target_is_brain / same_ws_no_anchor / self_loop /
+    // unverified_sender. The reply branch must route through that single
+    // decision point AND surface its outcome in the response (delivery.reason
+    // + hint) instead of skipping silently — the silent skip is what the
+    // 2026-08-13 dogfood hit.
     expect(block).toMatch(/const sameWsTask = task\.metadata\.from\.workspaceId === task\.metadata\.to\.workspaceId/);
     expect(block).toMatch(/const pinAnchor = replyingToReceiver \? task\.metadata\.to : task\.metadata\.from/);
-    expect(block).toMatch(/decideReplyDelivery\(sameWsTask, hasAnchor, pinnedAddressLost, explicitPty, callerPtyId\)/);
+    expect(block).toMatch(/decideReplyDelivery\(\s*sameWsTask,\s*hasAnchor,\s*pinnedAddressLost,\s*explicitPty,\s*callerPtyId,/);
+    // ...and it must hand the decision the commander binding MAIN stamped, or a
+    // brain (which owns no pane) stays suppressed as an unverifiable sender.
+    expect(block).toMatch(/commanderWorkspaceId:\s*\n?\s*typeof params\.commanderWorkspaceId === 'string'/);
     expect(block).toMatch(/REPLY_SUPPRESS_HINTS\[decision\.reason\]/);
     // a suppressed reply still emits the task pointer onto the bus (the ONLY
     // remaining signal to the receiver when the nudge is withheld)

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -234,6 +234,24 @@ export type ReplySuppressReason =
  */
 export interface ReplyCallerIdentity {
   commanderWorkspaceId?: string;
+  /** The workspace the request itself is acting as. A commander binding only
+   *  relaxes guards for ITS OWN workspace — see `decideReplyDelivery`. */
+  callerWorkspaceId?: string;
+}
+
+/**
+ * Is this caller a commander acting inside the workspace its token is bound to?
+ *
+ * The equality is the whole check. A token bound to workspace A says nothing
+ * about workspace B, so treating "a commander token exists" as "this caller is
+ * privileged here" would let one brain relax another workspace's guards. Main
+ * pins both fields from the validated binding, so they agree exactly when the
+ * commander is operating at home.
+ */
+export function isCommanderForWorkspace(caller: ReplyCallerIdentity): boolean {
+  return (
+    !!caller.commanderWorkspaceId && caller.commanderWorkspaceId === caller.callerWorkspaceId
+  );
 }
 
 export type ReplyDeliveryDecision =
@@ -253,22 +271,28 @@ export type ReplyDeliveryDecision =
  * Precedence (first match wins) only affects the REPORTED reason; any single
  * true guard suppresses, exactly as the original conjunction did.
  *
- * The BRAIN exception (orchestrator track, 2026-09-04). Two of those guards
- * are keyed on the caller having a pane: `same_ws_no_anchor` and
- * `unverified_sender` both exist so a route that cannot be proven non-self is
- * never pasted into the caller's own prompt. An orchestrator brain has no pane
- * in the workspace tree at all — `isTerminalPtyInLeaves` rejects its pty, so
- * `callerPtyId` arrives empty — which meant every brain→worker reply in its own
- * workspace was suppressed as "unverified", and the brain was told its message
- * was stored while the worker sat waiting. But a caller with no pane is exactly
- * a caller a delivery cannot loop back into, and MAIN has already validated the
- * commander binding it carries. So a commander-verified caller SATISFIES both
- * guards rather than tripping them.
+ * The BRAIN exception (orchestrator track, 2026-09-04). `unverified_sender`
+ * exists so a same-workspace route that cannot be proven non-self is never
+ * pasted into the caller's own prompt, and it identifies "provable" with "the
+ * caller owns a pane". An orchestrator brain owns none —
+ * `isTerminalPtyInLeaves` rejects its pty, so `callerPtyId` arrives empty —
+ * which meant every brain→worker reply inside its own workspace was suppressed
+ * as unverified, and the brain was told its message was stored while the worker
+ * sat waiting. A caller with no pane is precisely a caller a delivery cannot
+ * loop back into, and MAIN has already validated the commander binding it
+ * carries, so that ONE guard is satisfied rather than tripped.
  *
- * `self_loop` is untouched: it compares concrete pty ids, so it still protects
- * every pane caller, and a brain (empty callerPtyId) could never trip it
- * anyway. The brain's own self-send is caught by `target_is_brain` instead —
- * there is no pane behind a brain pty to write into.
+ * Exactly one guard, and only for the commander's OWN workspace:
+ *
+ *   - `same_ws_no_anchor` still suppresses, brain or not. With no pane anchor
+ *     the delivery helpers fall back to the target workspace's ACTIVE pane —
+ *     the #239 path — so relaxing it would hand an anchorless reply to
+ *     whichever pane happens to be focused. A brain that wants a worker nudged
+ *     addresses it (pane_id / surface_id), and then this guard never applies.
+ *   - `self_loop` compares concrete pty ids, so it still protects every pane
+ *     caller; a brain (empty callerPtyId) could never trip it anyway.
+ *   - the binding must name the CALLER'S OWN workspace (see
+ *     `isCommanderForWorkspace`) — a token bound to A must not relax B.
  */
 export function decideReplyDelivery(
   sameWsTask: boolean,
@@ -278,12 +302,14 @@ export function decideReplyDelivery(
   callerPtyId: string,
   caller: ReplyCallerIdentity = {},
 ): ReplyDeliveryDecision {
-  const commanderVerified = !!caller.commanderWorkspaceId;
+  const commanderVerified = isCommanderForWorkspace(caller);
   if (pinnedAddressLost) return { kind: 'suppress', reason: 'pin_lost' };
+  // Belt and braces. A brain pty cannot normally reach here — brains are not in
+  // the workspace pane tree, so `resolvePaneAddress` reports a lost pin long
+  // before this — but an anchor that ever did resolve to one would name a pane
+  // that does not exist, and that is not something to discover by writing to it.
   if (isBrainPtyId(explicitPtyId)) return { kind: 'suppress', reason: 'target_is_brain' };
-  if (sameWsTask && !hasAnchor && !commanderVerified) {
-    return { kind: 'suppress', reason: 'same_ws_no_anchor' };
-  }
+  if (sameWsTask && !hasAnchor) return { kind: 'suppress', reason: 'same_ws_no_anchor' };
   if (!!explicitPtyId && !!callerPtyId && explicitPtyId === callerPtyId) {
     return { kind: 'suppress', reason: 'self_loop' };
   }

--- a/src/renderer/hooks/a2aAddressing.ts
+++ b/src/renderer/hooks/a2aAddressing.ts
@@ -5,6 +5,7 @@
 
 import type { PaneLeaf } from '../../shared/types';
 import { getLeafPanes } from '../../shared/paneUtils';
+import { isBrainPtyId } from '../../shared/constants';
 
 export type PaneAddress = { ptyId: string; paneId: string; surfaceId: string };
 
@@ -218,9 +219,22 @@ export function resolvePaneRole(
  *  can act on it instead of believing the send reached the other party. */
 export type ReplySuppressReason =
   | 'pin_lost'            // pinned target pane no longer exists (fail closed, no active-pane fallback)
+  | 'target_is_brain'     // the pinned target IS an orchestrator brain — it has no pane to paste into
   | 'same_ws_no_anchor'   // same-ws task side has no pane anchor → active-pane fallback would risk the #239 self-paste loop
   | 'self_loop'           // pinned target resolves to the caller's own pty
   | 'unverified_sender';  // same-ws + no verified senderPtyId → cannot prove the route is not self
+
+/**
+ * What the SERVER knows about the caller, beyond its pane identity.
+ *
+ * `commanderWorkspaceId` is the workspace MAIN stamped onto the request from a
+ * VALIDATED commander per-spawn token (`confineWorkspaceId` in useRpcBridge) —
+ * never caller-supplied, so it cannot be forged into existence. Empty/absent
+ * for every ordinary caller, which is why every check below is `commander && …`.
+ */
+export interface ReplyCallerIdentity {
+  commanderWorkspaceId?: string;
+}
 
 export type ReplyDeliveryDecision =
   | { kind: 'deliver'; sameWs: boolean; explicitPtyId?: string }
@@ -238,6 +252,23 @@ export type ReplyDeliveryDecision =
  *
  * Precedence (first match wins) only affects the REPORTED reason; any single
  * true guard suppresses, exactly as the original conjunction did.
+ *
+ * The BRAIN exception (orchestrator track, 2026-09-04). Two of those guards
+ * are keyed on the caller having a pane: `same_ws_no_anchor` and
+ * `unverified_sender` both exist so a route that cannot be proven non-self is
+ * never pasted into the caller's own prompt. An orchestrator brain has no pane
+ * in the workspace tree at all — `isTerminalPtyInLeaves` rejects its pty, so
+ * `callerPtyId` arrives empty — which meant every brain→worker reply in its own
+ * workspace was suppressed as "unverified", and the brain was told its message
+ * was stored while the worker sat waiting. But a caller with no pane is exactly
+ * a caller a delivery cannot loop back into, and MAIN has already validated the
+ * commander binding it carries. So a commander-verified caller SATISFIES both
+ * guards rather than tripping them.
+ *
+ * `self_loop` is untouched: it compares concrete pty ids, so it still protects
+ * every pane caller, and a brain (empty callerPtyId) could never trip it
+ * anyway. The brain's own self-send is caught by `target_is_brain` instead —
+ * there is no pane behind a brain pty to write into.
  */
 export function decideReplyDelivery(
   sameWsTask: boolean,
@@ -245,13 +276,20 @@ export function decideReplyDelivery(
   pinnedAddressLost: boolean,
   explicitPtyId: string | undefined,
   callerPtyId: string,
+  caller: ReplyCallerIdentity = {},
 ): ReplyDeliveryDecision {
+  const commanderVerified = !!caller.commanderWorkspaceId;
   if (pinnedAddressLost) return { kind: 'suppress', reason: 'pin_lost' };
-  if (sameWsTask && !hasAnchor) return { kind: 'suppress', reason: 'same_ws_no_anchor' };
+  if (isBrainPtyId(explicitPtyId)) return { kind: 'suppress', reason: 'target_is_brain' };
+  if (sameWsTask && !hasAnchor && !commanderVerified) {
+    return { kind: 'suppress', reason: 'same_ws_no_anchor' };
+  }
   if (!!explicitPtyId && !!callerPtyId && explicitPtyId === callerPtyId) {
     return { kind: 'suppress', reason: 'self_loop' };
   }
-  if (sameWsTask && !callerPtyId) return { kind: 'suppress', reason: 'unverified_sender' };
+  if (sameWsTask && !callerPtyId && !commanderVerified) {
+    return { kind: 'suppress', reason: 'unverified_sender' };
+  }
   return { kind: 'deliver', sameWs: sameWsTask, ...(explicitPtyId ? { explicitPtyId } : {}) };
 }
 
@@ -262,6 +300,9 @@ export const REPLY_SUPPRESS_HINTS: Record<ReplySuppressReason, string> = {
   pin_lost:
     'The pinned target pane is gone. The reply is stored; the receiver can still poll ' +
     'a2a_task_query. To nudge a live pane, start a new task addressed with pane_id.',
+  target_is_brain:
+    'The pinned target is an orchestrator brain, which has no pane to write into. The reply ' +
+    'is stored; address a worker pane (pane_id / surface_id) if you meant to nudge one.',
   same_ws_no_anchor:
     'This same-workspace task has no pane anchor on the target side, so a nudge cannot be ' +
     'routed safely. The reply is stored; the receiver must poll a2a_task_query.',

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -2266,10 +2266,14 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
             explicitPty,
             callerPtyId,
             {
-              // Stamped by MAIN from the validated commander token (a2a.rpc.ts);
-              // absent for every ordinary caller.
+              // Stamped by MAIN from the validated commander token (a2a.rpc.ts),
+              // which pins `workspaceId` to the same binding; absent for every
+              // ordinary caller. Both are passed because the relaxation applies
+              // only when they AGREE — a token bound to another workspace must
+              // not relax this one's guards.
               commanderWorkspaceId:
                 typeof params.commanderWorkspaceId === 'string' ? params.commanderWorkspaceId : '',
+              callerWorkspaceId: workspaceId,
             },
           );
           if (decision.kind === 'suppress') {

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -2253,11 +2253,25 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
             if ('error' in addr) pinnedAddressLost = true;
             else explicitPty = addr.ptyId;
           }
-          // Four suppression guards, extracted to decideReplyDelivery (pure,
-          // unit-tested) — semantics unchanged, but the reason is now a VALUE
-          // that reaches the sender instead of a silent skip. See the extracted
-          // function for why each guard exists (same-ws self-paste safety).
-          const decision = decideReplyDelivery(sameWsTask, hasAnchor, pinnedAddressLost, explicitPty, callerPtyId);
+          // Suppression guards, extracted to decideReplyDelivery (pure,
+          // unit-tested) — the reason is a VALUE that reaches the sender
+          // instead of a silent skip. See the extracted function for why each
+          // guard exists (same-ws self-paste safety), and why a caller carrying
+          // MAIN's validated commander binding satisfies the two pane-keyed
+          // ones instead of tripping them.
+          const decision = decideReplyDelivery(
+            sameWsTask,
+            hasAnchor,
+            pinnedAddressLost,
+            explicitPty,
+            callerPtyId,
+            {
+              // Stamped by MAIN from the validated commander token (a2a.rpc.ts);
+              // absent for every ordinary caller.
+              commanderWorkspaceId:
+                typeof params.commanderWorkspaceId === 'string' ? params.commanderWorkspaceId : '',
+            },
+          );
           if (decision.kind === 'suppress') {
             delivery = {
               stored: true,


### PR DESCRIPTION
## Why

Four links in the orchestrator loop lied or went nowhere: `input.send` reported `submitted:true` after writing an Enter it never verified; the brain (no PTY) was an `unverified_sender` on its own workspace so it could not address sibling panes; `approvalPress` had no scope, so any pane could be pressed; the channel nudge carried only a hint and never reported whether it landed, and the CLI and MCP unread views disagreed. This is lane O1 of the orchestrator track (wave 1).

## What

- **Submit receipt.** After the `\r`, `input.send` waits (400 ms, named constant) for a turn start (agentStatus → running/awaiting_input via the WorkspaceMirror) or the composer line clearing (positional, since Claude Code re-renders the prompt into the transcript). Raw byte activity is deliberately NOT a signal. No receipt ⇒ one Enter retry at 2× delay, then `accepted:false` with the last 10 screen lines. New result fields `accepted`, `agentStatusAfter`, `receiptSignal`, `enterRetried`, `screenTail`; `unobservable` when neither signal exists. `terminal_send` no longer implies ok = submitted; `terminal_send_key` points at `accepted`. Baseline SHAs refreshed (descriptions only).
- **Brain as verified sender.** Main stamps the router-validated commander workspace onto `a2a.task.send` (a wire-supplied claim is dropped first); `decideReplyDelivery` accepts it for both pane-keyed guards (`same_ws_no_anchor`, `unverified_sender`). `self_loop` unchanged; new `target_is_brain` refusal.
- **Approval press scope.** `decideApprovalPress`: press only when the target is a task workspace, autonomy is on, the request came from a hook, and verify-then-press confirms the prompt; any unestablished fact ⇒ refuse (`out-of-scope`, request not expired). Wired at `ApprovalRegistry.resolve` via a `pressScope` dependency — see Notes.
- **Channel nudge.** The wake injection carries the oldest owed message's first line (≤ 200 chars, control chars stripped) after the hint; each inject outcome is recorded and a failure marks the recipient `target_gone` (success is never promoted to `delivered`; only the ack path may). `wmux channel unread` and `channel_unread` now compute the same set from the same daemon call.

## Tests

~30 added: receipt (turn-start accepts, echo-only rejected + retry, late turn-start, unobservable, `submit:false` never accepted), brain addressing (sibling allowed, brain→brain refused, forged claim dropped), nudge body/outcome, CLI parity, approval scope (four refusals + press + registry enforcement). `npm test`: 14,048 + 193 runtime passing. `probe:mcp` green.

## Notes

- **Integration follow-up (required before release):** `ApprovalRegistry.pressScope` is not yet supplied by main, so on this branch alone every approval press is refused fail-closed. The integration PR wires `(workspaceId) => ({ isTaskWorkspace, autonomyMode })` from the worktask registry and the deck autonomy store, and exempts human-origin presses.
- Live 20/20 tally was not run: the installed daemon predates `accepted`, so a tally would have been fabricated; the fake-PTY tests carry the proof.
- `SUBMIT_ENTER_DELAY_MS` was not re-measured; the receipt path now catches a bad value instead.
- Behavior change: `wmux channel unread` no longer reads `$WMUX_MEMBER_ID` and now prints caught-up rows. Changelog fragment: `changelog.d/orch-o1.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Terminal submissions now report whether they were accepted, with status and screen details when available.
  - Channel unread output now matches tool results, including up-to-date entries and message previews.
  - Wake notifications include a safe first-line preview for recognized agent interfaces.
  - Agents can receive messages from authorized commanders within the same workspace.

- **Bug Fixes**
  - Failed wake notifications are tracked as unavailable, while later acknowledgments can restore delivery.
  - Automated approval actions are restricted to eligible delegated tasks; refused approvals remain available for human review.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->