### PR TITLE
fix(orch): a no-gate repo can complete, adopt can commit, and git_status reads the caller's repo

### DIFF
--- a/changelog.d/orch-w2-e.md
+++ b/changelog.d/orch-w2-e.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **A project with no lint or test script can finish a task again.** The
+  completion gate refuses to certify a repository it cannot grade, but it also
+  recorded nothing when there was nothing to run — and the task ledger will not
+  mark a task completed without a recorded pass. So any repository that declares
+  neither `scripts/verify.sh` nor npm `lint`/`test` scripts could only be closed
+  by forcing it. Running the gate on such a project now records an honest
+  verdict — a pass whose command is `none` and whose note says no gate exists —
+  and the task completes normally. The two skips that mean the gate *could not*
+  run (missing dependencies, a command that would not start) still record
+  nothing, because there a human should look.
+
+- **The orchestrator can read the repository it just adopted into.** `git_status`
+  and `git_log` only accepted a task id, so after taking a task's work into the
+  parent checkout there was no way to look at that checkout — the parent
+  repository is not a task. Both now work with no task id at all and answer for
+  the repository your own terminal is in.
+
+### Added
+
+- **`task_adopt` can commit what it takes, so several tasks can be adopted in a
+  row.** Adopt left its changes staged, which made the first adopt easy to review
+  and the second one impossible: the target repository was now dirty, and adopt
+  refuses a dirty target rather than mixing two authors' edits together. Passing
+  `commit: true` commits exactly what was adopted, with a message naming the
+  task, and returns the commit's short hash. The default is unchanged — staged
+  and uncommitted — and nothing is ever pushed.

--- a/changelog.d/orch-w2-e.md
+++ b/changelog.d/orch-w2-e.md
@@ -9,7 +9,12 @@
   verdict — a pass whose command is `none` and whose note says no gate exists —
   and the task completes normally. The two skips that mean the gate *could not*
   run (missing dependencies, a command that would not start) still record
-  nothing, because there a human should look.
+  nothing, because there a human should look. The waiver needs the parent
+  repository to agree: a task worktree that has lost the lint or test script its
+  project declares records a *failing* gate naming what is missing, not a pass.
+  This also unblocks projects that are not Node projects at all, which used to
+  be turned away for having no `node_modules` before anything asked whether they
+  had a gate to run.
 
 - **The orchestrator can read the repository it just adopted into.** `git_status`
   and `git_log` only accepted a task id, so after taking a task's work into the
@@ -24,5 +29,8 @@
   and the second one impossible: the target repository was now dirty, and adopt
   refuses a dirty target rather than mixing two authors' edits together. Passing
   `commit: true` commits exactly what was adopted, with a message naming the
-  task, and returns the commit's short hash. The default is unchanged — staged
-  and uncommitted — and nothing is ever pushed.
+  task, and returns the commit's short hash. It commits only the adoption: if
+  anything else has been staged in the target since the adopt began, it refuses
+  and puts the adopted paths back rather than sweeping someone else's work into
+  the task's commit. The default is unchanged — staged and uncommitted — and
+  nothing is ever pushed.

--- a/docs/internal/orch-o2-tool-contract.md
+++ b/docs/internal/orch-o2-tool-contract.md
@@ -25,12 +25,32 @@ registerGitTools(server, { getSenderPtyId, resolveWorkspaceId });
 | Tool | Schema | Pipe RPC |
 | --- | --- | --- |
 | `task_gate_run` | `{ task_id: z.string().min(1) }` | `task.gate.run` |
-| `task_adopt` | `{ task_id: z.string().min(1) }` | `task.adopt` |
+| `task_adopt` | `{ task_id: z.string().min(1), commit?: z.boolean() }` | `task.adopt` |
 | `task_close` | `{ task_id: z.string().min(1) }` | `task.close` |
 | `task_pr` | `{ task_id: z.string().min(1), body?: z.string() }` | `task.pr` |
-| `git_status` | `{ task_id: z.string().min(1) }` | `task.git.status` |
-| `git_log` | `{ task_id: z.string().min(1), limit?: z.number().int().min(1).max(50) }` | `task.git.log` |
+| `git_status` | `{ task_id?: z.string().min(1) }` | `task.git.status` |
+| `git_log` | `{ task_id?: z.string().min(1), limit?: z.number().int().min(1).max(50) }` | `task.git.log` |
 | `gh_pr_view` | `{ task_id: z.string().min(1) }` | `task.gh.prView` |
+
+`task_adopt`'s `commit` defaults to `false` — the staged, uncommitted result this
+lane shipped with. `commit: true` commits the index the `--3way` apply filled
+(no pathspec: the target was verified clean, so the index holds the adopted
+patch and nothing else) with the subject `adopt: <title> (<task id>)`, taking the
+title from the server's projection row, and answers `{ commit: '<short sha>' }`.
+A commit that is refused — a hook, no author identity, a locked index — restores
+the applied paths exactly as the apply-failure path does and answers
+`reason: 'commit-failed'`. Sequential adoption needs it: the staged default
+leaves the target dirty, and the next adopt is then refused `dirty-target`.
+
+`git_status` and `git_log` take `task_id` **optionally**. Omitted, the repository
+is the CALLER'S OWN: main derives it from the calling terminal's cwd (the
+fan-out gate's derivation — the surface whose ptyId is the verified
+`senderPtyId`, or, for a commander caller with no pty of its own, its
+workspace's active pane), takes the git toplevel of it, and runs the same
+read-only argv there. The result carries `repoRoot` instead of `taskId`. There
+is still no path argument, and a `task_id` that is given is still ownership
+checked. `gh_pr_view` stays task-only — a pull request belongs to a task's
+branch.
 
 Descriptions live in the two source files and are the authority; they are
 written for the tools/list byte budget (short sentences, the refusal reasons
@@ -68,9 +88,11 @@ destructive edges (a branch with unpushed commits, or a dirty worktree, is
 refused and the worktree preserved), so the question for lane F is policy, not
 safety-of-last-resort.
 
-`task.adopt` writes to the parent repository, but only onto a **clean** tree and
-only as a staged, uncommitted patch (`--3way` needs the index for its merge), so
-it is recoverable with `git reset --hard`; it is not teardown-class. Its patch is taken against `merge-base(parent HEAD, task HEAD)`
+`task.adopt` writes to the parent repository, but only onto a **clean** tree, and
+only locally: staged and uncommitted by default (`--3way` needs the index for its
+merge), or as one local commit with `commit: true`. Recoverable with
+`git reset --hard` (or `git reset --hard HEAD~1`), never pushed; it is not
+teardown-class. Its patch is taken against `merge-base(parent HEAD, task HEAD)`
 rather than the parent's HEAD — diffing against HEAD turns every commit the
 parent has and the task lacks into a *reversal*, so adopting a second task
 would silently delete the first one's work. No shared commit ⇒
@@ -154,7 +176,14 @@ conclude the gate was rejected.
 `node_modules`, which makes lint/test results meaningless; reporting it as a
 failing gate would have a brain close healthy tasks as failed. A command that
 could not be started at all (ENOENT/EACCES) is `skipped: 'gate_unavailable'`,
-also not a failure. Timeout is 15 minutes and cannot be disabled (a
+also not a failure. A project that declares neither a verify script nor npm
+lint/test scripts is `skipped: 'no_gate_command'` — and that one skip is
+**recorded**, as a system gate with `exitCode: 0`, `command: 'none'`,
+`skipped: 'no_gate_command'` and the detail text as its tail. It has to be: the
+ledger refuses `completed` without a system-recorded pass, so a repository with
+no gate could otherwise never be closed except with `force`. The other two skips
+stay unrecorded, because there a gate existed and the environment stopped it.
+Timeout is 15 minutes and cannot be disabled (a
 non-positive value is clamped to the default); a cancel or a timeout kills the
 process group and yields `exitCode: null`. One gate per task: the slot is
 claimed synchronously, so a second concurrent call answers `{ status: 'busy' }`

--- a/docs/internal/orch-o2-tool-contract.md
+++ b/docs/internal/orch-o2-tool-contract.md
@@ -34,23 +34,43 @@ registerGitTools(server, { getSenderPtyId, resolveWorkspaceId });
 
 `task_adopt`'s `commit` defaults to `false` — the staged, uncommitted result this
 lane shipped with. `commit: true` commits the index the `--3way` apply filled
-(no pathspec: the target was verified clean, so the index holds the adopted
-patch and nothing else) with the subject `adopt: <title> (<task id>)`, taking the
-title from the server's projection row, and answers `{ commit: '<short sha>' }`.
-A commit that is refused — a hook, no author identity, a locked index — restores
-the applied paths exactly as the apply-failure path does and answers
-`reason: 'commit-failed'`. Sequential adoption needs it: the staged default
-leaves the target dirty, and the next adopt is then refused `dirty-target`.
+with the subject `adopt: <title> (<task id>)`, taking the title from the
+server's projection row (an LLM wrote that text, so control characters are
+stripped and the subject is bounded by code point), and answers
+`{ commit: '<short sha>' }` — or, if `rev-parse` will not name the commit,
+`{ warning }` with no `commit` key, never `commit: ''`.
+
+The commit takes **no pathspec** — `git commit -- <paths>` would record the
+working tree rather than the index `--3way` just filled — so the porcelain
+status is re-read in the instant before it and anything outside the adopted
+paths is `reason: 'commit-failed'` with the adopted paths restored. The clean
+check that justifies a pathspec-free commit is a dozen git calls earlier;
+without the re-read, a file a human staged in that window was swept into a
+commit whose message names someone else's task. Any commit refusal — a hook, no
+author identity, a locked index — restores the applied paths exactly as the
+apply-failure path does; the restore addresses them as `:(literal)` pathspecs,
+so a file named `a*.ts` restores itself and not everything it globs.
+Sequential adoption needs `commit: true`: the staged default leaves the target
+dirty, and the next adopt is then refused `dirty-target`.
 
 `git_status` and `git_log` take `task_id` **optionally**. Omitted, the repository
 is the CALLER'S OWN: main derives it from the calling terminal's cwd (the
 fan-out gate's derivation — the surface whose ptyId is the verified
 `senderPtyId`, or, for a commander caller with no pty of its own, its
-workspace's active pane), takes the git toplevel of it, and runs the same
-read-only argv there. The result carries `repoRoot` instead of `taskId`. There
-is still no path argument, and a `task_id` that is given is still ownership
-checked. `gh_pr_view` stays task-only — a pull request belongs to a task's
-branch.
+workspace's active pane), takes the git toplevel of it, **realpath'd** (two
+names for one repository must not read as two), and runs the same read-only
+argv there. A cwd that is not absolute is refused — `path.resolve` would
+otherwise anchor a relative one to the DAEMON's own working directory.
+
+Every result names which repository answered in `target`: `'task'` (with
+`taskId`, and `worktreePath` on `git_status`) or `'caller-repo'` (with
+`repoRoot`). It is always present, so an omitted `task_id` can never be read as
+a task's answer. `task_id` present-but-blank is `INVALID_ARGUMENT`, not an
+omission: `z.string().min(1)` accepts `' '`, and trimming it into the
+caller-repo branch answered a question about a task with another repository's
+state. There is still no path argument, and a `task_id` that is given is still
+ownership checked. `gh_pr_view` stays task-only — a pull request belongs to a
+task's branch.
 
 Descriptions live in the two source files and are the authority; they are
 written for the tools/list byte budget (short sentences, the refusal reasons
@@ -183,6 +203,23 @@ lint/test scripts is `skipped: 'no_gate_command'` — and that one skip is
 ledger refuses `completed` without a system-recorded pass, so a repository with
 no gate could otherwise never be closed except with `force`. The other two skips
 stay unrecorded, because there a gate existed and the environment stopped it.
+
+That waiver is the PARENT repository's to give, never the worktree's. The
+worktree is the tree the worker edits, so deciding "no gate exists" from its own
+package.json would let a worker delete its `lint`/`test` scripts and be handed a
+system-signed pass for it. When `projectRoot` declares either script and the
+worktree declares neither, the verdict is a FAILING gate (`exitCode: 1`,
+`command: 'none'`, a tail naming the missing scripts), recorded — not a waiver.
+The verify branch was already parent-anchored: `wmux.json` is read at
+`projectRoot`, and a project declaring `verify` whose worktree lacks the file is
+refused. A package.json that exists and cannot be read or parsed is neither
+answer — it is `gate_unavailable`, unrecorded.
+
+Step resolution runs BEFORE the `node_modules` check, and `deps_missing` is only
+possible once there are steps to run: asking about `node_modules` first made
+every gate in a non-Node checkout (no package.json, therefore no node_modules)
+answer `deps_missing`, which records nothing — the exact blockage the no-gate
+record exists to remove.
 Timeout is 15 minutes and cannot be disabled (a
 non-positive value is clamped to the default); a cancel or a timeout kills the
 process group and yields `exitCode: null`. One gate per task: the slot is

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -154,7 +154,7 @@
     },
     "commander": {
       "maxListBytes": 60000,
-      "wireResultSha256": "ac5bc2bac34af280ce908f8dd12506c7057a36610abe8cc6775750bfa7a15991",
+      "wireResultSha256": "58bc3db43ac64959d8178700c11a09978038c054e1703450a6bb4461d9ae8684",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",

--- a/src/daemon/ledger/TaskLedger.ts
+++ b/src/daemon/ledger/TaskLedger.ts
@@ -188,6 +188,8 @@ function boundGate(gate: LedgerGateResult): LedgerGateResult {
     at: typeof gate.at === 'number' ? gate.at : Date.now(),
     command: truncateHead(typeof gate.command === 'string' ? gate.command : '', LEDGER_GATE_COMMAND_MAX_BYTES),
     recordedBy: 'system',
+    // Carry the no-gate label through so the persisted entry says why exitCode is 0.
+    ...(gate.skipped === 'no_gate_command' ? { skipped: 'no_gate_command' as const } : {}),
   };
 }
 

--- a/src/daemon/ledger/__tests__/TaskLedger.test.ts
+++ b/src/daemon/ledger/__tests__/TaskLedger.test.ts
@@ -242,6 +242,15 @@ describe('TaskLedger — transition matrix', () => {
     expect(await a.update({ id: 'nope', status: 'failed', actor: SYSTEM, expectedRev: 1 })).toMatchObject({ ok: false, error: 'not_found' });
   });
 
+  it('a no-gate system record keeps its skipped label in the persisted entry, and a plain record carries none', async () => {
+    const a = open();
+    await seed(a);
+    await a.recordGate('wtask-1', { ...PASS, command: 'none', skipped: 'no_gate_command' });
+    expect(a.get('wtask-1')!.gate).toMatchObject({ exitCode: 0, command: 'none', skipped: 'no_gate_command', recordedBy: 'system' });
+    await a.recordGate('wtask-1', PASS);
+    expect(a.get('wtask-1')!.gate).not.toHaveProperty('skipped');
+  });
+
   it('completed needs a SYSTEM-recorded passing gate unless forced with a reason, and only a brain may set it', async () => {
     const a = open();
     await seed(a);

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -35,6 +35,10 @@ import type { TaskPrService } from '../../../worktask/TaskPrService';
 
 const LOCAL: RpcContext = { origin: 'local' };
 const CALLER_WS = 'ws-caller';
+/** Where the calling terminal is, and therefore the repository the read methods
+ *  answer for when no task is named. */
+const CALLER_CWD = '/repo/main/src';
+const CALLER_REPO = '/repo/main';
 const TASK = {
   id: 'wtask-1',
   title: 'lane one',
@@ -54,6 +58,7 @@ interface Harness {
   gateRun: ReturnType<typeof vi.fn>;
   gateCancel: ReturnType<typeof vi.fn>;
   requestApproval: ReturnType<typeof vi.fn>;
+  callerCwd: ReturnType<typeof vi.fn>;
   missionListParams: () => Record<string, unknown> | undefined;
 }
 
@@ -69,6 +74,8 @@ function harness(opts?: {
   approval?: TaskApprovalOutcome;
   /** Full control of the prompt (dedupe / cap tests hold it open). */
   requestApproval?: TaskApprovalPort;
+  /** The calling terminal's cwd, for the reads that name no task. */
+  callerCwd?: (workspaceId: string, senderPtyId: string) => Promise<string>;
 }): Harness {
   const handlers = new Map<string, Handler>();
   const router = { register: (m: string, h: Handler) => handlers.set(m, h) } as unknown as RpcRouter;
@@ -103,15 +110,24 @@ function harness(opts?: {
   const owner = opts?.ownerWorkspaceId === undefined ? CALLER_WS : opts.ownerWorkspaceId;
   vi.mocked(resolvePtyOwnerWorkspace).mockImplementation(async () => owner);
 
-  const exec = vi.fn(opts?.exec ?? (async () => ({ stdout: '', stderr: '', code: 0 })));
+  const exec = vi.fn(
+    opts?.exec ??
+      (async (_cmd: 'git' | 'gh', args: string[]) =>
+        args[0] === 'rev-parse' && args.includes('--show-toplevel')
+          ? { stdout: `${CALLER_REPO}\n`, stderr: '', code: 0 }
+          : { stdout: '', stderr: '', code: 0 }),
+  );
   const requestApproval = vi.fn(
     opts?.requestApproval ?? (async () => opts?.approval ?? ('approved' as TaskApprovalOutcome)),
   );
+
+  const callerCwd = vi.fn(opts?.callerCwd ?? (async () => CALLER_CWD));
 
   const deps: WorktaskRpcDeps = {
     daemon,
     exec: exec as unknown as WorktaskExec,
     requestApproval,
+    callerCwd,
     getWindow: () => null,
     close: { closeTask } as unknown as TaskCloseService,
     pr: { createPr } as unknown as TaskPrService,
@@ -134,9 +150,13 @@ function harness(opts?: {
     gateCancel,
     exec,
     requestApproval,
+    callerCwd,
     missionListParams: () => missionParams,
   };
 }
+
+/** The two reads that also answer for the caller's own repository. */
+const CALLER_REPO_METHODS = ['task.git.status', 'task.git.log'] as const;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -178,10 +198,14 @@ describe.each(WORKTASK_RPC_METHODS)('%s — shared gates', (method) => {
     expect(res).toMatchObject({ ok: false, error: { code: 'NOT_AUTHORIZED' } });
   });
 
-  it('requires a taskId', async () => {
+  it('requires a taskId, unless it is one of the two caller-repo reads', async () => {
     const h = harness();
     const res = await h.call(method, { senderPtyId: 'pty-1' });
-    expect(res).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+    if ((CALLER_REPO_METHODS as readonly string[]).includes(method)) {
+      expect(res).toMatchObject({ ok: true, repoRoot: CALLER_REPO });
+    } else {
+      expect(res).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+    }
   });
 
   it('reports an unknown task and a foreign task identically (owner-scoped list)', async () => {
@@ -414,6 +438,82 @@ describe('task.git.log', () => {
     expect((res as { commits: unknown[] }).commits).toEqual([
       { hash: 'abc', author: 'A Dev', date: '2026-09-04T00:00:00Z', subject: 'fix: a subject with -- dashes' },
     ]);
+  });
+});
+
+// ── No taskId: the CALLER'S OWN repository ─────────────────────────────────
+// A brain that had just adopted four tasks into its parent checkout could not
+// read that checkout — every read wanted a task id, and the parent repository
+// is not a task.
+describe('task.git.status / task.git.log without a taskId', () => {
+  const COMMANDER: RpcContext = { origin: 'local', commanderWorkspace: CALLER_WS };
+
+  it('reads the repository the calling terminal is in, and names it', async () => {
+    const h = harness();
+    const res = await h.call('task.git.status', { senderPtyId: 'pty-1' });
+    expect(h.callerCwd).toHaveBeenCalledWith(CALLER_WS, 'pty-1');
+    // The cwd is normalised to the git TOPLEVEL, so a subdirectory answers for
+    // the whole repository.
+    expect(h.exec).toHaveBeenCalledWith('git', ['rev-parse', '--show-toplevel'], CALLER_CWD);
+    expect(h.exec).toHaveBeenCalledWith('git', ['status', '--porcelain=v1', '--branch', '-z'], CALLER_REPO);
+    expect(res).toMatchObject({ ok: true, repoRoot: CALLER_REPO });
+    expect(res).not.toHaveProperty('taskId');
+  });
+
+  it('never asks the daemon for a task list it does not need', async () => {
+    const h = harness();
+    await h.call('task.git.log', { senderPtyId: 'pty-1' });
+    expect(h.missionListParams()).toBeUndefined();
+    expect(h.exec).toHaveBeenCalledWith('git', expect.arrayContaining(['log']), CALLER_REPO);
+  });
+
+  it('borrows the workspace active pane for a commander caller, which has no pty', async () => {
+    const h = harness();
+    expect(await h.call('task.git.status', {}, COMMANDER)).toMatchObject({ ok: true, repoRoot: CALLER_REPO });
+    expect(h.callerCwd).toHaveBeenCalledWith(CALLER_WS, '');
+  });
+
+  it('still refuses a task the caller does not own — omitting the id is the only way out', async () => {
+    const h = harness({ tasks: [] });
+    expect(await h.call('task.git.status', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      error: { code: 'NOT_FOUND' },
+    });
+  });
+
+  it('still refuses a caller-stated verifiedWorkspaceId with no taskId to hide behind', async () => {
+    const h = harness();
+    expect(
+      await h.call('task.git.status', { senderPtyId: 'pty-1', verifiedWorkspaceId: 'ws-other' }),
+    ).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+    expect(h.callerCwd).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the calling terminal reports no directory', async () => {
+    const h = harness({ callerCwd: async () => '' });
+    expect(await h.call('task.git.status', { senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      error: { code: 'FAILED_PRECONDITION' },
+    });
+  });
+
+  it('refuses a cwd that is not inside a git repository', async () => {
+    const h = harness({ exec: async () => ({ stdout: '', stderr: 'not a git repository', code: 128 }) });
+    expect(await h.call('task.git.log', { senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      error: { code: 'FAILED_PRECONDITION' },
+    });
+  });
+
+  it('refuses a cwd that looks like a flag or carries control characters', async () => {
+    for (const bad of ['--upload-pack=evil', '/repo\u0007/x']) {
+      const h = harness({ callerCwd: async () => bad });
+      expect(await h.call('task.git.status', { senderPtyId: 'pty-1' })).toMatchObject({
+        ok: false,
+        error: { code: 'FAILED_PRECONDITION' },
+      });
+      expect(h.exec).not.toHaveBeenCalled();
+    }
   });
 });
 

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -258,8 +258,31 @@ describe('task.adopt', () => {
   it('adopts the whole task worktree', async () => {
     const h = harness();
     const res = await h.call('task.adopt', { taskId: TASK.id, senderPtyId: 'pty-1' });
-    expect(h.adopt).toHaveBeenCalledWith({ taskId: TASK.id, worktreePath: TASK.worktreePath });
+    expect(h.adopt).toHaveBeenCalledWith({
+      taskId: TASK.id,
+      worktreePath: TASK.worktreePath,
+      commit: false,
+      title: TASK.title,
+    });
     expect(res).toMatchObject({ ok: true, files: ['a.ts'] });
+  });
+
+  it('passes commit: true through, with the title from the SERVER projection row', async () => {
+    const h = harness();
+    await h.call('task.adopt', { taskId: TASK.id, senderPtyId: 'pty-1', commit: true, title: 'spoofed' });
+    expect(h.adopt).toHaveBeenCalledWith({
+      taskId: TASK.id,
+      worktreePath: TASK.worktreePath,
+      commit: true,
+      title: TASK.title,
+    });
+  });
+
+  it('refuses a non-boolean commit rather than silently staging', async () => {
+    const h = harness();
+    const res = await h.call('task.adopt', { taskId: TASK.id, senderPtyId: 'pty-1', commit: 'true' });
+    expect(res).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+    expect(h.adopt).not.toHaveBeenCalled();
   });
 
   it('passes a dirty-target refusal straight through', async () => {

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -457,7 +457,8 @@ describe('task.git.status / task.git.log without a taskId', () => {
     expect(h.callerCwd).toHaveBeenCalledWith(CALLER_WS, 'pty-1');
     // The cwd is normalised to the git TOPLEVEL, so a subdirectory answers for
     // the whole repository.
-    expect(h.exec).toHaveBeenCalledWith('git', ['rev-parse', '--show-toplevel'], CALLER_CWD);
+    // path.resolve rewrites the POSIX fixture on win32 (D:\repo\...), so compare against it.
+    expect(h.exec).toHaveBeenCalledWith('git', ['rev-parse', '--show-toplevel'], path.resolve(CALLER_CWD));
     expect(h.exec).toHaveBeenCalledWith('git', ['status', '--porcelain=v1', '--branch', '-z'], CALLER_REPO);
     expect(res).toMatchObject({ ok: true, target: 'caller-repo', repoRoot: CALLER_REPO });
     expect(res).not.toHaveProperty('taskId');

--- a/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/worktask.rpc.test.ts
@@ -8,6 +8,9 @@
 // ordering, gh gates) is pinned in their own tests.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 vi.mock('../../../workspace/ptyOwnership', () => ({ resolvePtyOwnerWorkspace: vi.fn() }));
 vi.mock('../../../git/git', () => ({ git: vi.fn() }));
@@ -202,7 +205,7 @@ describe.each(WORKTASK_RPC_METHODS)('%s — shared gates', (method) => {
     const h = harness();
     const res = await h.call(method, { senderPtyId: 'pty-1' });
     if ((CALLER_REPO_METHODS as readonly string[]).includes(method)) {
-      expect(res).toMatchObject({ ok: true, repoRoot: CALLER_REPO });
+      expect(res).toMatchObject({ ok: true, target: 'caller-repo', repoRoot: CALLER_REPO });
     } else {
       expect(res).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
     }
@@ -456,7 +459,7 @@ describe('task.git.status / task.git.log without a taskId', () => {
     // the whole repository.
     expect(h.exec).toHaveBeenCalledWith('git', ['rev-parse', '--show-toplevel'], CALLER_CWD);
     expect(h.exec).toHaveBeenCalledWith('git', ['status', '--porcelain=v1', '--branch', '-z'], CALLER_REPO);
-    expect(res).toMatchObject({ ok: true, repoRoot: CALLER_REPO });
+    expect(res).toMatchObject({ ok: true, target: 'caller-repo', repoRoot: CALLER_REPO });
     expect(res).not.toHaveProperty('taskId');
   });
 
@@ -469,7 +472,11 @@ describe('task.git.status / task.git.log without a taskId', () => {
 
   it('borrows the workspace active pane for a commander caller, which has no pty', async () => {
     const h = harness();
-    expect(await h.call('task.git.status', {}, COMMANDER)).toMatchObject({ ok: true, repoRoot: CALLER_REPO });
+    expect(await h.call('task.git.status', {}, COMMANDER)).toMatchObject({
+      ok: true,
+      target: 'caller-repo',
+      repoRoot: CALLER_REPO,
+    });
     expect(h.callerCwd).toHaveBeenCalledWith(CALLER_WS, '');
   });
 
@@ -505,8 +512,10 @@ describe('task.git.status / task.git.log without a taskId', () => {
     });
   });
 
-  it('refuses a cwd that looks like a flag or carries control characters', async () => {
-    for (const bad of ['--upload-pack=evil', '/repo\u0007/x']) {
+  it('refuses a cwd that looks like a flag, carries control characters, or is relative', async () => {
+    // A RELATIVE cwd used to be resolved against the DAEMON's own working
+    // directory — a repository that has nothing to do with the calling pane.
+    for (const bad of ['--upload-pack=evil', '/repo\u0007/x', 'src', '.', '../elsewhere']) {
       const h = harness({ callerCwd: async () => bad });
       expect(await h.call('task.git.status', { senderPtyId: 'pty-1' })).toMatchObject({
         ok: false,
@@ -514,6 +523,66 @@ describe('task.git.status / task.git.log without a taskId', () => {
       });
       expect(h.exec).not.toHaveBeenCalled();
     }
+  });
+
+  // Same rule as the fan-out gate's repoRootOf: two names for one repository
+  // must not read as two repositories.
+  it('realpaths the toplevel, so a symlinked checkout cannot alias another repo', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-rpc-repo-'));
+    const real = path.join(dir, 'real');
+    const link = path.join(dir, 'link');
+    fs.mkdirSync(real);
+    fs.symlinkSync(real, link);
+    try {
+      const h = harness({
+        callerCwd: async () => link,
+        exec: async (_cmd, args) =>
+          args.includes('--show-toplevel')
+            ? { stdout: `${link}\n`, stderr: '', code: 0 }
+            : { stdout: '', stderr: '', code: 0 },
+      });
+      expect(await h.call('task.git.status', { senderPtyId: 'pty-1' })).toMatchObject({
+        ok: true,
+        target: 'caller-repo',
+        repoRoot: fs.realpathSync(real),
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // `z.string().min(1)` lets ' ' through. Trimming it to '' and falling into
+  // the caller-repo branch answered a question about a TASK with a different
+  // repository's state, under ok: true.
+  it('refuses a taskId that is present but blank rather than reading the caller repo', async () => {
+    for (const blank of ['', '   ', '\t']) {
+      const h = harness();
+      expect(await h.call('task.git.status', { taskId: blank, senderPtyId: 'pty-1' })).toMatchObject({
+        ok: false,
+        error: { code: 'INVALID_ARGUMENT' },
+      });
+      expect(h.callerCwd).not.toHaveBeenCalled();
+    }
+    const h = harness();
+    expect(await h.call('task.git.log', { taskId: 42, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT' },
+    });
+    expect(h.callerCwd).not.toHaveBeenCalled();
+  });
+
+  it('names the target on a task read too, so the two can never be confused', async () => {
+    const h = harness();
+    expect(await h.call('task.git.status', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: true,
+      target: 'task',
+      taskId: TASK.id,
+    });
+    expect(await h.call('task.git.log', { taskId: TASK.id, senderPtyId: 'pty-1' })).toMatchObject({
+      ok: true,
+      target: 'task',
+      taskId: TASK.id,
+    });
   });
 });
 

--- a/src/main/pipe/handlers/worktask.rpc.ts
+++ b/src/main/pipe/handlers/worktask.rpc.ts
@@ -426,14 +426,37 @@ function rendererCallerCwd(getWindow: GetWindow): (workspaceId: string, senderPt
 
 /** Keep control characters and flag-looking strings out of a child process's
  *  cwd. Belt and braces: the value never becomes an argv element, and the
- *  toplevel lookup below is what actually decides which repository answers. */
+ *  toplevel lookup below is what actually decides which repository answers.
+ *
+ *  ABSOLUTE ONLY. `path.resolve` on a relative value silently anchors it to the
+ *  DAEMON's own working directory — a repository that has nothing to do with
+ *  the calling pane — so a surface reporting `src` (or `.`, or '..') would have
+ *  answered for whatever tree the daemon happens to be started in. A cwd is
+ *  absolute or it is unusable; `resolve` then only folds `.`/`..` away. */
 export function normalizeCallerCwd(raw: string): string | null {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return null;
   if (trimmed.startsWith('-')) return null;
   // eslint-disable-next-line no-control-regex
   if (/[\x00-\x1f\x7f]/.test(trimmed)) return null;
+  if (!path.isAbsolute(trimmed)) return null;
   return path.resolve(trimmed);
+}
+
+/** The git toplevel of `dir`, realpath'd, or ''. Same rule as the fan-out
+ *  gate's repoRootOf: `--show-toplevel` so any subdirectory normalises to the
+ *  same answer, and realpath so a symlinked path cannot alias a different
+ *  repository (or make two names for one repo look like two repos). */
+async function callerRepoRoot(exec: WorktaskExec, dir: string): Promise<string> {
+  const res = await exec('git', ['rev-parse', '--show-toplevel'], dir);
+  if (res.code !== 0) return '';
+  const top = res.stdout.trim();
+  if (top.length === 0) return '';
+  try {
+    return fs.realpathSync(top);
+  } catch {
+    return top;
+  }
 }
 
 /**
@@ -617,7 +640,20 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
     params: Record<string, unknown>,
     ctx: RpcContext | undefined,
   ): Promise<{ taskId?: string; repoRoot?: string; cwd: string } | { code: string; message: string }> => {
-    if (typeof params['taskId'] === 'string' && params['taskId'].trim().length > 0) {
+    // PRESENT-BUT-EMPTY IS NOT OMITTED. `z.string().min(1)` lets ' ' through,
+    // and a `taskId` that trims to nothing used to fall silently into the
+    // caller-repo branch: the caller asked about a task and was answered about
+    // a different repository, with `ok: true`. Naming the field at all means
+    // naming a task; omit it entirely to read your own repository.
+    const rawTaskId = params['taskId'];
+    if (rawTaskId !== undefined) {
+      if (typeof rawTaskId !== 'string' || rawTaskId.trim().length === 0) {
+        return {
+          code: 'INVALID_ARGUMENT',
+          message:
+            'taskId must be a non-empty task id — omit the field entirely to read your own repository instead',
+        };
+      }
       const owned = await resolveOwnedTask(deps, params, ctx);
       if (!('task' in owned)) return owned;
       const { task } = owned;
@@ -645,8 +681,7 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
           'name a task, or call from a pane whose cwd is a git repository',
       };
     }
-    const top = await exec('git', ['rev-parse', '--show-toplevel'], resolved);
-    const repoRoot = top.code === 0 ? top.stdout.trim() : '';
+    const repoRoot = await callerRepoRoot(exec, resolved);
     if (!repoRoot) {
       return {
         code: 'FAILED_PRECONDITION',
@@ -827,11 +862,13 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
     const target = await resolveReadCwd(params, ctx);
     if ('code' in target) return deny(target.code, target.message);
     const res = await exec('git', ['status', '--porcelain=v1', '--branch', '-z'], target.cwd);
-    // `taskId` / `repoRoot` say WHICH repository answered, so a caller mixing
-    // task reads and parent-repo reads never has to guess.
+    // `target` says WHICH repository answered, in one field that is always
+    // present — a caller mixing task reads and own-repo reads should not have
+    // to infer it from which of two optional keys came back, and an omitted
+    // task id must never be readable as "this is the task".
     const where = target.taskId !== undefined
-      ? { taskId: target.taskId, worktreePath: target.cwd }
-      : { repoRoot: target.cwd };
+      ? { target: 'task' as const, taskId: target.taskId, worktreePath: target.cwd }
+      : { target: 'caller-repo' as const, repoRoot: target.cwd };
     if (res.code !== 0) {
       return { ok: false as const, ...where, reason: 'git-failed' as const, error: res.stderr.trim() };
     }
@@ -857,7 +894,11 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
       ['log', `-n`, String(limit), `--format=%H${LOG_SEP}%an${LOG_SEP}%aI${LOG_SEP}%s`],
       target.cwd,
     );
-    const where = target.taskId !== undefined ? { taskId: target.taskId } : { repoRoot: target.cwd };
+    // Always present, so an omitted task id cannot be mistaken for a task read.
+    const where =
+      target.taskId !== undefined
+        ? { target: 'task' as const, taskId: target.taskId }
+        : { target: 'caller-repo' as const, repoRoot: target.cwd };
     if (res.code !== 0) {
       return { ok: false as const, ...where, reason: 'git-failed' as const, error: res.stderr.trim() };
     }

--- a/src/main/pipe/handlers/worktask.rpc.ts
+++ b/src/main/pipe/handlers/worktask.rpc.ts
@@ -85,6 +85,14 @@ export const WORKTASK_RPC_METHODS = [
   // for one reason: the ownership check. A tool that shelled out locally would
   // first need the worktree path, and handing a caller a path to run git in is
   // the whole authorization problem over again.
+  //
+  // `task.git.status` / `task.git.log` also answer with NO taskId, and then the
+  // repository is the CALLER'S OWN — derived from its surface's cwd, never
+  // named. A brain that had just adopted four tasks into its parent checkout
+  // could not read that checkout: every read wanted a task id, and the parent
+  // repository is not a task. The derivation is the fan-out gate's (surface cwd
+  // → git toplevel), so the answer is about the same directory the caller could
+  // have typed `git status` in, and no argument chooses it.
   'task.git.status',
   'task.git.log',
   'task.gh.prView',
@@ -200,6 +208,9 @@ export interface WorktaskRpcDeps {
   exec?: WorktaskExec;
   /** Injected for tests; defaults to the renderer approval queue. */
   requestApproval?: TaskApprovalPort;
+  /** Injected for tests; the caller's OWN working directory, for the reads that
+   *  name no task. Defaults to the renderer surface lookup below. */
+  callerCwd?: (workspaceId: string, senderPtyId: string) => Promise<string>;
 }
 
 /** Projection task, minimal shape (task.mission.list). */
@@ -361,6 +372,71 @@ async function resolveRepoInfo(worktreePath: string): Promise<{ repoRoot: string
 }
 
 /**
+ * The caller's own working directory, for the reads that name no task.
+ *
+ * Same chain as the fan-out gate's R3: the surface whose ptyId is the
+ * senderPtyId we just verified, and that surface's live cwd. NOT
+ * `workspace.list` → `metadata.cwd`, which tracks whichever surface last
+ * changed directory and would let a sibling pane choose what the caller reads.
+ *
+ * A commander brain is a subprocess with no pane ancestry and therefore no
+ * senderPtyId, so it borrows its workspace's ACTIVE pane and then goes through
+ * the identical derivation — the same borrow the fan-out gate makes, and bounded
+ * the same way: `ctx.commanderWorkspace` names exactly one workspace, so the
+ * worst a brain can do is `pane_focus` its way to another repository ITS OWN
+ * workspace already has a pane in. These two calls only read, and only what
+ * that pane's own shell could print.
+ */
+function rendererCallerCwd(getWindow: GetWindow): (workspaceId: string, senderPtyId: string) => Promise<string> {
+  return async (workspaceId: string, senderPtyId: string): Promise<string> => {
+    let ptyId = senderPtyId;
+    if (!ptyId) {
+      let list: unknown;
+      try {
+        list = await sendToRenderer(getWindow, 'workspace.list', {});
+      } catch {
+        return '';
+      }
+      if (!Array.isArray(list)) return '';
+      for (const entry of list) {
+        if (!entry || typeof entry !== 'object') continue;
+        const row = entry as Record<string, unknown>;
+        if (row['id'] !== workspaceId) continue;
+        ptyId = typeof row['activePtyId'] === 'string' ? row['activePtyId'].trim() : '';
+        break;
+      }
+      if (!ptyId) return '';
+    }
+    let surfaces: unknown;
+    try {
+      surfaces = await sendToRenderer(getWindow, 'surface.list', { workspaceId });
+    } catch {
+      return '';
+    }
+    if (!Array.isArray(surfaces)) return '';
+    for (const entry of surfaces) {
+      if (!entry || typeof entry !== 'object') continue;
+      const row = entry as Record<string, unknown>;
+      if (row['ptyId'] !== ptyId) continue;
+      return typeof row['cwd'] === 'string' ? row['cwd'].trim() : '';
+    }
+    return '';
+  };
+}
+
+/** Keep control characters and flag-looking strings out of a child process's
+ *  cwd. Belt and braces: the value never becomes an argv element, and the
+ *  toplevel lookup below is what actually decides which repository answers. */
+export function normalizeCallerCwd(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.startsWith('-')) return null;
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(trimmed)) return null;
+  return path.resolve(trimmed);
+}
+
+/**
  * `git`/`gh` with the same contract as the shared git helper: argv only, cwd
  * fixed, never throws — a non-zero exit is DATA, because "gh is not installed"
  * and "there is no PR" are answers a caller acts on, not transport failures.
@@ -465,6 +541,7 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
   // disable.
   const exec: WorktaskExec = deps.exec ?? ((cmd, args, cwd) => runGitLike(cmd, args, cwd));
   const requestApproval: TaskApprovalPort = deps.requestApproval ?? rendererApprovalPort(deps.getWindow);
+  const callerCwd = deps.callerCwd ?? rendererCallerCwd(deps.getWindow);
   const register = (method: WorktaskRpcMethod, handler: Parameters<RpcRouter['register']>[1]): void =>
     router.register(method, handler);
 
@@ -529,6 +606,54 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
     const outcome = await pending;
     if (outcome === 'approved') return null;
     return deny('NOT_AUTHORIZED', `task.${action} needs a human approval and ${APPROVAL_DENY_MESSAGE[outcome]}`);
+  };
+
+  /**
+   * WHERE a read runs: the named task's worktree, or — when no task is named —
+   * the caller's own repository. Never a path the caller supplies; `taskId` is
+   * still checked for ownership and the repository is still derived.
+   */
+  const resolveReadCwd = async (
+    params: Record<string, unknown>,
+    ctx: RpcContext | undefined,
+  ): Promise<{ taskId?: string; repoRoot?: string; cwd: string } | { code: string; message: string }> => {
+    if (typeof params['taskId'] === 'string' && params['taskId'].trim().length > 0) {
+      const owned = await resolveOwnedTask(deps, params, ctx);
+      if (!('task' in owned)) return owned;
+      const { task } = owned;
+      if (!task.worktreePath || !fileExists(task.worktreePath)) {
+        return { code: 'FAILED_PRECONDITION', message: `task '${task.id}' has no worktree on disk` };
+      }
+      return { taskId: task.id, cwd: task.worktreePath };
+    }
+    const caller = await resolveCaller(deps.getWindow, params, ctx);
+    if (!('workspaceId' in caller)) return caller;
+    // A commander caller has no pty of its own; the derivation borrows its
+    // workspace's active pane (see rendererCallerCwd).
+    const senderPtyId = ctx?.commanderWorkspace
+      ? ''
+      : typeof params['senderPtyId'] === 'string'
+        ? params['senderPtyId'].trim()
+        : '';
+    const raw = await callerCwd(caller.workspaceId, senderPtyId);
+    const resolved = raw ? normalizeCallerCwd(raw) : null;
+    if (!resolved) {
+      return {
+        code: 'FAILED_PRECONDITION',
+        message:
+          "no taskId was given and the calling terminal's working directory could not be determined — " +
+          'name a task, or call from a pane whose cwd is a git repository',
+      };
+    }
+    const top = await exec('git', ['rev-parse', '--show-toplevel'], resolved);
+    const repoRoot = top.code === 0 ? top.stdout.trim() : '';
+    if (!repoRoot) {
+      return {
+        code: 'FAILED_PRECONDITION',
+        message: `the calling terminal's directory is not inside a git repository: ${resolved}`,
+      };
+    }
+    return { repoRoot, cwd: repoRoot };
   };
 
   const localOnly = (ctx: RpcContext | undefined, method: string): { ok: false; error: { code: string; message: string } } | null =>
@@ -699,33 +824,30 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
   register('task.git.status', async (params, ctx?: RpcContext) => {
     const blocked = localOnly(ctx, 'task.git.status');
     if (blocked) return blocked;
-    const owned = await resolveOwnedTask(deps, params, ctx);
-    if (!('task' in owned)) return deny(owned.code, owned.message);
-    const { task } = owned;
-    if (!task.worktreePath || !fileExists(task.worktreePath)) {
-      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk`);
-    }
-    const res = await exec('git', ['status', '--porcelain=v1', '--branch', '-z'], task.worktreePath);
+    const target = await resolveReadCwd(params, ctx);
+    if ('code' in target) return deny(target.code, target.message);
+    const res = await exec('git', ['status', '--porcelain=v1', '--branch', '-z'], target.cwd);
+    // `taskId` / `repoRoot` say WHICH repository answered, so a caller mixing
+    // task reads and parent-repo reads never has to guess.
+    const where = target.taskId !== undefined
+      ? { taskId: target.taskId, worktreePath: target.cwd }
+      : { repoRoot: target.cwd };
     if (res.code !== 0) {
-      return { ok: false as const, taskId: task.id, reason: 'git-failed' as const, error: res.stderr.trim() };
+      return { ok: false as const, ...where, reason: 'git-failed' as const, error: res.stderr.trim() };
     }
-    return { ok: true as const, taskId: task.id, worktreePath: task.worktreePath, ...parseGitStatus(res.stdout) };
+    return { ok: true as const, ...where, ...parseGitStatus(res.stdout) };
   });
 
   // ── task.git.log ─────────────────────────────────────────────────────
   register('task.git.log', async (params, ctx?: RpcContext) => {
     const blocked = localOnly(ctx, 'task.git.log');
     if (blocked) return blocked;
-    const owned = await resolveOwnedTask(deps, params, ctx);
-    if (!('task' in owned)) return deny(owned.code, owned.message);
-    const { task } = owned;
-    if (!task.worktreePath || !fileExists(task.worktreePath)) {
-      return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk`);
-    }
     const raw = params['limit'];
     if (raw !== undefined && (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1)) {
       return deny('INVALID_ARGUMENT', 'limit must be a positive integer');
     }
+    const target = await resolveReadCwd(params, ctx);
+    if ('code' in target) return deny(target.code, target.message);
     // Clamped rather than rejected at the top end: a caller asking for 500
     // commits wants "as many as I can have", and refusing the whole call helps
     // nobody. The number that actually ran is reported back.
@@ -733,12 +855,13 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
     const res = await exec(
       'git',
       ['log', `-n`, String(limit), `--format=%H${LOG_SEP}%an${LOG_SEP}%aI${LOG_SEP}%s`],
-      task.worktreePath,
+      target.cwd,
     );
+    const where = target.taskId !== undefined ? { taskId: target.taskId } : { repoRoot: target.cwd };
     if (res.code !== 0) {
-      return { ok: false as const, taskId: task.id, reason: 'git-failed' as const, error: res.stderr.trim() };
+      return { ok: false as const, ...where, reason: 'git-failed' as const, error: res.stderr.trim() };
     }
-    return { ok: true as const, taskId: task.id, limit, commits: parseGitLog(res.stdout) };
+    return { ok: true as const, ...where, limit, commits: parseGitLog(res.stdout) };
   });
 
   // ── task.gh.prView ───────────────────────────────────────────────────

--- a/src/main/pipe/handlers/worktask.rpc.ts
+++ b/src/main/pipe/handlers/worktask.rpc.ts
@@ -39,8 +39,9 @@
 // are the two effects here a human cannot undo by reading a result.
 //
 // Gate/adopt/read stay unprompted: a gate run is reversible by ignoring it,
-// adopt lands STAGED and never commits (`git reset --hard` undoes it), and the
-// git/gh views only read.
+// adopt lands in the LOCAL repository and never pushes (`git reset --hard`
+// undoes the staged default, `git reset --hard HEAD~1` the `commit: true`
+// form), and the git/gh views only read.
 //
 // `task.close` is deliberately NOT in COMMANDER_TEARDOWN_DENY. That set is an
 // unconditional refusal in RpcRouter, evaluated before any handler runs, so
@@ -582,7 +583,21 @@ export function registerWorktaskRpc(router: RpcRouter, deps: WorktaskRpcDeps): v
     if (!task.worktreePath || !fileExists(task.worktreePath)) {
       return deny('FAILED_PRECONDITION', `task '${task.id}' has no worktree on disk, so it has produced nothing to adopt`);
     }
-    return deps.adopt.adopt({ taskId: task.id, worktreePath: task.worktreePath });
+    // Opt-in, and rejected rather than coerced: a caller sending `"true"` and
+    // silently getting the staged default would discover it one adopt later,
+    // as a dirty-target refusal it cannot explain.
+    const rawCommit = params['commit'];
+    if (rawCommit !== undefined && typeof rawCommit !== 'boolean') {
+      return deny('INVALID_ARGUMENT', 'commit must be a boolean');
+    }
+    // The title comes from the SERVER's projection row, never from params — the
+    // commit subject names what the daemon believes this task is.
+    return deps.adopt.adopt({
+      taskId: task.id,
+      worktreePath: task.worktreePath,
+      commit: rawCommit === true,
+      title: task.title,
+    });
   });
 
   // ── task.close ───────────────────────────────────────────────────────

--- a/src/main/worktask/TaskAdoptService.ts
+++ b/src/main/worktask/TaskAdoptService.ts
@@ -34,7 +34,11 @@
 //   index already holds exactly the adopted patch, so the service commits it
 //   with a message naming the task and hands back the short sha. The
 //   dirty-target check is unchanged: a target dirtied by a HUMAN is still
-//   refused, because that is the state the check exists for.
+//   refused, because that is the state the check exists for — and because a
+//   pathspec-free commit takes the whole index, that check is REPEATED in the
+//   instant before committing. Anything outside the adopted paths that appeared
+//   in between (a human staging a file, the GUI's own apply path) is a refusal,
+//   not a passenger in someone else's commit.
 //
 //   THE TASK'S INDEX IS NOT TOUCHED. Untracked files only appear in a diff
 //   after `git add -N`, which would leave intent-to-add entries in the index of
@@ -119,18 +123,31 @@ export type AdoptFailureReason =
   | 'commit-failed'
   | 'error';
 
-/** Longest commit SUBJECT this service will build from a task title. Titles are
- *  server-side projection rows, not prose, but a pasted paragraph should not
- *  become a 4 KB subject line. */
+/** Longest commit SUBJECT this service will build from a task title, in CODE
+ *  POINTS. A title is a line from a fan-out prompt, not prose, but a pasted
+ *  paragraph should not become a 4 KB subject line. */
 export const ADOPT_SUBJECT_MAX = 120;
 
-/** `adopt: <title> (<taskId>)`, first line only and bounded. Argv, never a
- *  shell string, so the only thing being defended against here is a subject
- *  nobody can read. */
+/**
+ * `adopt: <title> (<taskId>)`, first line only and bounded.
+ *
+ * The title reaches this function from the daemon's own projection row, but the
+ * row's text was written by the BRAIN — an LLM authored it when the task was
+ * fanned out — so it is untrusted text that happens to arrive by a trusted
+ * route. It never becomes a shell string (git is argv-only here), so what is
+ * being defended against is a subject nobody can read: control characters and
+ * escape sequences are replaced, and the bound is applied per code point so a
+ * cut never lands between the halves of a surrogate pair and leaves a lone
+ * surrogate in the commit message.
+ */
 export function adoptCommitMessage(taskId: string, title?: string): string {
-  const firstLine = (title ?? '').split('\n')[0]?.trim() ?? '';
-  const name = firstLine.length > 0 ? firstLine : taskId;
-  const bounded = name.length > ADOPT_SUBJECT_MAX ? `${name.slice(0, ADOPT_SUBJECT_MAX - 1)}…` : name;
+  const firstLine = (title ?? '').split('\n')[0] ?? '';
+  // eslint-disable-next-line no-control-regex
+  const clean = firstLine.replace(/[\x00-\x1f\x7f]/g, ' ').trim();
+  const name = clean.length > 0 ? clean : taskId;
+  const points = Array.from(name);
+  const bounded =
+    points.length > ADOPT_SUBJECT_MAX ? `${points.slice(0, ADOPT_SUBJECT_MAX - 1).join('')}…` : name;
   return `adopt: ${bounded} (${taskId})`;
 }
 
@@ -145,8 +162,14 @@ export type AdoptTaskResult =
       /** The merge base the patch was taken against. */
       base: string;
       /** Short sha of the commit, present only when `commit: true` was asked
-       *  for. Absent means the changes are staged and uncommitted. */
+       *  for AND the sha could be read back. Absent means the changes are
+       *  staged and uncommitted — or, with `warning` set, committed but
+       *  unnamed. Never an empty string: '' read as "no commit" to every caller
+       *  that checks truthiness, which is the opposite of what happened. */
       commit?: string;
+      /** Set when something non-fatal could not be established — currently only
+       *  "the commit was made and `git rev-parse` would not name it". */
+      warning?: string;
     }
   | {
       ok: false;
@@ -408,10 +431,52 @@ export class TaskAdoptService {
 
     if (!commit) return { ok: true, taskId, targetRepo, files, base };
 
-    // No pathspec: the target was verified CLEAN before the apply, so the index
-    // now holds the adopted patch and nothing else. A pathspec would commit the
-    // working tree's version of those paths instead of the `--3way` merge git
-    // just staged, which is a different (and wrong) thing to record.
+    // ── Nothing but the adopted patch may be in this commit ──────────────
+    // `git commit` with no pathspec commits the WHOLE index, and the clean
+    // check that justifies that ran several git invocations ago. A human (or
+    // the GUI's own apply path, or a second wmux) staging a file in that window
+    // would have their work swept into a commit whose message says it is one
+    // task's adoption. So the tree is re-read HERE, immediately before the
+    // commit, and anything outside the adopted set is a refusal.
+    //
+    // The pathspec alternative was rejected: `git commit -- <paths>` (and its
+    // `-o` spelling) commits the WORKING TREE's version of those paths, not the
+    // index `--3way` just filled, which is a different and wrong thing to
+    // record. Verifying the index is what makes the pathspec-free commit exact.
+    const before = await this.git(['status', '--porcelain=v1', '-z'], targetRepo);
+    if (before.code !== 0) {
+      await this.restore(targetRepo, files);
+      return {
+        ok: false,
+        taskId,
+        reason: 'commit-failed',
+        error:
+          `the task's changes applied to ${targetRepo} but its state could not be re-read before committing, ` +
+          `so nothing was committed and the affected paths were restored: ${before.stderr.trim()}`,
+        files,
+      };
+    }
+    const adopted = new Set(files);
+    const stray = parsePorcelainZ(before.stdout)
+      .map((e) => e.path)
+      .filter((p) => !adopted.has(p));
+    if (stray.length > 0) {
+      await this.restore(targetRepo, files);
+      return {
+        ok: false,
+        taskId,
+        reason: 'commit-failed',
+        error:
+          `${targetRepo} changed while this task was being adopted — ${stray.slice(0, 5).join(', ')}` +
+          `${stray.length > 5 ? ` and ${stray.length - 5} more` : ''} ` +
+          'are not part of this task, and committing would have swept them into it. The adopted paths were ' +
+          'restored; commit or stash the other changes and adopt again.',
+        files,
+      };
+    }
+
+    // No pathspec, now that the index has been verified to hold the adopted
+    // patch and nothing else.
     const committed = await this.git(['commit', '-m', adoptCommitMessage(taskId, title)], targetRepo);
     if (committed.code !== 0) {
       // A hook refused it, there is no author identity, the index is locked.
@@ -430,13 +495,20 @@ export class TaskAdoptService {
       };
     }
     const head = await this.git(['rev-parse', '--short', 'HEAD'], targetRepo);
+    const sha = head.code === 0 ? head.stdout.trim() : '';
     return {
       ok: true,
       taskId,
       targetRepo,
       files,
       base,
-      commit: head.code === 0 ? head.stdout.trim() : '',
+      // The commit happened; only its name is missing. Reporting `commit: ''`
+      // told every caller that checks truthiness the opposite — that nothing
+      // was committed — and the next adopt would then be refused dirty-target
+      // for a reason the caller had been told did not exist.
+      ...(sha
+        ? { commit: sha }
+        : { warning: `the commit was made in ${targetRepo} but git would not name it: ${head.stderr.trim()}` }),
     };
   }
 
@@ -445,9 +517,15 @@ export class TaskAdoptService {
    *  the repository is never touched. */
   private async restore(targetRepo: string, files: string[]): Promise<void> {
     if (files.length === 0) return;
-    await this.git(['reset', '-q', '--', ...files], targetRepo);
-    await this.git(['checkout', '--', ...files], targetRepo);
+    // These are PATHSPECS, not filenames: git reads `*`, `?`, `[…]` and a
+    // leading `:` as pattern syntax, so restoring a file genuinely named
+    // `a*.ts` would reset, check out and CLEAN every path that glob matches —
+    // a wider blast radius than the patch had, in the error path. `:(literal)`
+    // says the rest is exactly one path.
+    const specs = files.map((f) => `:(literal)${f}`);
+    await this.git(['reset', '-q', '--', ...specs], targetRepo);
+    await this.git(['checkout', '--', ...specs], targetRepo);
     // A file the patch CREATED has nothing to check out; remove the leftovers.
-    await this.git(['clean', '-qfd', '--', ...files], targetRepo);
+    await this.git(['clean', '-qfd', '--', ...specs], targetRepo);
   }
 }

--- a/src/main/worktask/TaskAdoptService.ts
+++ b/src/main/worktask/TaskAdoptService.ts
@@ -22,10 +22,19 @@
 //   patch is validated with `--check` first, and if the real apply still fails
 //   the touched paths are restored (`checkout` + `reset`) before returning.
 //
-//   WHAT LANDS IS STAGED, NEVER COMMITTED. `git apply --3way` needs the index
-//   to do its merge, so the adopted changes arrive staged — `git diff --cached`
-//   in the parent is exactly what was taken. Nothing is committed and nothing
-//   is pushed; the human (or the brain, with a commit of its own) still decides.
+//   WHAT LANDS IS STAGED, NEVER COMMITTED — UNLESS THE CALLER ASKS. `git apply
+//   --3way` needs the index to do its merge, so the adopted changes arrive
+//   staged: `git diff --cached` in the parent is exactly what was taken.
+//   Nothing is pushed either way.
+//
+//   That default makes ONE adopt reviewable and makes the SECOND one
+//   impossible: the first adopt leaves the target dirty, and the dirty-target
+//   check (rightly) refuses everything after it. A brain adopting four tasks in
+//   a row therefore dead-ended on task two. `commit: true` closes the loop — the
+//   index already holds exactly the adopted patch, so the service commits it
+//   with a message naming the task and hands back the short sha. The
+//   dirty-target check is unchanged: a target dirtied by a HUMAN is still
+//   refused, because that is the state the check exists for.
 //
 //   THE TASK'S INDEX IS NOT TOUCHED. Untracked files only appear in a diff
 //   after `git add -N`, which would leave intent-to-add entries in the index of
@@ -88,6 +97,14 @@ export interface TaskAdoptServiceOptions {
 export interface AdoptTaskInput {
   taskId: string;
   worktreePath: string;
+  /** Commit what was applied instead of leaving it staged. Default false =
+   *  the behaviour this service shipped with. Needed to adopt several tasks in
+   *  sequence: without it the second adopt hits `dirty-target`. */
+  commit?: boolean;
+  /** The task's title, used in the commit subject. Falls back to the task id —
+   *  the caller (the RPC handler) reads it from the SERVER's own projection
+   *  row, so it is never caller-supplied text. */
+  title?: string;
 }
 
 export type AdoptFailureReason =
@@ -97,7 +114,25 @@ export type AdoptFailureReason =
   | 'empty'
   | 'needs_rebase'
   | 'conflict'
+  /** The patch applied and the commit did not (a hook refused it, no author
+   *  identity, an index lock). The applied paths were restored. */
+  | 'commit-failed'
   | 'error';
+
+/** Longest commit SUBJECT this service will build from a task title. Titles are
+ *  server-side projection rows, not prose, but a pasted paragraph should not
+ *  become a 4 KB subject line. */
+export const ADOPT_SUBJECT_MAX = 120;
+
+/** `adopt: <title> (<taskId>)`, first line only and bounded. Argv, never a
+ *  shell string, so the only thing being defended against here is a subject
+ *  nobody can read. */
+export function adoptCommitMessage(taskId: string, title?: string): string {
+  const firstLine = (title ?? '').split('\n')[0]?.trim() ?? '';
+  const name = firstLine.length > 0 ? firstLine : taskId;
+  const bounded = name.length > ADOPT_SUBJECT_MAX ? `${name.slice(0, ADOPT_SUBJECT_MAX - 1)}…` : name;
+  return `adopt: ${bounded} (${taskId})`;
+}
 
 export type AdoptTaskResult =
   | {
@@ -109,6 +144,9 @@ export type AdoptTaskResult =
       files: string[];
       /** The merge base the patch was taken against. */
       base: string;
+      /** Short sha of the commit, present only when `commit: true` was asked
+       *  for. Absent means the changes are staged and uncommitted. */
+      commit?: string;
     }
   | {
       ok: false;
@@ -195,7 +233,7 @@ export class TaskAdoptService {
   }
 
   async adopt(input: AdoptTaskInput): Promise<AdoptTaskResult> {
-    const { taskId, worktreePath } = input;
+    const { taskId, worktreePath, commit = false, title } = input;
 
     // ── The target, derived ──────────────────────────────────────────────
     const commonDir = await this.git(['rev-parse', '--path-format=absolute', '--git-common-dir'], worktreePath);
@@ -219,7 +257,9 @@ export class TaskAdoptService {
       };
     }
 
-    return this.withRepoLock(targetRepo, () => this.applyInto(taskId, worktreePath, targetRepo));
+    return this.withRepoLock(targetRepo, () =>
+      this.applyInto(taskId, worktreePath, targetRepo, commit, title),
+    );
   }
 
   /** Serialize on the target repo, and never let one adopt's failure poison the
@@ -239,7 +279,13 @@ export class TaskAdoptService {
     return run;
   }
 
-  private async applyInto(taskId: string, worktreePath: string, targetRepo: string): Promise<AdoptTaskResult> {
+  private async applyInto(
+    taskId: string,
+    worktreePath: string,
+    targetRepo: string,
+    commit: boolean,
+    title: string | undefined,
+  ): Promise<AdoptTaskResult> {
     // ── The target must be clean ─────────────────────────────────────────
     const status = await this.git(['status', '--porcelain=v1', '-z'], targetRepo);
     if (status.code !== 0) {
@@ -360,7 +406,38 @@ export class TaskAdoptService {
       this.removePatch(patchFile);
     }
 
-    return { ok: true, taskId, targetRepo, files, base };
+    if (!commit) return { ok: true, taskId, targetRepo, files, base };
+
+    // No pathspec: the target was verified CLEAN before the apply, so the index
+    // now holds the adopted patch and nothing else. A pathspec would commit the
+    // working tree's version of those paths instead of the `--3way` merge git
+    // just staged, which is a different (and wrong) thing to record.
+    const committed = await this.git(['commit', '-m', adoptCommitMessage(taskId, title)], targetRepo);
+    if (committed.code !== 0) {
+      // A hook refused it, there is no author identity, the index is locked.
+      // Whatever it was, leaving the patch staged is the one outcome the caller
+      // did not ask for — it is the state that blocks the NEXT adopt — so put
+      // the target back exactly as the apply-failure path does.
+      await this.restore(targetRepo, files);
+      return {
+        ok: false,
+        taskId,
+        reason: 'commit-failed',
+        error:
+          `the task's changes applied to ${targetRepo} but could not be committed, and the affected paths were restored: ` +
+          (committed.stderr.trim() || committed.stdout.trim()),
+        files,
+      };
+    }
+    const head = await this.git(['rev-parse', '--short', 'HEAD'], targetRepo);
+    return {
+      ok: true,
+      taskId,
+      targetRepo,
+      files,
+      base,
+      commit: head.code === 0 ? head.stdout.trim() : '',
+    };
   }
 
   /** Undo a half-applied patch: unstage anything `--3way` staged, then restore

--- a/src/main/worktask/TaskGateRunner.ts
+++ b/src/main/worktask/TaskGateRunner.ts
@@ -56,6 +56,24 @@
 // `deps_missing` and `gate_unavailable` stay unrecorded — there a gate existed
 // and the environment stopped it, which is exactly the case a human should see.
 //
+// ── WHO GETS TO SAY THERE IS NO GATE ────────────────────────────────────────
+//
+// Not the task worktree. That tree is what the WORKER has been editing, so
+// deciding "no gate exists" from its own package.json would let a worker delete
+// its `lint` and `test` scripts and be handed a system-signed passing verdict
+// for it — a forged pass, in the one record `completed` trusts. So the waiver
+// needs the PARENT repository's agreement: when the parent root declares npm
+// lint/test scripts and the worktree does not, the worktree dropped them, and
+// that is a FAILING gate (`exitCode: 1`, `command: 'none'`, a tail that names
+// the missing scripts), never a waiver. Only when the parent declares no gate
+// either is `no_gate_command` recorded. The verify-script branch was already
+// parent-anchored: `wmux.json` is read at `projectRoot`, and a project that
+// declares `verify` while the worktree lacks the file is refused, not waived.
+//
+// A package.json that EXISTS but cannot be read or parsed is a third thing
+// again: neither "no gate" nor "a gate that failed", but a gate whose existence
+// is unknown. That answers `gate_unavailable` (unrecorded) rather than guessing.
+//
 // Ledger writes go through LedgerPort (see ledgerPort.ts) as a `system` actor —
 // the daemon ran the gate, not the worker whose code it graded — and a ledger
 // that is unreachable does not fail the gate: the run happened, only its receipt
@@ -86,6 +104,12 @@ export const GATE_PROJECT_COMMAND_ID = 'verify';
 /** Path, relative to the worktree root, of the only project-declared gate this
  *  runner will execute. */
 export const GATE_VERIFY_SCRIPT = 'scripts/verify.sh';
+
+/** The package.json scripts that make up the fallback gate, in run order. A
+ *  worktree declaring neither has no npm gate — but a PARENT repository
+ *  declaring either has a gate its worktree does not get to waive by deleting
+ *  the script. */
+export const GATE_NPM_SCRIPTS = ['lint', 'test'] as const;
 
 /** The spellings of GATE_VERIFY_SCRIPT a wmux.json may use for its `verify`
  *  command. Compared literally; anything else is refused. */
@@ -161,8 +185,10 @@ export interface TaskGateRunnerOptions {
   spawn?: GateSpawn;
   timeoutMs?: number;
   now?: () => number;
-  /** Injected for tests; defaults to reading `<worktree>/package.json`. */
-  readPackageScripts?: (worktreePath: string) => Record<string, string>;
+  /** Injected for tests; defaults to reading `<root>/package.json`. `null` means
+   *  the file is there and could not be read or parsed — see
+   *  defaultReadPackageScripts. An absent package.json is `{}`. */
+  readPackageScripts?: (root: string) => Record<string, string> | null;
   /** Injected for tests; defaults to an lstat of `<worktree>/node_modules`. */
   depsState?: (worktreePath: string) => 'ok' | 'missing' | 'symlink';
   /** Injected for tests; defaults to fs.existsSync. */
@@ -292,18 +318,35 @@ function defaultDepsState(worktreePath: string): 'ok' | 'missing' | 'symlink' {
   }
 }
 
-function defaultReadPackageScripts(worktreePath: string): Record<string, string> {
+/**
+ * `<root>/package.json`'s scripts, or `null` when the file is there and this
+ * process cannot make sense of it.
+ *
+ * The distinction is the whole point: one `catch {} → {}` used to fold three
+ * unrelated facts together. "There is no package.json" is a legitimate no-gate
+ * (a repository that is not a Node project). "There is one and it is
+ * unreadable" (EACCES, EISDIR, an I/O error) or "there is one and it is not
+ * JSON" is NOT evidence that no gate exists — treating it as such waives the
+ * gate for a corrupt tree, and the waiver writes a passing system record.
+ */
+function defaultReadPackageScripts(root: string): Record<string, string> | null {
+  let raw: string;
   try {
-    const raw = fs.readFileSync(path.join(worktreePath, 'package.json'), 'utf8');
-    const parsed = JSON.parse(raw) as { scripts?: Record<string, unknown> };
-    const out: Record<string, string> = {};
-    for (const [k, v] of Object.entries(parsed.scripts ?? {})) {
-      if (typeof v === 'string') out[k] = v;
-    }
-    return out;
-  } catch {
-    return {};
+    raw = fs.readFileSync(path.join(root, 'package.json'), 'utf8');
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === 'ENOENT' ? {} : null;
   }
+  let parsed: { scripts?: Record<string, unknown> } | null;
+  try {
+    parsed = JSON.parse(raw) as { scripts?: Record<string, unknown> } | null;
+  } catch {
+    return null;
+  }
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed?.scripts ?? {})) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
 }
 
 // ── The runner ───────────────────────────────────────────────────────────────
@@ -318,7 +361,7 @@ export class TaskGateRunner {
   private readonly spawn: GateSpawn;
   private readonly timeoutMs: number;
   private readonly now: () => number;
-  private readonly readPackageScripts: (worktreePath: string) => Record<string, string>;
+  private readonly readPackageScripts: (root: string) => Record<string, string> | null;
   private readonly depsState: (worktreePath: string) => 'ok' | 'missing' | 'symlink';
   private readonly fileExists: (p: string) => boolean;
   /** One gate per task — the second concurrent call is `busy`, not a second
@@ -364,7 +407,7 @@ export class TaskGateRunner {
   async resolveSteps(
     worktreePath: string,
     configRoot: string = worktreePath,
-  ): Promise<{ steps: GateStep[] } | { refused: string }> {
+  ): Promise<{ steps: GateStep[] } | { refused: string } | { unavailable: string }> {
     // The verdict is read at the PARENT root (that is where the user approved a
     // wmux.json); the script runs in the worktree.
     const declared = await this.declaredVerifyCommand(configRoot);
@@ -387,6 +430,11 @@ export class TaskGateRunner {
     }
 
     const scripts = this.readPackageScripts(worktreePath);
+    if (scripts === null) {
+      return {
+        unavailable: `the package.json in ${worktreePath} could not be read or parsed, so whether this project has a gate is unknown`,
+      };
+    }
     const steps: GateStep[] = [];
     if (typeof scripts['lint'] === 'string') steps.push(step([npmBin(), 'run', 'lint']));
     if (typeof scripts['test'] === 'string') steps.push(step([npmBin(), 'test']));
@@ -437,6 +485,19 @@ export class TaskGateRunner {
     };
 
     try {
+      // WHICH steps first, THEN whether the environment can run them. The other
+      // order asked `node_modules` about a repository that may not be a Node
+      // project at all: a task in a Go or Rust checkout has no node_modules, so
+      // every gate answered `deps_missing` — unrecorded — and the task could
+      // never reach `completed`. That is the exact blockage the no-gate record
+      // exists to remove, reintroduced one step earlier.
+      const resolved = await this.resolveSteps(worktreePath, input.projectRoot ?? worktreePath);
+      if ('refused' in resolved) return { ok: false, status: 'refused', taskId, error: resolved.refused };
+      if ('unavailable' in resolved) {
+        return { ok: true, status: 'skipped', taskId, skipped: 'gate_unavailable', detail: resolved.unavailable };
+      }
+      if (resolved.steps.length === 0) return this.noGateVerdict(input);
+
       const deps = this.depsState(worktreePath);
       if (deps !== 'ok') {
         return {
@@ -449,26 +510,6 @@ export class TaskGateRunner {
               ? 'node_modules is missing in the task worktree — run npm ci there, then re-run the gate'
               : 'node_modules in the task worktree is a symlink, which makes lint/test results meaningless — run a real npm ci there',
         };
-      }
-
-      const resolved = await this.resolveSteps(worktreePath, input.projectRoot ?? worktreePath);
-      if ('refused' in resolved) return { ok: false, status: 'refused', taskId, error: resolved.refused };
-      if (resolved.steps.length === 0) {
-        const detail =
-          'this project declares no verify script and no npm lint/test scripts, so there is no gate to run';
-        // Recorded, unlike the other two skips: nothing failed here, and an
-        // unrecorded skip left `completed` unreachable without `force` for every
-        // repository that declares no gate. The verdict says what it is —
-        // `command: 'none'` and `skipped: 'no_gate_command'` — so nobody reads
-        // it as a suite that passed.
-        const recorded = await this.record(taskId, input.systemWorkspaceId, {
-          exitCode: 0,
-          tail: detail,
-          at: this.now(),
-          command: 'none',
-          skipped: 'no_gate_command',
-        });
-        return { ok: true, status: 'skipped', taskId, skipped: 'no_gate_command', detail, recorded };
       }
 
       let output = '';
@@ -550,6 +591,61 @@ export class TaskGateRunner {
     } finally {
       release();
     }
+  }
+
+  /**
+   * The worktree resolved to zero steps. That is either a project with no gate
+   * — recorded as a passing system verdict, because otherwise `completed` is
+   * unreachable — or a worktree that DROPPED the gate its parent declares,
+   * which is a failure and must never be recorded as a pass.
+   *
+   * The parent root is the daemon's own derivation of the repository the task
+   * was fanned out from (`git rev-parse --show-toplevel` of the worktree's
+   * git-common-dir), not anything the worker can write. When it is absent or is
+   * the worktree itself, there is no second opinion to ask and the worktree
+   * answers alone — that is the task-runs-in-the-main-checkout case, where the
+   * two trees are the same tree.
+   */
+  private async noGateVerdict(input: GateRunInput): Promise<GateRunResult> {
+    const { taskId, worktreePath } = input;
+    const parentRoot = input.projectRoot ?? worktreePath;
+    if (path.resolve(parentRoot) !== path.resolve(worktreePath)) {
+      const parentScripts = this.readPackageScripts(parentRoot);
+      if (parentScripts === null) {
+        return {
+          ok: true,
+          status: 'skipped',
+          taskId,
+          skipped: 'gate_unavailable',
+          detail: `the package.json in ${parentRoot} could not be read or parsed, so whether this project has a gate is unknown`,
+        };
+      }
+      const declared = GATE_NPM_SCRIPTS.filter((s) => typeof parentScripts[s] === 'string');
+      if (declared.length > 0) {
+        const detail =
+          `the parent repository declares npm ${declared.join(' and ')} ` +
+          `${declared.length > 1 ? 'scripts' : 'script'}, and the task worktree's package.json declares neither — ` +
+          'the gate is missing from the tree it was supposed to grade, which is a failed gate and not a waiver';
+        const result: LedgerGateResult = { exitCode: 1, tail: detail, at: this.now(), command: 'none' };
+        const recorded = await this.record(taskId, input.systemWorkspaceId, result);
+        return { ok: true, status: 'completed', taskId, result, recorded };
+      }
+    }
+    const detail =
+      'this project declares no verify script and no npm lint/test scripts, so there is no gate to run';
+    // Recorded, unlike the other two skips: nothing failed here, and an
+    // unrecorded skip left `completed` unreachable without `force` for every
+    // repository that declares no gate. The verdict says what it is —
+    // `command: 'none'` and `skipped: 'no_gate_command'` — so nobody reads it as
+    // a suite that passed.
+    const recorded = await this.record(taskId, input.systemWorkspaceId, {
+      exitCode: 0,
+      tail: detail,
+      at: this.now(),
+      command: 'none',
+      skipped: 'no_gate_command',
+    });
+    return { ok: true, status: 'skipped', taskId, skipped: 'no_gate_command', detail, recorded };
   }
 
   /** Compare-and-swap write of the verdict. A ledger that is missing or

--- a/src/main/worktask/TaskGateRunner.ts
+++ b/src/main/worktask/TaskGateRunner.ts
@@ -46,6 +46,16 @@
 // facts and a brain that cannot tell them apart will close a healthy task as
 // failed.
 //
+// NO GATE IS NOT A FAILED GATE. A project that declares neither a verify script
+// nor npm lint/test scripts has nothing to fail, but the ledger refuses
+// `completed` without a system-recorded pass — so such a repository could never
+// reach `completed` except by `force`, which is how a live brain got stuck. The
+// `no_gate_command` skip therefore RECORDS a system gate (`exitCode: 0`,
+// `command: 'none'`, `skipped: 'no_gate_command'`, the detail text as its tail):
+// the verdict is honest about having run nothing, and `completed` is reachable.
+// `deps_missing` and `gate_unavailable` stay unrecorded — there a gate existed
+// and the environment stopped it, which is exactly the case a human should see.
+//
 // Ledger writes go through LedgerPort (see ledgerPort.ts) as a `system` actor —
 // the daemon ran the gate, not the worker whose code it graded — and a ledger
 // that is unreachable does not fail the gate: the run happened, only its receipt
@@ -166,8 +176,18 @@ export type GateSkipReason = 'deps_missing' | 'no_gate_command' | 'gate_unavaila
 export type GateRunResult =
   /** The gate ran to a verdict. `result.exitCode === 0` is the only pass. */
   | { ok: true; status: 'completed'; taskId: string; result: LedgerGateResult; recorded: boolean }
-  /** Nothing ran, and that is not a failure. */
-  | { ok: true; status: 'skipped'; taskId: string; skipped: GateSkipReason; detail: string }
+  /** Nothing ran, and that is not a failure. `recorded` is present only for
+   *  `no_gate_command`, the one skip that still writes a verdict (a passing
+   *  system gate, so a project without a gate can reach `completed`); its
+   *  absence on the other two says the ledger was deliberately left untouched. */
+  | {
+      ok: true;
+      status: 'skipped';
+      taskId: string;
+      skipped: GateSkipReason;
+      detail: string;
+      recorded?: boolean;
+    }
   /** A gate for this task is already running. */
   | { ok: false; status: 'busy'; taskId: string }
   /** The project declared a gate this runner will not execute. */
@@ -434,13 +454,21 @@ export class TaskGateRunner {
       const resolved = await this.resolveSteps(worktreePath, input.projectRoot ?? worktreePath);
       if ('refused' in resolved) return { ok: false, status: 'refused', taskId, error: resolved.refused };
       if (resolved.steps.length === 0) {
-        return {
-          ok: true,
-          status: 'skipped',
-          taskId,
+        const detail =
+          'this project declares no verify script and no npm lint/test scripts, so there is no gate to run';
+        // Recorded, unlike the other two skips: nothing failed here, and an
+        // unrecorded skip left `completed` unreachable without `force` for every
+        // repository that declares no gate. The verdict says what it is —
+        // `command: 'none'` and `skipped: 'no_gate_command'` — so nobody reads
+        // it as a suite that passed.
+        const recorded = await this.record(taskId, input.systemWorkspaceId, {
+          exitCode: 0,
+          tail: detail,
+          at: this.now(),
+          command: 'none',
           skipped: 'no_gate_command',
-          detail: 'this project declares no verify script and no npm lint/test scripts, so there is no gate to run',
-        };
+        });
+        return { ok: true, status: 'skipped', taskId, skipped: 'no_gate_command', detail, recorded };
       }
 
       let output = '';

--- a/src/main/worktask/__tests__/TaskAdoptService.test.ts
+++ b/src/main/worktask/__tests__/TaskAdoptService.test.ts
@@ -30,28 +30,45 @@ interface Call {
 /** A git that answers by subcommand. Every knob is a refusal path. */
 function fakeGit(opts: {
   status?: string;
+  /** The SECOND status read — the one taken immediately before the commit, to
+   *  see whether anything outside the adopted set appeared in the meantime.
+   *  Defaults to `status`. */
+  statusBeforeCommit?: string;
+  /** What `diff --name-only` reports, NUL-framed. Defaults to two paths. */
+  names?: string;
   diff?: string;
   mergeBaseCode?: number;
   checkCode?: number;
   applyCode?: number;
   addCode?: number;
   commitCode?: number;
+  statusCode?: number;
+  shortCode?: number;
   calls?: Call[];
 }): AdoptGit {
+  let statusReads = 0;
   return async (args, cwd, env) => {
     opts.calls?.push({ cwd, args, ...(env ? { env } : {}) });
     const ok = (stdout: string) => ({ stdout, stderr: '', code: 0 });
     const fail = (stderr: string, code = 1) => ({ stdout: '', stderr, code });
     if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) return ok(`${REPO}/.git\n`);
     if (args[0] === 'rev-parse' && args.includes('--show-toplevel')) return ok(`${REPO}\n`);
-    if (args[0] === 'rev-parse' && args[1] === '--short') return ok('deadbee\n');
+    if (args[0] === 'rev-parse' && args[1] === '--short') {
+      return opts.shortCode ? fail('fatal: bad revision', opts.shortCode) : ok('deadbee\n');
+    }
     if (args[0] === 'rev-parse' && args[1] === 'HEAD') return ok(cwd === REPO ? `${PARENT_HEAD}\n` : `${TASK_HEAD}\n`);
     if (args[0] === 'commit') return opts.commitCode ? fail('pre-commit hook refused') : ok('');
     if (args[0] === 'merge-base') return opts.mergeBaseCode ? fail('no merge base') : ok(`${BASE}\n`);
-    if (args[0] === 'status') return ok(opts.status ?? '');
+    if (args[0] === 'status') {
+      statusReads += 1;
+      if (opts.statusCode && statusReads > 1) return fail('status failed', opts.statusCode);
+      return ok(statusReads === 1 ? (opts.status ?? '') : (opts.statusBeforeCommit ?? opts.status ?? ''));
+    }
     if (args[0] === 'read-tree') return ok('');
     if (args[0] === 'add') return opts.addCode ? fail('add failed') : ok('');
-    if (args[0] === 'diff' && args.includes('--name-only')) return ok(opts.diff ? 'src/a.ts\0src/b.ts\0' : '');
+    if (args[0] === 'diff' && args.includes('--name-only')) {
+      return ok(opts.diff ? (opts.names ?? 'src/a.ts\0src/b.ts\0') : '');
+    }
     if (args[0] === 'diff') return ok(opts.diff ?? '');
     if (args[0] === 'apply' && args.includes('--check')) {
       return opts.checkCode ? fail('patch does not apply') : ok('');
@@ -174,10 +191,11 @@ describe('TaskAdoptService', () => {
     const reset = calls.find((c) => c.args[0] === 'reset');
     const checkout = calls.find((c) => c.args[0] === 'checkout');
     const clean = calls.find((c) => c.args[0] === 'clean');
-    expect(reset?.args).toEqual(['reset', '-q', '--', 'src/a.ts', 'src/b.ts']);
-    expect(checkout?.args).toEqual(['checkout', '--', 'src/a.ts', 'src/b.ts']);
+    // `:(literal)` on every path — see the restore-globbing test below.
+    expect(reset?.args).toEqual(['reset', '-q', '--', ':(literal)src/a.ts', ':(literal)src/b.ts']);
+    expect(checkout?.args).toEqual(['checkout', '--', ':(literal)src/a.ts', ':(literal)src/b.ts']);
     // A file the patch CREATED cannot be checked out — it has to be removed.
-    expect(clean?.args).toEqual(['clean', '-qfd', '--', 'src/a.ts', 'src/b.ts']);
+    expect(clean?.args).toEqual(['clean', '-qfd', '--', ':(literal)src/a.ts', ':(literal)src/b.ts']);
     expect(reset?.cwd).toBe(REPO);
   });
 
@@ -245,9 +263,15 @@ describe('TaskAdoptService', () => {
     expect(res).toMatchObject({ ok: false, reason: 'commit-failed', files: ['src/a.ts', 'src/b.ts'] });
     // Leaving the patch staged is the one outcome the caller did not ask for —
     // it is exactly the state that blocks the next adopt.
-    expect(calls.find((c) => c.args[0] === 'reset')?.args).toEqual(['reset', '-q', '--', 'src/a.ts', 'src/b.ts']);
-    expect(calls.find((c) => c.args[0] === 'checkout')?.args).toEqual(['checkout', '--', 'src/a.ts', 'src/b.ts']);
-    expect(calls.find((c) => c.args[0] === 'clean')?.args).toEqual(['clean', '-qfd', '--', 'src/a.ts', 'src/b.ts']);
+    expect(calls.find((c) => c.args[0] === 'reset')?.args).toEqual([
+      'reset', '-q', '--', ':(literal)src/a.ts', ':(literal)src/b.ts',
+    ]);
+    expect(calls.find((c) => c.args[0] === 'checkout')?.args).toEqual([
+      'checkout', '--', ':(literal)src/a.ts', ':(literal)src/b.ts',
+    ]);
+    expect(calls.find((c) => c.args[0] === 'clean')?.args).toEqual([
+      'clean', '-qfd', '--', ':(literal)src/a.ts', ':(literal)src/b.ts',
+    ]);
   });
 
   it('still leaves the changes staged when commit is omitted', async () => {
@@ -257,6 +281,71 @@ describe('TaskAdoptService', () => {
     expect(res).toMatchObject({ ok: true });
     expect(res).not.toHaveProperty('commit');
     expect(calls.some((c) => c.args[0] === 'commit')).toBe(false);
+  });
+
+  // ── The commit takes the whole index, so the index is re-checked ─────────
+  //
+  // The clean check and the commit are a dozen git calls apart. A human staging
+  // a file in that window would have their work committed under a message that
+  // says it is one task's adoption — and nobody would look, because the adopt
+  // reported ok.
+  it('refuses to commit when a path outside the adopted set was staged after the clean check', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(
+      fakeGit({ diff: 'patch', statusBeforeCommit: 'M  src/a.ts\0A  NOTES.md\0', calls }),
+    );
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true, title: 'lane one' });
+
+    expect(res).toMatchObject({ ok: false, reason: 'commit-failed' });
+    if (res.ok) throw new Error('unreachable');
+    expect(res.error).toContain('NOTES.md');
+    expect(calls.some((c) => c.args[0] === 'commit')).toBe(false);
+    // The human's file is not in the restore either — only the adopted paths.
+    const reset = calls.find((c) => c.args[0] === 'reset');
+    expect(reset?.args).toEqual(['reset', '-q', '--', ':(literal)src/a.ts', ':(literal)src/b.ts']);
+  });
+
+  it('commits when the only staged paths are the adopted ones', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', statusBeforeCommit: 'M  src/a.ts\0A  src/b.ts\0', calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true, title: 'lane one' });
+    expect(res).toMatchObject({ ok: true, commit: 'deadbee' });
+    expect(calls.filter((c) => c.args[0] === 'status')).toHaveLength(2);
+  });
+
+  it('treats a failed re-read as a refusal rather than committing blind', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', statusCode: 128, calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true });
+    expect(res).toMatchObject({ ok: false, reason: 'commit-failed' });
+    expect(calls.some((c) => c.args[0] === 'commit')).toBe(false);
+  });
+
+  // ── Restore is pathspec-shaped, so paths must be marked literal ───────────
+  it('never lets a path with glob characters widen the restore', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', names: 'src/a*.ts\0', commitCode: 1, calls }));
+    await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true });
+    // Without `:(literal)` this would reset, check out and CLEAN every path
+    // matching `src/a*.ts` — a wider blast radius than the patch had.
+    expect(calls.find((c) => c.args[0] === 'clean')?.args).toEqual([
+      'clean',
+      '-qfd',
+      '--',
+      ':(literal)src/a*.ts',
+    ]);
+  });
+
+  // ── A commit that happened must never be reported as one that did not ────
+  it('omits commit and warns when the sha cannot be read back', async () => {
+    const { svc } = service(fakeGit({ diff: 'patch', shortCode: 1 }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true });
+    expect(res).toMatchObject({ ok: true });
+    // '' read as "nothing was committed" to every caller that checks
+    // truthiness — the opposite of what happened.
+    expect(res).not.toHaveProperty('commit');
+    if (!res.ok) throw new Error('unreachable');
+    expect(res.warning).toContain('would not name it');
   });
 
   // Two adopts landing at once would both see a clean tree, and the second
@@ -315,7 +404,27 @@ describe('adoptCommitMessage', () => {
     expect(adoptCommitMessage('wtask-1', 'first\nsecond')).toBe('adopt: first (wtask-1)');
     const long = adoptCommitMessage('wtask-1', 'x'.repeat(ADOPT_SUBJECT_MAX + 40));
     expect(long.length).toBe(`adopt:  (wtask-1)`.length + ADOPT_SUBJECT_MAX);
-    expect(long.endsWith('… (wtask-1)')).toBe(true);
+    expect(long.endsWith('\u2026 (wtask-1)')).toBe(true);
+  });
+
+  // The projection row is the daemon's, but an LLM wrote the text in it when
+  // the task was fanned out — so the title is untrusted text arriving by a
+  // trusted route.
+  it('strips control characters an LLM-written title may carry', () => {
+    expect(adoptCommitMessage('wtask-1', 'lane\u001b[31mone\r')).toBe('adopt: lane [31mone (wtask-1)');
+    expect(adoptCommitMessage('wtask-1', 'a\tb')).toBe('adopt: a b (wtask-1)');
+    expect(adoptCommitMessage('wtask-1', '\u0000\u0007')).toBe('adopt: wtask-1 (wtask-1)');
+  });
+
+  it('bounds by code point, so a cut never leaves half a surrogate pair', () => {
+    // Each emoji is TWO UTF-16 units: a length-based slice at ADOPT_SUBJECT_MAX
+    // would land inside one and emit a lone surrogate.
+    const subject = adoptCommitMessage('wtask-1', '\u{1f642}'.repeat(ADOPT_SUBJECT_MAX + 10));
+    const title = subject.slice('adopt: '.length, -' (wtask-1)'.length);
+    expect(Array.from(title)).toHaveLength(ADOPT_SUBJECT_MAX);
+    expect(title.endsWith('\u2026')).toBe(true);
+    // No lone surrogate survives once the well-formed pairs are removed.
+    expect(/[\uD800-\uDFFF]/.test(title.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, ''))).toBe(false);
   });
 });
 

--- a/src/main/worktask/__tests__/TaskAdoptService.test.ts
+++ b/src/main/worktask/__tests__/TaskAdoptService.test.ts
@@ -7,7 +7,13 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-import { parsePorcelainZ, TaskAdoptService, type AdoptGit } from '../TaskAdoptService';
+import {
+  adoptCommitMessage,
+  ADOPT_SUBJECT_MAX,
+  parsePorcelainZ,
+  TaskAdoptService,
+  type AdoptGit,
+} from '../TaskAdoptService';
 
 const WT = '/wt/lane-one';
 const REPO = '/repo';
@@ -29,6 +35,7 @@ function fakeGit(opts: {
   checkCode?: number;
   applyCode?: number;
   addCode?: number;
+  commitCode?: number;
   calls?: Call[];
 }): AdoptGit {
   return async (args, cwd, env) => {
@@ -37,7 +44,9 @@ function fakeGit(opts: {
     const fail = (stderr: string, code = 1) => ({ stdout: '', stderr, code });
     if (args[0] === 'rev-parse' && args.includes('--git-common-dir')) return ok(`${REPO}/.git\n`);
     if (args[0] === 'rev-parse' && args.includes('--show-toplevel')) return ok(`${REPO}\n`);
+    if (args[0] === 'rev-parse' && args[1] === '--short') return ok('deadbee\n');
     if (args[0] === 'rev-parse' && args[1] === 'HEAD') return ok(cwd === REPO ? `${PARENT_HEAD}\n` : `${TASK_HEAD}\n`);
+    if (args[0] === 'commit') return opts.commitCode ? fail('pre-commit hook refused') : ok('');
     if (args[0] === 'merge-base') return opts.mergeBaseCode ? fail('no merge base') : ok(`${BASE}\n`);
     if (args[0] === 'status') return ok(opts.status ?? '');
     if (args[0] === 'read-tree') return ok('');
@@ -209,6 +218,47 @@ describe('TaskAdoptService', () => {
     expect(removePatch).toHaveBeenCalledWith('/tmp/patch');
   });
 
+  // ── commit: true — the sequential-adoption path ───────────────────────────
+  //
+  // Without it a brain adopting four tasks in a row dead-ends on task two: the
+  // first adopt leaves the target staged-dirty and the dirty-target check
+  // refuses everything after it.
+  it('commits what it applied and returns the short sha when commit: true', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true, title: 'lane one' });
+
+    expect(res).toMatchObject({ ok: true, targetRepo: REPO, commit: 'deadbee' });
+    const commit = calls.find((c) => c.args[0] === 'commit');
+    // No pathspec: the target was clean, so the index holds the adopted patch
+    // and nothing else. A pathspec would commit the working tree instead of the
+    // --3way merge git just staged.
+    expect(commit?.args).toEqual(['commit', '-m', 'adopt: lane one (wtask-1)']);
+    expect(commit?.cwd).toBe(REPO);
+  });
+
+  it('restores the applied paths and reports commit-failed when the commit is refused', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', commitCode: 1, calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT, commit: true, title: 'lane one' });
+
+    expect(res).toMatchObject({ ok: false, reason: 'commit-failed', files: ['src/a.ts', 'src/b.ts'] });
+    // Leaving the patch staged is the one outcome the caller did not ask for —
+    // it is exactly the state that blocks the next adopt.
+    expect(calls.find((c) => c.args[0] === 'reset')?.args).toEqual(['reset', '-q', '--', 'src/a.ts', 'src/b.ts']);
+    expect(calls.find((c) => c.args[0] === 'checkout')?.args).toEqual(['checkout', '--', 'src/a.ts', 'src/b.ts']);
+    expect(calls.find((c) => c.args[0] === 'clean')?.args).toEqual(['clean', '-qfd', '--', 'src/a.ts', 'src/b.ts']);
+  });
+
+  it('still leaves the changes staged when commit is omitted', async () => {
+    const calls: Call[] = [];
+    const { svc } = service(fakeGit({ diff: 'patch', calls }));
+    const res = await svc.adopt({ taskId: 'wtask-1', worktreePath: WT });
+    expect(res).toMatchObject({ ok: true });
+    expect(res).not.toHaveProperty('commit');
+    expect(calls.some((c) => c.args[0] === 'commit')).toBe(false);
+  });
+
   // Two adopts landing at once would both see a clean tree, and the second
   // would apply on top of the first's output — with no conflict to report.
   it('serializes adopts against the same target repository', async () => {
@@ -251,6 +301,21 @@ describe('TaskAdoptService', () => {
     await expect(svc.adopt({ taskId: 'wtask-1', worktreePath: WT })).rejects.toThrow('boom');
     // A poisoned chain would leave every later adopt rejecting with 'boom'.
     expect(await svc.adopt({ taskId: 'wtask-2', worktreePath: WT })).toMatchObject({ ok: true });
+  });
+});
+
+describe('adoptCommitMessage', () => {
+  it('names the task, and falls back to the id when there is no title', () => {
+    expect(adoptCommitMessage('wtask-1', 'lane one')).toBe('adopt: lane one (wtask-1)');
+    expect(adoptCommitMessage('wtask-1')).toBe('adopt: wtask-1 (wtask-1)');
+    expect(adoptCommitMessage('wtask-1', '   ')).toBe('adopt: wtask-1 (wtask-1)');
+  });
+
+  it('keeps the subject to one bounded line', () => {
+    expect(adoptCommitMessage('wtask-1', 'first\nsecond')).toBe('adopt: first (wtask-1)');
+    const long = adoptCommitMessage('wtask-1', 'x'.repeat(ADOPT_SUBJECT_MAX + 40));
+    expect(long.length).toBe(`adopt:  (wtask-1)`.length + ADOPT_SUBJECT_MAX);
+    expect(long.endsWith('… (wtask-1)')).toBe(true);
   });
 });
 

--- a/src/main/worktask/__tests__/TaskGateRunner.test.ts
+++ b/src/main/worktask/__tests__/TaskGateRunner.test.ts
@@ -5,6 +5,8 @@
 // npm's behaviour.
 
 import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {
@@ -18,7 +20,8 @@ import {
   type GateSpawn,
 } from '../TaskGateRunner';
 import { LEDGER_GATE_TAIL_MAX_BYTES } from '../../../shared/ledger';
-import type { LedgerPort, LedgerGateWrite } from '../ledgerPort';
+import { TaskLedger } from '../../../daemon/ledger/TaskLedger';
+import { createHostedLedgerPort, type LedgerPort, type LedgerGateWrite } from '../ledgerPort';
 
 const WT = '/tmp/wt-task-1';
 /** The parent repository — the path a wmux.json trust record is keyed by. */
@@ -177,26 +180,55 @@ describe('TaskGateRunner', () => {
 
   it('skips with deps_missing rather than failing when node_modules is absent or symlinked', async () => {
     for (const state of ['missing', 'symlink'] as const) {
+      const ledger = fakeLedger();
       const runner = new TaskGateRunner({
-        ledger: fakeLedger(),
+        ledger,
         spawn: fakeSpawn({ code: 1 }),
         readPackageScripts: () => npmProject,
         depsState: () => state,
       });
       const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
       expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'deps_missing' });
+      // A gate existed and the environment stopped it: nothing is recorded, so
+      // `completed` still needs a human's force and the reason stays visible.
+      expect(ledger.writes).toHaveLength(0);
     }
   });
 
-  it('skips when the project declares no gate at all', async () => {
+  it('skips when the project declares no gate at all, and records a passing system gate', async () => {
+    const ledger = fakeLedger();
     const runner = new TaskGateRunner({
-      ledger: fakeLedger(),
+      ledger,
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => ({}),
+      depsState: () => 'ok',
+      now: () => 4242,
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'no_gate_command', recorded: true });
+    // A project that declares no gate has nothing to fail — without this the
+    // ledger refuses `completed` forever (gate_required) for such a repository.
+    expect(ledger.writes).toHaveLength(1);
+    expect(ledger.writes[0]?.actor).toEqual({ kind: 'system', workspaceId: 'ws-daemon' });
+    expect(ledger.writes[0]?.gate).toMatchObject({
+      exitCode: 0,
+      command: 'none',
+      skipped: 'no_gate_command',
+      at: 4242,
+    });
+    expect(ledger.writes[0]?.gate.tail).toContain('no verify script');
+  });
+
+  it('reports recorded: false when the no-gate verdict cannot reach the ledger', async () => {
+    const runner = new TaskGateRunner({
+      // No entry for this task — the gate ran (well, ran nothing) either way.
+      ledger: { read: async () => null, writeGate: async () => ({ ok: true, rev: 1 }) },
       spawn: fakeSpawn({ code: 0 }),
       readPackageScripts: () => ({}),
       depsState: () => 'ok',
     });
     const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
-    expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'no_gate_command' });
+    expect(res).toMatchObject({ status: 'skipped', skipped: 'no_gate_command', recorded: false });
   });
 
   it('answers a second concurrent run with busy', async () => {
@@ -408,6 +440,53 @@ describe('TaskGateRunner', () => {
     if (res.status !== 'completed') throw new Error('unreachable');
     expect(res.result.exitCode).toBe(0);
     expect(res.recorded).toBe(false);
+  });
+});
+
+// The point of E-1 is not the shape of the write, it is that `completed`
+// becomes reachable. Only the REAL ledger can prove that, so this wires the
+// runner to one through the production adapter and asks it.
+describe('TaskGateRunner + the real ledger', () => {
+  it('lets a project with no gate reach completed without force', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-gate-nogate-'));
+    try {
+      const ledger = new TaskLedger({ dir });
+      await ledger.register({
+        id: 'wtask-1',
+        taskWorkspaceId: 'ws-task',
+        ownerWorkspaceId: 'ws-owner',
+        title: 'lane',
+      });
+      const runner = new TaskGateRunner({
+        ledger: createHostedLedgerPort(() => ledger),
+        spawn: fakeSpawn({ code: 0 }),
+        readPackageScripts: () => ({}),
+        depsState: () => 'ok',
+      });
+      const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+      expect(res).toMatchObject({ status: 'skipped', skipped: 'no_gate_command', recorded: true });
+
+      const brain = { kind: 'brain', workspaceId: 'ws-owner' } as const;
+      const review = await ledger.update({
+        id: 'wtask-1',
+        status: 'review_requested',
+        actor: brain,
+        expectedRev: ledger.get('wtask-1')?.rev ?? -1,
+      });
+      expect(review.ok).toBe(true);
+      const done = await ledger.update({
+        id: 'wtask-1',
+        status: 'completed',
+        actor: brain,
+        expectedRev: ledger.get('wtask-1')?.rev ?? -1,
+      });
+      // Before E-1 this was `gate_required`: nothing was ever recorded, so a
+      // repository without lint/test scripts could only be closed with `force`.
+      expect(done).toMatchObject({ ok: true });
+      expect(ledger.get('wtask-1')?.gate).toMatchObject({ exitCode: 0, command: 'none', recordedBy: 'system' });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/main/worktask/__tests__/TaskGateRunner.test.ts
+++ b/src/main/worktask/__tests__/TaskGateRunner.test.ts
@@ -219,6 +219,127 @@ describe('TaskGateRunner', () => {
     expect(ledger.writes[0]?.gate.tail).toContain('no verify script');
   });
 
+  // ── The waiver is the parent's to give, not the worktree's ───────────────
+  //
+  // The worktree is the tree the WORKER edits. Reading "no gate exists" out of
+  // it alone let a worker delete its own lint/test scripts and be handed a
+  // system-signed passing verdict — a forged pass in the one record `completed`
+  // trusts.
+  it('records a FAILING gate when the worktree dropped the npm scripts its parent declares', async () => {
+    const ledger = fakeLedger();
+    const runner = new TaskGateRunner({
+      ledger,
+      spawn: fakeSpawn({ code: 0 }),
+      // The worktree's package.json says there is nothing to run; the parent's
+      // says otherwise.
+      readPackageScripts: (root) => (root === REPO ? npmProject : {}),
+      depsState: () => 'ok',
+      now: () => 77,
+    });
+    const res = await runner.run({
+      taskId: 'wtask-1',
+      worktreePath: WT,
+      systemWorkspaceId: 'ws-daemon',
+      projectRoot: REPO,
+    });
+
+    expect(res).toMatchObject({ ok: true, status: 'completed', recorded: true });
+    if (res.status !== 'completed') throw new Error('unreachable');
+    expect(res.result.exitCode).toBe(1);
+    expect(res.result.tail).toContain('lint and test');
+    // Recorded as a failure and NOT as a waiver: no `skipped` label, and a
+    // non-zero exit, so the ledger still refuses `completed`.
+    expect(ledger.writes).toHaveLength(1);
+    expect(ledger.writes[0]?.gate.exitCode).toBe(1);
+    expect(ledger.writes[0]?.gate).not.toHaveProperty('skipped');
+  });
+
+  it('waives only when the PARENT declares no gate either', async () => {
+    const ledger = fakeLedger();
+    const runner = new TaskGateRunner({
+      ledger,
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => ({}),
+      depsState: () => 'ok',
+    });
+    const res = await runner.run({
+      taskId: 'wtask-1',
+      worktreePath: WT,
+      systemWorkspaceId: 'ws-daemon',
+      projectRoot: REPO,
+    });
+    expect(res).toMatchObject({ status: 'skipped', skipped: 'no_gate_command', recorded: true });
+    expect(ledger.writes[0]?.gate).toMatchObject({ exitCode: 0, skipped: 'no_gate_command' });
+  });
+
+  // ── Unreadable is not the same fact as absent ────────────────────────────
+  it('answers gate_unavailable, and records nothing, when a package.json cannot be read', async () => {
+    for (const unreadable of [WT, REPO]) {
+      const ledger = fakeLedger();
+      const runner = new TaskGateRunner({
+        ledger,
+        spawn: fakeSpawn({ code: 0 }),
+        // null = the file is there and could not be read or parsed.
+        readPackageScripts: (root) => (root === unreadable ? null : {}),
+        depsState: () => 'ok',
+      });
+      const res = await runner.run({
+        taskId: 'wtask-1',
+        worktreePath: WT,
+        systemWorkspaceId: 'ws-daemon',
+        projectRoot: REPO,
+      });
+      expect(res).toMatchObject({ ok: true, status: 'skipped', skipped: 'gate_unavailable' });
+      if (res.status !== 'skipped') throw new Error('unreachable');
+      expect(res.detail).toContain('could not be read');
+      // Never a waiver: a corrupt tree must not buy a passing system record.
+      expect(ledger.writes).toHaveLength(0);
+    }
+  });
+
+  // ── A repository that is not a Node project at all ───────────────────────
+  //
+  // depsState used to be asked FIRST, so a Go/Rust checkout — no package.json,
+  // and therefore no node_modules — answered `deps_missing`, which records
+  // nothing, and the task could never reach `completed`. That is exactly the
+  // blockage the no-gate record exists to remove.
+  it('records the no-gate verdict for a non-Node repository instead of deps_missing', async () => {
+    const ledger = fakeLedger();
+    const runner = new TaskGateRunner({
+      ledger,
+      spawn: fakeSpawn({ code: 0 }),
+      readPackageScripts: () => ({}),
+      depsState: () => 'missing',
+    });
+    const res = await runner.run({ taskId: 'wtask-1', worktreePath: WT, systemWorkspaceId: 'ws-daemon' });
+    expect(res).toMatchObject({ status: 'skipped', skipped: 'no_gate_command', recorded: true });
+    expect(ledger.writes).toHaveLength(1);
+  });
+
+  // The default reader is what production uses; the three cases it must not
+  // conflate are only observable through it.
+  it('reads a real package.json: absent is a waiver, corrupt is gate_unavailable', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-gate-pkg-'));
+    try {
+      const make = (ledger: LedgerPort): TaskGateRunner =>
+        new TaskGateRunner({ ledger, spawn: fakeSpawn({ code: 0 }), depsState: () => 'ok' });
+
+      const absent = fakeLedger();
+      expect(
+        await make(absent).run({ taskId: 'wtask-1', worktreePath: dir, systemWorkspaceId: 'ws-daemon' }),
+      ).toMatchObject({ status: 'skipped', skipped: 'no_gate_command', recorded: true });
+
+      fs.writeFileSync(path.join(dir, 'package.json'), '{ "scripts": { "test": ');
+      const corrupt = fakeLedger();
+      expect(
+        await make(corrupt).run({ taskId: 'wtask-1', worktreePath: dir, systemWorkspaceId: 'ws-daemon' }),
+      ).toMatchObject({ status: 'skipped', skipped: 'gate_unavailable' });
+      expect(corrupt.writes).toHaveLength(0);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('reports recorded: false when the no-gate verdict cannot reach the ledger', async () => {
     const runner = new TaskGateRunner({
       // No entry for this task — the gate ran (well, ran nothing) either way.

--- a/src/mcp/__tests__/git.test.ts
+++ b/src/mcp/__tests__/git.test.ts
@@ -75,6 +75,24 @@ describe('the wire call', () => {
     expect(mockSendRpc).toHaveBeenCalledWith(method, { taskId: 'wtask-1', senderPtyId: 'pty-mine' });
   });
 
+  it('omits taskId when no task is named, so main reads the caller\'s own repository', async () => {
+    await tools.get('git_status')?.({});
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.git.status', { senderPtyId: 'pty-mine' });
+    await tools.get('git_log')?.({ limit: 5 });
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.git.log', { limit: 5, senderPtyId: 'pty-mine' });
+  });
+
+  it('keeps task_id required on gh_pr_view — a PR belongs to a task branch', () => {
+    const prTask = (shapes.get('gh_pr_view') ?? {})['task_id'] as z.ZodTypeAny;
+    expect(prTask.safeParse(undefined).success).toBe(false);
+    for (const name of ['git_status', 'git_log']) {
+      const optional = (shapes.get(name) ?? {})['task_id'] as z.ZodTypeAny;
+      expect(optional.safeParse(undefined).success).toBe(true);
+      // Still a real id when given: '' would be a task nobody owns.
+      expect(optional.safeParse('').success).toBe(false);
+    }
+  });
+
   it('omits limit entirely when the caller does not give one', async () => {
     await tools.get('git_log')?.({ task_id: 'wtask-1' });
     expect(mockSendRpc).toHaveBeenCalledWith('task.git.log', { taskId: 'wtask-1', senderPtyId: 'pty-mine' });

--- a/src/mcp/__tests__/worktask.test.ts
+++ b/src/mcp/__tests__/worktask.test.ts
@@ -83,6 +83,17 @@ describe('the wire call', () => {
     expect(resolveCalls).toBe(1);
   });
 
+  it('passes an optional adopt commit flag and omits it otherwise', async () => {
+    await tools.get('task_adopt')?.({ task_id: 'wtask-1', commit: true });
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.adopt', {
+      taskId: 'wtask-1',
+      commit: true,
+      senderPtyId: 'pty-mine',
+    });
+    await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
+    expect(mockSendRpc).toHaveBeenLastCalledWith('task.adopt', { taskId: 'wtask-1', senderPtyId: 'pty-mine' });
+  });
+
   it('passes an optional PR body and omits it otherwise', async () => {
     await tools.get('task_pr')?.({ task_id: 'wtask-1', body: 'why' });
     expect(mockSendRpc).toHaveBeenLastCalledWith('task.pr', {

--- a/src/mcp/git.ts
+++ b/src/mcp/git.ts
@@ -10,6 +10,13 @@
 // has already checked the caller owns, and runs a fixed argv there. `git_log`'s
 // limit is a number, clamped server-side.
 //
+// `git_status` and `git_log` also answer with NO task id, and then the
+// repository is the CALLER'S OWN — main derives it from the calling terminal's
+// working directory, so there is still no path argument. A brain that had just
+// adopted several tasks into its parent checkout could not read that checkout:
+// every read wanted a task id, and the parent repository is not a task.
+// `gh_pr_view` stays task-only; a pull request belongs to a task's branch.
+//
 // Failures come back as DATA, not as thrown errors: "there is no PR for this
 // branch" and "gh is not installed" are answers a caller acts on.
 
@@ -36,6 +43,15 @@ const TASK_ID = z
   .string()
   .min(1)
   .describe('The task id (wtask-…) whose worktree to read. Must be a task your workspace owns.');
+
+/** The same id, optional: omitting it reads the caller's own repository. */
+const TASK_ID_OPTIONAL = z
+  .string()
+  .min(1)
+  .optional()
+  .describe(
+    'A task id (wtask-…) your workspace owns, to read that task\'s worktree. Omit it to read YOUR OWN repository — the one your terminal is in, which is where task_adopt lands.',
+  );
 
 async function callGit(
   method: string,
@@ -70,18 +86,20 @@ async function callGit(
 export function registerGitTools(server: McpServer, deps: GitToolDeps): void {
   server.tool(
     'git_status',
-    'Working-tree state of a task\'s worktree, as data: { branch, ahead, behind, clean, files: [{ status, path }] }. ' +
-      'Use it before task_close (which refuses on a dirty or unpushed branch) and instead of reading a terminal screen to guess whether a worker has finished.',
-    { task_id: TASK_ID },
-    async ({ task_id }) => callGit('task.git.status', { taskId: task_id }, deps),
+    'Working-tree state as data: { branch, ahead, behind, clean, files: [{ status, path }] }. ' +
+      'With task_id, a task\'s worktree — use it before task_close (which refuses on a dirty or unpushed branch) and instead of reading a terminal screen to guess whether a worker has finished. ' +
+      'Without task_id, your own repository (the result names it in repoRoot), which is how you check what task_adopt just staged or committed.',
+    { task_id: TASK_ID_OPTIONAL },
+    async ({ task_id }) =>
+      callGit('task.git.status', { ...(task_id !== undefined ? { taskId: task_id } : {}) }, deps),
   );
 
   server.tool(
     'git_log',
-    `Recent commits in a task's worktree: [{ hash, author, date, subject }], newest first. ` +
+    `Recent commits as [{ hash, author, date, subject }], newest first — a task's worktree with task_id, your own repository without it. ` +
       `limit defaults to ${TASK_GIT_LOG_DEFAULT} and is clamped to ${TASK_GIT_LOG_MAX}; the limit that actually ran comes back in the result.`,
     {
-      task_id: TASK_ID,
+      task_id: TASK_ID_OPTIONAL,
       limit: z
         .number()
         .int()
@@ -91,7 +109,11 @@ export function registerGitTools(server: McpServer, deps: GitToolDeps): void {
         .describe(`How many commits (default ${TASK_GIT_LOG_DEFAULT}, max ${TASK_GIT_LOG_MAX}).`),
     },
     async ({ task_id, limit }) =>
-      callGit('task.git.log', { taskId: task_id, ...(limit !== undefined ? { limit } : {}) }, deps),
+      callGit(
+        'task.git.log',
+        { ...(task_id !== undefined ? { taskId: task_id } : {}), ...(limit !== undefined ? { limit } : {}) },
+        deps,
+      ),
   );
 
   server.tool(

--- a/src/mcp/git.ts
+++ b/src/mcp/git.ts
@@ -50,7 +50,7 @@ const TASK_ID_OPTIONAL = z
   .min(1)
   .optional()
   .describe(
-    'A task id (wtask-…) your workspace owns, to read that task\'s worktree. Omit it to read YOUR OWN repository — the one your terminal is in, which is where task_adopt lands.',
+    'A task id (wtask-…) your workspace owns, to read that task\'s worktree. Omit the field entirely to read YOUR OWN repository instead — the one your terminal is in, which is where task_adopt lands. An empty or blank value is refused, not treated as omitted.',
   );
 
 async function callGit(
@@ -88,7 +88,8 @@ export function registerGitTools(server: McpServer, deps: GitToolDeps): void {
     'git_status',
     'Working-tree state as data: { branch, ahead, behind, clean, files: [{ status, path }] }. ' +
       'With task_id, a task\'s worktree — use it before task_close (which refuses on a dirty or unpushed branch) and instead of reading a terminal screen to guess whether a worker has finished. ' +
-      'Without task_id, your own repository (the result names it in repoRoot), which is how you check what task_adopt just staged or committed.',
+      'Without task_id, YOUR OWN repository — not the task\'s — which is how you check what task_adopt just staged or committed. ' +
+      'Every result says which one answered: target: "task" (with taskId) or "caller-repo" (with repoRoot).',
     { task_id: TASK_ID_OPTIONAL },
     async ({ task_id }) =>
       callGit('task.git.status', { ...(task_id !== undefined ? { taskId: task_id } : {}) }, deps),
@@ -96,7 +97,8 @@ export function registerGitTools(server: McpServer, deps: GitToolDeps): void {
 
   server.tool(
     'git_log',
-    `Recent commits as [{ hash, author, date, subject }], newest first — a task's worktree with task_id, your own repository without it. ` +
+    `Recent commits as [{ hash, author, date, subject }], newest first — a task's worktree with task_id, YOUR OWN repository (not the task's) without it. ` +
+      `The result says which answered in target: "task" | "caller-repo". ` +
       `limit defaults to ${TASK_GIT_LOG_DEFAULT} and is clamped to ${TASK_GIT_LOG_MAX}; the limit that actually ran comes back in the result.`,
     {
       task_id: TASK_ID_OPTIONAL,

--- a/src/mcp/worktask.ts
+++ b/src/mcp/worktask.ts
@@ -97,9 +97,19 @@ export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps)
       'The target repository is derived from the task\'s own worktree and must be clean: a dirty target is refused ({ reason: "dirty-target" }) rather than mixing two authors\' edits together. ' +
       'The patch is taken against the merge base the two share (never the parent\'s HEAD, which would turn the parent\'s own newer commits into deletions) and covers committed and uncommitted work alike; no shared commit answers { reason: "needs_rebase" }. ' +
       'It is validated before anything is written, and a patch that will not apply answers { reason: "conflict", files } with the parent left untouched. ' +
-      'What lands is STAGED and never committed — review it (git diff --cached) and commit it yourself.',
-    { task_id: TASK_ID },
-    async ({ task_id }) => callTask('task.adopt', { taskId: task_id }, deps),
+      'By default what lands is STAGED and never committed — review it (git diff --cached) and commit it yourself. ' +
+      'Adopting several tasks in sequence needs commit: true, otherwise the second adopt is refused dirty-target by the first one\'s staged changes. Nothing is ever pushed.',
+    {
+      task_id: TASK_ID,
+      commit: z
+        .boolean()
+        .optional()
+        .describe(
+          'Commit what was adopted (message: "adopt: <title> (<task id>)") and return { commit } — the short sha. Default false leaves it staged.',
+        ),
+    },
+    async ({ task_id, commit }) =>
+      callTask('task.adopt', { taskId: task_id, ...(commit !== undefined ? { commit } : {}) }, deps),
   );
 
   server.tool(

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -60,6 +60,14 @@ export interface LedgerGateResult {
    *  (the gate runner); `completed` trusts ONLY such a gate. Absent on a
    *  result that did not come through the writer's own recordGate path. */
   recordedBy?: LedgerActorKind;
+  /** Set by the gate runner when this result is a RECORDED SKIP rather than a
+   *  run: the project declares no verify script and no npm lint/test scripts,
+   *  so there was nothing to execute. A project that declares no gate has
+   *  nothing to fail — `completed` is allowed (the exitCode is 0) and the
+   *  ledger says why, in `command: 'none'` and in the tail. The other two skips
+   *  (`deps_missing`, `gate_unavailable`) are NOT recorded at all: there a gate
+   *  existed and the environment stopped it, which is a human's problem. */
+  skipped?: 'no_gate_command';
 }
 
 export interface LedgerEntry {


### PR DESCRIPTION
## Summary

Orchestrator wave 2, lane E: three pieces of brain-loop friction found in the live dogfood (packaged main, isolated instance, four tasks) that made a task impossible to finish without `force` or a human.

- **No gate is not a failed gate** (E-1): when the task repository declares no verify/lint/test script, the gate runner now records a passing SYSTEM gate (`exitCode: 0`, `command: 'none'`, `skipped: 'no_gate_command'`, detail as tail) instead of nothing, so `completed` is reachable. `deps_missing` and `gate_unavailable` stay unrecorded because the gate did not run. The ledger's `boundGate` carries the label through to the persisted entry.
- **Sequential adoption** (E-2): `task.adopt` / `task_adopt` gain `commit?: boolean` (default false, today's behaviour). With `commit: true` the applied index is committed as `adopt: <title> (<taskId>)` and the short SHA returned; a refused commit restores the applied paths exactly like the apply-failure path and answers `commit-failed`. Without it the second adopt was always refused `dirty-target`.
- **Parent-repo reads** (E-3): `git_status` / `git_log` accept `task_id` optionally; omitted, they run in the caller's own repository (derived through the fan-out chain to the git toplevel) and return `repoRoot`. `gh_pr_view` stays task-only. Foreign workspaces are still refused.
- Tool contracts updated in `docs/internal/orch-o2-tool-contract.md`; changelog fragment `changelog.d/orch-w2-e.md`.

Byte counts: commander 53,373 / 60,000, full 77,060 / 78,000 (unchanged; the tools are commander-only).

Spec: `plans/orch-w2-lane-e.md`.

## Test plan

- [x] 13 new tests: TaskGateRunner (no-gate records a passing system gate, deps_missing records nothing, `recorded: false` when the ledger is unreachable, end-to-end against a real `TaskLedger` proving `completed` is accepted), TaskAdoptService (commit argv + sha, commit-failure restore, default still staged, message format), RPC (commit passthrough, non-boolean refusal, caller-repo derivation, commander pane borrow, foreign task NOT_FOUND, no-cwd / not-a-repo / control-char cwd refusals), MCP schemas, TaskLedger (skipped label persisted, absent on a plain record).
- [x] `tsc --noEmit` all tsconfigs, eslint clean on touched files, `build:mcp && probe:mcp` green, scoped vitest over every touched directory 3,671 pass.
- [x] Full `npm test`: 40 timeouts in 23 untouched files under a machine load average above 100 (other sessions' ffmpeg/uvicorn); re-run in isolation they pass. CI is the clean run.
- [ ] Live re-run of the four-task brain loop (wave 2 dogfood step).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `git_status` and `git_log` can now inspect the caller’s repository without a task ID.
  * `task_adopt` optionally commits adopted changes and returns the short commit hash.
  * Projects without configured verification commands can complete successfully with a recorded gate result.

* **Bug Fixes**
  * Improved repository and working-directory validation for Git operations.
  * Commit failures during adoption now restore affected changes and report the failure clearly.

* **Documentation**
  * Updated tool contracts and changelog entries for the new Git and adoption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->