### PR TITLE
test(mcp): scan only the index.ts wiring point for reserved commander tool names

### DIFF
--- a/src/shared/__tests__/commanderSurface.test.ts
+++ b/src/shared/__tests__/commanderSurface.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import {
   COMMANDER_TOOL_SURFACE,
@@ -74,18 +74,6 @@ const baseline = JSON.parse(
   readFileSync(path.join(__dirname, '..', '..', '..', 'scripts', 'mcp-protocol-baseline.json'), 'utf8'),
 ) as { profiles: Record<string, { toolNames: string[] }> };
 
-function walkSources(dir: string, out: string[] = []): string[] {
-  for (const name of readdirSync(dir)) {
-    const p = path.join(dir, name);
-    if (statSync(p).isDirectory()) {
-      if (name !== '__tests__') walkSources(p, out);
-    } else if (p.endsWith('.ts')) {
-      out.push(readFileSync(p, 'utf8'));
-    }
-  }
-  return out;
-}
-
 describe('commander-only lane invariants (COMMANDER_ONLY_TOOLS)', () => {
   it('is disjoint from the filtered commander surface, core and full — except the declared variants', () => {
     const full = new Set(baseline.profiles.full.toolNames);
@@ -132,8 +120,11 @@ describe('commander-only lane invariants (COMMANDER_ONLY_TOOLS)', () => {
     }
   });
 
-  it('reserved lane-O2 names are absent from every profile and from every src/mcp registration', () => {
-    const sources = walkSources(path.join(__dirname, '..', '..', 'mcp')).join('\n');
+  it('reserved lane-O2 names are absent from every profile and from the src/mcp/index.ts wiring', () => {
+    // The wiring point is index.ts. The implementations (src/mcp/worktask.ts,
+    // src/mcp/git.ts) may exist ahead of being wired — that is exactly the
+    // reserved state — so only the entry file is scanned.
+    const sources = readFileSync(path.join(__dirname, '..', '..', 'mcp', 'index.ts'), 'utf8');
     for (const name of COMMANDER_ONLY_RESERVED_TOOLS) {
       expect(COMMANDER_ONLY_TOOLS).not.toContain(name);
       expect(COMMANDER_TOOL_SURFACE).not.toContain(name);


### PR DESCRIPTION
## Why

#1197 (lane O2) landed the task/git tool implementations under `src/mcp` ahead of their registration, which is exactly the reserved state the invariant from #1198 (lane F) protects. The test scanned every `src/mcp` source for the reserved names, so the two PRs turned main red together (`reserved lane-O2 names are absent … task_gate_run is registered in src/mcp before being wired`).

## What

The invariant now scans only `src/mcp/index.ts`, the wiring point. A reserved name is "wired" when the entry file registers it, not when a module defines it. The integration PR that wires those tools flips the names from reserved to commander-only and updates this test again.

## Verification

`npx vitest run src/shared/__tests__/commanderSurface.test.ts` green; eslint clean. Test-only change, no changelog fragment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation coverage to inspect the MCP entry file directly.
  * Simplified file-reading imports and removed broad recursive source scanning.
  * Clarified test descriptions and comments to reflect the narrower validation scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->