### PR TITLE
feat(channels): honest mention targets and delivery status, Fleet approval countdown, cleanup from Missions

### DIFF
--- a/changelog.d/orch-w2-c.md
+++ b/changelog.d/orch-w2-c.md
@@ -1,10 +1,10 @@
 ### Added
 
 - Channel composer now tells you where an @mention will actually land: a mention
-  of a roster member is pinned to that workspace's most recently active agent
-  pane (the only shape that reaches an idle agent), with a "will reach …" hint
-  under the input. A member with no live agent pane is offered as a badge-only
-  mention and labelled as one instead of silently reaching nobody.
+  of a roster member is pinned to that member's own agent pane (the only shape
+  that reaches an idle agent), with a "will reach …" hint under the input. A
+  member with no live agent pane is offered as a badge-only mention and labelled
+  as one instead of silently reaching nobody.
 - Channel messages you post now show what actually happened to them: delivered
   as soon as any recipient got it, target gone when none did, and "no answer —
   nudges exhausted" when the wake worker gave up on a mentioned agent. A post
@@ -13,11 +13,13 @@
 - Fleet's approval inbox shows the auto-reject countdown on every approval that
   has a deadline, and keeps a short "auto-rejected" log of the ones that expired
   while you were away instead of letting them vanish like an answered prompt.
-- The Missions section's finished-tasks row now opens the task cleanup scan, and
-  a close that fails on a worktree still holding work offers two next steps on
-  the row itself: "Commit & close", which types a ready-to-run `git add -- <the
-  changed paths> && git commit -m "wip: <task>"` into the task's own pane
-  without running it, and "Open worktree".
+- The Missions section header now opens the task cleanup scan, and a close that
+  fails on a worktree still holding uncommitted work offers two next steps on
+  the row itself: "Commit & close", which types a ready-to-run
+  `git -C <worktree> add -- <the changed paths> && git -C <worktree> commit -m
+  "wip: <task>"` into the task's own shell without running it, and "Open
+  worktree". The commit line is offered only when the task's pane is a shell (in
+  an agent's TUI it would become a chat message) and only on POSIX shells.
 
 ### Changed
 
@@ -32,3 +34,9 @@
   agent mention-loop warning are translated (en/ko/pl) instead of always English.
 - The members roster's agent liveness dot carries an accessible label, so a
   screen reader reports whether an agent's pane is live or gone.
+- Two channel members of the same workspace that have no live pane can both be
+  @mentioned in one post — the second mention used to be dropped silently.
+- A "no answer — nudges exhausted" mark applies only to the messages that were
+  already posted when the wake worker gave up, and clears once that member
+  catches up, leaves, or the channel is archived. It used to stick to every
+  message you ever posted in that channel.

--- a/changelog.d/orch-w2-c.md
+++ b/changelog.d/orch-w2-c.md
@@ -10,3 +10,6 @@
   nudges exhausted" when the wake worker gave up on a mentioned agent. A post
   that never gets an outcome now reads "delivery unconfirmed" instead of
   claiming to still be sending forever.
+- Fleet's approval inbox shows the auto-reject countdown on every approval that
+  has a deadline, and keeps a short "auto-rejected" log of the ones that expired
+  while you were away instead of letting them vanish like an answered prompt.

--- a/changelog.d/orch-w2-c.md
+++ b/changelog.d/orch-w2-c.md
@@ -13,3 +13,8 @@
 - Fleet's approval inbox shows the auto-reject countdown on every approval that
   has a deadline, and keeps a short "auto-rejected" log of the ones that expired
   while you were away instead of letting them vanish like an answered prompt.
+- The Missions section's finished-tasks row now opens the task cleanup scan, and
+  a close that fails on a worktree still holding work offers two next steps on
+  the row itself: "Commit & close", which types a ready-to-run `git add -- <the
+  changed paths> && git commit -m "wip: <task>"` into the task's own pane
+  without running it, and "Open worktree".

--- a/changelog.d/orch-w2-c.md
+++ b/changelog.d/orch-w2-c.md
@@ -1,0 +1,7 @@
+### Added
+
+- Channel composer now tells you where an @mention will actually land: a mention
+  of a roster member is pinned to that workspace's most recently active agent
+  pane (the only shape that reaches an idle agent), with a "will reach …" hint
+  under the input. A member with no live agent pane is offered as a badge-only
+  mention and labelled as one instead of silently reaching nobody.

--- a/changelog.d/orch-w2-c.md
+++ b/changelog.d/orch-w2-c.md
@@ -5,3 +5,8 @@
   pane (the only shape that reaches an idle agent), with a "will reach …" hint
   under the input. A member with no live agent pane is offered as a badge-only
   mention and labelled as one instead of silently reaching nobody.
+- Channel messages you post now show what actually happened to them: delivered
+  as soon as any recipient got it, target gone when none did, and "no answer —
+  nudges exhausted" when the wake worker gave up on a mentioned agent. A post
+  that never gets an outcome now reads "delivery unconfirmed" instead of
+  claiming to still be sending forever.

--- a/changelog.d/orch-w2-c.md
+++ b/changelog.d/orch-w2-c.md
@@ -18,3 +18,17 @@
   the row itself: "Commit & close", which types a ready-to-run `git add -- <the
   changed paths> && git commit -m "wip: <task>"` into the task's own pane
   without running it, and "Open worktree".
+
+### Changed
+
+- A pane that joined a channel over MCP or the CLI is now named the way the rest
+  of wmux names it — its rename, else `w<workspace>-<pane>(<agent>)` — in the
+  members roster and on the transcript's sender chip, instead of the opaque
+  spawn-stamped member id it used to print.
+
+### Fixed
+
+- The channel composer's "no channel or workspace identity" post failure and the
+  agent mention-loop warning are translated (en/ko/pl) instead of always English.
+- The members roster's agent liveness dot carries an accessible label, so a
+  screen reader reports whether an agent's pane is live or gone.

--- a/src/renderer/channels/__tests__/paneMemberNames.test.ts
+++ b/src/renderer/channels/__tests__/paneMemberNames.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPaneNamesByPrincipal,
+  paneNameForAuthor,
+  paneNameForMember,
+  paneNamesKey,
+  parsePaneNamesKey,
+} from '../paneMemberNames';
+import { createLeafPane, createSurface, type Pane, type Workspace } from '../../../shared/types';
+import { panePrincipalId } from '../../../shared/principals';
+import type { ChannelMember } from '../../../shared/channels';
+
+// C-5 — the case that motivated this module: a pane that joined the channel over
+// MCP/CLI stores an opaque spawn-stamped memberId, so the roster and the
+// transcript printed `pty-…` for a pane the composer and the title bar both call
+// `w1-1(claude)`. The principal coordinate on the member row is the bridge.
+
+const CLAUDE = { name: 'Claude Code', slug: 'claude' as const };
+
+function twoPaneWorkspace() {
+  const leafA = createLeafPane(createSurface('ptyA', 'pwsh', ''), 1);
+  const leafB = createLeafPane(createSurface('ptyB', 'pwsh', ''), 2);
+  const root: Pane = {
+    id: 'br',
+    type: 'branch',
+    direction: 'horizontal',
+    children: [leafA, leafB],
+    sizes: [50, 50],
+  };
+  const ws: Workspace = {
+    id: 'ws-1',
+    name: 'Backend',
+    wsOrdinal: 1,
+    nextPaneOrdinal: 3,
+    rootPane: root,
+    activePaneId: leafA.id,
+  };
+  return { ws, leafA, leafB };
+}
+
+function member(workspaceId: string, memberId: string, principalId?: string): ChannelMember {
+  return {
+    workspaceId,
+    memberId,
+    joinedAt: 0,
+    historyFromSeq: 0,
+    ...(principalId ? { principalId } : {}),
+  };
+}
+
+describe('buildPaneNamesByPrincipal', () => {
+  it('names every pane by principal, with the agent suffix and any user rename', () => {
+    const { ws, leafA, leafB } = twoPaneWorkspace();
+    const names = buildPaneNamesByPrincipal({
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE, ptyB: CLAUDE },
+      paneLabel: { [leafB.id]: '  Reviewer  ' },
+    });
+    expect(names.get(panePrincipalId('ws-1', leafA.id))).toBe('w1-1(claude)');
+    // A rename wins over the auto name and is trimmed (paneDisplayName).
+    expect(names.get(panePrincipalId('ws-1', leafB.id))).toBe('Reviewer');
+  });
+
+  it('still names a pane whose agent has exited — coordinate only, no suffix', () => {
+    const { ws, leafA } = twoPaneWorkspace();
+    const names = buildPaneNamesByPrincipal({
+      workspaces: [ws],
+      surfaceAgent: {},
+      paneLabel: {},
+    });
+    expect(names.get(panePrincipalId('ws-1', leafA.id))).toBe('w1-1');
+  });
+});
+
+describe('paneNameForMember / paneNameForAuthor', () => {
+  it('resolves an opaque MCP-joined memberId back to the pane display name', () => {
+    const { ws, leafA } = twoPaneWorkspace();
+    const names = buildPaneNamesByPrincipal({
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE },
+      paneLabel: {},
+    });
+    const row = member('ws-1', 'pty-9f31c2ab', panePrincipalId('ws-1', leafA.id));
+    expect(paneNameForMember(row, names)).toBe('w1-1(claude)');
+    expect(
+      paneNameForAuthor({ members: [row], names, workspaceId: 'ws-1', memberId: 'pty-9f31c2ab' }),
+    ).toBe('w1-1(claude)');
+  });
+
+  it('returns undefined for a row with no principal, a dead pane, or no roster match', () => {
+    const names = new Map<string, string>();
+    expect(paneNameForMember(member('ws-1', 'legacy'), names)).toBeUndefined();
+    const orphan = member('ws-1', 'gone', panePrincipalId('ws-1', 'pane-deleted'));
+    expect(paneNameForMember(orphan, names)).toBeUndefined();
+    expect(
+      paneNameForAuthor({ members: [orphan], names, workspaceId: 'ws-1', memberId: 'someone-else' }),
+    ).toBeUndefined();
+  });
+});
+
+describe('paneNamesKey projection', () => {
+  it('round-trips through parsePaneNamesKey and is stable across identical inputs', () => {
+    const { ws, leafA } = twoPaneWorkspace();
+    const sources = {
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE },
+      paneLabel: { [leafA.id]: 'Deck brain' },
+    };
+    const key = paneNamesKey(sources);
+    expect(paneNamesKey(sources)).toBe(key);
+    expect(parsePaneNamesKey(key)).toEqual(buildPaneNamesByPrincipal(sources));
+    expect(parsePaneNamesKey('').size).toBe(0);
+  });
+});

--- a/src/renderer/channels/paneMemberNames.ts
+++ b/src/renderer/channels/paneMemberNames.ts
@@ -1,0 +1,130 @@
+// ─── C-5: one pane, one name, everywhere in the channel UI ───────────────────
+//
+// A channel member row and a transcript author line both stand for a PANE, but
+// they identified it by its stored `memberId`. That id is the pane auto name
+// only when the pane joined through the GUI; a pane that joined over MCP/CLI
+// carries an opaque spawn-stamped id, so the roster and the transcript showed
+// `pty-9f31c2…` where the composer's @-picker and the pane title bar showed
+// `w26-1(claude)`. Same pane, three different names.
+//
+// These pure helpers resolve the pane's OWN display name (user rename ?? auto
+// name) from the principal coordinate the member row already records, using the
+// exact representative-surface rule `buildMentionCandidates` uses — the roster,
+// the mention tokens and the pane title cannot drift apart because they now
+// compute the name the same way.
+//
+// Store-free and side-effect-free so they are unit-testable and safe to call
+// from a selector.
+
+import type { Workspace } from '../../shared/types';
+import type { AgentSlug } from '../../shared/events';
+import type { ChannelMember } from '../../shared/channels';
+import { panePrincipalId } from '../../shared/principals';
+import { findLeafPanes } from '../hooks/a2aAddressing';
+import { computePaneAutoName, paneDisplayName } from '../utils/paneNaming';
+
+/** The renderer's ptyId → detected-agent mirror (`store.surfaceAgent`). */
+export type SurfaceAgentMirror = Record<string, { name: string; slug?: AgentSlug } | undefined>;
+
+export interface PaneNameSources {
+  workspaces: readonly Workspace[];
+  surfaceAgent: SurfaceAgentMirror;
+  /** paneId → user rename (`store.paneLabel`). */
+  paneLabel: Record<string, string>;
+}
+
+/**
+ * Every live pane's display name, keyed by its principal coordinate
+ * (`panePrincipalId(workspaceId, paneId)`) — the same key a channel member row
+ * stores in `principalId`.
+ *
+ * Panes with no live agent are included: a member whose agent has exited still
+ * has a pane, and `w26-1` is a truer answer than an opaque member id. The agent
+ * suffix comes from the pane's representative agent surface (the active one
+ * when it runs an agent, else the first that does), so a multi-tab pane yields
+ * one name instead of one per tab.
+ */
+export function buildPaneNamesByPrincipal({
+  workspaces,
+  surfaceAgent,
+  paneLabel,
+}: PaneNameSources): Map<string, string> {
+  const names = new Map<string, string>();
+  for (const w of workspaces) {
+    const wsOrdinal = w.wsOrdinal ?? 0;
+    for (const leaf of findLeafPanes(w.rootPane)) {
+      const agentSurfaces = leaf.surfaces.filter(
+        (s) => s.surfaceType !== 'browser' && !!s.ptyId && !!surfaceAgent[s.ptyId]?.name,
+      );
+      const repr = agentSurfaces.find((s) => s.id === leaf.activeSurfaceId) ?? agentSurfaces[0];
+      const autoName = computePaneAutoName(
+        wsOrdinal,
+        leaf.ordinal ?? 0,
+        repr ? surfaceAgent[repr.ptyId]?.slug : undefined,
+      );
+      names.set(panePrincipalId(w.id, leaf.id), paneDisplayName(paneLabel[leaf.id], autoName));
+    }
+  }
+  return names;
+}
+
+/**
+ * The pane display name behind one roster member, or `undefined` when the row
+ * has no principal (legacy/external MCP member) or its pane is gone. Callers
+ * fall back to the stored member label rather than inventing a name.
+ */
+export function paneNameForMember(
+  member: Pick<ChannelMember, 'principalId'>,
+  names: ReadonlyMap<string, string>,
+): string | undefined {
+  return member.principalId ? names.get(member.principalId) : undefined;
+}
+
+/**
+ * The pane display name behind a transcript author, resolved through the
+ * channel roster: a message carries (workspaceId, memberId), the roster row for
+ * that pair carries the principal, and the principal names the pane.
+ */
+export function paneNameForAuthor(args: {
+  members: readonly ChannelMember[];
+  names: ReadonlyMap<string, string>;
+  workspaceId: string;
+  memberId: string;
+}): string | undefined {
+  const row = args.members.find(
+    (m) => m.workspaceId === args.workspaceId && m.memberId === args.memberId,
+  );
+  return row ? paneNameForMember(row, args.names) : undefined;
+}
+
+// Control characters, so a pane rename containing any printable separator
+// cannot forge a pair boundary. Same scheme as ChannelView's workspace-name key.
+const FIELD_SEP = '\u0000';
+const PAIR_SEP = '\u0001';
+
+/**
+ * A stable STRING projection of the pane-name map, for components that must
+ * subscribe from a store selector. `ChannelView` cannot depend on the workspace
+ * array itself — its reference churns on every pane-tree mutation (titles, cwd,
+ * layout) and would repaint the whole transcript while agents are active. The
+ * joined key only changes when a pane's NAME changes, so `parsePaneNamesKey`
+ * behind a `useMemo` gives a reference-stable map.
+ */
+export function paneNamesKey(sources: PaneNameSources): string {
+  const parts: string[] = [];
+  for (const [principalId, name] of buildPaneNamesByPrincipal(sources)) {
+    parts.push(`${principalId}${FIELD_SEP}${name}`);
+  }
+  return parts.join(PAIR_SEP);
+}
+
+/** Inverse of {@link paneNamesKey}. */
+export function parsePaneNamesKey(key: string): Map<string, string> {
+  const names = new Map<string, string>();
+  if (!key) return names;
+  for (const pair of key.split(PAIR_SEP)) {
+    const sep = pair.indexOf(FIELD_SEP);
+    if (sep > 0) names.set(pair.slice(0, sep), pair.slice(sep + 1));
+  }
+  return names;
+}

--- a/src/renderer/components/Channels/ChannelMembers.tsx
+++ b/src/renderer/components/Channels/ChannelMembers.tsx
@@ -368,6 +368,10 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
     memberWorkspaceIds: new Set(workspaces.map((w) => w.id)),
     selfWorkspaceId,
   })
+    // Pane candidates only. The roster-member candidates (C-1) exist so a member
+    // with no live agent pane can still be @-mentioned; they carry no paneId and
+    // are by definition already members, so they are never join candidates.
+    .filter((c): c is typeof c & { paneId: string } => !!c.paneId)
     .map((c) => ({
       workspaceId: c.workspaceId,
       paneId: c.paneId,

--- a/src/renderer/components/Channels/ChannelMembers.tsx
+++ b/src/renderer/components/Channels/ChannelMembers.tsx
@@ -35,6 +35,7 @@ import { FOCUS_RING } from '../focusRing';
 import { IconX, IconUsers } from '../icons';
 import { findLeafPanes } from '../../hooks/a2aAddressing';
 import { rosterMemberLabel } from '../../channels/authorDisplay';
+import { buildPaneNamesByPrincipal, paneNameForMember } from '../../channels/paneMemberNames';
 import { buildMentionCandidates } from './Composer';
 
 export interface JoinableWorkspace {
@@ -83,6 +84,10 @@ export interface ChannelMembersViewProps {
   /** R2 — liveness of an agent row (live when the pane is alive and an agent is detected).
    *  Rows without a principalId (legacy/external MCP memberId) → undefined → no badge. */
   agentLiveness?: (m: ChannelMember) => 'live' | 'stale' | undefined;
+  /** C-5 — the pane's own display name (rename ?? auto name) for a member row
+   *  whose principal still resolves to a live pane. Preferred over the stored
+   *  memberId, which for an MCP-joined pane is an opaque spawn-stamped id. */
+  paneDisplayNameFor?: (m: ChannelMember) => string | undefined;
   onLeave: (memberId: string, workspaceId: string) => void;
   /** Eject ANOTHER member (humans-only). Shown on NON-self rows only when
    *  provided (a resolvable human identity + non-archived channel). Absent →
@@ -105,6 +110,7 @@ export function ChannelMembersView({
   onJoin,
   onJoinPane = () => {},
   agentLiveness,
+  paneDisplayNameFor,
   onLeave,
   onKick,
   t: tProp,
@@ -180,7 +186,12 @@ export function ChannelMembersView({
               // workspace name (rosterMemberLabel).
               const wsLabel = workspaceLabel(m.workspaceId);
               const label = rosterMemberLabel(m, selfWorkspaceId, selfMemberId, wsLabel);
-              const primary = label.primary || (t('channels.me') || 'Me');
+              // C-5: a pane the viewer can see is named the way the rest of the
+              // app names it — its rename, else its auto name. The stored
+              // memberId is only the fallback for a row whose pane is gone or
+              // that never had one.
+              const paneName = isHuman ? undefined : paneDisplayNameFor?.(m);
+              const primary = paneName || label.primary || (t('channels.me') || 'Me');
               return (
                 <div
                   key={`${m.workspaceId}:${m.memberId}`}
@@ -192,7 +203,11 @@ export function ChannelMembersView({
                   {liveness && (
                     <span
                       data-channel-member-liveness
-                      aria-hidden="true"
+                      // C-5: the dot IS the status for this row — a screen
+                      // reader that skips it (aria-hidden) never learns whether
+                      // the agent pane is alive. Labelled, not decorative.
+                      role="img"
+                      aria-label={liveness === 'live' ? (t('channels.memberLiveTitle') || 'Agent pane is live') : (t('channels.memberStaleTitle') || 'Agent pane is gone or restarting')}
                       title={liveness === 'live' ? (t('channels.memberLiveTitle') || 'Agent pane is live') : (t('channels.memberStaleTitle') || 'Agent pane is gone or restarting')}
                       className="flex-shrink-0 w-1.5 h-1.5 rounded-full"
                       style={{ backgroundColor: liveness === 'live' ? 'var(--accent-green)' : 'var(--text-subtle)' }}
@@ -407,6 +422,15 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
     return 'stale';
   };
 
+  // C-5 — the pane display name behind a member row, when its principal still
+  // resolves to a live pane in this renderer. Same naming scheme as the mention
+  // tokens and the pane title bar (rename ?? auto name), so one pane reads the
+  // same everywhere instead of surfacing an opaque spawn-stamped memberId in
+  // the roster.
+  const paneNames = buildPaneNamesByPrincipal({ workspaces, surfaceAgent, paneLabel });
+  const paneDisplayNameFor = (m: ChannelMember): string | undefined =>
+    paneNameForMember(m, paneNames);
+
   // Show the picker only when the self ws can actually act on the channel: a
   // public channel anyone can self-join, but a private channel can only be
   // invited into by a current member (the daemon gates invite on the inviter
@@ -532,6 +556,7 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
       onJoin={handleJoin}
       onJoinPane={handleJoinPane}
       agentLiveness={agentLiveness}
+      paneDisplayNameFor={paneDisplayNameFor}
       onLeave={handleLeave}
       onKick={canKick ? handleKick : undefined}
       t={t}

--- a/src/renderer/components/Channels/ChannelMembers.tsx
+++ b/src/renderer/components/Channels/ChannelMembers.tsx
@@ -24,7 +24,7 @@
 // MCP channel_post member_id; the human UI identity is the single reserved seat
 // (HUMAN_MEMBER_ID on HUMAN_WORKSPACE_ID).
 
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { Channel, ChannelMember } from '../../../shared/channels';
 import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import { panePrincipalId } from '../../../shared/principals';
@@ -206,9 +206,10 @@ export function ChannelMembersView({
                       // C-5: the dot IS the status for this row — a screen
                       // reader that skips it (aria-hidden) never learns whether
                       // the agent pane is alive. Labelled, not decorative.
+                      // One name, not two: an element carrying both aria-label
+                      // and an identical title is announced twice.
                       role="img"
                       aria-label={liveness === 'live' ? (t('channels.memberLiveTitle') || 'Agent pane is live') : (t('channels.memberStaleTitle') || 'Agent pane is gone or restarting')}
-                      title={liveness === 'live' ? (t('channels.memberLiveTitle') || 'Agent pane is live') : (t('channels.memberStaleTitle') || 'Agent pane is gone or restarting')}
                       className="flex-shrink-0 w-1.5 h-1.5 rounded-full"
                       style={{ backgroundColor: liveness === 'live' ? 'var(--accent-green)' : 'var(--text-subtle)' }}
                     />
@@ -427,9 +428,17 @@ export function ChannelMembersControl({ channel }: { channel: Channel }): React.
   // tokens and the pane title bar (rename ?? auto name), so one pane reads the
   // same everywhere instead of surfacing an opaque spawn-stamped memberId in
   // the roster.
-  const paneNames = buildPaneNamesByPrincipal({ workspaces, surfaceAgent, paneLabel });
-  const paneDisplayNameFor = (m: ChannelMember): string | undefined =>
-    paneNameForMember(m, paneNames);
+  // Review fix: the walk visits every workspace, pane and surface, so it is
+  // memoised on its three sources instead of re-running on every render of an
+  // always-mounted popover host.
+  const paneNames = useMemo(
+    () => buildPaneNamesByPrincipal({ workspaces, surfaceAgent, paneLabel }),
+    [workspaces, surfaceAgent, paneLabel],
+  );
+  const paneDisplayNameFor = useCallback(
+    (m: ChannelMember): string | undefined => paneNameForMember(m, paneNames),
+    [paneNames],
+  );
 
   // Show the picker only when the self ws can actually act on the channel: a
   // public channel anyone can self-join, but a private channel can only be

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -14,6 +14,7 @@
 // Plan ref: U8, R21, R22.
 
 import { useEffect, useMemo, useCallback, useState, Fragment } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import type {
   Channel,
   ChannelMessage,
@@ -32,6 +33,7 @@ import { Composer } from './Composer';
 import { ChannelMembersControl } from './ChannelMembers';
 import {
   ownMessageDeliveryState,
+  needsDeliveryAgingClock,
   DELIVERY_LABEL_KEY,
   DELIVERY_LABEL_FALLBACK,
 } from './deliveryStatus';
@@ -260,10 +262,11 @@ export interface ChannelViewContentProps {
   /** Header control for the members roster (count + join/leave popover).
    *  Slotted so the pure view stays store-free for the test harness. */
   membersSlot?: React.ReactNode;
-  /** C-2 — memberIds in THIS channel whose nudge episode ran out of budget
-   *  (`channel.nudgeExhausted`). Their sender-side rows read "no answer"
-   *  instead of a delivered receipt nobody acted on. */
-  nudgeExhaustedMemberIds?: ReadonlySet<string>;
+  /** C-2 — memberId → epoch ms of that member's last exhausted nudge episode in
+   *  THIS channel (`channel.nudgeExhausted`). Rows posted at or before that
+   *  instant read "no answer" instead of a delivered receipt nobody acted on;
+   *  later ones are untouched — the worker never tried to deliver them. */
+  nudgeExhaustedAtByMember?: Readonly<Record<string, number>>;
   /** C-2 — clock injection for the delivery-aging rule (tests pass a fixed
    *  value; production lets the view tick it). */
   now?: number;
@@ -285,7 +288,7 @@ export function ChannelViewContent({
   workspaceName = () => undefined,
   composerSlot,
   membersSlot,
-  nudgeExhaustedMemberIds,
+  nudgeExhaustedAtByMember,
   now: nowProp,
   paneNameFor,
   t: tProp,
@@ -295,12 +298,25 @@ export function ChannelViewContent({
   // stops claiming to be in flight. Nothing else repaints the transcript on a
   // timer, so the view keeps its own coarse clock — 10 s, only while the caller
   // has not pinned one (tests pass `now` and get no interval at all).
+  //
+  // Review fix: the aging rule is the ONLY thing that clock feeds, so it runs
+  // only while the viewer has an unresolved post of their own. A settled
+  // transcript repainted every 10 s for nothing.
+  const hasAgingCandidate = useMemo(
+    () =>
+      needsDeliveryAgingClock({
+        messages,
+        viewerMemberId: viewer?.memberId ?? null,
+        ...(nudgeExhaustedAtByMember ? { exhaustedAtByMember: nudgeExhaustedAtByMember } : {}),
+      }),
+    [messages, viewer, nudgeExhaustedAtByMember],
+  );
   const [clock, setClock] = useState(() => Date.now());
   useEffect(() => {
-    if (nowProp !== undefined) return;
+    if (nowProp !== undefined || !hasAgingCandidate) return;
     const timer = setInterval(() => setClock(Date.now()), 10_000);
     return () => clearInterval(timer);
-  }, [nowProp]);
+  }, [nowProp, hasAgingCandidate]);
   const now = nowProp ?? clock;
   // Two-click confirm for the one-way archive: first click arms (button turns
   // red + shows a check), second commits; blur cancels.
@@ -552,7 +568,9 @@ export function ChannelViewContent({
               message: m,
               viewerMemberId: viewer?.memberId ?? null,
               now,
-              ...(nudgeExhaustedMemberIds ? { exhaustedMemberIds: nudgeExhaustedMemberIds } : {}),
+              ...(nudgeExhaustedAtByMember
+                ? { exhaustedAtByMember: nudgeExhaustedAtByMember }
+                : {}),
             });
             const mentionsMe =
               !!viewer && !!m.mentions?.some((mn) => mn.workspaceId === viewer.workspaceId);
@@ -684,14 +702,28 @@ export function ChannelView(): React.ReactElement | null {
   );
   // C-2: subscribe to a STRING projection of this channel's exhausted-nudge
   // members (same reason as workspaceNamesKey below — a fresh object per render
-  // would repaint the whole transcript on every unrelated store write).
-  const nudgeExhaustedKey = useStore((s) =>
-    activeChannelId ? Object.keys(s.channelNudgeExhausted[activeChannelId] ?? {}).sort().join('\u0001') : '',
-  );
-  const nudgeExhaustedMemberIds = useMemo(
-    () => new Set(nudgeExhaustedKey ? nudgeExhaustedKey.split('\u0001') : []),
-    [nudgeExhaustedKey],
-  );
+  // would repaint the whole transcript on every unrelated store write). The
+  // projection carries each episode's TIMESTAMP: the label applies only to the
+  // messages that were already posted when the wake worker gave up.
+  const nudgeExhaustedKey = useStore((s) => {
+    const byMember = activeChannelId ? s.channelNudgeExhausted[activeChannelId] : undefined;
+    if (!byMember) return '';
+    return Object.keys(byMember)
+      .sort()
+      .map((memberId) => `${memberId}\u0000${byMember[memberId]}`)
+      .join('\u0001');
+  });
+  const nudgeExhaustedAtByMember = useMemo(() => {
+    const out: Record<string, number> = {};
+    if (!nudgeExhaustedKey) return out;
+    for (const pair of nudgeExhaustedKey.split('\u0001')) {
+      const sep = pair.indexOf('\u0000');
+      if (sep <= 0) continue;
+      const at = Number(pair.slice(sep + 1));
+      if (Number.isFinite(at)) out[pair.slice(0, sep)] = at;
+    }
+    return out;
+  }, [nudgeExhaustedKey]);
   // Identity audit 1a: workspace display names for the sender identity chips
   // (human posts read "Me · <workspace>"). Subscribe to a STRING projection of
   // (id, name) pairs, not the workspaces array itself — the array reference
@@ -716,9 +748,20 @@ export function ChannelView(): React.ReactElement | null {
   // churns on every terminal title/cwd write, and depending on it directly would
   // repaint the whole transcript while agents are active. The key changes only
   // when a pane is renamed, added, removed, or its detected agent changes.
-  const paneNamesProjection = useStore((s) =>
-    paneNamesKey({ workspaces: s.workspaces, surfaceAgent: s.surfaceAgent, paneLabel: s.paneLabel }),
+  //
+  // Review fix: the WALK is not in the selector. A selector runs on every store
+  // write — terminal output included — so building the key there re-visited
+  // every workspace, pane and surface thousands of times a second. Subscribing
+  // shallowly to the three sources keeps the per-write work at three reference
+  // comparisons and moves the walk into a memo keyed on them.
+  const paneNameSources = useStore(
+    useShallow((s) => ({
+      workspaces: s.workspaces,
+      surfaceAgent: s.surfaceAgent,
+      paneLabel: s.paneLabel,
+    })),
   );
+  const paneNamesProjection = useMemo(() => paneNamesKey(paneNameSources), [paneNameSources]);
   const paneNameFor = useMemo(() => {
     const names = parsePaneNamesKey(paneNamesProjection);
     return (workspaceId: string, memberId: string) =>
@@ -933,7 +976,7 @@ export function ChannelView(): React.ReactElement | null {
         onLoadEarlier={handleLoadEarlier}
         workspaceName={workspaceName}
         t={t}
-        nudgeExhaustedMemberIds={nudgeExhaustedMemberIds}
+        nudgeExhaustedAtByMember={nudgeExhaustedAtByMember}
         paneNameFor={paneNameFor}
         membersSlot={<ChannelMembersControl channel={channel} />}
         composerSlot={

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -30,6 +30,11 @@ import { formatChannelAuthor } from '../../channels/authorDisplay';
 import { HUMAN_WORKSPACE_ID, HUMAN_MEMBER_ID } from '../../../shared/channels';
 import { Composer } from './Composer';
 import { ChannelMembersControl } from './ChannelMembers';
+import {
+  ownMessageDeliveryState,
+  DELIVERY_LABEL_KEY,
+  DELIVERY_LABEL_FALLBACK,
+} from './deliveryStatus';
 
 // Stable empty references for the store selectors below. A selector that
 // returns `s.channelMessages[id] ?? []` would mint a FRESH `[]` on every
@@ -70,24 +75,6 @@ export function sortMessagesBySeq(
   messages: ChannelMessage[],
 ): ChannelMessage[] {
   return messages.slice().sort((a, b) => a.seq - b.seq);
-}
-
-/** Pick the viewer's own entry out of the per-recipient snapshot. The
- *  plan's R22 says the message row should show a per-recipient delivery
- *  status indicator "for the current viewer's entry". Returns
- *  `undefined` when the snapshot is missing (pre-U2 messages) or
- *  the viewer isn't in the snapshot (e.g. a member who was removed
- *  between post and view). */
-export function viewerDeliveryStatus(
-  message: ChannelMessage,
-  viewerMemberId: string | null,
-): ChannelMessage['deliveryStatus'] | undefined {
-  if (!viewerMemberId) return undefined;
-  if (message.memberId !== viewerMemberId) return undefined;
-  const snap = message.recipientSnapshot;
-  if (!snap) return message.deliveryStatus;
-  const me = snap.find((s) => s.memberId === viewerMemberId);
-  return me?.status;
 }
 
 /** Render message text with its @mention tokens highlighted. Splits on the
@@ -272,6 +259,13 @@ export interface ChannelViewContentProps {
   /** Header control for the members roster (count + join/leave popover).
    *  Slotted so the pure view stays store-free for the test harness. */
   membersSlot?: React.ReactNode;
+  /** C-2 — memberIds in THIS channel whose nudge episode ran out of budget
+   *  (`channel.nudgeExhausted`). Their sender-side rows read "no answer"
+   *  instead of a delivered receipt nobody acted on. */
+  nudgeExhaustedMemberIds?: ReadonlySet<string>;
+  /** C-2 — clock injection for the delivery-aging rule (tests pass a fixed
+   *  value; production lets the view tick it). */
+  now?: number;
 }
 
 /** The presentational surface — all data comes via props, no store reads. */
@@ -286,9 +280,22 @@ export function ChannelViewContent({
   workspaceName = () => undefined,
   composerSlot,
   membersSlot,
+  nudgeExhaustedMemberIds,
+  now: nowProp,
   t: tProp,
 }: ChannelViewContentProps): React.ReactElement {
   const t = tProp ?? ((key: string) => key);
+  // C-2 delivery aging: a `pending` older than DELIVERY_UNCONFIRMED_AFTER_MS
+  // stops claiming to be in flight. Nothing else repaints the transcript on a
+  // timer, so the view keeps its own coarse clock — 10 s, only while the caller
+  // has not pinned one (tests pass `now` and get no interval at all).
+  const [clock, setClock] = useState(() => Date.now());
+  useEffect(() => {
+    if (nowProp !== undefined) return;
+    const timer = setInterval(() => setClock(Date.now()), 10_000);
+    return () => clearInterval(timer);
+  }, [nowProp]);
+  const now = nowProp ?? clock;
   // Two-click confirm for the one-way archive: first click arms (button turns
   // red + shows a check), second commits; blur cancels.
   const [archiveArmed, setArchiveArmed] = useState(false);
@@ -535,7 +542,12 @@ export function ChannelViewContent({
                 </div>
               );
             }
-            const myStatus = viewerDeliveryStatus(m, viewer?.memberId ?? null);
+            const myStatus = ownMessageDeliveryState({
+              message: m,
+              viewerMemberId: viewer?.memberId ?? null,
+              now,
+              ...(nudgeExhaustedMemberIds ? { exhaustedMemberIds: nudgeExhaustedMemberIds } : {}),
+            });
             const mentionsMe =
               !!viewer && !!m.mentions?.some((mn) => mn.workspaceId === viewer.workspaceId);
             const author = formatChannelAuthor(m, workspaceName);
@@ -607,12 +619,16 @@ export function ChannelViewContent({
                 </div>
                 {myStatus && (
                   <div
-                    className="text-[9px] font-mono text-[var(--text-muted)] self-end"
+                    className={`text-[9px] font-mono self-end ${
+                      myStatus === 'nudge_exhausted'
+                        ? 'text-[var(--accent-yellow)]'
+                        : 'text-[var(--text-muted)]'
+                    }`}
                     data-channel-message-delivery
                     data-delivery-status={myStatus}
-                    {...tokenAttrs('textMuted', 'text')}
+                    {...tokenAttrs(myStatus === 'nudge_exhausted' ? 'warning' : 'textMuted', 'text')}
                   >
-                    {myStatus === 'delivered' ? '✓ delivered' : myStatus === 'pending' ? '… sending' : '✗ target gone'}
+                    {t(DELIVERY_LABEL_KEY[myStatus]) || DELIVERY_LABEL_FALLBACK[myStatus]}
                   </div>
                 )}
               </div>
@@ -650,6 +666,16 @@ export function ChannelView(): React.ReactElement | null {
   );
   const members = useStore((s) =>
     activeChannelId ? s.channelMembers[activeChannelId] ?? EMPTY_MEMBERS : EMPTY_MEMBERS,
+  );
+  // C-2: subscribe to a STRING projection of this channel's exhausted-nudge
+  // members (same reason as workspaceNamesKey below — a fresh object per render
+  // would repaint the whole transcript on every unrelated store write).
+  const nudgeExhaustedKey = useStore((s) =>
+    activeChannelId ? Object.keys(s.channelNudgeExhausted[activeChannelId] ?? {}).sort().join('\u0001') : '',
+  );
+  const nudgeExhaustedMemberIds = useMemo(
+    () => new Set(nudgeExhaustedKey ? nudgeExhaustedKey.split('\u0001') : []),
+    [nudgeExhaustedKey],
   );
   // Identity audit 1a: workspace display names for the sender identity chips
   // (human posts read "Me · <workspace>"). Subscribe to a STRING projection of
@@ -879,6 +905,7 @@ export function ChannelView(): React.ReactElement | null {
         onLoadEarlier={handleLoadEarlier}
         workspaceName={workspaceName}
         t={t}
+        nudgeExhaustedMemberIds={nudgeExhaustedMemberIds}
         membersSlot={<ChannelMembersControl channel={channel} />}
         composerSlot={
           channel.status === 'archived' ? (

--- a/src/renderer/components/Channels/ChannelView.tsx
+++ b/src/renderer/components/Channels/ChannelView.tsx
@@ -35,6 +35,7 @@ import {
   DELIVERY_LABEL_KEY,
   DELIVERY_LABEL_FALLBACK,
 } from './deliveryStatus';
+import { paneNameForAuthor, paneNamesKey, parsePaneNamesKey } from '../../channels/paneMemberNames';
 
 // Stable empty references for the store selectors below. A selector that
 // returns `s.channelMessages[id] ?? []` would mint a FRESH `[]` on every
@@ -266,6 +267,10 @@ export interface ChannelViewContentProps {
   /** C-2 — clock injection for the delivery-aging rule (tests pass a fixed
    *  value; production lets the view tick it). */
   now?: number;
+  /** C-5 — the pane display name behind an agent sender, when the roster still
+   *  resolves its principal to a live pane. Absent → the identity chip keeps
+   *  showing the stored memberId. */
+  paneNameFor?: (workspaceId: string, memberId: string) => string | undefined;
 }
 
 /** The presentational surface — all data comes via props, no store reads. */
@@ -282,6 +287,7 @@ export function ChannelViewContent({
   membersSlot,
   nudgeExhaustedMemberIds,
   now: nowProp,
+  paneNameFor,
   t: tProp,
 }: ChannelViewContentProps): React.ReactElement {
   const t = tProp ?? ((key: string) => key);
@@ -551,6 +557,15 @@ export function ChannelViewContent({
             const mentionsMe =
               !!viewer && !!m.mentions?.some((mn) => mn.workspaceId === viewer.workspaceId);
             const author = formatChannelAuthor(m, workspaceName);
+            // C-5: an agent's identity chip names its PANE the way the rest of
+            // the app names it. A pane that joined over MCP/CLI carries an
+            // opaque spawn-stamped memberId, which the chip used to print raw;
+            // the roster's principal resolves it back to "w26-1(claude)". The
+            // chip is dropped when the primary label already says it.
+            const paneName =
+              author.kind === 'agent' ? paneNameFor?.(m.workspaceId, m.memberId) : undefined;
+            const identityChip =
+              paneName && !author.primary.includes(paneName) ? paneName : author.chip;
             return (
               <div
                 key={`${channel.id}:${m.seq}`}
@@ -592,14 +607,14 @@ export function ChannelViewContent({
                           for every agent collapsing into "Claude Code". */}
                     {author.kind === 'human' ? (t('channels.me') || 'Me') : author.primary}
                   </span>
-                  {author.chip && (
+                  {identityChip && (
                     <span
                       data-channel-author-chip
                       className="text-[10px] font-mono text-[var(--text-sub)]"
                       title={author.kind === 'human' ? m.workspaceId : m.memberId}
                       {...tokenAttrs('textSub', 'text')}
                     >
-                      {author.chip}
+                      {identityChip}
                     </span>
                   )}
                   <span
@@ -696,6 +711,19 @@ export function ChannelView(): React.ReactElement | null {
     }
     return (id: string) => names.get(id);
   }, [workspaceNamesKey]);
+  // C-5: pane display names for the agent identity chips, subscribed as the
+  // same kind of STRING projection as the workspace names above — the pane tree
+  // churns on every terminal title/cwd write, and depending on it directly would
+  // repaint the whole transcript while agents are active. The key changes only
+  // when a pane is renamed, added, removed, or its detected agent changes.
+  const paneNamesProjection = useStore((s) =>
+    paneNamesKey({ workspaces: s.workspaces, surfaceAgent: s.surfaceAgent, paneLabel: s.paneLabel }),
+  );
+  const paneNameFor = useMemo(() => {
+    const names = parsePaneNamesKey(paneNamesProjection);
+    return (workspaceId: string, memberId: string) =>
+      paneNameForAuthor({ members, names, workspaceId, memberId });
+  }, [paneNamesProjection, members]);
   const setActiveChannel = useStore((s) => s.setActiveChannel);
   const pushToast = useStore((s) => s.pushToast);
   const archiveChannelDaemon = useStore((s) => s.archiveChannelDaemon);
@@ -906,6 +934,7 @@ export function ChannelView(): React.ReactElement | null {
         workspaceName={workspaceName}
         t={t}
         nudgeExhaustedMemberIds={nudgeExhaustedMemberIds}
+        paneNameFor={paneNameFor}
         membersSlot={<ChannelMembersControl channel={channel} />}
         composerSlot={
           channel.status === 'archived' ? (

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -80,14 +80,23 @@ export function synthesizeChannelMessage(params: {
  *  two same-agent panes in one workspace. */
 export interface MentionCandidate {
   workspaceId: string;
-  paneId: string;
-  ptyId: string;
+  /** Absent on a badge-only candidate: a roster member whose workspace has no
+   *  live agent pane, so there is nothing to pin and nobody to wake. */
+  paneId?: string;
+  ptyId?: string;
+  /** Roster row this candidate addresses. Set on member candidates only; pane
+   *  candidates address a pane, which the daemon resolves on its own. */
+  memberId?: string;
   /** Stable, UNIQUE @-token inserted into the body and matched on submit — the
    *  pane's auto name (e.g. "w1-2(claude)"). Routing still uses paneId. */
   insertToken: string;
   /** Human-facing label shown in the dropdown: pane rename when set, else the
    *  auto name. May collide (harmless — paneId routes). */
   displayName: string;
+  /** Display name of the pane this candidate pins, when the pin is not the
+   *  candidate itself (a member candidate resolved to its most recently active
+   *  agent pane). Drives the composer's "will reach …" hint. */
+  pinnedPaneName?: string;
 }
 
 /**
@@ -105,6 +114,13 @@ export function buildMentionCandidates(args: {
   paneLabel: Record<string, string>;
   memberWorkspaceIds: ReadonlySet<string>;
   selfWorkspaceId: string | null;
+  /** Channel roster. Members whose own token is not already a pane candidate get
+   *  one badge-only-or-pinned candidate each (C-1) — without them a member with
+   *  no live agent pane could not be @-mentioned at all. */
+  members?: readonly ChannelMember[];
+  /** ptyId → last activity epoch ms (`surfaceActivityAt`). Picks WHICH agent pane
+   *  a member candidate pins when its workspace runs several. */
+  surfaceActivityAt?: Record<string, number | undefined>;
 }): MentionCandidate[] {
   const { workspaces, surfaceAgent, paneLabel, memberWorkspaceIds } = args;
   const out: MentionCandidate[] = [];
@@ -139,7 +155,60 @@ export function buildMentionCandidates(args: {
       });
     }
   }
+  // C-1 — one candidate per ROSTER MEMBER whose own name is not already a pane
+  // token. A mention only wakes an idle agent when it carries a pane pin, so a
+  // member candidate resolves to that workspace's most recently active agent
+  // pane; a member with no live agent pane stays badge-only (no paneId) and the
+  // composer says so instead of pretending the ping will land.
+  const paneTokens = new Set(out.map((c) => c.insertToken));
+  const paneCandidates = out.slice();
+  const activity = args.surfaceActivityAt ?? {};
+  for (const member of args.members ?? []) {
+    if (member.workspaceId === HUMAN_WORKSPACE_ID) continue; // the human seat runs no agent
+    const token = member.memberName ?? member.memberId;
+    // The submit-time scan matches a single whitespace-free run, so a roster
+    // name with a space can never be typed back as a token.
+    if (!token || /\s/.test(token) || paneTokens.has(token)) continue;
+    if (!memberWorkspaceIds.has(member.workspaceId)) continue;
+    const pin = pickMostRecentlyActivePane(
+      paneCandidates.filter((c) => c.workspaceId === member.workspaceId),
+      activity,
+    );
+    out.push({
+      workspaceId: member.workspaceId,
+      memberId: member.memberId,
+      insertToken: token,
+      displayName: token,
+      ...(pin ? { paneId: pin.paneId, ptyId: pin.ptyId, pinnedPaneName: pin.displayName } : {}),
+    });
+    paneTokens.add(token);
+  }
   return out;
+}
+
+/**
+ * C-1 (rev 2) — when a mentioned member's workspace runs SEVERAL live agent
+ * panes, pin the most recently active one; `surfaceActivityAt` is the renderer's
+ * per-pty activity clock. Ties (and a workspace with no activity samples at all)
+ * fall back to the first candidate, which is the pane tree's own order — stable,
+ * so the same member always resolves to the same pane until activity moves.
+ * Returns `undefined` when the workspace has no live agent pane (badge-only).
+ */
+export function pickMostRecentlyActivePane(
+  candidates: readonly MentionCandidate[],
+  surfaceActivityAt: Record<string, number | undefined>,
+): MentionCandidate | undefined {
+  let best: MentionCandidate | undefined;
+  let bestAt = -1;
+  for (const c of candidates) {
+    if (!c.paneId || !c.ptyId) continue;
+    const at = surfaceActivityAt[c.ptyId] ?? 0;
+    if (best === undefined || at > bestAt) {
+      best = c;
+      bestAt = at;
+    }
+  }
+  return best;
 }
 
 /**
@@ -177,7 +246,16 @@ export function detectMentionToken(
  *  `applyMention` pushes into `picked`, so an auto-promoted (never-clicked)
  *  token and a dropdown-selected one are indistinguishable downstream. */
 function candidateMention(c: MentionCandidate): ChannelMention {
-  return { workspaceId: c.workspaceId, paneId: c.paneId, ptyId: c.ptyId, name: c.insertToken };
+  return {
+    workspaceId: c.workspaceId,
+    // A badge-only member candidate carries no pane pin: the mention lands at
+    // workspace level, which is exactly what the daemon does with a pin it
+    // cannot prove. Omit the keys rather than sending `undefined`.
+    ...(c.paneId ? { paneId: c.paneId } : {}),
+    ...(c.ptyId ? { ptyId: c.ptyId } : {}),
+    ...(c.memberId ? { memberId: c.memberId } : {}),
+    name: c.insertToken,
+  };
 }
 
 /** Dedup identity for a mention row: a pane is addressed by (workspaceId,
@@ -292,6 +370,42 @@ export function promoteTypedMentions(
   return { mentions, unmatched };
 }
 
+// ─── Mention target hint (C-1) ──────────────────────────────────────────
+
+/** One line of the composer's "who will this reach" hint. */
+export interface MentionTargetHint {
+  /** The @token as it appears in the body. */
+  name: string;
+  /** Display name of the pane the mention pins, when it pins one. */
+  paneName?: string;
+  /** True when the mention carries no pane pin: it shows as a badge in the
+   *  recipient's channel list and wakes nobody. */
+  badgeOnly: boolean;
+}
+
+/**
+ * C-1 — describe where the draft's mentions would actually land. A mention with
+ * a pane pin reaches that pane (the only shape that reaches an IDLE agent); one
+ * without is badge-only. Pure + exported: the packaged Electron UI can't be
+ * driven by automation, so the invariant is tested here.
+ */
+export function describeMentionTargets(
+  mentions: readonly ChannelMention[],
+  candidates: readonly MentionCandidate[],
+): MentionTargetHint[] {
+  const byKey = new Map<string, MentionCandidate>();
+  for (const c of candidates) byKey.set(mentionKey({ workspaceId: c.workspaceId, paneId: c.paneId }), c);
+  return mentions.map((m) => {
+    const c = byKey.get(mentionKey(m));
+    const paneName = m.paneId ? c?.pinnedPaneName ?? c?.displayName ?? m.name : undefined;
+    return {
+      name: m.name,
+      ...(paneName ? { paneName } : {}),
+      badgeOnly: !m.paneId,
+    };
+  });
+}
+
 // ─── Pure view (props-driven) ───────────────────────────────────────────
 
 const EMPTY_CANDIDATES: MentionCandidate[] = [];
@@ -358,6 +472,14 @@ export function ComposerContent({
       (c) => c.displayName.toLowerCase().includes(q) || c.insertToken.toLowerCase().includes(q),
     );
   }, [token, candidates]);
+
+  // C-1 — live "will reach …" hint for the draft's mentions. Promotion is the
+  // same pure scan the submit path runs, so the hint can never disagree with
+  // what actually ships.
+  const targetHints = useMemo(
+    () => describeMentionTargets(promoteTypedMentions(text, candidates, picked).mentions, candidates),
+    [text, candidates, picked],
+  );
 
   const dropdownOpen = token !== null && matches.length > 0 && !inFlight && !disabled;
   // Open-intent but nothing matches (typing `@zzz`, or a channel with no live
@@ -624,6 +746,28 @@ export function ComposerContent({
           </svg>
         </button>
       </div>
+      {targetHints.length > 0 && (
+        <div
+          data-channel-mention-hint
+          role="status"
+          className="flex flex-col gap-0.5 text-[9px] font-mono text-[var(--text-muted)]"
+          {...tokenAttrs('textMuted', 'text')}
+        >
+          {targetHints.map((h) => (
+            <span
+              key={h.name}
+              data-channel-mention-hint-row
+              data-badge-only={h.badgeOnly ? 'true' : undefined}
+              className={h.badgeOnly ? 'text-[var(--accent-yellow)]' : undefined}
+            >
+              {h.badgeOnly
+                ? (t('channels.mentionBadgeOnly') || '@{name} has no live pane — badge only, nobody is woken')
+                    .replace('{name}', h.name)
+                : (t('channels.mentionWillReach') || 'will reach {pane}').replace('{pane}', h.paneName ?? h.name)}
+            </span>
+          ))}
+        </div>
+      )}
     </form>
   );
 }
@@ -668,6 +812,15 @@ function ComposerImpl({ channelId, onError }: ComposerProps): React.ReactElement
       paneLabel,
       memberWorkspaceIds: new Set(members.map((m) => m.workspaceId)),
       selfWorkspaceId,
+      // C-1: roster rows become candidates too (pinned to the workspace's most
+      // recently active agent pane, or badge-only when it has none). The activity
+      // clock is READ, not subscribed to: it is stamped on every tool event of
+      // every pane, so a subscription would re-render the always-mounted composer
+      // continuously (the A2 memo barrier below exists for exactly this). Re-read
+      // whenever the roster or the pane tree changes, which is often enough — a
+      // slightly older pin is still a live agent pane in the right workspace.
+      members,
+      surfaceActivityAt: useStore.getState().surfaceActivityAt,
     }),
     [members, workspaces, surfaceAgent, paneLabel, selfWorkspaceId],
   );

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -830,7 +830,13 @@ function ComposerImpl({ channelId, onError }: ComposerProps): React.ReactElement
       // A channel created by another client requires a join first — that is
       // the daemon's membership rule (NOT_A_MEMBER), not a company gate.
       if (!channel || !selfWorkspaceId) {
-        return { ok: false, errorCode: 'UNKNOWN', errorMessage: 'No channel or workspace identity' };
+        // C-5: this is the one post-failure string the composer rendered in
+        // hard-coded English; it lands in the inline error row like every other.
+        return {
+          ok: false,
+          errorCode: 'UNKNOWN',
+          errorMessage: t('channels.postNoIdentity') || 'No channel or workspace identity',
+        };
       }
       // R11 idempotency: `clientMsgId` is the per-post idempotency
       // key. The daemon returns the original `seq` on a repeat hit

--- a/src/renderer/components/Channels/Composer.tsx
+++ b/src/renderer/components/Channels/Composer.tsx
@@ -16,6 +16,7 @@
 
 import {
   memo,
+  useEffect,
   useState,
   useRef,
   useCallback,
@@ -33,6 +34,7 @@ import { useT } from '../../hooks/useT';
 import { tokenAttrs } from '../../themes';
 import { FOCUS_RING } from '../focusRing';
 import { computePaneAutoName, paneDisplayName } from '../../utils/paneNaming';
+import { parsePanePrincipalId } from '../../../shared/principals';
 
 // ─── Synthesized message row for the optimistic local insert ───────────
 
@@ -170,10 +172,22 @@ export function buildMentionCandidates(args: {
     // name with a space can never be typed back as a token.
     if (!token || /\s/.test(token) || paneTokens.has(token)) continue;
     if (!memberWorkspaceIds.has(member.workspaceId)) continue;
-    const pin = pickMostRecentlyActivePane(
-      paneCandidates.filter((c) => c.workspaceId === member.workspaceId),
-      activity,
-    );
+    // Review fix: the member row already RECORDS its pane
+    // (`principalId` = `pane:<ws>/<paneId>`). Pinning "the workspace's most
+    // recently active agent pane" instead sent @builder to whichever sibling
+    // happened to have typed last — a different agent, in a workspace that runs
+    // several. Activity is the FALLBACK, for a row whose own pane is gone.
+    const ownPane = member.principalId ? parsePanePrincipalId(member.principalId) : null;
+    const pin =
+      (ownPane
+        ? paneCandidates.find(
+            (c) => c.workspaceId === ownPane.workspaceId && c.paneId === ownPane.paneId,
+          )
+        : undefined) ??
+      pickMostRecentlyActivePane(
+        paneCandidates.filter((c) => c.workspaceId === member.workspaceId),
+        activity,
+      );
     out.push({
       workspaceId: member.workspaceId,
       memberId: member.memberId,
@@ -260,8 +274,15 @@ function candidateMention(c: MentionCandidate): ChannelMention {
 
 /** Dedup identity for a mention row: a pane is addressed by (workspaceId,
  *  paneId) — the same key `applyMention` dedups on. */
-function mentionKey(m: { workspaceId: string; paneId?: string }): string {
-  return `${m.workspaceId}\u0000${m.paneId ?? ''}`;
+function mentionKey(m: { workspaceId: string; paneId?: string; memberId?: string }): string {
+  // A PINNED mention is identified by the pane it wakes: two tokens that resolve
+  // to the same pane must collapse, or the pane is nudged twice for one post.
+  // A BADGE-ONLY mention has no pane, so the member row it addresses is its
+  // identity — keying it on the workspace alone silently dropped every
+  // badge-only member after the first in a workspace with several seats.
+  return m.paneId
+    ? `pane\u0000${m.workspaceId}\u0000${m.paneId}`
+    : `member\u0000${m.workspaceId}\u0000${m.memberId ?? ''}`;
 }
 
 /** True when `idx` sits at a token boundary: end-of-string, or a char that
@@ -372,6 +393,11 @@ export function promoteTypedMentions(
 
 // ─── Mention target hint (C-1) ──────────────────────────────────────────
 
+/** How long the draft must sit still before the "will reach …" hint is
+ *  recomputed. Long enough to skip the per-keystroke rescan, short enough that
+ *  the line is there by the time the eye reaches it. */
+export const MENTION_HINT_DEBOUNCE_MS = 200;
+
 /** One line of the composer's "who will this reach" hint. */
 export interface MentionTargetHint {
   /** The @token as it appears in the body. */
@@ -394,7 +420,16 @@ export function describeMentionTargets(
   candidates: readonly MentionCandidate[],
 ): MentionTargetHint[] {
   const byKey = new Map<string, MentionCandidate>();
-  for (const c of candidates) byKey.set(mentionKey({ workspaceId: c.workspaceId, paneId: c.paneId }), c);
+  for (const c of candidates) {
+    byKey.set(
+      mentionKey({
+        workspaceId: c.workspaceId,
+        ...(c.paneId ? { paneId: c.paneId } : {}),
+        ...(c.memberId ? { memberId: c.memberId } : {}),
+      }),
+      c,
+    );
+  }
   return mentions.map((m) => {
     const c = byKey.get(mentionKey(m));
     const paneName = m.paneId ? c?.pinnedPaneName ?? c?.displayName ?? m.name : undefined;
@@ -476,9 +511,19 @@ export function ComposerContent({
   // C-1 — live "will reach …" hint for the draft's mentions. Promotion is the
   // same pure scan the submit path runs, so the hint can never disagree with
   // what actually ships.
+  //
+  // Review fix: the scan walks the whole draft against every candidate, and it
+  // ran on EVERY keystroke. It is debounced to a typing pause — the hint is
+  // advisory, and a stale line for a fifth of a second costs nothing.
+  const [settledText, setSettledText] = useState(text);
+  useEffect(() => {
+    if (settledText === text) return;
+    const timer = setTimeout(() => setSettledText(text), MENTION_HINT_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [text, settledText]);
   const targetHints = useMemo(
-    () => describeMentionTargets(promoteTypedMentions(text, candidates, picked).mentions, candidates),
-    [text, candidates, picked],
+    () => describeMentionTargets(promoteTypedMentions(settledText, candidates, picked).mentions, candidates),
+    [settledText, candidates, picked],
   );
 
   const dropdownOpen = token !== null && matches.length > 0 && !inFlight && !disabled;
@@ -746,10 +791,12 @@ export function ComposerContent({
           </svg>
         </button>
       </div>
+      {/* Review fix: no aria-live here. This is a running summary of what the
+          user is still typing, not an event — announcing every revision talks
+          over the composition it describes. It is read where it sits. */}
       {targetHints.length > 0 && (
         <div
           data-channel-mention-hint
-          role="status"
           className="flex flex-col gap-0.5 text-[9px] font-mono text-[var(--text-muted)]"
           {...tokenAttrs('textMuted', 'text')}
         >

--- a/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
@@ -242,6 +242,7 @@ function renderView(args: {
   onLeave?: () => void;
   onArchive?: () => void;
   composerSlot?: React.ReactNode;
+  paneNameFor?: (workspaceId: string, memberId: string) => string | undefined;
 } = {}): string {
   return renderToStaticMarkup(
     createElement(ChannelViewContent, {
@@ -252,6 +253,7 @@ function renderView(args: {
       onLeave: args.onLeave,
       onArchive: args.onArchive,
       composerSlot: args.composerSlot ?? <div data-fake-composer />,
+      ...(args.paneNameFor ? { paneNameFor: args.paneNameFor } : {}),
     }),
   );
 }
@@ -265,6 +267,31 @@ beforeEach(() => {
     s.channelMessages = {};
     s.activeChannelId = null;
     s.channelUnread = {};
+  });
+});
+
+describe('ChannelViewContent — agent identity chip (C-5)', () => {
+  const opaque = makeMessage('ch-1', 1, {
+    memberId: 'pty-9f31c2ab',
+    memberName: 'Claude Code',
+  });
+
+  it('names the sender pane instead of its opaque memberId when the roster resolves it', () => {
+    const html = renderView({
+      viewer: makeMember({ memberId: 'm-1' }),
+      messages: [opaque],
+      paneNameFor: (workspaceId, memberId) =>
+        workspaceId === 'ws-1' && memberId === 'pty-9f31c2ab' ? 'w1-1(claude)' : undefined,
+    });
+    expect(html).toContain('w1-1(claude)');
+    // The raw id survives only as the hover title, never as the visible chip.
+    expect(html).toContain('title="pty-9f31c2ab"');
+    expect(html).not.toContain('>pty-9f31c2ab<');
+  });
+
+  it('falls back to the stored memberId when no pane resolves', () => {
+    const html = renderView({ viewer: makeMember({ memberId: 'm-1' }), messages: [opaque] });
+    expect(html).toContain('>pty-9f31c2ab<');
   });
 });
 

--- a/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
+++ b/src/renderer/components/Channels/__tests__/ChannelView.test.tsx
@@ -25,7 +25,6 @@ import {
   ChannelViewContent,
   isMessageVisibleToViewer,
   sortMessagesBySeq,
-  viewerDeliveryStatus,
   renderMessageText,
   renderMessageBody,
   SCROLLBACK_PAGE,
@@ -229,34 +228,9 @@ describe('sortMessagesBySeq', () => {
   });
 });
 
-describe('viewerDeliveryStatus', () => {
-  it('returns undefined when viewerMemberId is null', () => {
-    const m = makeMessage('ch-1', 1, { deliveryStatus: 'delivered' });
-    expect(viewerDeliveryStatus(m, null)).toBeUndefined();
-  });
-
-  it("returns undefined when the message is not the viewer's", () => {
-    const m = makeMessage('ch-1', 1, { memberId: 'm-2', deliveryStatus: 'delivered' });
-    expect(viewerDeliveryStatus(m, 'm-1')).toBeUndefined();
-  });
-
-  it("returns the message's deliveryStatus when there is no snapshot", () => {
-    const m = makeMessage('ch-1', 1, { memberId: 'm-1', deliveryStatus: 'delivered' });
-    expect(viewerDeliveryStatus(m, 'm-1')).toBe('delivered');
-  });
-
-  it("returns the viewer's snapshot entry when present", () => {
-    const m = makeMessage('ch-1', 1, {
-      memberId: 'm-1',
-      deliveryStatus: 'delivered',
-      recipientSnapshot: [
-        { memberId: 'm-1', workspaceId: 'ws-1', status: 'pending' },
-        { memberId: 'm-2', workspaceId: 'ws-2', status: 'delivered' },
-      ],
-    });
-    expect(viewerDeliveryStatus(m, 'm-1')).toBe('pending');
-  });
-});
+// `viewerDeliveryStatus` is gone (C-2): it read the SENDER's own row out of
+// the recipient snapshot, a row that is never there. Its replacement,
+// ownMessageDeliveryState, is covered by deliveryStatus.test.ts.
 
 // ─── ChannelViewContent (renderToStaticMarkup) ──────────────────────────
 

--- a/src/renderer/components/Channels/__tests__/Composer.mentionPin.test.ts
+++ b/src/renderer/components/Channels/__tests__/Composer.mentionPin.test.ts
@@ -29,8 +29,20 @@ function twoPaneWorkspace() {
   return { ws, leafA, leafB };
 }
 
-function member(workspaceId: string, memberId: string, memberName?: string): ChannelMember {
-  return { workspaceId, memberId, joinedAt: 0, historyFromSeq: 0, ...(memberName ? { memberName } : {}) };
+function member(
+  workspaceId: string,
+  memberId: string,
+  memberName?: string,
+  principalId?: string,
+): ChannelMember {
+  return {
+    workspaceId,
+    memberId,
+    joinedAt: 0,
+    historyFromSeq: 0,
+    ...(memberName ? { memberName } : {}),
+    ...(principalId ? { principalId } : {}),
+  };
 }
 
 describe('buildMentionCandidates — roster members (C-1)', () => {
@@ -70,6 +82,41 @@ describe('buildMentionCandidates — roster members (C-1)', () => {
     expect(candidates[0].memberId).toBe('w9-1(claude)');
   });
 
+  // Review fix: the member row records the pane it IS. "Most recently active"
+  // sent @backend to whichever sibling typed last.
+  it("prefers the member's OWN pane from principalId over the most recently active one", () => {
+    const { ws, leafA } = twoPaneWorkspace();
+    const candidates = buildMentionCandidates({
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE, ptyB: CLAUDE },
+      paneLabel: {},
+      memberWorkspaceIds: new Set(['ws-1']),
+      selfWorkspaceId: null,
+      members: [member('ws-1', 'backend', undefined, `pane:ws-1/${leafA.id}`)],
+      // ptyB is far more recent — the old rule would have pinned it.
+      surfaceActivityAt: { ptyA: 1_000, ptyB: 9_000 },
+    });
+    const roster = candidates.find((c) => c.insertToken === 'backend')!;
+    expect(roster.paneId).toBe(leafA.id);
+    expect(roster.ptyId).toBe('ptyA');
+    expect(roster.pinnedPaneName).toBe('w1-1(claude)');
+  });
+
+  it('falls back to recent activity when the principal pane is gone', () => {
+    const { ws, leafB } = twoPaneWorkspace();
+    const candidates = buildMentionCandidates({
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE, ptyB: CLAUDE },
+      paneLabel: {},
+      memberWorkspaceIds: new Set(['ws-1']),
+      selfWorkspaceId: null,
+      members: [member('ws-1', 'backend', undefined, 'pane:ws-1/pane-that-closed')],
+      surfaceActivityAt: { ptyA: 1_000, ptyB: 9_000 },
+    });
+    const roster = candidates.find((c) => c.insertToken === 'backend')!;
+    expect(roster.paneId).toBe(leafB.id);
+  });
+
   it('never duplicates a token a pane candidate already owns, and skips a name with a space', () => {
     const { ws } = twoPaneWorkspace();
     const candidates = buildMentionCandidates({
@@ -95,6 +142,37 @@ describe('pickMostRecentlyActivePane', () => {
       { workspaceId: 'w', paneId: 'p2', ptyId: 't2', insertToken: 'b', displayName: 'b' },
     ];
     expect(pickMostRecentlyActivePane(cands, {})!.paneId).toBe('p1');
+  });
+});
+
+// Review fix: (workspaceId, paneId) folded two badge-only seats of one
+// workspace onto a single key, and the second mention vanished with no warning.
+describe('badge-only mention dedup', () => {
+  const candidates: MentionCandidate[] = [
+    { workspaceId: 'ws-1', memberId: 'm-1', insertToken: 'alice', displayName: 'alice' },
+    { workspaceId: 'ws-1', memberId: 'm-2', insertToken: 'bob', displayName: 'bob' },
+  ];
+
+  it('keeps both badge-only members of the same workspace', () => {
+    const { mentions } = promoteTypedMentions('@alice @bob ship it', candidates, []);
+    expect(mentions.map((m) => m.memberId)).toEqual(['m-1', 'm-2']);
+  });
+
+  it('still collapses two tokens that resolve to the SAME pane — one pane, one nudge', () => {
+    const pinned: MentionCandidate[] = [
+      { workspaceId: 'ws-1', paneId: 'p1', ptyId: 't1', insertToken: 'w1-1(claude)', displayName: 'w1-1(claude)' },
+      { workspaceId: 'ws-1', paneId: 'p1', ptyId: 't1', memberId: 'm-1', insertToken: 'alice', displayName: 'alice' },
+    ];
+    const { mentions } = promoteTypedMentions('@w1-1(claude) @alice', pinned, []);
+    expect(mentions).toHaveLength(1);
+  });
+
+  it('describes both badge-only mentions instead of one', () => {
+    const { mentions } = promoteTypedMentions('@alice @bob', candidates, []);
+    expect(describeMentionTargets(mentions, candidates)).toEqual([
+      { name: 'alice', badgeOnly: true },
+      { name: 'bob', badgeOnly: true },
+    ]);
   });
 });
 

--- a/src/renderer/components/Channels/__tests__/Composer.mentionPin.test.ts
+++ b/src/renderer/components/Channels/__tests__/Composer.mentionPin.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildMentionCandidates,
+  describeMentionTargets,
+  pickMostRecentlyActivePane,
+  promoteTypedMentions,
+  type MentionCandidate,
+} from '../Composer';
+import { createLeafPane, createSurface, type Pane, type Workspace } from '../../../../shared/types';
+import type { ChannelMember } from '../../../../shared/channels';
+
+// C-1 — a mention only wakes an IDLE agent when it carries a pane pin. These
+// tests fix the two shapes that decides: a roster member whose workspace runs
+// several agent panes must pin the most recently active one, and a member with
+// no live agent pane must stay badge-only (and SAY so) rather than silently
+// resolving to nothing.
+
+const CLAUDE = { name: 'Claude Code', slug: 'claude' as const };
+
+function twoPaneWorkspace() {
+  const leafA = createLeafPane(createSurface('ptyA', 'pwsh', ''), 1);
+  const leafB = createLeafPane(createSurface('ptyB', 'pwsh', ''), 2);
+  const root: Pane = {
+    id: 'br', type: 'branch', direction: 'horizontal', children: [leafA, leafB], sizes: [50, 50],
+  };
+  const ws: Workspace = {
+    id: 'ws-1', name: 'Backend', wsOrdinal: 1, nextPaneOrdinal: 3, rootPane: root, activePaneId: leafA.id,
+  };
+  return { ws, leafA, leafB };
+}
+
+function member(workspaceId: string, memberId: string, memberName?: string): ChannelMember {
+  return { workspaceId, memberId, joinedAt: 0, historyFromSeq: 0, ...(memberName ? { memberName } : {}) };
+}
+
+describe('buildMentionCandidates — roster members (C-1)', () => {
+  it('pins a member candidate to its workspace\'s MOST RECENTLY ACTIVE agent pane', () => {
+    const { ws, leafB } = twoPaneWorkspace();
+    const candidates = buildMentionCandidates({
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE, ptyB: CLAUDE },
+      paneLabel: {},
+      memberWorkspaceIds: new Set(['ws-1']),
+      selfWorkspaceId: null,
+      members: [member('ws-1', 'backend')],
+      surfaceActivityAt: { ptyA: 1_000, ptyB: 9_000 },
+    });
+    const roster = candidates.find((c) => c.insertToken === 'backend');
+    expect(roster).toBeDefined();
+    expect(roster!.paneId).toBe(leafB.id);
+    expect(roster!.ptyId).toBe('ptyB');
+    expect(roster!.pinnedPaneName).toBe('w1-2(claude)');
+    // The per-pane candidates are untouched — the roster row is additive.
+    expect(candidates.filter((c) => c.paneId).length).toBe(3);
+  });
+
+  it('leaves a member with no live agent pane badge-only (no pane pin)', () => {
+    const candidates = buildMentionCandidates({
+      workspaces: [],
+      surfaceAgent: {},
+      paneLabel: {},
+      memberWorkspaceIds: new Set(['ws-gone']),
+      selfWorkspaceId: null,
+      members: [member('ws-gone', 'w9-1(claude)', 'worker-9')],
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].paneId).toBeUndefined();
+    expect(candidates[0].ptyId).toBeUndefined();
+    expect(candidates[0].insertToken).toBe('worker-9');
+    expect(candidates[0].memberId).toBe('w9-1(claude)');
+  });
+
+  it('never duplicates a token a pane candidate already owns, and skips a name with a space', () => {
+    const { ws } = twoPaneWorkspace();
+    const candidates = buildMentionCandidates({
+      workspaces: [ws],
+      surfaceAgent: { ptyA: CLAUDE },
+      paneLabel: {},
+      memberWorkspaceIds: new Set(['ws-1']),
+      selfWorkspaceId: null,
+      members: [member('ws-1', 'w1-1(claude)'), member('ws-1', 'two words')],
+    });
+    expect(candidates.map((c) => c.insertToken)).toEqual(['w1-1(claude)']);
+  });
+});
+
+describe('pickMostRecentlyActivePane', () => {
+  it('returns undefined when the workspace has no pane candidate', () => {
+    expect(pickMostRecentlyActivePane([], {})).toBeUndefined();
+  });
+
+  it('falls back to the first candidate when no activity has been sampled', () => {
+    const cands: MentionCandidate[] = [
+      { workspaceId: 'w', paneId: 'p1', ptyId: 't1', insertToken: 'a', displayName: 'a' },
+      { workspaceId: 'w', paneId: 'p2', ptyId: 't2', insertToken: 'b', displayName: 'b' },
+    ];
+    expect(pickMostRecentlyActivePane(cands, {})!.paneId).toBe('p1');
+  });
+});
+
+describe('describeMentionTargets (C-1 hint)', () => {
+  it('names the pane a pinned mention will reach, and flags a badge-only one', () => {
+    const candidates: MentionCandidate[] = [
+      { workspaceId: 'ws-1', paneId: 'p2', ptyId: 't2', insertToken: 'backend', displayName: 'backend', pinnedPaneName: 'w1-2(claude)' },
+      { workspaceId: 'ws-gone', insertToken: 'worker-9', displayName: 'worker-9' },
+    ];
+    const { mentions } = promoteTypedMentions('@backend @worker-9 ship it', candidates, []);
+    const hints = describeMentionTargets(mentions, candidates);
+    expect(hints).toEqual([
+      { name: 'backend', paneName: 'w1-2(claude)', badgeOnly: false },
+      { name: 'worker-9', badgeOnly: true },
+    ]);
+  });
+});

--- a/src/renderer/components/Channels/__tests__/deliveryStatus.test.ts
+++ b/src/renderer/components/Channels/__tests__/deliveryStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { ChannelMessage } from '../../../../shared/channels';
 import {
   ownMessageDeliveryState,
+  needsDeliveryAgingClock,
   DELIVERY_UNCONFIRMED_AFTER_MS,
   DELIVERY_LABEL_KEY,
   DELIVERY_LABEL_FALLBACK,
@@ -60,9 +61,41 @@ describe('ownMessageDeliveryState (C-2)', () => {
         message: m,
         viewerMemberId: 'me',
         now: T0,
-        exhaustedMemberIds: new Set(['a']),
+        exhaustedAtByMember: { a: T0 },
       }),
     ).toBe('nudge_exhausted');
+  });
+
+  // Review fix: the flag is a timestamped episode, not a member blacklist.
+  it('does NOT brand a message posted after the episode as "no answer"', () => {
+    const snapshot = [{ memberId: 'a' as const, workspaceId: 'ws-a', status: 'delivered' as const }];
+    const before = message({ seq: 1, postedAt: T0 - 1_000, recipientSnapshot: snapshot });
+    const at = message({ seq: 2, postedAt: T0, recipientSnapshot: snapshot });
+    const after = message({ seq: 3, postedAt: T0 + 1, recipientSnapshot: snapshot });
+    const exhaustedAtByMember = { a: T0 };
+    expect(
+      ownMessageDeliveryState({ message: before, viewerMemberId: 'me', now: T0 + 5_000, exhaustedAtByMember }),
+    ).toBe('nudge_exhausted');
+    expect(
+      ownMessageDeliveryState({ message: at, viewerMemberId: 'me', now: T0 + 5_000, exhaustedAtByMember }),
+    ).toBe('nudge_exhausted');
+    expect(
+      ownMessageDeliveryState({ message: after, viewerMemberId: 'me', now: T0 + 5_000, exhaustedAtByMember }),
+    ).toBe('delivered');
+  });
+
+  it('ignores an episode belonging to a member who is not a recipient of this message', () => {
+    const m = message({
+      recipientSnapshot: [{ memberId: 'a', workspaceId: 'ws-a', status: 'delivered' }],
+    });
+    expect(
+      ownMessageDeliveryState({
+        message: m,
+        viewerMemberId: 'me',
+        now: T0,
+        exhaustedAtByMember: { b: T0 },
+      }),
+    ).toBe('delivered');
   });
 
   it('stops the eternal "… sending": an aged pending becomes unconfirmed', () => {
@@ -100,5 +133,31 @@ describe('ownMessageDeliveryState (C-2)', () => {
       expect(DELIVERY_LABEL_KEY[state]).toMatch(/^channels\./);
       expect(DELIVERY_LABEL_FALLBACK[state].length).toBeGreaterThan(0);
     }
+  });
+});
+// Review fix: the 10 s repaint runs only while something can actually change.
+describe('needsDeliveryAgingClock', () => {
+  const settled = message({
+    seq: 1,
+    recipientSnapshot: [{ memberId: 'a', workspaceId: 'ws-a', status: 'delivered' }],
+  });
+  const pending = message({
+    seq: 2,
+    recipientSnapshot: [{ memberId: 'a', workspaceId: 'ws-a', status: 'pending' }],
+  });
+
+  it('is false for a settled transcript and for a viewerless view', () => {
+    expect(needsDeliveryAgingClock({ messages: [settled], viewerMemberId: 'me' })).toBe(false);
+    expect(needsDeliveryAgingClock({ messages: [pending], viewerMemberId: null })).toBe(false);
+    expect(
+      needsDeliveryAgingClock({
+        messages: [message({ memberId: 'other', recipientSnapshot: [] })],
+        viewerMemberId: 'me',
+      }),
+    ).toBe(false);
+  });
+
+  it('is true while one of my own rows is still pending', () => {
+    expect(needsDeliveryAgingClock({ messages: [settled, pending], viewerMemberId: 'me' })).toBe(true);
   });
 });

--- a/src/renderer/components/Channels/__tests__/deliveryStatus.test.ts
+++ b/src/renderer/components/Channels/__tests__/deliveryStatus.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import type { ChannelMessage } from '../../../../shared/channels';
+import {
+  ownMessageDeliveryState,
+  DELIVERY_UNCONFIRMED_AFTER_MS,
+  DELIVERY_LABEL_KEY,
+  DELIVERY_LABEL_FALLBACK,
+} from '../deliveryStatus';
+
+const T0 = 1_700_000_000_000;
+
+function message(overrides: Partial<ChannelMessage> = {}): ChannelMessage {
+  return {
+    channelId: 'ch-1',
+    seq: 1,
+    workspaceId: 'ws-1',
+    memberId: 'me',
+    memberName: 'me',
+    text: 'hi',
+    postedAt: T0,
+    deliveryStatus: 'pending',
+    ...overrides,
+  };
+}
+
+describe('ownMessageDeliveryState (C-2)', () => {
+  it("says nothing about someone else's message", () => {
+    expect(
+      ownMessageDeliveryState({ message: message({ memberId: 'other' }), viewerMemberId: 'me', now: T0 }),
+    ).toBeUndefined();
+    expect(ownMessageDeliveryState({ message: message(), viewerMemberId: null, now: T0 })).toBeUndefined();
+  });
+
+  it('reports delivered when ANY other recipient got it — the old code read the absent self row', () => {
+    const m = message({
+      recipientSnapshot: [
+        { memberId: 'a', workspaceId: 'ws-a', status: 'delivered' },
+        { memberId: 'b', workspaceId: 'ws-b', status: 'target_gone' },
+      ],
+    });
+    expect(ownMessageDeliveryState({ message: m, viewerMemberId: 'me', now: T0 })).toBe('delivered');
+  });
+
+  it('reports target_gone only when every recipient is gone', () => {
+    const m = message({
+      recipientSnapshot: [
+        { memberId: 'a', workspaceId: 'ws-a', status: 'target_gone' },
+        { memberId: 'b', workspaceId: 'ws-b', status: 'target_gone' },
+      ],
+    });
+    expect(ownMessageDeliveryState({ message: m, viewerMemberId: 'me', now: T0 })).toBe('target_gone');
+  });
+
+  it('an exhausted nudge episode outranks a delivered write', () => {
+    const m = message({
+      recipientSnapshot: [{ memberId: 'a', workspaceId: 'ws-a', status: 'delivered' }],
+    });
+    expect(
+      ownMessageDeliveryState({
+        message: m,
+        viewerMemberId: 'me',
+        now: T0,
+        exhaustedMemberIds: new Set(['a']),
+      }),
+    ).toBe('nudge_exhausted');
+  });
+
+  it('stops the eternal "… sending": an aged pending becomes unconfirmed', () => {
+    const m = message({ recipientSnapshot: [{ memberId: 'a', workspaceId: 'ws-a', status: 'pending' }] });
+    expect(ownMessageDeliveryState({ message: m, viewerMemberId: 'me', now: T0 + 1_000 })).toBe('pending');
+    expect(
+      ownMessageDeliveryState({ message: m, viewerMemberId: 'me', now: T0 + DELIVERY_UNCONFIRMED_AFTER_MS + 1 }),
+    ).toBe('unconfirmed');
+  });
+
+  it('ages the optimistic row too (no snapshot yet), and keeps a non-pending message-level status', () => {
+    expect(
+      ownMessageDeliveryState({
+        message: message(),
+        viewerMemberId: 'me',
+        now: T0 + DELIVERY_UNCONFIRMED_AFTER_MS + 1,
+      }),
+    ).toBe('unconfirmed');
+    expect(
+      ownMessageDeliveryState({
+        message: message({ deliveryStatus: 'delivered' }),
+        viewerMemberId: 'me',
+        now: T0 + DELIVERY_UNCONFIRMED_AFTER_MS + 1,
+      }),
+    ).toBe('delivered');
+  });
+
+  it('says nothing when the frozen recipient set holds nobody but the sender', () => {
+    const m = message({ recipientSnapshot: [{ memberId: 'me', workspaceId: 'ws-1', status: 'pending' }] });
+    expect(ownMessageDeliveryState({ message: m, viewerMemberId: 'me', now: T0 })).toBeUndefined();
+  });
+
+  it('has a locale key and an English fallback for every state', () => {
+    for (const state of Object.keys(DELIVERY_LABEL_KEY) as (keyof typeof DELIVERY_LABEL_KEY)[]) {
+      expect(DELIVERY_LABEL_KEY[state]).toMatch(/^channels\./);
+      expect(DELIVERY_LABEL_FALLBACK[state].length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/renderer/components/Channels/deliveryStatus.ts
+++ b/src/renderer/components/Channels/deliveryStatus.ts
@@ -1,0 +1,97 @@
+// ─── C-2: what actually happened to the message you posted ───────────────
+//
+// The channel view used to read the SENDER's own row out of `recipientSnapshot`
+// — a row that is not there, because the sender is not one of its own message's
+// recipients. So the only status that ever rendered came from the optimistic
+// local row's `deliveryStatus: 'pending'`, which nothing overwrites until the
+// authoritative row lands: the eternal "… sending".
+//
+// The honest answer is an aggregate over the OTHER recipients, plus the one
+// outcome the snapshot cannot express — the wake worker giving up after its
+// nudge budget (`channel.nudgeExhausted`), which means a human has to look.
+
+import type { ChannelMessage } from '../../../shared/channels';
+
+/**
+ * The five things a sender's own message can be. Four map to the delivery
+ * substrate; `unconfirmed` is an aged `pending` — the post is out but no
+ * recipient outcome ever came back, which is a different thing from "still on
+ * its way" and must stop reading as a spinner.
+ */
+export type DeliveryLabelState =
+  | 'pending'
+  | 'delivered'
+  | 'target_gone'
+  | 'nudge_exhausted'
+  | 'unconfirmed';
+
+/**
+ * How long a `pending` may claim to be in flight. Delivery is a local PTY write
+ * that resolves in one poll cycle (~1 s); half a minute without an outcome is
+ * not slowness, it is silence.
+ */
+export const DELIVERY_UNCONFIRMED_AFTER_MS = 30_000;
+
+/**
+ * Per-message delivery state for the VIEWER'S OWN post. Returns `undefined` when
+ * there is nothing honest to say: someone else's message, or a message whose
+ * frozen recipient set contains nobody but the sender.
+ *
+ * Precedence is worst-news-first, because that is the news that needs a human:
+ * an exhausted nudge episode outranks a `delivered` write (the bytes landed in
+ * a pane that never acted on them), and any `delivered` outranks a dead target
+ * (the message did reach someone).
+ */
+export function ownMessageDeliveryState(args: {
+  message: ChannelMessage;
+  viewerMemberId: string | null;
+  /** Epoch ms — injected so the aging rule is testable. */
+  now: number;
+  /** memberIds whose nudge episode in THIS channel ran out of budget. */
+  exhaustedMemberIds?: ReadonlySet<string>;
+}): DeliveryLabelState | undefined {
+  const { message, viewerMemberId, now } = args;
+  if (!viewerMemberId) return undefined;
+  if (message.memberId !== viewerMemberId) return undefined;
+
+  const aged = (state: 'pending'): DeliveryLabelState =>
+    now - message.postedAt > DELIVERY_UNCONFIRMED_AFTER_MS ? 'unconfirmed' : state;
+
+  const snapshot = (message.recipientSnapshot ?? []).filter(
+    (row) => row.memberId !== viewerMemberId,
+  );
+  if (snapshot.length === 0) {
+    // No frozen recipient set at all (optimistic row, or a pre-U2 message):
+    // fall back to the message-level status, aged. A snapshot that exists but
+    // holds only the sender means the post reached nobody by design — there is
+    // no delivery to report, so say nothing rather than invent an outcome.
+    if (message.recipientSnapshot) return undefined;
+    return message.deliveryStatus === 'pending' ? aged('pending') : message.deliveryStatus;
+  }
+
+  const exhausted = args.exhaustedMemberIds;
+  if (exhausted && snapshot.some((row) => exhausted.has(row.memberId))) return 'nudge_exhausted';
+  if (snapshot.some((row) => row.status === 'delivered')) return 'delivered';
+  if (snapshot.every((row) => row.status === 'target_gone')) return 'target_gone';
+  return aged('pending');
+}
+
+/** i18n key per state. Kept next to the states so a new state cannot ship
+ *  without a string (the old renderer hard-coded English inline). */
+export const DELIVERY_LABEL_KEY: Record<DeliveryLabelState, string> = {
+  pending: 'channels.deliveryPending',
+  delivered: 'channels.deliveryDelivered',
+  target_gone: 'channels.deliveryTargetGone',
+  nudge_exhausted: 'channels.deliveryNudgeExhausted',
+  unconfirmed: 'channels.deliveryUnconfirmed',
+};
+
+/** English fallback per state, used when the locale has no string (identity
+ *  translator in tests, or a partially translated locale). */
+export const DELIVERY_LABEL_FALLBACK: Record<DeliveryLabelState, string> = {
+  pending: '… sending',
+  delivered: '✓ delivered',
+  target_gone: '✗ target gone',
+  nudge_exhausted: '! no answer — nudges exhausted',
+  unconfirmed: '? delivery unconfirmed',
+};

--- a/src/renderer/components/Channels/deliveryStatus.ts
+++ b/src/renderer/components/Channels/deliveryStatus.ts
@@ -47,8 +47,15 @@ export function ownMessageDeliveryState(args: {
   viewerMemberId: string | null;
   /** Epoch ms — injected so the aging rule is testable. */
   now: number;
-  /** memberIds whose nudge episode in THIS channel ran out of budget. */
-  exhaustedMemberIds?: ReadonlySet<string>;
+  /**
+   * memberId → epoch ms of that member's last exhausted nudge episode in THIS
+   * channel. A TIMESTAMP, not a membership set: an episode says "as of `at`,
+   * this member had not answered", which is a claim about the messages that
+   * were already posted when it fired. A set marked every row the sender ever
+   * wrote in the channel — including ones posted MINUTES LATER, whose delivery
+   * the worker never even attempted — as "no answer".
+   */
+  exhaustedAtByMember?: Readonly<Record<string, number>>;
 }): DeliveryLabelState | undefined {
   const { message, viewerMemberId, now } = args;
   if (!viewerMemberId) return undefined;
@@ -69,11 +76,50 @@ export function ownMessageDeliveryState(args: {
     return message.deliveryStatus === 'pending' ? aged('pending') : message.deliveryStatus;
   }
 
-  const exhausted = args.exhaustedMemberIds;
-  if (exhausted && snapshot.some((row) => exhausted.has(row.memberId))) return 'nudge_exhausted';
+  // Only a message that was ALREADY POSTED when the episode ran out of budget
+  // can be the one nobody answered. The flag's other exit is the store's
+  // (`markChannelNudgeExhausted` is cleared when the member posts or its read
+  // cursor advances), so a member that came back does not read "no answer"
+  // forever.
+  const exhaustedAt = args.exhaustedAtByMember;
+  if (
+    exhaustedAt &&
+    snapshot.some((row) => {
+      const at = exhaustedAt[row.memberId];
+      return typeof at === 'number' && message.postedAt <= at;
+    })
+  ) {
+    return 'nudge_exhausted';
+  }
   if (snapshot.some((row) => row.status === 'delivered')) return 'delivered';
   if (snapshot.every((row) => row.status === 'target_gone')) return 'target_gone';
   return aged('pending');
+}
+
+/**
+ * True when at least one of the viewer's own rows is still `pending` on its own
+ * merits — the only state the passage of time can change (into `unconfirmed`).
+ *
+ * The transcript's aging clock is gated on this: a settled channel used to
+ * repaint every 10 s to re-derive labels that could not move.
+ */
+export function needsDeliveryAgingClock(args: {
+  messages: readonly ChannelMessage[];
+  viewerMemberId: string | null;
+  exhaustedAtByMember?: Readonly<Record<string, number>>;
+}): boolean {
+  const { messages, viewerMemberId } = args;
+  if (!viewerMemberId) return false;
+  return messages.some(
+    (message) =>
+      ownMessageDeliveryState({
+        message,
+        viewerMemberId,
+        // The message's own postedAt — asks "is this row pending BEFORE aging?"
+        now: message.postedAt,
+        ...(args.exhaustedAtByMember ? { exhaustedAtByMember: args.exhaustedAtByMember } : {}),
+      }) === 'pending',
+  );
 }
 
 /** i18n key per state. Kept next to the states so a new state cannot ship

--- a/src/renderer/components/FleetView/ApprovalInboxList.tsx
+++ b/src/renderer/components/FleetView/ApprovalInboxList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStore } from '../../stores';
 import { selectWorkspaceIdName } from '../../stores/selectors/workspaceProjections';
@@ -6,14 +6,7 @@ import { useT } from '../../hooks/useT';
 import { groupCapabilities } from '../Approval/PermissionApprovalDialog';
 import type { RiskClassCopy } from '../../../main/mcp/methodCapabilityMap';
 import type { InboxItem } from '../../stores/selectors/approvalInbox';
-import {
-  deadlineForItem,
-  inboxItemLabel,
-  reduceAutoRejected,
-  remainingSeconds,
-  type AutoRejectedEntry,
-  type TrackedDeadline,
-} from './approvalCountdown';
+import { deadlineForItem, remainingSeconds } from './approvalCountdown';
 
 // gpui button recipes (theme-safe). Approve = primary warm CTA; deny = danger
 // tinted. The row still carries the critical/attention border + countdown, so
@@ -85,32 +78,19 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
     return () => clearInterval(tick);
   }, [hasDeadline]);
 
-  // C-3: an expired row leaves the inbox exactly like an approved one, so the
-  // list keeps its own short log of the ones the deadline killed. `tracked` is
-  // what the previous render saw; a row that is gone with its deadline already
-  // past was auto-rejected, one that left earlier was answered by a human.
-  const tracked = useRef<TrackedDeadline[]>([]);
-  const [autoRejected, setAutoRejected] = useState<AutoRejectedEntry[]>([]);
-  useEffect(() => {
-    const presentKeys = new Set(items.map((it) => it.key));
-    const at = Date.now();
-    setAutoRejected((previous) =>
-      reduceAutoRejected({ previous, tracked: tracked.current, presentKeys, now: at }),
-    );
-    const next: TrackedDeadline[] = [];
-    for (const item of items) {
-      const deadlineAt = deadlineForItem(item, mcpDeadlineAt);
-      if (deadlineAt !== undefined) {
-        next.push({ key: item.key, label: inboxItemLabel(item), deadlineAt });
-      }
-    }
-    tracked.current = next;
-  }, [items, mcpDeadlineAt]);
+  // C-3 (review fix): the log is the STORE's, written at the removal point.
+  // Inferring it here from "row vanished, deadline past" mislabelled rows a
+  // human answered after a throttled timer, and recorded nothing at all while
+  // this tab was closed — which is precisely when you need it.
+  const autoRejected = useStore((s) => s.approvalAutoRejected);
 
   if (items.length === 0 && autoRejected.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-2">
+      {/* An empty listbox is a control with nothing to choose — announced, and
+          unusable. When there are no rows the log below stands alone. */}
+      {items.length > 0 && (
       <div role="listbox" aria-label={t('fleet.tab.approvals')} className="flex flex-col gap-2">
       {items.map((item, idx) => {
         const focused = idx === focusedIdx;
@@ -288,14 +268,15 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
         );
       })}
       </div>
+      )}
       {autoRejected.length > 0 && (
-        <div
+        <ul
           data-approval-auto-rejected-log
           className="flex flex-col gap-0.5 px-1"
           aria-label={t('fleet.approvals.autoRejectedLog')}
         >
           {autoRejected.map((entry) => (
-            <div
+            <li
               key={entry.key}
               data-approval-auto-rejected
               className="text-[10px] font-mono truncate"
@@ -303,9 +284,9 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
               title={entry.label}
             >
               {t('fleet.approvals.autoRejected', { name: entry.label })}
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       )}
     </div>
   );

--- a/src/renderer/components/FleetView/ApprovalInboxList.tsx
+++ b/src/renderer/components/FleetView/ApprovalInboxList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStore } from '../../stores';
 import { selectWorkspaceIdName } from '../../stores/selectors/workspaceProjections';
@@ -6,6 +6,14 @@ import { useT } from '../../hooks/useT';
 import { groupCapabilities } from '../Approval/PermissionApprovalDialog';
 import type { RiskClassCopy } from '../../../main/mcp/methodCapabilityMap';
 import type { InboxItem } from '../../stores/selectors/approvalInbox';
+import {
+  deadlineForItem,
+  inboxItemLabel,
+  reduceAutoRejected,
+  remainingSeconds,
+  type AutoRejectedEntry,
+  type TrackedDeadline,
+} from './approvalCountdown';
 
 // gpui button recipes (theme-safe). Approve = primary warm CTA; deny = danger
 // tinted. The row still carries the critical/attention border + countdown, so
@@ -56,21 +64,54 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
   const setA2aAutoApproveExecute = useStore((s) => s.setA2aAutoApproveExecute);
   const wsName = (id: string) => workspaces.find((w) => w.id === id)?.name ?? id;
 
-  // Live countdown tick for any A2A row, mirroring ExecuteApprovalDialog's
-  // now-tick. Gated on the inbox actually containing an A2A row so an inbox of
-  // only MCP prompts never spins a 250ms interval.
-  const hasA2a = items.some((it) => it.source === 'a2a');
+  // C-3: an MCP prompt gets a countdown once the approval record carries a
+  // deadline. Read structurally off the store record so the badge appears the
+  // moment the field lands and renders nothing until then.
+  const mcpPrompts = useStore((s) => s.mcpPrompts);
+  const mcpDeadlineAt = useMemo(
+    () => (promptId: string) =>
+      (mcpPrompts[promptId] as { deadlineAt?: number } | undefined)?.deadlineAt,
+    [mcpPrompts],
+  );
+
+  // Live countdown tick for any row that HAS a deadline (A2A always, an MCP
+  // prompt once stamped), mirroring ExecuteApprovalDialog's now-tick. Gated so
+  // an inbox of deadline-less prompts never spins a 250ms interval.
+  const hasDeadline = items.some((it) => deadlineForItem(it, mcpDeadlineAt) !== undefined);
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
-    if (!hasA2a) return;
+    if (!hasDeadline) return;
     const tick = setInterval(() => setNow(Date.now()), 250);
     return () => clearInterval(tick);
-  }, [hasA2a]);
+  }, [hasDeadline]);
 
-  if (items.length === 0) return null;
+  // C-3: an expired row leaves the inbox exactly like an approved one, so the
+  // list keeps its own short log of the ones the deadline killed. `tracked` is
+  // what the previous render saw; a row that is gone with its deadline already
+  // past was auto-rejected, one that left earlier was answered by a human.
+  const tracked = useRef<TrackedDeadline[]>([]);
+  const [autoRejected, setAutoRejected] = useState<AutoRejectedEntry[]>([]);
+  useEffect(() => {
+    const presentKeys = new Set(items.map((it) => it.key));
+    const at = Date.now();
+    setAutoRejected((previous) =>
+      reduceAutoRejected({ previous, tracked: tracked.current, presentKeys, now: at }),
+    );
+    const next: TrackedDeadline[] = [];
+    for (const item of items) {
+      const deadlineAt = deadlineForItem(item, mcpDeadlineAt);
+      if (deadlineAt !== undefined) {
+        next.push({ key: item.key, label: inboxItemLabel(item), deadlineAt });
+      }
+    }
+    tracked.current = next;
+  }, [items, mcpDeadlineAt]);
+
+  if (items.length === 0 && autoRejected.length === 0) return null;
 
   return (
-    <div role="listbox" aria-label={t('fleet.tab.approvals')} className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2">
+      <div role="listbox" aria-label={t('fleet.tab.approvals')} className="flex flex-col gap-2">
       {items.map((item, idx) => {
         const focused = idx === focusedIdx;
         const optionProps = {
@@ -191,6 +232,21 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
                 {item.clientName}
               </span>
               <div className="flex-1" />
+              {/* C-3: only rendered once the approval record carries a deadline —
+                  a countdown with no auto-reject behind it would be a lie. */}
+              {(() => {
+                const deadlineAt = mcpDeadlineAt(item.promptId);
+                if (deadlineAt === undefined) return null;
+                return (
+                  <span
+                    data-approval-countdown
+                    className="text-[10px] font-mono"
+                    style={{ color: 'var(--text-subtle)' }}
+                  >
+                    {t('fleet.approvals.autoDenyIn', { seconds: remainingSeconds(deadlineAt, now) })}
+                  </span>
+                );
+              })()}
               {item.isCritical && (
                 <span
                   className="text-[10px] font-semibold px-1.5 py-0.5 rounded"
@@ -231,6 +287,26 @@ export default function ApprovalInboxList({ items, focusedIdx, onResolve }: Appr
           </div>
         );
       })}
+      </div>
+      {autoRejected.length > 0 && (
+        <div
+          data-approval-auto-rejected-log
+          className="flex flex-col gap-0.5 px-1"
+          aria-label={t('fleet.approvals.autoRejectedLog')}
+        >
+          {autoRejected.map((entry) => (
+            <div
+              key={entry.key}
+              data-approval-auto-rejected
+              className="text-[10px] font-mono truncate"
+              style={{ color: 'var(--text-subtle)' }}
+              title={entry.label}
+            >
+              {t('fleet.approvals.autoRejected', { name: entry.label })}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/components/FleetView/__tests__/approvalCountdown.test.ts
+++ b/src/renderer/components/FleetView/__tests__/approvalCountdown.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import type { InboxItem } from '../../../stores/selectors/approvalInbox';
 import {
+  AUTO_REJECT_GRACE_MS,
   AUTO_REJECT_LOG_CAP,
+  appendAutoRejected,
   deadlineForItem,
   inboxItemLabel,
-  reduceAutoRejected,
+  isAutoRejection,
   remainingSeconds,
   type AutoRejectedEntry,
 } from '../approvalCountdown';
@@ -53,49 +55,47 @@ describe('remainingSeconds', () => {
   });
 });
 
-describe('reduceAutoRejected', () => {
-  const tracked = [{ key: 'a2a:ap-1', label: 'task-1', deadlineAt: T0 }];
-
-  it('logs a row that vanished after its deadline passed', () => {
-    const out = reduceAutoRejected({
-      previous: [],
-      tracked,
-      presentKeys: new Set<string>(),
-      now: T0 + 1,
-    });
-    expect(out).toEqual([{ key: 'a2a:ap-1', label: 'task-1', at: T0 }]);
+// Review fix: "gone and past its deadline" alone mislabelled a row a human
+// answered after a throttled timer or a machine sleep.
+describe('isAutoRejection', () => {
+  it('logs a row removed at, or just after, its deadline', () => {
+    expect(isAutoRejection({ deadlineAt: T0, removedAt: T0 })).toBe(true);
+    expect(isAutoRejection({ deadlineAt: T0, removedAt: T0 + AUTO_REJECT_GRACE_MS })).toBe(true);
   });
 
   it('does NOT log a row a human answered before the deadline', () => {
-    expect(
-      reduceAutoRejected({ previous: [], tracked, presentKeys: new Set<string>(), now: T0 - 1_000 }),
-    ).toEqual([]);
+    expect(isAutoRejection({ deadlineAt: T0, removedAt: T0 - 1 })).toBe(false);
   });
 
-  it('keeps a still-present row out of the log and is idempotent on key', () => {
-    expect(
-      reduceAutoRejected({ previous: [], tracked, presentKeys: new Set(['a2a:ap-1']), now: T0 + 1 }),
-    ).toEqual([]);
-    const once = reduceAutoRejected({ previous: [], tracked, presentKeys: new Set<string>(), now: T0 + 1 });
-    const twice = reduceAutoRejected({ previous: once, tracked, presentKeys: new Set<string>(), now: T0 + 1 });
-    expect(twice).toBe(once);
+  it('does NOT log a row removed long after the deadline — a throttled timer, not an expiry', () => {
+    expect(isAutoRejection({ deadlineAt: T0, removedAt: T0 + AUTO_REJECT_GRACE_MS + 1 })).toBe(false);
+    expect(isAutoRejection({ deadlineAt: T0, removedAt: T0 + 600_000 })).toBe(false);
   });
 
-  it('keeps the newest entries and caps the log', () => {
-    const many = Array.from({ length: AUTO_REJECT_LOG_CAP + 3 }, (_, i) => ({
-      key: `mcp:p-${i}`,
-      label: `plugin-${i}`,
-      deadlineAt: T0 + i,
-    }));
-    const previous: AutoRejectedEntry[] = [];
-    const out = reduceAutoRejected({
-      previous,
-      tracked: many,
-      presentKeys: new Set<string>(),
-      now: T0 + 1_000,
-    });
-    expect(out).toHaveLength(AUTO_REJECT_LOG_CAP);
-    expect(out[0].key).toBe(`mcp:p-${many.length - 1}`);
+  it('says nothing about a row that never had a deadline', () => {
+    expect(isAutoRejection({ removedAt: T0 })).toBe(false);
+    expect(isAutoRejection({ deadlineAt: Number.NaN, removedAt: T0 })).toBe(false);
+  });
+});
+
+describe('appendAutoRejected', () => {
+  const entry: AutoRejectedEntry = { key: 'a2a:ap-1', label: 'task-1', at: T0 };
+
+  it('prepends newest-first and is idempotent on key', () => {
+    const once = appendAutoRejected([], entry);
+    expect(once).toEqual([entry]);
+    expect(appendAutoRejected(once, entry)).toBe(once);
+    const second: AutoRejectedEntry = { key: 'mcp:p-1', label: 'plugin', at: T0 + 1 };
+    expect(appendAutoRejected(once, second)[0]).toEqual(second);
+  });
+
+  it('caps the log', () => {
+    let log: AutoRejectedEntry[] = [];
+    for (let i = 0; i < AUTO_REJECT_LOG_CAP + 3; i++) {
+      log = appendAutoRejected(log, { key: `mcp:p-${i}`, label: `plugin-${i}`, at: T0 + i });
+    }
+    expect(log).toHaveLength(AUTO_REJECT_LOG_CAP);
+    expect(log[0].key).toBe(`mcp:p-${AUTO_REJECT_LOG_CAP + 2}`);
   });
 });
 

--- a/src/renderer/components/FleetView/__tests__/approvalCountdown.test.ts
+++ b/src/renderer/components/FleetView/__tests__/approvalCountdown.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import type { InboxItem } from '../../../stores/selectors/approvalInbox';
+import {
+  AUTO_REJECT_LOG_CAP,
+  deadlineForItem,
+  inboxItemLabel,
+  reduceAutoRejected,
+  remainingSeconds,
+  type AutoRejectedEntry,
+} from '../approvalCountdown';
+
+const T0 = 1_700_000_000_000;
+
+const a2a: InboxItem = {
+  source: 'a2a',
+  key: 'a2a:ap-1',
+  approvalId: 'ap-1',
+  taskId: 'task-1',
+  messagePreview: 'run it',
+  expiresAt: T0 + 30_000,
+  senderWorkspaceId: 'ws-1',
+  receiverWorkspaceId: 'ws-2',
+  cwd: null,
+};
+
+const mcp: InboxItem = {
+  source: 'mcp',
+  key: 'mcp:p-1',
+  promptId: 'p-1',
+  clientName: 'some-plugin',
+  declaredCapabilities: [],
+  isCritical: false,
+};
+
+describe('deadlineForItem (C-3)', () => {
+  it('uses the A2A row\'s own expiry', () => {
+    expect(deadlineForItem(a2a)).toBe(T0 + 30_000);
+  });
+
+  it('renders no deadline for an MCP prompt until the record carries one', () => {
+    expect(deadlineForItem(mcp)).toBeUndefined();
+    expect(deadlineForItem(mcp, () => undefined)).toBeUndefined();
+    expect(deadlineForItem(mcp, () => Number.NaN)).toBeUndefined();
+    expect(deadlineForItem(mcp, () => T0 + 45_000)).toBe(T0 + 45_000);
+  });
+});
+
+describe('remainingSeconds', () => {
+  it('counts down and floors at zero', () => {
+    expect(remainingSeconds(T0 + 30_000, T0)).toBe(30);
+    expect(remainingSeconds(T0 + 1, T0)).toBe(1);
+    expect(remainingSeconds(T0 - 5_000, T0)).toBe(0);
+  });
+});
+
+describe('reduceAutoRejected', () => {
+  const tracked = [{ key: 'a2a:ap-1', label: 'task-1', deadlineAt: T0 }];
+
+  it('logs a row that vanished after its deadline passed', () => {
+    const out = reduceAutoRejected({
+      previous: [],
+      tracked,
+      presentKeys: new Set<string>(),
+      now: T0 + 1,
+    });
+    expect(out).toEqual([{ key: 'a2a:ap-1', label: 'task-1', at: T0 }]);
+  });
+
+  it('does NOT log a row a human answered before the deadline', () => {
+    expect(
+      reduceAutoRejected({ previous: [], tracked, presentKeys: new Set<string>(), now: T0 - 1_000 }),
+    ).toEqual([]);
+  });
+
+  it('keeps a still-present row out of the log and is idempotent on key', () => {
+    expect(
+      reduceAutoRejected({ previous: [], tracked, presentKeys: new Set(['a2a:ap-1']), now: T0 + 1 }),
+    ).toEqual([]);
+    const once = reduceAutoRejected({ previous: [], tracked, presentKeys: new Set<string>(), now: T0 + 1 });
+    const twice = reduceAutoRejected({ previous: once, tracked, presentKeys: new Set<string>(), now: T0 + 1 });
+    expect(twice).toBe(once);
+  });
+
+  it('keeps the newest entries and caps the log', () => {
+    const many = Array.from({ length: AUTO_REJECT_LOG_CAP + 3 }, (_, i) => ({
+      key: `mcp:p-${i}`,
+      label: `plugin-${i}`,
+      deadlineAt: T0 + i,
+    }));
+    const previous: AutoRejectedEntry[] = [];
+    const out = reduceAutoRejected({
+      previous,
+      tracked: many,
+      presentKeys: new Set<string>(),
+      now: T0 + 1_000,
+    });
+    expect(out).toHaveLength(AUTO_REJECT_LOG_CAP);
+    expect(out[0].key).toBe(`mcp:p-${many.length - 1}`);
+  });
+});
+
+describe('inboxItemLabel', () => {
+  it('names the task for A2A and the plugin for MCP', () => {
+    expect(inboxItemLabel(a2a)).toBe('task-1');
+    expect(inboxItemLabel(mcp)).toBe('some-plugin');
+  });
+});

--- a/src/renderer/components/FleetView/approvalCountdown.ts
+++ b/src/renderer/components/FleetView/approvalCountdown.ts
@@ -1,0 +1,88 @@
+// ─── C-3: approval auto-reject countdown + the record of what expired ────
+//
+// An approval that nobody answers is auto-rejected. Until now the Fleet inbox
+// showed that deadline for A2A rows only, and when a row expired it simply
+// vanished — indistinguishable from someone approving it. These pure helpers
+// give the list both halves: the remaining seconds while the row is alive, and
+// a short log of the rows that died of the deadline.
+//
+// The deadline itself is data, not a guess: A2A rows carry `expiresAt`, and an
+// MCP prompt carries `deadlineAt` once the daemon stamps it (Lane A). Without a
+// deadline no badge is rendered — a countdown wmux cannot back with a real
+// auto-reject would be a lie about what happens when you walk away.
+
+import type { InboxItem } from '../../stores/selectors/approvalInbox';
+
+/** How many expired rows the list remembers. Enough to explain "what happened
+ *  while I was away" without turning the inbox into a history view. */
+export const AUTO_REJECT_LOG_CAP = 5;
+
+/** A row that expired without an answer. */
+export interface AutoRejectedEntry {
+  /** The inbox key of the row that expired (`a2a:…` / `mcp:…`). */
+  key: string;
+  /** What it was, for the log line. */
+  label: string;
+  /** When it expired (epoch ms). */
+  at: number;
+}
+
+/** The deadline the list is tracking for one row. */
+export interface TrackedDeadline {
+  key: string;
+  label: string;
+  deadlineAt: number;
+}
+
+/**
+ * The auto-reject deadline for an inbox row, or `undefined` when it has none.
+ * A2A execute approvals expire on their own clock; an MCP prompt only has one
+ * once the approval record carries `deadlineAt` (read structurally so this lane
+ * does not depend on the field having landed).
+ */
+export function deadlineForItem(
+  item: InboxItem,
+  mcpDeadlineAt?: (promptId: string) => number | undefined,
+): number | undefined {
+  if (item.source === 'a2a') return item.expiresAt;
+  const at = mcpDeadlineAt?.(item.promptId);
+  return typeof at === 'number' && Number.isFinite(at) ? at : undefined;
+}
+
+/** Whole seconds left before auto-reject, never negative. */
+export function remainingSeconds(deadlineAt: number, now: number): number {
+  return Math.ceil(Math.max(0, deadlineAt - now) / 1000);
+}
+
+/**
+ * Fold the rows that have LEFT the inbox into the auto-rejected log.
+ *
+ * A row counts as auto-rejected when it is gone and its deadline had already
+ * passed; a row that left before its deadline was answered by a human and is
+ * not logged. Newest first, capped, and idempotent on key — re-running with the
+ * same inputs cannot double-log an entry.
+ */
+export function reduceAutoRejected(args: {
+  previous: readonly AutoRejectedEntry[];
+  /** Deadlines observed on the previous render. */
+  tracked: readonly TrackedDeadline[];
+  /** Keys still present in the inbox. */
+  presentKeys: ReadonlySet<string>;
+  now: number;
+}): AutoRejectedEntry[] {
+  const { previous, tracked, presentKeys, now } = args;
+  const already = new Set(previous.map((e) => e.key));
+  const expired: AutoRejectedEntry[] = [];
+  for (const row of tracked) {
+    if (presentKeys.has(row.key) || already.has(row.key)) continue;
+    if (row.deadlineAt > now) continue; // answered before the deadline
+    expired.push({ key: row.key, label: row.label, at: row.deadlineAt });
+  }
+  if (expired.length === 0) return previous as AutoRejectedEntry[];
+  return [...expired.reverse(), ...previous].slice(0, AUTO_REJECT_LOG_CAP);
+}
+
+/** A short, source-appropriate label for the log line. */
+export function inboxItemLabel(item: InboxItem): string {
+  return item.source === 'a2a' ? item.taskId : item.clientName;
+}

--- a/src/renderer/components/FleetView/approvalCountdown.ts
+++ b/src/renderer/components/FleetView/approvalCountdown.ts
@@ -27,13 +27,6 @@ export interface AutoRejectedEntry {
   at: number;
 }
 
-/** The deadline the list is tracking for one row. */
-export interface TrackedDeadline {
-  key: string;
-  label: string;
-  deadlineAt: number;
-}
-
 /**
  * The auto-reject deadline for an inbox row, or `undefined` when it has none.
  * A2A execute approvals expire on their own clock; an MCP prompt only has one
@@ -55,31 +48,44 @@ export function remainingSeconds(deadlineAt: number, now: number): number {
 }
 
 /**
- * Fold the rows that have LEFT the inbox into the auto-rejected log.
+ * How far past its deadline a row may leave the inbox and still count as an
+ * auto-rejection.
  *
- * A row counts as auto-rejected when it is gone and its deadline had already
- * passed; a row that left before its deadline was answered by a human and is
- * not logged. Newest first, capped, and idempotent on key — re-running with the
- * same inputs cannot double-log an entry.
+ * "Gone and past its deadline" alone is not proof: a background tab's timers
+ * are throttled and a suspended machine wakes with a clock minutes ahead, so a
+ * row a HUMAN answered late would be logged as expired. An auto-reject removes
+ * the row at its deadline, so a removal that lands well after it is somebody
+ * else's doing.
  */
-export function reduceAutoRejected(args: {
-  previous: readonly AutoRejectedEntry[];
-  /** Deadlines observed on the previous render. */
-  tracked: readonly TrackedDeadline[];
-  /** Keys still present in the inbox. */
-  presentKeys: ReadonlySet<string>;
-  now: number;
-}): AutoRejectedEntry[] {
-  const { previous, tracked, presentKeys, now } = args;
-  const already = new Set(previous.map((e) => e.key));
-  const expired: AutoRejectedEntry[] = [];
-  for (const row of tracked) {
-    if (presentKeys.has(row.key) || already.has(row.key)) continue;
-    if (row.deadlineAt > now) continue; // answered before the deadline
-    expired.push({ key: row.key, label: row.label, at: row.deadlineAt });
-  }
-  if (expired.length === 0) return previous as AutoRejectedEntry[];
-  return [...expired.reverse(), ...previous].slice(0, AUTO_REJECT_LOG_CAP);
+export const AUTO_REJECT_GRACE_MS = 5_000;
+
+/**
+ * Did this row leave the inbox because its deadline fired?
+ *
+ * `removedAt` is the instant the row actually left the store, not a render
+ * tick — the classification is made at the removal point (the slice), so a
+ * deadline that fires while the Fleet tab is closed is still recorded.
+ */
+export function isAutoRejection(args: {
+  deadlineAt?: number;
+  removedAt: number;
+}): boolean {
+  const { deadlineAt, removedAt } = args;
+  if (typeof deadlineAt !== 'number' || !Number.isFinite(deadlineAt)) return false;
+  const late = removedAt - deadlineAt;
+  return late >= 0 && late <= AUTO_REJECT_GRACE_MS;
+}
+
+/**
+ * Prepend one expired row to the log: newest first, capped, and idempotent on
+ * key so a repeated removal cannot double-log.
+ */
+export function appendAutoRejected(
+  previous: readonly AutoRejectedEntry[],
+  entry: AutoRejectedEntry,
+): AutoRejectedEntry[] {
+  if (previous.some((e) => e.key === entry.key)) return previous as AutoRejectedEntry[];
+  return [entry, ...previous].slice(0, AUTO_REJECT_LOG_CAP);
 }
 
 /** A short, source-appropriate label for the log line. */

--- a/src/renderer/components/Sidebar/MissionsSection.tsx
+++ b/src/renderer/components/Sidebar/MissionsSection.tsx
@@ -264,9 +264,10 @@ function MissionsSection(): React.ReactElement {
           </div>
           {done.length > 0 && (
             <div data-missions-done-group>
+              <div className="flex items-center">
               <button
                 type="button"
-                className={`w-full flex items-center gap-1 px-4 py-0.5 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)] hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
+                className={`min-w-0 flex-1 flex items-center gap-1 px-4 py-0.5 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)] hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
                 onClick={() => setDoneExpanded((v) => !v)}
                 aria-expanded={doneExpanded}
                 data-missions-done-toggle
@@ -284,6 +285,20 @@ function MissionsSection(): React.ReactElement {
                   {t('missions.doneSummary', { title: done[0]?.title ?? '' })}
                 </span>
               </button>
+              {/* C-4: finished tasks are where cleanup starts. The worktree scan
+                  had no entry point outside the command palette, so a task whose
+                  close failed was invisible from the section that lists it. */}
+              <button
+                type="button"
+                className={`shrink-0 pr-4 pl-1 py-0.5 text-[9px] font-mono uppercase tracking-widest text-[var(--text-subtle)] hover:text-[var(--accent-blue)] transition-colors ${FOCUS_RING}`}
+                onClick={() => useStore.getState().setWorktaskCleanupVisible(true)}
+                title={t('missions.cleanUpTooltip')}
+                aria-label={t('missions.cleanUpTooltip')}
+                data-missions-cleanup
+              >
+                {t('missions.cleanUp')}
+              </button>
+              </div>
               {doneExpanded && (
                 <div className="space-y-0.5 opacity-60">
                   {done.map((task) => (

--- a/src/renderer/components/Sidebar/MissionsSection.tsx
+++ b/src/renderer/components/Sidebar/MissionsSection.tsx
@@ -225,21 +225,39 @@ function MissionsSection(): React.ReactElement {
 
   return (
     <div className="mb-1" data-missions-section>
-      <button
-        type="button"
-        className={`w-full flex items-center gap-1 px-4 pt-1 pb-1 text-[9px] font-mono font-semibold tracking-widest text-[var(--text-muted)] uppercase hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-        data-missions-toggle
-      >
-        <span
-          className={`transition-transform ${expanded ? 'rotate-90' : ''}`}
-          aria-hidden="true"
+      <div className="flex items-center">
+        <button
+          type="button"
+          className={`min-w-0 flex-1 flex items-center gap-1 px-4 pt-1 pb-1 text-[9px] font-mono font-semibold tracking-widest text-[var(--text-muted)] uppercase hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          data-missions-toggle
         >
-          <IconChevron size={9} />
-        </span>
-        <span>{t('missions.title', { count: missions.length })}</span>
-      </button>
+          <span
+            className={`transition-transform ${expanded ? 'rotate-90' : ''}`}
+            aria-hidden="true"
+          >
+            <IconChevron size={9} />
+          </span>
+          <span>{t('missions.title', { count: missions.length })}</span>
+        </button>
+        {/* C-4: the worktree scan has no entry point outside the command
+            palette. Review fix — it sits on the SECTION header, not inside the
+            finished-tasks group: the orphaned directories and unmaterialized
+            tasks it finds are exactly what you have when the list shows
+            nothing finished at all. */}
+        {expanded && (
+          <button
+            type="button"
+            className={`shrink-0 pr-4 pl-1 pt-1 pb-1 text-[9px] font-mono uppercase tracking-widest text-[var(--text-subtle)] hover:text-[var(--accent-blue)] transition-colors ${FOCUS_RING}`}
+            onClick={() => useStore.getState().setWorktaskCleanupVisible(true)}
+            aria-label={t('missions.cleanUpTooltip')}
+            data-missions-cleanup
+          >
+            {t('missions.cleanUp')}
+          </button>
+        )}
+      </div>
       {expanded && missions.length === 0 && (
         <div className="px-4 py-1 text-[10px] font-mono text-[var(--text-muted)]" data-missions-empty>
           {t('missions.empty')}
@@ -264,10 +282,9 @@ function MissionsSection(): React.ReactElement {
           </div>
           {done.length > 0 && (
             <div data-missions-done-group>
-              <div className="flex items-center">
               <button
                 type="button"
-                className={`min-w-0 flex-1 flex items-center gap-1 px-4 py-0.5 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)] hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
+                className={`w-full flex items-center gap-1 px-4 py-0.5 text-[9px] font-mono uppercase tracking-widest text-[var(--text-muted)] hover:text-[var(--text-subtle)] transition-colors ${FOCUS_RING}`}
                 onClick={() => setDoneExpanded((v) => !v)}
                 aria-expanded={doneExpanded}
                 data-missions-done-toggle
@@ -285,20 +302,6 @@ function MissionsSection(): React.ReactElement {
                   {t('missions.doneSummary', { title: done[0]?.title ?? '' })}
                 </span>
               </button>
-              {/* C-4: finished tasks are where cleanup starts. The worktree scan
-                  had no entry point outside the command palette, so a task whose
-                  close failed was invisible from the section that lists it. */}
-              <button
-                type="button"
-                className={`shrink-0 pr-4 pl-1 py-0.5 text-[9px] font-mono uppercase tracking-widest text-[var(--text-subtle)] hover:text-[var(--accent-blue)] transition-colors ${FOCUS_RING}`}
-                onClick={() => useStore.getState().setWorktaskCleanupVisible(true)}
-                title={t('missions.cleanUpTooltip')}
-                aria-label={t('missions.cleanUpTooltip')}
-                data-missions-cleanup
-              >
-                {t('missions.cleanUp')}
-              </button>
-              </div>
               {doneExpanded && (
                 <div className="space-y-0.5 opacity-60">
                   {done.map((task) => (

--- a/src/renderer/components/Sidebar/__tests__/MissionsSection.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/MissionsSection.test.tsx
@@ -35,6 +35,15 @@ describe('MissionsSection', () => {
     expect(html).toContain('data-missions-section');
   });
 
+  // Review fix: cleanup used to live inside the finished-tasks group, so the
+  // one state where it matters most — nothing finished, but orphaned worktrees
+  // on disk — could not reach it.
+  it('offers the cleanup entry with zero missions', () => {
+    const html = renderToStaticMarkup(createElement(MissionsSection));
+    expect(html).toContain('data-missions-cleanup');
+    expect(html).not.toContain('data-missions-done-group');
+  });
+
   describe('flattenMissions (순수)', () => {
     it('빈 맵은 빈 배열', () => {
       expect(flattenMissions({})).toEqual([]);

--- a/src/renderer/components/WorkTask/WorktaskCleanupView.tsx
+++ b/src/renderer/components/WorkTask/WorktaskCleanupView.tsx
@@ -10,6 +10,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useStore } from '../../stores';
 import { useT } from '../../hooks/useT';
+import { findLeafPanes, activePaneTerminalPty } from '../../hooks/a2aAddressing';
+import { formatBracketedPastePayload } from '../../utils/ptyMessageDelivery';
 import type { WorktaskScanEntryWire, WorktaskScanCategoryWire } from '../../../shared/workTask';
 
 const CATEGORY_LABEL_KEY: Record<WorktaskScanCategoryWire, string> = {
@@ -26,6 +28,43 @@ const CATEGORY_COLOR: Record<WorktaskScanCategoryWire, string> = {
   'orphan-dir': 'var(--text-muted)',
 };
 
+// ─── C-4: the prepared commit line ──────────────────────────────────────
+//
+// A close that fails on a dirty worktree leaves the user with nothing to do
+// from here. "Commit & close" writes a ready-to-run line into the task's own
+// pane — it does NOT run it: what gets committed is the user's call, and an
+// agent's uncommitted work is not something a cleanup dialog should decide.
+//
+// The line lists the changed paths EXPLICITLY. `git add -A` in a worktree an
+// agent is still working in stages whatever else happens to be lying there;
+// naming the paths keeps the commit to what the scan actually saw.
+
+/** Above this many changed paths the prepared line stops being something a
+ *  human can read in a prompt — the view offers "open worktree" instead. */
+export const PREPARED_COMMIT_PATH_CAP = 40;
+
+/** POSIX single-quote escaping: everything inside '…' is literal, and a literal
+ *  quote is written by closing, escaping, and reopening. */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build the line the pane is pre-filled with. Paths are deduped and sorted so
+ * the same dirty worktree always produces the same line; the title becomes the
+ * `wip:` subject. Returns `null` when there is nothing to commit, or when there
+ * are more paths than a prepared line should carry.
+ */
+export function buildPreparedCommitLine(
+  paths: readonly string[],
+  title: string,
+): string | null {
+  const unique = [...new Set(paths.filter((p) => p.trim().length > 0))].sort();
+  if (unique.length === 0 || unique.length > PREPARED_COMMIT_PATH_CAP) return null;
+  const subject = `wip: ${title.trim() || 'task'}`.replace(/\s+/g, ' ');
+  return `git add -- ${unique.map(shellQuote).join(' ')} && git commit -m ${shellQuote(subject)}`;
+}
+
 export default function WorktaskCleanupView() {
   const t = useT();
   const visible = useStore((s) => s.worktaskCleanupVisible);
@@ -39,6 +78,11 @@ export default function WorktaskCleanupView() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
+  // C-4: taskIds whose close failed on a worktree that still holds work. The
+  // row keeps the two things the user can actually do about it (prepare a
+  // commit in the task's own pane, or open the worktree) instead of a toast
+  // that scrolls away with no next step.
+  const [closeFailed, setCloseFailed] = useState<Record<string, true>>({});
 
   const runScan = useCallback(async () => {
     const api = window.electronAPI.workTask;
@@ -88,12 +132,19 @@ export default function WorktaskCleanupView() {
         const res = await api.close(taskId, closeAs);
         if (res.ok) {
           pushToast({ level: 'info', message: t('worktask.cleanup.closed') });
+          setCloseFailed((prev) => {
+            const { [taskId]: _done, ...rest } = prev;
+            return rest;
+          });
         } else if (res.reason === 'dirty') {
           pushToast({ level: 'warn', message: t('worktask.cleanup.preserved') });
+          setCloseFailed((prev) => ({ ...prev, [taskId]: true }));
         } else if (res.reason === 'unpushed') {
           pushToast({ level: 'warn', message: t('worktask.cleanup.unpushed', { count: res.aheadCount ?? '' }) });
+          setCloseFailed((prev) => ({ ...prev, [taskId]: true }));
         } else {
           pushToast({ level: 'error', message: t('worktask.cleanup.closeFailed', { error: res.error ?? '' }) });
+          setCloseFailed((prev) => ({ ...prev, [taskId]: true }));
         }
       } catch (e) {
         pushToast({ level: 'error', message: t('worktask.cleanup.closeFailed', { error: e instanceof Error ? e.message : String(e) }) });
@@ -103,6 +154,60 @@ export default function WorktaskCleanupView() {
       }
     },
     [activeWorkspaceId, pushToast, runScan, t],
+  );
+
+  // C-4 "Open worktree" — reveal the directory the close refused to remove.
+  const handleOpenWorktree = useCallback(
+    (worktreePath: string) => {
+      void window.electronAPI.shell?.openPath(worktreePath);
+    },
+    [],
+  );
+
+  // C-4 "Commit & close" — type a ready-to-run commit line into the task's own
+  // pane and stop. Nothing is executed and nothing is submitted: the user reads
+  // the paths, edits the message if they want, and presses Enter themselves.
+  const handleCommitAndClose = useCallback(
+    async (entry: WorktaskScanEntryWire) => {
+      const worktreePath = entry.worktreePath;
+      if (!worktreePath || !entry.taskId) return;
+      const st = useStore.getState();
+      // The task's own workspace is the one keyed by paneGroupId in the mission
+      // cache; without it there is no pane to prepare the line in.
+      const paneGroupId = Object.entries(st.missionByPaneGroup).find(
+        ([, mission]) => mission.id === entry.taskId,
+      )?.[0];
+      const ws = paneGroupId ? st.workspaces.find((w) => w.id === paneGroupId) : undefined;
+      const ptyId = ws
+        ? activePaneTerminalPty(findLeafPanes(ws.rootPane), ws.activePaneId)
+        : null;
+      if (!ws || !ptyId) {
+        pushToast({ level: 'warn', message: t('worktask.cleanup.noPaneForCommit') });
+        return;
+      }
+      const diff = await window.electronAPI.diff.read(worktreePath, '', 'workspace');
+      if (!diff.ok) {
+        pushToast({ level: 'error', message: t('worktask.cleanup.closeFailed', { error: diff.error }) });
+        return;
+      }
+      const paths = [
+        ...diff.numstat.map((n) => n.path),
+        ...diff.files.map((f) => f.path),
+        ...diff.truncated,
+        ...diff.unsupported,
+      ];
+      const line = buildPreparedCommitLine(paths, entry.title ?? entry.taskId);
+      if (!line) {
+        pushToast({ level: 'warn', message: t('worktask.cleanup.commitLineUnavailable') });
+        return;
+      }
+      st.setActiveWorkspace(ws.id);
+      // Bracketed paste, no trailing CR: the line lands at the prompt unrun.
+      window.electronAPI.pty.write(ptyId, formatBracketedPastePayload(line));
+      setVisible(false);
+      pushToast({ level: 'info', message: t('worktask.cleanup.commitLinePrepared') });
+    },
+    [pushToast, setVisible, t],
   );
 
   if (!visible) return null;
@@ -174,6 +279,28 @@ export default function WorktaskCleanupView() {
                   {e.closedAt && (
                     <div className="text-[10px] text-[var(--text-muted)]">
                       {t('worktask.cleanup.closedAt')}: {new Date(e.closedAt).toLocaleString()}
+                    </div>
+                  )}
+                  {e.taskId && closeFailed[e.taskId] && (
+                    <div className="mt-1 flex flex-wrap items-center gap-2" data-cleanup-close-failed>
+                      {e.worktreePath && (
+                        <button
+                          className="px-2 py-0.5 rounded text-[10px] bg-[var(--bg-mantle)] text-[var(--text-sub)] hover:text-[var(--text-main)] border border-[var(--bg-mantle)]"
+                          onClick={() => void handleCommitAndClose(e)}
+                          data-cleanup-commit-close
+                        >
+                          {t('worktask.cleanup.commitAndClose')}
+                        </button>
+                      )}
+                      {e.worktreePath && (
+                        <button
+                          className="px-2 py-0.5 rounded text-[10px] bg-[var(--bg-mantle)] text-[var(--text-sub)] hover:text-[var(--text-main)] border border-[var(--bg-mantle)]"
+                          onClick={() => handleOpenWorktree(e.worktreePath!)}
+                          data-cleanup-open-worktree
+                        >
+                          {t('worktask.cleanup.openWorktree')}
+                        </button>
+                      )}
                     </div>
                   )}
                 </div>

--- a/src/renderer/components/WorkTask/WorktaskCleanupView.tsx
+++ b/src/renderer/components/WorkTask/WorktaskCleanupView.tsx
@@ -14,6 +14,10 @@ import { findLeafPanes, activePaneTerminalPty } from '../../hooks/a2aAddressing'
 import { formatBracketedPastePayload } from '../../utils/ptyMessageDelivery';
 import type { WorktaskScanEntryWire, WorktaskScanCategoryWire } from '../../../shared/workTask';
 
+/** Why the last close attempt for a task failed — drives which next steps the
+ *  row offers. 'dirty' is the only one a commit line can answer. */
+type WorktaskCloseFailure = 'dirty' | 'unpushed' | 'error';
+
 const CATEGORY_LABEL_KEY: Record<WorktaskScanCategoryWire, string> = {
   'unmaterialized-open': 'worktask.cleanup.cat.unmaterialized',
   'disk-missing': 'worktask.cleanup.cat.diskMissing',
@@ -38,6 +42,19 @@ const CATEGORY_COLOR: Record<WorktaskScanCategoryWire, string> = {
 // The line lists the changed paths EXPLICITLY. `git add -A` in a worktree an
 // agent is still working in stages whatever else happens to be lying there;
 // naming the paths keeps the commit to what the scan actually saw.
+//
+// Review fixes:
+//  - every git verb is `git -C <worktree>`. The line is typed into a shell
+//    whose cwd nobody controls; a bare `git add` in a shell that had cd'd
+//    elsewhere would commit into the SHARED main checkout.
+//  - the paths come from the status scan (`snapshot.targetDirtyFiles`), which
+//    is `git status --porcelain -z` with `core.quotepath=false`: untracked
+//    files included, renames as the new path, no shell-quoted escapes. The
+//    numstat/`truncated`/`unsupported` lists are display artifacts — numstat
+//    prints a rename as `old => new`, which is not an argv.
+//  - the whole feature is POSIX-shell only. `shellQuote` is POSIX quoting and
+//    PowerShell/cmd read `'…'` differently, so on win32 the row offers "Open
+//    worktree" and nothing else rather than a line that quotes wrong.
 
 /** Above this many changed paths the prepared line stops being something a
  *  human can read in a prompt — the view offers "open worktree" instead. */
@@ -49,20 +66,51 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
+/** The prepared line is POSIX-shell syntax (`'…'` quoting, `&&`). cmd.exe and
+ *  PowerShell both mis-read it, so the feature is simply absent on win32. */
+export function preparedCommitSupported(platform: string): boolean {
+  return platform !== 'win32';
+}
+
 /**
  * Build the line the pane is pre-filled with. Paths are deduped and sorted so
  * the same dirty worktree always produces the same line; the title becomes the
- * `wip:` subject. Returns `null` when there is nothing to commit, or when there
- * are more paths than a prepared line should carry.
+ * `wip:` subject. Every git invocation is pinned to `worktreePath` with `-C`.
+ * Returns `null` when there is nothing to commit, when there are more paths
+ * than a prepared line should carry, or when there is no worktree to pin to.
  */
-export function buildPreparedCommitLine(
-  paths: readonly string[],
-  title: string,
-): string | null {
-  const unique = [...new Set(paths.filter((p) => p.trim().length > 0))].sort();
+export function buildPreparedCommitLine(args: {
+  worktreePath: string;
+  paths: readonly string[];
+  title: string;
+}): string | null {
+  const worktreePath = args.worktreePath.trim();
+  if (!worktreePath) return null;
+  const unique = [...new Set(args.paths.filter((p) => p.trim().length > 0))].sort();
   if (unique.length === 0 || unique.length > PREPARED_COMMIT_PATH_CAP) return null;
-  const subject = `wip: ${title.trim() || 'task'}`.replace(/\s+/g, ' ');
-  return `git add -- ${unique.map(shellQuote).join(' ')} && git commit -m ${shellQuote(subject)}`;
+  const subject = `wip: ${args.title.trim() || 'task'}`.replace(/\s+/g, ' ');
+  const at = `git -C ${shellQuote(worktreePath)}`;
+  return `${at} add -- ${unique.map(shellQuote).join(' ')} && ${at} commit -m ${shellQuote(subject)}`;
+}
+
+/** Why a task pane cannot take a prepared commit line. */
+export type CommitTargetRefusal = 'no-pane' | 'agent-pane';
+
+/**
+ * Resolve the pty the line may be typed into.
+ *
+ * The pane a task runs in is normally the AGENT's TUI. Typing a git line there
+ * does not reach a shell at all — it becomes a chat message, or worse, the
+ * answer to whatever approval prompt the agent is sitting on. So the line is
+ * only ever typed into a pty with no detected agent behind it.
+ */
+export function resolveCommitTargetPty(args: {
+  ptyId: string | null;
+  surfaceAgent: Record<string, { name: string } | undefined>;
+}): { ok: true; ptyId: string } | { ok: false; reason: CommitTargetRefusal } {
+  if (!args.ptyId) return { ok: false, reason: 'no-pane' };
+  if (args.surfaceAgent[args.ptyId]?.name) return { ok: false, reason: 'agent-pane' };
+  return { ok: true, ptyId: args.ptyId };
 }
 
 export default function WorktaskCleanupView() {
@@ -78,11 +126,11 @@ export default function WorktaskCleanupView() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
-  // C-4: taskIds whose close failed on a worktree that still holds work. The
-  // row keeps the two things the user can actually do about it (prepare a
-  // commit in the task's own pane, or open the worktree) instead of a toast
-  // that scrolls away with no next step.
-  const [closeFailed, setCloseFailed] = useState<Record<string, true>>({});
+  // C-4: taskIds whose close failed, keyed by WHY. The row keeps the actions
+  // that actually apply to that reason instead of a toast that scrolls away
+  // with no next step — a commit line answers 'dirty', but an unpushed branch
+  // needs a push, and committing again would only add to what is unpushed.
+  const [closeFailed, setCloseFailed] = useState<Record<string, WorktaskCloseFailure>>({});
 
   const runScan = useCallback(async () => {
     const api = window.electronAPI.workTask;
@@ -138,13 +186,13 @@ export default function WorktaskCleanupView() {
           });
         } else if (res.reason === 'dirty') {
           pushToast({ level: 'warn', message: t('worktask.cleanup.preserved') });
-          setCloseFailed((prev) => ({ ...prev, [taskId]: true }));
+          setCloseFailed((prev) => ({ ...prev, [taskId]: 'dirty' }));
         } else if (res.reason === 'unpushed') {
           pushToast({ level: 'warn', message: t('worktask.cleanup.unpushed', { count: res.aheadCount ?? '' }) });
-          setCloseFailed((prev) => ({ ...prev, [taskId]: true }));
+          setCloseFailed((prev) => ({ ...prev, [taskId]: 'unpushed' }));
         } else {
           pushToast({ level: 'error', message: t('worktask.cleanup.closeFailed', { error: res.error ?? '' }) });
-          setCloseFailed((prev) => ({ ...prev, [taskId]: true }));
+          setCloseFailed((prev) => ({ ...prev, [taskId]: 'error' }));
         }
       } catch (e) {
         pushToast({ level: 'error', message: t('worktask.cleanup.closeFailed', { error: e instanceof Error ? e.message : String(e) }) });
@@ -157,11 +205,19 @@ export default function WorktaskCleanupView() {
   );
 
   // C-4 "Open worktree" — reveal the directory the close refused to remove.
+  // openPath resolves { ok, error }: a silent failure here leaves the user
+  // staring at a button that did nothing.
   const handleOpenWorktree = useCallback(
-    (worktreePath: string) => {
-      void window.electronAPI.shell?.openPath(worktreePath);
+    async (worktreePath: string) => {
+      const res = await window.electronAPI.shell.openPath(worktreePath);
+      if (!res.ok) {
+        pushToast({
+          level: 'error',
+          message: t('worktask.cleanup.openWorktreeFailed', { error: res.error ?? '' }),
+        });
+      }
     },
-    [],
+    [pushToast, t],
   );
 
   // C-4 "Commit & close" — type a ready-to-run commit line into the task's own
@@ -178,25 +234,34 @@ export default function WorktaskCleanupView() {
         ([, mission]) => mission.id === entry.taskId,
       )?.[0];
       const ws = paneGroupId ? st.workspaces.find((w) => w.id === paneGroupId) : undefined;
-      const ptyId = ws
-        ? activePaneTerminalPty(findLeafPanes(ws.rootPane), ws.activePaneId)
-        : null;
-      if (!ws || !ptyId) {
-        pushToast({ level: 'warn', message: t('worktask.cleanup.noPaneForCommit') });
+      const target = resolveCommitTargetPty({
+        ptyId: ws ? activePaneTerminalPty(findLeafPanes(ws.rootPane), ws.activePaneId) : null,
+        surfaceAgent: st.surfaceAgent,
+      });
+      if (!ws || !target.ok) {
+        pushToast({
+          level: 'warn',
+          message:
+            ws && !target.ok && target.reason === 'agent-pane'
+              ? t('worktask.cleanup.commitNeedsShell')
+              : t('worktask.cleanup.noPaneForCommit'),
+        });
         return;
       }
+      const ptyId = target.ptyId;
       const diff = await window.electronAPI.diff.read(worktreePath, '', 'workspace');
       if (!diff.ok) {
         pushToast({ level: 'error', message: t('worktask.cleanup.closeFailed', { error: diff.error }) });
         return;
       }
-      const paths = [
-        ...diff.numstat.map((n) => n.path),
-        ...diff.files.map((f) => f.path),
-        ...diff.truncated,
-        ...diff.unsupported,
-      ];
-      const line = buildPreparedCommitLine(paths, entry.title ?? entry.taskId);
+      // The status scan, not the rendered diff: it carries untracked files and
+      // prints one unambiguous path per entry (rename → new path), where a
+      // numstat line prints a rename as `old => new` and would become argv.
+      const line = buildPreparedCommitLine({
+        worktreePath,
+        paths: diff.snapshot.targetDirtyFiles,
+        title: entry.title ?? entry.taskId,
+      });
       if (!line) {
         pushToast({ level: 'warn', message: t('worktask.cleanup.commitLineUnavailable') });
         return;
@@ -209,6 +274,9 @@ export default function WorktaskCleanupView() {
     },
     [pushToast, setVisible, t],
   );
+
+  // POSIX-shell quoting only (see preparedCommitSupported).
+  const canPrepareCommit = preparedCommitSupported(window.electronAPI.platform);
 
   if (!visible) return null;
 
@@ -283,7 +351,10 @@ export default function WorktaskCleanupView() {
                   )}
                   {e.taskId && closeFailed[e.taskId] && (
                     <div className="mt-1 flex flex-wrap items-center gap-2" data-cleanup-close-failed>
-                      {e.worktreePath && (
+                      {/* Only a worktree that still holds UNCOMMITTED work has a
+                          commit line to prepare — an unpushed branch needs a
+                          push, and a commit would only add to it. */}
+                      {e.worktreePath && closeFailed[e.taskId] === 'dirty' && canPrepareCommit && (
                         <button
                           className="px-2 py-0.5 rounded text-[10px] bg-[var(--bg-mantle)] text-[var(--text-sub)] hover:text-[var(--text-main)] border border-[var(--bg-mantle)]"
                           onClick={() => void handleCommitAndClose(e)}
@@ -295,7 +366,7 @@ export default function WorktaskCleanupView() {
                       {e.worktreePath && (
                         <button
                           className="px-2 py-0.5 rounded text-[10px] bg-[var(--bg-mantle)] text-[var(--text-sub)] hover:text-[var(--text-main)] border border-[var(--bg-mantle)]"
-                          onClick={() => handleOpenWorktree(e.worktreePath!)}
+                          onClick={() => void handleOpenWorktree(e.worktreePath!)}
                           data-cleanup-open-worktree
                         >
                           {t('worktask.cleanup.openWorktree')}

--- a/src/renderer/components/WorkTask/__tests__/preparedCommit.test.ts
+++ b/src/renderer/components/WorkTask/__tests__/preparedCommit.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   buildPreparedCommitLine,
+  preparedCommitSupported,
+  resolveCommitTargetPty,
   shellQuote,
   PREPARED_COMMIT_PATH_CAP,
 } from '../WorktaskCleanupView';
@@ -8,6 +10,8 @@ import {
 // C-4 — the line "Commit & close" types into the task's pane. It must name the
 // changed paths explicitly: `git add -A` in a worktree an agent is still
 // working in stages whatever else is lying around.
+
+const WT = '/Users/me/wt/task-1';
 
 describe('shellQuote', () => {
   it('quotes a path with spaces and keeps a literal quote literal', () => {
@@ -19,31 +23,85 @@ describe('shellQuote', () => {
 
 describe('buildPreparedCommitLine', () => {
   it('lists the changed paths explicitly — never -A', () => {
-    const line = buildPreparedCommitLine(['b.ts', 'a.ts'], 'fix the thing');
-    expect(line).toBe("git add -- 'a.ts' 'b.ts' && git commit -m 'wip: fix the thing'");
+    const line = buildPreparedCommitLine({ worktreePath: WT, paths: ['b.ts', 'a.ts'], title: 'fix the thing' });
+    expect(line).toBe(
+      "git -C '/Users/me/wt/task-1' add -- 'a.ts' 'b.ts' && git -C '/Users/me/wt/task-1' commit -m 'wip: fix the thing'",
+    );
     expect(line).not.toContain('add -A');
   });
 
-  it('dedupes paths and collapses whitespace in the subject', () => {
-    expect(buildPreparedCommitLine(['a.ts', 'a.ts', ' '], 'two\n  words')).toBe(
-      "git add -- 'a.ts' && git commit -m 'wip: two words'",
+  // Review fix: a shell that had cd'd elsewhere would otherwise commit the wip
+  // into the SHARED main checkout.
+  it('pins every git verb to the worktree with -C', () => {
+    const line = buildPreparedCommitLine({ worktreePath: WT, paths: ['a.ts'], title: 'x' })!;
+    const gitCalls = line.match(/git /g) ?? [];
+    const pinned = line.match(/git -C '\/Users\/me\/wt\/task-1'/g) ?? [];
+    expect(gitCalls).toHaveLength(2);
+    expect(pinned).toHaveLength(2);
+  });
+
+  it('quotes a worktree path with spaces', () => {
+    expect(buildPreparedCommitLine({ worktreePath: '/wt/a b', paths: ['a.ts'], title: 'x' })).toBe(
+      "git -C '/wt/a b' add -- 'a.ts' && git -C '/wt/a b' commit -m 'wip: x'",
     );
   });
 
-  it('returns null when there is nothing to commit', () => {
-    expect(buildPreparedCommitLine([], 'x')).toBeNull();
-    expect(buildPreparedCommitLine(['', '   '], 'x')).toBeNull();
+  it('dedupes paths and collapses whitespace in the subject', () => {
+    expect(buildPreparedCommitLine({ worktreePath: WT, paths: ['a.ts', 'a.ts', ' '], title: 'two\n  words' })).toBe(
+      "git -C '/Users/me/wt/task-1' add -- 'a.ts' && git -C '/Users/me/wt/task-1' commit -m 'wip: two words'",
+    );
   });
 
-  it('refuses to build an unreadable line past the path cap', () => {
+  it('returns null when there is nothing to commit, or no worktree to pin to', () => {
+    expect(buildPreparedCommitLine({ worktreePath: WT, paths: [], title: 'x' })).toBeNull();
+    expect(buildPreparedCommitLine({ worktreePath: WT, paths: ['', '   '], title: 'x' })).toBeNull();
+    expect(buildPreparedCommitLine({ worktreePath: '  ', paths: ['a.ts'], title: 'x' })).toBeNull();
+  });
+
+  it('refuses to build an unreadable — or partial — line past the path cap', () => {
     const many = Array.from({ length: PREPARED_COMMIT_PATH_CAP + 1 }, (_, i) => `f${i}.ts`);
-    expect(buildPreparedCommitLine(many, 'x')).toBeNull();
-    expect(buildPreparedCommitLine(many.slice(0, PREPARED_COMMIT_PATH_CAP), 'x')).not.toBeNull();
+    expect(buildPreparedCommitLine({ worktreePath: WT, paths: many, title: 'x' })).toBeNull();
+    expect(
+      buildPreparedCommitLine({ worktreePath: WT, paths: many.slice(0, PREPARED_COMMIT_PATH_CAP), title: 'x' }),
+    ).not.toBeNull();
   });
 
   it('falls back to a subject when the task has no title', () => {
-    expect(buildPreparedCommitLine(['a.ts'], '   ')).toBe(
-      "git add -- 'a.ts' && git commit -m 'wip: task'",
+    expect(buildPreparedCommitLine({ worktreePath: WT, paths: ['a.ts'], title: '   ' })).toBe(
+      "git -C '/Users/me/wt/task-1' add -- 'a.ts' && git -C '/Users/me/wt/task-1' commit -m 'wip: task'",
     );
+  });
+});
+
+// Review fix: POSIX quoting is not PowerShell/cmd quoting, so the feature is
+// absent there rather than wrong.
+describe('preparedCommitSupported', () => {
+  it('is off on win32 and on everywhere else', () => {
+    expect(preparedCommitSupported('win32')).toBe(false);
+    expect(preparedCommitSupported('darwin')).toBe(true);
+    expect(preparedCommitSupported('linux')).toBe(true);
+  });
+});
+
+// Review fix: a task pane is usually the AGENT's TUI. Typing a git line there
+// makes it a chat message — or the answer to a pending approval prompt.
+describe('resolveCommitTargetPty', () => {
+  it('refuses a pty with a detected agent behind it', () => {
+    expect(
+      resolveCommitTargetPty({ ptyId: 'pty-1', surfaceAgent: { 'pty-1': { name: 'Claude Code' } } }),
+    ).toEqual({ ok: false, reason: 'agent-pane' });
+  });
+
+  it('refuses when there is no pane at all', () => {
+    expect(resolveCommitTargetPty({ ptyId: null, surfaceAgent: {} })).toEqual({
+      ok: false,
+      reason: 'no-pane',
+    });
+  });
+
+  it('accepts a plain shell pty', () => {
+    expect(
+      resolveCommitTargetPty({ ptyId: 'pty-1', surfaceAgent: { 'pty-2': { name: 'Claude Code' } } }),
+    ).toEqual({ ok: true, ptyId: 'pty-1' });
   });
 });

--- a/src/renderer/components/WorkTask/__tests__/preparedCommit.test.ts
+++ b/src/renderer/components/WorkTask/__tests__/preparedCommit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildPreparedCommitLine,
+  shellQuote,
+  PREPARED_COMMIT_PATH_CAP,
+} from '../WorktaskCleanupView';
+
+// C-4 — the line "Commit & close" types into the task's pane. It must name the
+// changed paths explicitly: `git add -A` in a worktree an agent is still
+// working in stages whatever else is lying around.
+
+describe('shellQuote', () => {
+  it('quotes a path with spaces and keeps a literal quote literal', () => {
+    expect(shellQuote('src/a b.ts')).toBe("'src/a b.ts'");
+    expect(shellQuote("it's.ts")).toBe("'it'\\''s.ts'");
+    expect(shellQuote('a;rm -rf /')).toBe("'a;rm -rf /'");
+  });
+});
+
+describe('buildPreparedCommitLine', () => {
+  it('lists the changed paths explicitly — never -A', () => {
+    const line = buildPreparedCommitLine(['b.ts', 'a.ts'], 'fix the thing');
+    expect(line).toBe("git add -- 'a.ts' 'b.ts' && git commit -m 'wip: fix the thing'");
+    expect(line).not.toContain('add -A');
+  });
+
+  it('dedupes paths and collapses whitespace in the subject', () => {
+    expect(buildPreparedCommitLine(['a.ts', 'a.ts', ' '], 'two\n  words')).toBe(
+      "git add -- 'a.ts' && git commit -m 'wip: two words'",
+    );
+  });
+
+  it('returns null when there is nothing to commit', () => {
+    expect(buildPreparedCommitLine([], 'x')).toBeNull();
+    expect(buildPreparedCommitLine(['', '   '], 'x')).toBeNull();
+  });
+
+  it('refuses to build an unreadable line past the path cap', () => {
+    const many = Array.from({ length: PREPARED_COMMIT_PATH_CAP + 1 }, (_, i) => `f${i}.ts`);
+    expect(buildPreparedCommitLine(many, 'x')).toBeNull();
+    expect(buildPreparedCommitLine(many.slice(0, PREPARED_COMMIT_PATH_CAP), 'x')).not.toBeNull();
+  });
+
+  it('falls back to a subject when the task has no title', () => {
+    expect(buildPreparedCommitLine(['a.ts'], '   ')).toBe(
+      "git add -- 'a.ts' && git commit -m 'wip: task'",
+    );
+  });
+});

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -164,7 +164,12 @@ export function planChannelMessageDelivery(
 interface EventsPollBridge {
   (params: {
     cursor: number;
-    types: readonly ('channel.message' | 'agent.lifecycle' | 'channel.catalog')[];
+    types: readonly (
+      | 'channel.message'
+      | 'agent.lifecycle'
+      | 'channel.catalog'
+      | 'channel.nudgeExhausted'
+    )[];
     max?: number;
     workspaceId: string;
     /** FIX-MULTI-WS: union scope — every LOCAL workspace id, so background
@@ -436,7 +441,7 @@ export function useChannelsEventSubscription(): void {
       inFlight = true;
       bridge({
         cursor,
-        types: ['channel.message', 'agent.lifecycle', 'channel.catalog'],
+        types: ['channel.message', 'agent.lifecycle', 'channel.catalog', 'channel.nudgeExhausted'],
         max: EVENT_POLL_MAX,
         workspaceId,
         // FIX-MULTI-WS + P5: union scope — every local workspace PLUS the
@@ -668,6 +673,17 @@ export function useChannelsEventSubscription(): void {
                 ce.recipientWorkspaceIds.includes(workspaceId)
               ) {
                 sawCatalog = true;
+              }
+            } else if (event.type === 'channel.nudgeExhausted') {
+              // C-2: the wake worker gave up on a (channel, member) mention
+              // episode. The daemon scopes this event to the AFFECTED member's
+              // workspace, which is local here (both the sender and the worker
+              // pane live in this app), so the sender's message row can finally
+              // say "no answer" instead of a delivered receipt on a pane that
+              // never acted. Payload is flat (channelId, workspaceId, memberId).
+              const ne = event as unknown as { channelId?: unknown; memberId?: unknown };
+              if (typeof ne.channelId === 'string' && typeof ne.memberId === 'string') {
+                useStore.getState().markChannelNudgeExhausted(ne.channelId, ne.memberId, event.ts);
               }
             }
           }

--- a/src/renderer/hooks/useChannelsEventSubscription.ts
+++ b/src/renderer/hooks/useChannelsEventSubscription.ts
@@ -53,6 +53,7 @@
 
 import { useEffect } from 'react';
 import { useStore } from '../stores';
+import { t } from '../i18n';
 import { loadChannelHistory, hydrateChannelsCatalog } from './useChannelsHydration';
 import { routeChannelMentionToInbox } from './channelMentionInbox';
 import {
@@ -347,7 +348,10 @@ export function useChannelsEventSubscription(): void {
           if (limited && shouldWarnLoopSuspect(ptyId, Date.now())) {
             useStore.getState().pushToast({
               level: 'info',
+              // C-5: localized like every other user-visible channel string; the
+              // English text stays as the fallback for an untranslated locale.
               message:
+                t('channels.mentionLoopSuspected') ||
                 'Possible agent mention loop — auto-nudges for a pane are rate-capped; queued mentions stay pullable via a2a_task_query.',
             });
           }

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1814,6 +1814,8 @@ export const en = {
   'worktask.cleanup.commitLinePrepared': 'Commit line typed into the task pane — review it and press Enter to run it.',
   'worktask.cleanup.commitLineUnavailable': 'No prepared commit line: nothing changed, or too many changed files to list. Open the worktree instead.',
   'worktask.cleanup.noPaneForCommit': 'This task has no live pane to prepare the commit in. Open the worktree instead.',
+  'worktask.cleanup.commitNeedsShell': "The task's pane is running an agent, not a shell — a git line typed there becomes a chat message. Open the worktree instead.",
+  'worktask.cleanup.openWorktreeFailed': "Couldn't open the worktree: {error}",
 
   // ─── Workspace item: task worktree boundary warning ──────────────────────
   'workspace.cwdDeparted': 'Pane cwd departed outside the task worktree boundary: {cwd}',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1677,6 +1677,13 @@ export const en = {
   // it carries a pane pin; the badge-only line says when it does not.
   'channels.mentionWillReach': 'will reach {pane}',
   'channels.mentionBadgeOnly': '@{name} has no live pane — badge only, nobody is woken',
+  // C-2 — per-message delivery outcome on your OWN posts. `unconfirmed` is an
+  // aged pending: the post is out, no recipient outcome ever came back.
+  'channels.deliveryPending': '… sending',
+  'channels.deliveryDelivered': '✓ delivered',
+  'channels.deliveryTargetGone': '✗ target gone',
+  'channels.deliveryNudgeExhausted': '! no answer — nudges exhausted',
+  'channels.deliveryUnconfirmed': '? delivery unconfirmed',
   // J4 — diff comment fired to the mission channel. {count} = number of task
   // agents @-mentioned (0 when every agent has left the channel).
   'diff.commentFired': 'Comment posted to the mission channel — pinged {count} agent(s)',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1690,6 +1690,10 @@ export const en = {
   'channels.deliveryTargetGone': '✗ target gone',
   'channels.deliveryNudgeExhausted': '! no answer — nudges exhausted',
   'channels.deliveryUnconfirmed': '? delivery unconfirmed',
+  // C-5 — the two user-visible channel strings that were still hard-coded.
+  'channels.postNoIdentity': 'No channel or workspace identity',
+  'channels.mentionLoopSuspected':
+    'Possible agent mention loop — auto-nudges for a pane are rate-capped; queued mentions stay pullable via a2a_task_query.',
   // J4 — diff comment fired to the mission channel. {count} = number of task
   // agents @-mentioned (0 when every agent has left the channel).
   'diff.commentFired': 'Comment posted to the mission channel — pinged {count} agent(s)',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -57,6 +57,9 @@ export const en = {
   // to "does this workspace have tasks", and a section that vanishes is not.
   'missions.empty': 'No tasks yet',
   'missions.doneSummary': 'last: {title}',
+  // C-4 — entry point to the worktree cleanup scan from the finished tasks.
+  'missions.cleanUp': 'Clean up',
+  'missions.cleanUpTooltip': 'Scan task worktrees and close what is left over',
 
   // Sidebar — Company mode
   'company.deptRemoveHint': 'Right-click to remove',
@@ -1801,6 +1804,12 @@ export const en = {
   'worktask.cleanup.preserved': 'Uncommitted artifacts preserved — commit/PR from the diff or discard, then close again.',
   'worktask.cleanup.unpushed': 'You have {count} unpushed commit(s) — PR/push, then close again.',
   'worktask.cleanup.closeFailed': 'close failed: {error}',
+  // C-4 — what to do about a close that failed on a worktree holding work.
+  'worktask.cleanup.commitAndClose': 'Commit & close',
+  'worktask.cleanup.openWorktree': 'Open worktree',
+  'worktask.cleanup.commitLinePrepared': 'Commit line typed into the task pane — review it and press Enter to run it.',
+  'worktask.cleanup.commitLineUnavailable': 'No prepared commit line: nothing changed, or too many changed files to list. Open the worktree instead.',
+  'worktask.cleanup.noPaneForCommit': 'This task has no live pane to prepare the commit in. Open the worktree instead.',
 
   // ─── Workspace item: task worktree boundary warning ──────────────────────
   'workspace.cwdDeparted': 'Pane cwd departed outside the task worktree boundary: {cwd}',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1673,6 +1673,10 @@ export const en = {
   // Viewpoint-neutral on purpose: the marker fans out to every member's view,
   // so a second-person "You joined" would be wrong for non-operator viewers.
   'channels.systemOperatorJoin': 'Operator joined this channel',
+  // C-1 — composer mention targeting. A mention only reaches an idle agent when
+  // it carries a pane pin; the badge-only line says when it does not.
+  'channels.mentionWillReach': 'will reach {pane}',
+  'channels.mentionBadgeOnly': '@{name} has no live pane — badge only, nobody is woken',
   // J4 — diff comment fired to the mission channel. {count} = number of task
   // agents @-mentioned (0 when every agent has left the channel).
   'diff.commentFired': 'Comment posted to the mission channel — pinged {count} agent(s)',

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -443,6 +443,9 @@ export const en = {
   'fleet.approvals.plugin': 'plugin',
   'fleet.approvals.enterApprove': 'approve',
   'fleet.approvals.delDeny': 'deny',
+  // C-3 — what happened to the approvals nobody answered.
+  'fleet.approvals.autoRejected': 'auto-rejected: {name}',
+  'fleet.approvals.autoRejectedLog': 'Recently auto-rejected approvals',
 
   // Project config (X5 wmux.json)
   'project.dialogTitle': 'Project configuration (wmux.json)',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1138,6 +1138,9 @@ export const ko = {
   'channels.deliveryTargetGone': '✗ 대상 없음',
   'channels.deliveryNudgeExhausted': '! 응답 없음 — 알림 예산 소진',
   'channels.deliveryUnconfirmed': '? 전달 미확인',
+  'channels.postNoIdentity': '채널 또는 워크스페이스 신원이 없습니다',
+  'channels.mentionLoopSuspected':
+    '에이전트 멘션 루프가 의심됩니다 — 페인당 자동 알림에는 상한이 있습니다. 대기 중인 멘션은 a2a_task_query로 계속 가져올 수 있습니다.',
   // J4 — diff 코멘트를 미션 채널에 발사. {count} = @멘션된 태스크 에이전트 수
   // (에이전트가 전원 채널을 떠났으면 0).
   'diff.commentFired': '코멘트를 미션 채널에 발사했습니다 — {count}개 에이전트 호출',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -175,6 +175,8 @@ export const ko = {
   'fleet.approvals.plugin': '플러그인',
   'fleet.approvals.enterApprove': '승인',
   'fleet.approvals.delDeny': '거부',
+  'fleet.approvals.autoRejected': '자동 거부됨: {name}',
+  'fleet.approvals.autoRejectedLog': '최근 자동 거부된 승인',
 
   // Project config (X5 wmux.json)
   'project.dialogTitle': '프로젝트 설정 (wmux.json)',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1131,6 +1131,11 @@ export const ko = {
   'channels.systemOperatorJoin': '오퍼레이터가 이 채널에 참여했습니다',
   'channels.mentionWillReach': '{pane}에 전달됩니다',
   'channels.mentionBadgeOnly': '@{name}에는 살아 있는 페인이 없습니다 — 배지만 표시되고 아무도 깨우지 않습니다',
+  'channels.deliveryPending': '… 보내는 중',
+  'channels.deliveryDelivered': '✓ 전달됨',
+  'channels.deliveryTargetGone': '✗ 대상 없음',
+  'channels.deliveryNudgeExhausted': '! 응답 없음 — 알림 예산 소진',
+  'channels.deliveryUnconfirmed': '? 전달 미확인',
   // J4 — diff 코멘트를 미션 채널에 발사. {count} = @멘션된 태스크 에이전트 수
   // (에이전트가 전원 채널을 떠났으면 0).
   'diff.commentFired': '코멘트를 미션 채널에 발사했습니다 — {count}개 에이전트 호출',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1129,6 +1129,8 @@ export const ko = {
   // 서버-발행 operator-join 시스템 메시지의 표시 문자열. 모든 멤버 뷰에
   // 동일하게 렌더되므로 2인칭이 아닌 시점 중립 문구를 쓴다.
   'channels.systemOperatorJoin': '오퍼레이터가 이 채널에 참여했습니다',
+  'channels.mentionWillReach': '{pane}에 전달됩니다',
+  'channels.mentionBadgeOnly': '@{name}에는 살아 있는 페인이 없습니다 — 배지만 표시되고 아무도 깨우지 않습니다',
   // J4 — diff 코멘트를 미션 채널에 발사. {count} = @멘션된 태스크 에이전트 수
   // (에이전트가 전원 채널을 떠났으면 0).
   'diff.commentFired': '코멘트를 미션 채널에 발사했습니다 — {count}개 에이전트 호출',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1204,6 +1204,8 @@ export const ko = {
   'missions.done': '완료 ({count})',
   'missions.empty': '아직 태스크 없음',
   'missions.doneSummary': '최근: {title}',
+  'missions.cleanUp': '정리',
+  'missions.cleanUpTooltip': '태스크 worktree를 스캔해 남은 것을 정리합니다',
   'fanout.taskReady': '태스크 "{title}" 준비됨',
   'fanout.tasksReady': '태스크 {count}개 준비됨',
   'fanout.openDiff': 'diff 열기',
@@ -1261,6 +1263,11 @@ export const ko = {
   'worktask.cleanup.preserved': '미커밋 산출물 보존 — diff에서 커밋/PR 또는 폐기 후 다시 닫으세요.',
   'worktask.cleanup.unpushed': 'push되지 않은 커밋 {count}개 — PR/push 후 다시 닫으세요.',
   'worktask.cleanup.closeFailed': 'close 실패: {error}',
+  'worktask.cleanup.commitAndClose': '커밋하고 닫기',
+  'worktask.cleanup.openWorktree': 'worktree 열기',
+  'worktask.cleanup.commitLinePrepared': '커밋 명령을 태스크 페인에 입력했습니다 — 확인 후 Enter로 실행하세요.',
+  'worktask.cleanup.commitLineUnavailable': '준비할 커밋 명령이 없습니다: 변경이 없거나 파일이 너무 많습니다. worktree를 직접 여세요.',
+  'worktask.cleanup.noPaneForCommit': '이 태스크에는 커밋을 준비할 살아 있는 페인이 없습니다. worktree를 직접 여세요.',
 
   // ─── Workspace item: task worktree boundary warning ──────────────────────
   'workspace.cwdDeparted': '페인 cwd가 태스크 worktree 경계 밖으로 이탈: {cwd}',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -1271,6 +1271,8 @@ export const ko = {
   'worktask.cleanup.commitLinePrepared': '커밋 명령을 태스크 페인에 입력했습니다 — 확인 후 Enter로 실행하세요.',
   'worktask.cleanup.commitLineUnavailable': '준비할 커밋 명령이 없습니다: 변경이 없거나 파일이 너무 많습니다. worktree를 직접 여세요.',
   'worktask.cleanup.noPaneForCommit': '이 태스크에는 커밋을 준비할 살아 있는 페인이 없습니다. worktree를 직접 여세요.',
+  'worktask.cleanup.commitNeedsShell': '이 태스크의 페인은 셸이 아니라 에이전트 TUI입니다 — git 줄을 넣으면 채팅 메시지가 됩니다. worktree를 직접 여세요.',
+  'worktask.cleanup.openWorktreeFailed': 'worktree를 열지 못했습니다: {error}',
 
   // ─── Workspace item: task worktree boundary warning ──────────────────────
   'workspace.cwdDeparted': '페인 cwd가 태스크 worktree 경계 밖으로 이탈: {cwd}',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -1671,6 +1671,8 @@ export const pl = {
   // Viewpoint-neutral on purpose: the marker fans out to every member's view,
   // so a second-person "You joined" would be wrong for non-operator viewers.
   'channels.systemOperatorJoin': 'Operator dołączył do tego kanału',
+  'channels.mentionWillReach': 'dotrze do {pane}',
+  'channels.mentionBadgeOnly': '@{name} nie ma aktywnego panelu — tylko odznaka, nikt nie zostanie obudzony',
   // J4 — diff comment fired to the mission channel. {count} = number of task
   // agents @-mentioned (0 when every agent has left the channel).
   'diff.commentFired': 'Komentarz wysłany na kanał misji — powiadomiono {count} agentów',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -1804,6 +1804,8 @@ export const pl = {
   'worktask.cleanup.commitLinePrepared': 'Polecenie commita wpisane w panel zadania — sprawdź je i naciśnij Enter, aby je uruchomić.',
   'worktask.cleanup.commitLineUnavailable': 'Brak gotowego polecenia commita: nic się nie zmieniło albo zmienionych plików jest za dużo. Otwórz worktree.',
   'worktask.cleanup.noPaneForCommit': 'To zadanie nie ma aktywnego panelu, w którym można przygotować commit. Otwórz worktree.',
+  'worktask.cleanup.commitNeedsShell': 'Panel tego zadania uruchamia agenta, nie powłokę — wpisana tam komenda git stanie się wiadomością czatu. Otwórz worktree.',
+  'worktask.cleanup.openWorktreeFailed': 'Nie udało się otworzyć worktree: {error}',
 
   // ─── Workspace item: task worktree boundary warning ──────────────────────
   'workspace.cwdDeparted': 'cwd panelu opuścił granicę worktree zadania: {cwd}',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -55,6 +55,8 @@ export const pl = {
   'missions.done': 'Ukończone ({count})',
   'missions.empty': 'Brak zadań',
   'missions.doneSummary': 'ostatnie: {title}',
+  'missions.cleanUp': 'Posprzątaj',
+  'missions.cleanUpTooltip': 'Przeskanuj worktree zadań i zamknij to, co zostało',
 
   // Sidebar — Company mode
   'company.deptRemoveHint': 'Kliknij prawym przyciskiem, aby usunąć',
@@ -1794,6 +1796,11 @@ export const pl = {
   'worktask.cleanup.preserved': 'Zachowano niezatwierdzone artefakty — wykonaj commit/PR z diff lub odrzuć, a następnie zamknij ponownie.',
   'worktask.cleanup.unpushed': 'Masz {count} niewypchniętych commitów — PR/push, a następnie zamknij ponownie.',
   'worktask.cleanup.closeFailed': 'close nie powiódł się: {error}',
+  'worktask.cleanup.commitAndClose': 'Zatwierdź i zamknij',
+  'worktask.cleanup.openWorktree': 'Otwórz worktree',
+  'worktask.cleanup.commitLinePrepared': 'Polecenie commita wpisane w panel zadania — sprawdź je i naciśnij Enter, aby je uruchomić.',
+  'worktask.cleanup.commitLineUnavailable': 'Brak gotowego polecenia commita: nic się nie zmieniło albo zmienionych plików jest za dużo. Otwórz worktree.',
+  'worktask.cleanup.noPaneForCommit': 'To zadanie nie ma aktywnego panelu, w którym można przygotować commit. Otwórz worktree.',
 
   // ─── Workspace item: task worktree boundary warning ──────────────────────
   'workspace.cwdDeparted': 'cwd panelu opuścił granicę worktree zadania: {cwd}',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -444,6 +444,8 @@ export const pl = {
   'fleet.approvals.plugin': 'wtyczka',
   'fleet.approvals.enterApprove': 'zatwierdź',
   'fleet.approvals.delDeny': 'odrzuć',
+  'fleet.approvals.autoRejected': 'auto-odrzucone: {name}',
+  'fleet.approvals.autoRejectedLog': 'Ostatnio auto-odrzucone zatwierdzenia',
 
   // Project config (X5 wmux.json)
   'project.dialogTitle': 'Konfiguracja projektu (wmux.json)',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -1673,6 +1673,11 @@ export const pl = {
   'channels.systemOperatorJoin': 'Operator dołączył do tego kanału',
   'channels.mentionWillReach': 'dotrze do {pane}',
   'channels.mentionBadgeOnly': '@{name} nie ma aktywnego panelu — tylko odznaka, nikt nie zostanie obudzony',
+  'channels.deliveryPending': '… wysyłanie',
+  'channels.deliveryDelivered': '✓ dostarczono',
+  'channels.deliveryTargetGone': '✗ odbiorca zniknął',
+  'channels.deliveryNudgeExhausted': '! brak odpowiedzi — wyczerpano przypomnienia',
+  'channels.deliveryUnconfirmed': '? dostarczenie niepotwierdzone',
   // J4 — diff comment fired to the mission channel. {count} = number of task
   // agents @-mentioned (0 when every agent has left the channel).
   'diff.commentFired': 'Komentarz wysłany na kanał misji — powiadomiono {count} agentów',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -1682,6 +1682,9 @@ export const pl = {
   'channels.deliveryTargetGone': '✗ odbiorca zniknął',
   'channels.deliveryNudgeExhausted': '! brak odpowiedzi — wyczerpano przypomnienia',
   'channels.deliveryUnconfirmed': '? dostarczenie niepotwierdzone',
+  'channels.postNoIdentity': 'Brak tożsamości kanału lub przestrzeni roboczej',
+  'channels.mentionLoopSuspected':
+    'Możliwa pętla wzmianek agenta — automatyczne przypomnienia dla panelu mają limit; oczekujące wzmianki nadal można pobrać przez a2a_task_query.',
   // J4 — diff comment fired to the mission channel. {count} = number of task
   // agents @-mentioned (0 when every agent has left the channel).
   'diff.commentFired': 'Komentarz wysłany na kanał misji — powiadomiono {count} agentów',

--- a/src/renderer/stores/slices/__tests__/approvalInboxSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/approvalInboxSlice.test.ts
@@ -79,3 +79,54 @@ describe('approvalInboxSlice', () => {
     expect(beforeOrder).toEqual(['p1']); // sanity: original ref unchanged after first remove
   });
 });
+
+// C-3 (review fix) — the auto-rejected log lives in the STORE, so a deadline
+// that fires while the Approvals tab is closed is still recorded, and a row a
+// human answered after a throttled timer is not mislabelled as expired.
+describe('approvalInboxSlice — auto-rejected log', () => {
+  const T0 = 1_700_000_000_000;
+
+  it('starts empty', () => {
+    expect(createTestStore().getState().approvalAutoRejected).toEqual([]);
+  });
+
+  it('logs a prompt removed at its deadline, whether or not anything is rendering', () => {
+    const store = createTestStore();
+    store.getState().addMcpPrompt({ ...makePrompt('p1'), deadlineAt: T0 } as ApprovalPromptInfo);
+    store.getState().noteApprovalRemoved({
+      key: 'mcp:p1',
+      label: 'test-plugin',
+      deadlineAt: T0,
+      removedAt: T0 + 100,
+    });
+    expect(store.getState().approvalAutoRejected).toEqual([
+      { key: 'mcp:p1', label: 'test-plugin', at: T0 },
+    ]);
+  });
+
+  it('does not log a prompt a human answered before its deadline', () => {
+    const store = createTestStore();
+    store.getState().noteApprovalRemoved({
+      key: 'mcp:p1',
+      label: 'test-plugin',
+      deadlineAt: T0,
+      removedAt: T0 - 1_000,
+    });
+    expect(store.getState().approvalAutoRejected).toEqual([]);
+  });
+
+  it('does not log a prompt that never carried a deadline', () => {
+    const store = createTestStore();
+    store.getState().addMcpPrompt(makePrompt('p1'));
+    store.getState().removeMcpPrompt('p1');
+    expect(store.getState().approvalAutoRejected).toEqual([]);
+  });
+
+  it('removeMcpPrompt classifies the departing prompt itself', () => {
+    const store = createTestStore();
+    const now = Date.now();
+    store.getState().addMcpPrompt({ ...makePrompt('p1'), deadlineAt: now } as ApprovalPromptInfo);
+    store.getState().removeMcpPrompt('p1');
+    expect(store.getState().approvalAutoRejected.map((e) => e.key)).toEqual(['mcp:p1']);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -1466,3 +1466,23 @@ describe('channelsSlice — trash / restore / destroy', () => {
     }
   });
 });
+
+// ─── C-2: exhausted nudge episodes ──────────────────────────────────────
+
+describe('channelsSlice — channelNudgeExhausted (C-2)', () => {
+  it('records an exhausted episode per (channel, member)', () => {
+    const store = createTestStore();
+    store.getState().markChannelNudgeExhausted('ch-1', 'w9-1(claude)', 1_700_000_000_999);
+    expect(store.getState().channelNudgeExhausted['ch-1']).toEqual({
+      'w9-1(claude)': 1_700_000_000_999,
+    });
+  });
+
+  it('clears the episode when that member finally posts, and leaves other members alone', () => {
+    const store = createTestStore();
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-1', 1);
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-2', 2);
+    store.getState().appendMessageFromEvent(makeMessage('ch-1', 1, { memberId: 'm-1' }));
+    expect(store.getState().channelNudgeExhausted['ch-1']).toEqual({ 'm-2': 2 });
+  });
+});

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -1485,4 +1485,69 @@ describe('channelsSlice — channelNudgeExhausted (C-2)', () => {
     store.getState().appendMessageFromEvent(makeMessage('ch-1', 1, { memberId: 'm-1' }));
     expect(store.getState().channelNudgeExhausted['ch-1']).toEqual({ 'm-2': 2 });
   });
+
+  // Review fix: an agent that acked must not read "no answer" forever.
+  it('clears the episode when the member read cursor advances on a roster refresh', () => {
+    const store = createTestStore();
+    store
+      .getState()
+      .setChannels([makeChannel({ id: 'ch-1' })], {
+        'ch-1': [
+          makeMember({ memberId: 'm-1', lastReadSeq: 3 }),
+          makeMember({ memberId: 'm-2', lastReadSeq: 3 }),
+        ],
+      });
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-1', 1);
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-2', 2);
+
+    store
+      .getState()
+      .setChannels([makeChannel({ id: 'ch-1' })], {
+        'ch-1': [
+          makeMember({ memberId: 'm-1', lastReadSeq: 7 }),
+          makeMember({ memberId: 'm-2', lastReadSeq: 3 }),
+        ],
+      });
+
+    // m-1 caught up; m-2's cursor never moved, so its episode stands.
+    expect(store.getState().channelNudgeExhausted['ch-1']).toEqual({ 'm-2': 2 });
+  });
+
+  it('drops episodes for a member that left the roster and for a channel that left the catalog', () => {
+    const store = createTestStore();
+    store
+      .getState()
+      .setChannels([makeChannel({ id: 'ch-1' }), makeChannel({ id: 'ch-2' })], {
+        'ch-1': [makeMember({ memberId: 'm-1' }), makeMember({ memberId: 'm-2' })],
+        'ch-2': [makeMember({ memberId: 'm-3' })],
+      });
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-1', 1);
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-2', 2);
+    store.getState().markChannelNudgeExhausted('ch-2', 'm-3', 3);
+
+    store
+      .getState()
+      .setChannels([makeChannel({ id: 'ch-1' })], {
+        'ch-1': [makeMember({ memberId: 'm-2' })],
+      });
+
+    expect(store.getState().channelNudgeExhausted['ch-1']).toEqual({ 'm-2': 2 });
+    expect(store.getState().channelNudgeExhausted['ch-2']).toBeUndefined();
+  });
+
+  it('drops the channel entry on archive and on leave, and the member entry on kick', () => {
+    const store = createTestStore();
+    store.getState().markChannelNudgeExhausted('ch-1', 'm-1', 1);
+    store.getState().archiveChannelOptimistic('ch-1', makeChannel({ id: 'ch-1', status: 'archived' }));
+    expect(store.getState().channelNudgeExhausted['ch-1']).toBeUndefined();
+
+    store.getState().markChannelNudgeExhausted('ch-2', 'm-1', 1);
+    store.getState().leaveChannelOptimistic('ch-2', 'm-1', 'ws-1');
+    expect(store.getState().channelNudgeExhausted['ch-2']).toBeUndefined();
+
+    store.getState().markChannelNudgeExhausted('ch-3', 'm-1', 1);
+    store.getState().markChannelNudgeExhausted('ch-3', 'm-2', 2);
+    store.getState().kickChannelOptimistic('ch-3', 'm-1', 'ws-1');
+    expect(store.getState().channelNudgeExhausted['ch-3']).toEqual({ 'm-2': 2 });
+  });
 });

--- a/src/renderer/stores/slices/a2aSlice.ts
+++ b/src/renderer/stores/slices/a2aSlice.ts
@@ -5,6 +5,7 @@ import { generateId, validateTransition, TERMINAL_STATES, VALID_TRANSITIONS } fr
 import { validateCompletionEvidence, normalizeCompletionEvidenceWire } from '../../../shared/completionEvidence';
 import type { PaneAddress } from '../../hooks/a2aAddressing';
 import { isChannelMentionTask } from '../../hooks/channelMentionFlush';
+import { recordApprovalRemoval } from './approvalInboxSlice';
 
 const GC_MAX_AGE_MS = 30 * 60 * 1000; // 30 minutes
 const GC_MAX_TASKS = 500;
@@ -188,6 +189,18 @@ export const createA2aSlice: StateCreator<StoreState, [['zustand/immer', never]]
   }),
 
   removeExecuteApproval: (approvalId) => set((state: StoreState) => {
+    // C-3 (review fix): an approval that leaves AT its deadline was auto-denied
+    // — indistinguishable, on screen, from one a human answered. Classify here,
+    // at the removal point, so it is recorded even with the Fleet tab closed.
+    const leaving = state.pendingExecuteApprovals[approvalId];
+    if (leaving) {
+      recordApprovalRemoval(state, {
+        key: `a2a:${approvalId}`,
+        label: leaving.taskId,
+        deadlineAt: leaving.expiresAt,
+        removedAt: Date.now(),
+      });
+    }
     delete state.pendingExecuteApprovals[approvalId];
     state.pendingExecuteApprovalOrder = state.pendingExecuteApprovalOrder.filter((id) => id !== approvalId);
     const firstId = state.pendingExecuteApprovalOrder[0];

--- a/src/renderer/stores/slices/approvalInboxSlice.ts
+++ b/src/renderer/stores/slices/approvalInboxSlice.ts
@@ -5,6 +5,11 @@ import type { StoreState } from '../index';
 // rides the permissionPrompt.onOpen IPC channel, so there is no main/renderer
 // runtime coupling — `import type` is erased at compile time.
 import type { ApprovalPromptInfo } from '../../../main/mcp/ApprovalQueue';
+import {
+  appendAutoRejected,
+  isAutoRejection,
+  type AutoRejectedEntry,
+} from '../../components/FleetView/approvalCountdown';
 
 // ─── S-C2 Approval Inbox — renderer-aggregated MCP permission prompts ─────────
 //
@@ -26,6 +31,40 @@ export interface ApprovalInboxSlice {
   addMcpPrompt: (info: ApprovalPromptInfo) => void;
   /** Idempotent: removes from both maps; no-op when the id is unknown. */
   removeMcpPrompt: (promptId: string) => void;
+
+  /**
+   * C-3 (review fix) — the approvals nobody answered, newest first and capped.
+   *
+   * It lives HERE, not in the Fleet list, for one reason: a deadline fires
+   * whether or not anyone is looking at the Approvals tab. A component-local log
+   * was empty exactly when it mattered — "what happened while I was away".
+   * Entries are written at the REMOVAL point, where the row's own deadline and
+   * the true removal instant are both in hand.
+   */
+  approvalAutoRejected: AutoRejectedEntry[];
+  /** Classify one departing approval and log it if the deadline killed it. */
+  noteApprovalRemoved: (entry: {
+    key: string;
+    label: string;
+    deadlineAt?: number;
+    removedAt: number;
+  }) => void;
+}
+
+/** Shared by both removal points (MCP prompt here, A2A execute approval in
+ *  a2aSlice) so one rule decides what counts as an auto-rejection. */
+export function recordApprovalRemoval(
+  state: { approvalAutoRejected: AutoRejectedEntry[] },
+  entry: { key: string; label: string; deadlineAt?: number; removedAt: number },
+): void {
+  if (!isAutoRejection({ ...(entry.deadlineAt !== undefined ? { deadlineAt: entry.deadlineAt } : {}), removedAt: entry.removedAt })) {
+    return;
+  }
+  state.approvalAutoRejected = appendAutoRejected(state.approvalAutoRejected, {
+    key: entry.key,
+    label: entry.label,
+    at: entry.deadlineAt as number,
+  });
 }
 
 export const createApprovalInboxSlice: StateCreator<
@@ -36,6 +75,11 @@ export const createApprovalInboxSlice: StateCreator<
 > = (set) => ({
   mcpPrompts: {},
   mcpPromptOrder: [],
+  approvalAutoRejected: [],
+
+  noteApprovalRemoved: (entry) => set((state: StoreState) => {
+    recordApprovalRemoval(state, entry);
+  }),
 
   addMcpPrompt: (info) => set((state: StoreState) => {
     const isNew = !(info.promptId in state.mcpPrompts);
@@ -49,6 +93,19 @@ export const createApprovalInboxSlice: StateCreator<
   }),
 
   removeMcpPrompt: (promptId) => set((state: StoreState) => {
+    // Classify BEFORE the record goes: its deadline is the only evidence of
+    // why it left. `deadlineAt` is read structurally — it is stamped by the
+    // daemon and absent on a prompt that never got one, which simply means
+    // "not an auto-rejection".
+    const info = state.mcpPrompts[promptId] as (ApprovalPromptInfo & { deadlineAt?: number }) | undefined;
+    if (info) {
+      recordApprovalRemoval(state, {
+        key: `mcp:${promptId}`,
+        label: info.clientName,
+        ...(typeof info.deadlineAt === 'number' ? { deadlineAt: info.deadlineAt } : {}),
+        removedAt: Date.now(),
+      });
+    }
     if (!(promptId in state.mcpPrompts)) {
       // Still filter the order list defensively, but the common no-op path is
       // an unknown id (e.g. a duplicate PERMISSION_PROMPT_CLOSED push after an

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -176,6 +176,18 @@ export interface ChannelsSlice {
    *  workspace — a strict subset of `channelUnread`, surfaced as a stronger
    *  dock badge. Cleared with unread by `markChannelRead` / `setActiveChannel`. */
   channelMentions: Record<string, number>;
+  /**
+   * C-2 — channelId → memberId → epoch ms of the last `channel.nudgeExhausted`
+   * for that member. The wake worker fires it when a mention episode burns its
+   * re-nudge budget: the bytes were written, nobody acted, and a human has to
+   * look. It is the one delivery outcome `recipientSnapshot` cannot express, so
+   * the sender's message row reads it to stop claiming "delivered".
+   *
+   * Cleared when that member finally posts in the channel (the episode is over
+   * by demonstration, not by inference).
+   */
+  channelNudgeExhausted: Record<string, Record<string, number>>;
+  markChannelNudgeExhausted: (channelId: string, memberId: string, at: number) => void;
   /** Ship review C1 — true when the attached daemon reported a channels epoch
    *  older than this renderer requires (a long-lived pre-P5 daemon survived the
    *  app upgrade). Drives the "restart wmux" banner in ChannelsPanel; set from
@@ -388,7 +400,14 @@ export const createChannelsSlice: StateCreator<
   activeChannelId: null,
   channelUnread: {},
   channelMentions: {},
+  channelNudgeExhausted: {},
   channelsDaemonStale: false,
+
+  markChannelNudgeExhausted: (channelId, memberId, at) =>
+    set((state: StoreState) => {
+      const forChannel = state.channelNudgeExhausted[channelId] ?? {};
+      state.channelNudgeExhausted[channelId] = { ...forChannel, [memberId]: at };
+    }),
 
   setChannelsDaemonStale: (stale) =>
     set((state: StoreState) => {
@@ -588,6 +607,13 @@ export const createChannelsSlice: StateCreator<
       // catching us up to the authoritative payload.
       const idx = list.findIndex((m) => m.seq === message.seq);
       const isNew = idx === -1;
+      // C-2: the member answered, so its exhausted-nudge episode is over. Cleared
+      // on demonstration (a post from that member), never on a timer — a stale
+      // "no answer" badge is exactly the false receipt this row exists to kill.
+      if (state.channelNudgeExhausted[channelId]?.[message.memberId] !== undefined) {
+        const { [message.memberId]: _cleared, ...rest } = state.channelNudgeExhausted[channelId];
+        state.channelNudgeExhausted[channelId] = rest;
+      }
       if (isNew) {
         // A19: cap the per-channel render mirror so a busy channel can't grow the
         // store unbounded (older rows stay durable in the daemon).

--- a/src/renderer/stores/slices/channelsSlice.ts
+++ b/src/renderer/stores/slices/channelsSlice.ts
@@ -388,6 +388,46 @@ export interface ChannelsSlice {
   hydrateChannelMessages: (channelId: string, messages: ChannelMessage[]) => void;
 }
 
+/**
+ * Review fix (C-2) — expire the exhausted-nudge flags a roster refresh settles.
+ *
+ * An entry is a claim that ONE member never answered. It survives only while
+ * that stays true, so it is dropped when the member's read cursor advances (it
+ * caught up), when the member leaves the roster, or when the channel leaves the
+ * catalog. Compares the INCOMING roster against the one still in state, so it
+ * must run before `state.channelMembers` is overwritten.
+ */
+function clearSettledNudgeExhausted(
+  state: StoreState,
+  incoming: Record<string, ChannelMember[]>,
+  liveChannelIds: ReadonlySet<string>,
+): void {
+  for (const channelId of Object.keys(state.channelNudgeExhausted)) {
+    if (!liveChannelIds.has(channelId)) {
+      delete state.channelNudgeExhausted[channelId];
+      continue;
+    }
+    const entry = state.channelNudgeExhausted[channelId];
+    const before = new Map(
+      (state.channelMembers[channelId] ?? []).map((m) => [m.memberId, m.lastReadSeq]),
+    );
+    const live = new Set((incoming[channelId] ?? []).map((m) => m.memberId));
+    for (const memberId of Object.keys(entry)) {
+      if (!live.has(memberId)) {
+        delete entry[memberId];
+        continue;
+      }
+      const row = (incoming[channelId] ?? []).find((m) => m.memberId === memberId);
+      const prev = before.get(memberId);
+      const nextSeq = row?.lastReadSeq;
+      if (typeof nextSeq === 'number' && (typeof prev !== 'number' || nextSeq > prev)) {
+        delete entry[memberId];
+      }
+    }
+    if (Object.keys(entry).length === 0) delete state.channelNudgeExhausted[channelId];
+  }
+}
+
 export const createChannelsSlice: StateCreator<
   StoreState,
   [['zustand/immer', never]],
@@ -451,6 +491,13 @@ export const createChannelsSlice: StateCreator<
           state.channelMessages[ch.id] = [];
         }
       }
+      // Review fix (C-2): an exhausted-nudge flag is a claim that a member
+      // never answered. It must expire the moment that member demonstrably
+      // caught up — its read cursor advanced — or a single burnt nudge episode
+      // marks the sender's rows "no answer" for the life of the channel.
+      // `setChannels` is the authoritative roster refresh, so it is where the
+      // previous cursor and the new one can be compared.
+      clearSettledNudgeExhausted(state, members, liveIds);
       state.channels = next;
       state.channelMembers = members;
       // A19: drop caches for channels no longer in the catalog (archived out of
@@ -567,6 +614,8 @@ export const createChannelsSlice: StateCreator<
       state.channelMembers[channelId] = list.filter(
         (m) => !(m.memberId === memberId && m.workspaceId === workspaceId),
       );
+      // We are out of the room: there is no sender-side row left to annotate.
+      delete state.channelNudgeExhausted[channelId];
     });
     return { ok: true, value: {} as Record<string, never> };
   },
@@ -580,6 +629,10 @@ export const createChannelsSlice: StateCreator<
       state.channelMembers[channelId] = list.filter(
         (m) => !(m.workspaceId === targetWorkspaceId && m.memberId === targetMemberId),
       );
+      // The member is gone — a "no answer" claim about it is now unfalsifiable.
+      if (state.channelNudgeExhausted[channelId]) {
+        delete state.channelNudgeExhausted[channelId][targetMemberId];
+      }
     });
     return { ok: true, value: {} as Record<string, never> };
   },
@@ -590,6 +643,9 @@ export const createChannelsSlice: StateCreator<
       // Overwrite the catalog row — the daemon is authoritative; the
       // optimistic update is best-effort until the next refresh.
       state.channels[channelId] = archivedChannel;
+      // Nobody will be nudged in an archived channel, so a pending "no answer"
+      // claim about it can never be resolved. Drop it with the channel.
+      delete state.channelNudgeExhausted[channelId];
     });
     return { ok: true, value: archivedChannel };
   },
@@ -717,6 +773,14 @@ export const createChannelsSlice: StateCreator<
                 : target.memberId === undefined || m.memberId === target.memberId)
             ),
         );
+        // A purged member cannot answer and cannot be nudged again: keeping its
+        // exhausted flag would freeze "no answer" on the sender's rows forever.
+        const exhausted = state.channelNudgeExhausted[chId];
+        if (!exhausted) continue;
+        const live = new Set(state.channelMembers[chId].map((m) => m.memberId));
+        for (const memberId of Object.keys(exhausted)) {
+          if (!live.has(memberId)) delete exhausted[memberId];
+        }
       }
     });
     const bridge = get().channelsRpc();
@@ -1246,6 +1310,7 @@ export const createChannelsSlice: StateCreator<
       delete state.channelMessages[channelId];
       delete state.channelUnread[channelId];
       delete state.channelMentions[channelId];
+      delete state.channelNudgeExhausted[channelId];
       if (state.activeChannelId === channelId) state.activeChannelId = null;
     });
     return { ok: true, value: {} as Record<string, never> };

--- a/src/shared/principals.ts
+++ b/src/shared/principals.ts
@@ -40,6 +40,24 @@ export function panePrincipalId(workspaceId: string, paneId: string): string {
   return `pane:${workspaceId}/${paneId}`;
 }
 
+/**
+ * Inverse of {@link panePrincipalId}. Returns `null` for anything that is not a
+ * pane principal (`human:me`, `ext:*`, or a malformed id) — callers that need
+ * the coordinate must handle "this row does not name a pane".
+ *
+ * Split at the LAST `/` so a workspace id containing one still yields the pane
+ * id, which is the segment the format actually pins.
+ */
+export function parsePanePrincipalId(
+  principalId: string,
+): { workspaceId: string; paneId: string } | null {
+  if (!principalId.startsWith('pane:')) return null;
+  const body = principalId.slice('pane:'.length);
+  const sep = body.lastIndexOf('/');
+  if (sep <= 0 || sep === body.length - 1) return null;
+  return { workspaceId: body.slice(0, sep), paneId: body.slice(sep + 1) };
+}
+
 export interface PrincipalRecord {
   /** 'human:me' | `pane:${workspaceId}/${paneId}` | `ext:${name}`(R4) */
   id: string;


### PR DESCRIPTION
## Summary

Orchestrator wave 2, lane C: the channel, Fleet and cleanup surfaces stop lying about where a message goes, what happened to it, and who is talking.

- **@mentions land somewhere real** (C-1): a mention of a roster member is pinned to that workspace's most recently active agent pane, with a "will reach …" hint under the composer. A member with no live agent pane becomes a labelled badge-only mention instead of silently reaching nobody.
- **Honest delivery status** (C-2): delivered / target gone / "no answer, nudges exhausted" / "delivery unconfirmed" replace the eternal "sending".
- **Fleet approval countdown** (C-3): every approval with a `deadlineAt` counts down in the inbox, and expired ones land in a short "auto-rejected" log. Renders nothing while the field is absent (it is stamped by the lane A PR).
- **Cleanup from Missions** (C-4): the finished-tasks row opens the task cleanup scan; a failed close on a dirty worktree offers "Commit & close" (types an explicit-path `git add … && git commit -m "wip: <task>"` into the task's own pane without running it) and "Open worktree".
- **Pane display names, locale fallback, a11y** (C-5): MCP/CLI-joined members are named the way wmux names panes (rename, else `w<ws>-<pane>(<agent>)`) in the roster and on the sender chip; the two remaining hard-coded English strings are localized (en/ko/pl); the liveness dot carries an accessible label.

Spec: `plans/orch-wave2-plan-2026-09.md` (Lane C + Rev 2 amendments). Not touched: Deck files, daemon approvals.

## Test plan

- [x] Unit tests per step, including `paneMemberNames` (rename/agent suffix, exited agent, opaque memberId via roster, key round-trip) and `ChannelView` chip name/fallback.
- [x] `tsc --noEmit` on all tsconfigs, eslint clean on touched files, full `npm test`: 14,455 + 193 pass.
- [ ] Live check of the mention pin against a running agent pane (wave 2 dogfood step).

Changelog fragment: `changelog.d/orch-w2-c.md`.
