### PR TITLE
fix(browser): smartRef everywhere, contenteditable refs, multiline typing, snapshot text filter

### DIFF
--- a/changelog.d/browser-dogfood.md
+++ b/changelog.d/browser-dogfood.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `browser_type` and `browser_fill` now accept `smartRef` (from `browser_smart_snapshot`) as well as `ref`, the way `browser_click` already did. A smart ref passed as `ref` no longer reads as a missing element: the error names which ref space the argument was read in and which parameter the number belongs to.

--- a/changelog.d/browser-dogfood.md
+++ b/changelog.d/browser-dogfood.md
@@ -1,11 +1,12 @@
 ### Added
 
-- `browser_type` takes a `selector`, for an element neither snapshot handed out a number for.
-- `browser_type` takes `newline: 'enter' | 'shift-enter'`, which splits the text on `\n` and presses a real key between the lines instead of inserting a newline character a single-line input or a rich-text editor drops. Default stays `literal`, today's behaviour.
+- `browser_type` takes a `selector`, for an element neither snapshot handed out a number for. It is CSS on every transport — a Playwright engine prefix (`text=`, `xpath=`, `>>`) is refused rather than accepted on one lane and not the others — and it must match exactly one element, the same uniqueness rule a ref carries.
+- `browser_type` takes `newline: 'enter' | 'shift-enter'`, which splits the text on `\n` and presses a real key between the lines instead of inserting a newline character a single-line input or a rich-text editor drops. Default stays `literal`, today's behaviour. If a keypress submits the field, the remaining lines are not typed into whatever the next page focuses: the type stops and reports how many lines went in.
 - `browser_snapshot` takes `q`, keeping only the nodes that match it (case-insensitive substring, or `/pattern/flags`) plus their ancestors — a way to ask a 250-option listbox one question instead of reading it whole.
 
 ### Fixed
 
 - `browser_type` and `browser_fill` now accept `smartRef` (from `browser_smart_snapshot`) as well as `ref`, the way `browser_click` already did. A smart ref passed as `ref` no longer reads as a missing element: the error names which ref space the argument was read in and which parameter the number belongs to.
 - `contenteditable` fields (a rich-text title or caption) now count as interactive in `browser_snapshot`, page-level and under a `selector`. They were absent from `filter: 'interactive'` entirely, so a dialog built out of them looked like it had no fields.
+- On the RPC transport (a surface with no live Chrome page), `browser_fill` and `browser_type` stop when the element they were pointed at did not take focus, instead of typing over whichever field the page had focused. A `smartRef` is refused there rather than resolved through a `browser_snapshot` tag that numbers a different element.
 - The `LIVE_CHROME_UNAVAILABLE` hint names the "Remote debugging" item in the `chrome://inspect` sidebar. Its old `chrome://inspect/#remote-debugging` link opens the Devices tab, leaving the user on the wrong page.

--- a/changelog.d/browser-dogfood.md
+++ b/changelog.d/browser-dogfood.md
@@ -1,3 +1,11 @@
+### Added
+
+- `browser_type` takes a `selector`, for an element neither snapshot handed out a number for.
+- `browser_type` takes `newline: 'enter' | 'shift-enter'`, which splits the text on `\n` and presses a real key between the lines instead of inserting a newline character a single-line input or a rich-text editor drops. Default stays `literal`, today's behaviour.
+- `browser_snapshot` takes `q`, keeping only the nodes that match it (case-insensitive substring, or `/pattern/flags`) plus their ancestors — a way to ask a 250-option listbox one question instead of reading it whole.
+
 ### Fixed
 
 - `browser_type` and `browser_fill` now accept `smartRef` (from `browser_smart_snapshot`) as well as `ref`, the way `browser_click` already did. A smart ref passed as `ref` no longer reads as a missing element: the error names which ref space the argument was read in and which parameter the number belongs to.
+- `contenteditable` fields (a rich-text title or caption) now count as interactive in `browser_snapshot`, page-level and under a `selector`. They were absent from `filter: 'interactive'` entirely, so a dialog built out of them looked like it had no fields.
+- The `LIVE_CHROME_UNAVAILABLE` hint names the "Remote debugging" item in the `chrome://inspect` sidebar. Its old `chrome://inspect/#remote-debugging` link opens the Devices tab, leaving the user on the wrong page.

--- a/docs/browser-backends.md
+++ b/docs/browser-backends.md
@@ -46,8 +46,8 @@ reach for when you want per-workspace accounts.
 with the tabs and logins you already have. There is no way to scope it to one
 tab or one profile: the agent gets the browser.
 
-Three separate consents gate it — you enable remote debugging once at
-`chrome://inspect/#remote-debugging` (Chrome 144+), you confirm the binding in
+Three separate consents gate it — you enable remote debugging once from the
+**Remote debugging** item in the `chrome://inspect` sidebar (Chrome 144+), you confirm the binding in
 wmux, and Chrome itself asks on every connection — because the grant is that
 large. Use it when you genuinely want an agent working inside your own session,
 and prefer option 2 when you do not.
@@ -156,7 +156,10 @@ genuinely is the user's, and the user genuinely allowed the connection.
 
 Enabling it, once:
 
-1. Tick **Remote debugging** at `chrome://inspect/#remote-debugging` (Chrome 144+).
+1. Open `chrome://inspect` and click **Remote debugging** in the left sidebar
+   (Chrome 144+), then tick the setting. The `#remote-debugging` fragment does
+   not select that item — the page opens on **Devices** whatever fragment it is
+   given.
 2. **Restart Chrome.** The setting persists in the profile
    (`Local State` → `devtools.remote_debugging.user-enabled`), but the running
    instance does not open the endpoint — the port stayed closed for the ~17 s

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "07b6415277a6858aeacb0b9827137e058449cdbf547a1236ae876b10bd148759",
+      "wireResultSha256": "bd208c0e41a644caff30ce3b6f3fd5a17448833f4df8dfe6b508cdd73c3f7fc2",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "bd208c0e41a644caff30ce3b6f3fd5a17448833f4df8dfe6b508cdd73c3f7fc2",
+      "wireResultSha256": "1b3fdf768594fd75a2fd200990eec743bcec9de64e2b56cc7767ff9e8e616caa",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "1b3fdf768594fd75a2fd200990eec743bcec9de64e2b56cc7767ff9e8e616caa",
+      "wireResultSha256": "382381d3292ebbf8544f793beb559d0f93b1dcb8fda4f9b3a8937bea309b95e0",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "382381d3292ebbf8544f793beb559d0f93b1dcb8fda4f9b3a8937bea309b95e0",
+      "wireResultSha256": "610525def102b44f92e20c4be2570d539055cfe33780f8c734e2809768f2c7a7",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "e775c78adeedca5fff3b29890adc9166e898c817b60fdc1b171081a74369f6c2",
+      "wireResultSha256": "07b6415277a6858aeacb0b9827137e058449cdbf547a1236ae876b10bd148759",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",

--- a/src/main/browser-session/LiveChromeClient.ts
+++ b/src/main/browser-session/LiveChromeClient.ts
@@ -48,10 +48,17 @@ const LIVE_CONNECT_NOTICE_MS = 5_000;
  *  refused almost instantly, so this only bounds a black-holed port. */
 const LIVE_TCP_PROBE_TIMEOUT_MS = 500;
 
+/**
+ * The `#remote-debugging` fragment does NOT open that page: chrome://inspect
+ * lands on its Devices tab whatever fragment it is given, and the switch lives
+ * behind a sidebar item the user has to click (dogfood 2026-09-04 — the user
+ * followed the link, saw a list of devices, and had no reason to look further).
+ * So name the item instead of trusting the URL to arrive at it.
+ */
 const ENABLE_HINT =
   'LIVE_CHROME_UNAVAILABLE: could not find your Chrome’s remote-debugging endpoint. ' +
-  'Make sure Chrome is running and remote debugging is enabled at chrome://inspect/#remote-debugging ' +
-  '(Chrome 144+), then retry.';
+  'Make sure Chrome is running, then open chrome://inspect and click "Remote debugging" in the ' +
+  'left sidebar (Chrome 144+) to enable it, and retry.';
 
 /**
  * Listening, but the handshake was never accepted — Chrome is almost certainly

--- a/src/main/browser-session/__tests__/LiveChromeClient.attach.test.ts
+++ b/src/main/browser-session/__tests__/LiveChromeClient.attach.test.ts
@@ -178,6 +178,12 @@ describe('describeLiveConnectFailure: three failures, three remedies', () => {
       const msg = await describeLiveConnectFailure(reason, endpoint, async () => false);
       expect(msg).toContain('LIVE_CHROME_UNAVAILABLE');
       expect(msg).toContain('chrome://inspect');
+      // Naming the sidebar item, not a fragment: chrome://inspect opens its
+      // Devices tab whatever fragment it is handed, so the old
+      // `#remote-debugging` link left the user on the wrong page with no clue
+      // what to click (dogfood 2026-09-04).
+      expect(msg).toContain('"Remote debugging"');
+      expect(msg).not.toContain('#remote-debugging');
     }
   });
 

--- a/src/mcp/browser-replay/__tests__/replayRunner.test.ts
+++ b/src/mcp/browser-replay/__tests__/replayRunner.test.ts
@@ -62,7 +62,13 @@ function fireNavigation(): void {
 const page = {
   url: () => 'https://example.com/app',
   goto: async (url: string) => { goneTo.push(url); },
-  keyboard: { press: async (key: string) => { pressed.push(key); } },
+  keyboard: {
+    press: async (key: string) => { pressed.push(key); },
+    // Recorded in the same list as the presses: a browser_type step with a
+    // `newline` mode is an ordered interleaving of the two, and the order is
+    // the thing under test.
+    insertText: async (text: string) => { pressed.push(`insert:${text}`); },
+  },
   waitForLoadState: async (state: string) => { waits.push(`load:${state}`); },
   on: (_event: string, fn: (frame: unknown) => void) => { navListeners.add(fn); },
   off: (_event: string, fn: (frame: unknown) => void) => { navListeners.delete(fn); },
@@ -903,6 +909,22 @@ describe('replayTrace — flow control', () => {
     const result = await replayTrace(page, trace([typing]), { email: 'a@b.c' });
     expect(result.ok).toBe(true);
     expect(clicks).toEqual(['field:fill=a@b.c']);
+  });
+
+  it('replays a newline-mode step as the same keypresses it was recorded from', async () => {
+    // Filling it whole would put the newline characters back into a field that
+    // drops them — the defect browser_type's `newline` exists to fix, reproduced
+    // by the replay of its own fix.
+    const mod = await import('../../playwright/snapshot');
+    vi.spyOn(mod, 'resolveRef').mockResolvedValue(element('caption'));
+    const typing = refStep({
+      tool: 'browser_type',
+      args: { text: 'one\ntwo', newline: 'enter' },
+    });
+    const result = await replayTrace(page, trace([typing]), undefined);
+    expect(result.ok).toBe(true);
+    expect(clicks).toEqual(['caption:fill=one']);
+    expect(pressed).toEqual(['Enter', 'insert:two']);
   });
 
   it('presses a key without needing an element', async () => {

--- a/src/mcp/browser-replay/replayRunner.ts
+++ b/src/mcp/browser-replay/replayRunner.ts
@@ -477,10 +477,27 @@ async function runStep(
       if (args.double === true) await element.dblclick();
       else await element.click();
       return { detail: `clicked ${describeAxis(step.axis)}` };
-    case 'browser_type':
-      await element.fill(String(args.text ?? ''));
+    case 'browser_type': {
+      const typed = String(args.text ?? '');
+      // A step recorded with browser_type's `newline` mode split the text on
+      // keypresses; a replay that filled it whole would put the newline
+      // characters back into a field that drops them — the defect the mode
+      // exists to fix, reproduced by the replay of its own fix.
+      const newlineKey =
+        args.newline === 'enter' ? 'Enter' : args.newline === 'shift-enter' ? 'Shift+Enter' : null;
+      if (newlineKey === null) {
+        await element.fill(typed);
+      } else {
+        const segments = typed.split('\n');
+        await element.fill(segments[0]);
+        for (const segment of segments.slice(1)) {
+          await page.keyboard.press(newlineKey);
+          if (segment.length > 0) await page.keyboard.insertText(segment);
+        }
+      }
       if (args.submit === true) await page.keyboard.press('Enter');
       return { detail: `typed into ${describeAxis(step.axis)}` };
+    }
     case 'browser_fill':
       await element.fill(String(args.value ?? ''));
       return { detail: `filled ${describeAxis(step.axis)}` };

--- a/src/mcp/playwright/__tests__/inspection.snapshotDiffKey.test.ts
+++ b/src/mcp/playwright/__tests__/inspection.snapshotDiffKey.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({ getPageForScope: getPage, drainLocalLifecycle: () => [] }),
+  },
+}));
+
+import { registerInspectionTools } from '../tools/inspection';
+
+// browser_snapshot's diff baseline is keyed on the arguments that change what
+// the snapshot IS. `selector` and `q` are both free caller text, so joining the
+// parts with `|` let them run together: `{selector:"a", q:"b||c"}` and
+// `{selector:"a||b", q:"c"}` spelled the same key, and the second call was
+// answered with a diff against the first one's rendering.
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test') };
+
+const tools = new Map<string, ToolHandler>();
+registerInspectionTools(
+  {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  } as never,
+  browserToolDeps as never,
+);
+const snapshot = tools.get('browser_snapshot');
+if (!snapshot) throw new Error('browser_snapshot failed to register');
+
+// The RPC lane: no live page, so a scoped call is served by the DOM listing and
+// every call in one test returns the same text. Anything but a full listing on
+// the second call therefore means the two shared a baseline.
+const LISTING = [
+  'Page: Settings',
+  'URL: https://x.test/settings',
+  '',
+  'Interactive elements (use ref number for click/fill/type):',
+  '  [ref=0] button name="Save"',
+].join('\n');
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({ value: LISTING });
+  getPage.mockReset();
+  getPage.mockResolvedValue(null);
+});
+
+describe('the browser_snapshot diff key survives a separator in the caller text', () => {
+  it('does not let a q and a selector run together into one key', async () => {
+    const first = await snapshot({ selector: 'a', q: 'b||c', surfaceId: 'surf-key-1' });
+    expect(first.content[0].text).toContain('button name="Save"');
+
+    // Different arguments, same surface: a different rendering, so the full
+    // listing — not "(no changes since previous snapshot)" about the other one.
+    const second = await snapshot({ selector: 'a||b', q: 'c', surfaceId: 'surf-key-1' });
+    expect(second.content[0].text).not.toContain('no changes since previous snapshot');
+    expect(second.content[0].text).toContain('button name="Save"');
+  });
+
+  it('still diffs a repeat of the very same question', async () => {
+    await snapshot({ selector: 'a', q: 'b||c', surfaceId: 'surf-key-2' });
+
+    const again = await snapshot({ selector: 'a', q: 'b||c', surfaceId: 'surf-key-2' });
+    expect(again.content[0].text).toContain('no changes since previous snapshot');
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.fallback.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.fallback.test.ts
@@ -68,12 +68,21 @@ describe('browser_fill RPC fallback workspace scope', () => {
     expect(calls[0][0]).toBe('browser.evaluate');
     expect(String(calls[0][1].expression)).toContain('isPasswordField');
     expect(calls[0][1]).toMatchObject({ workspaceId: 'ws-test', surfaceId: 'surface-1' });
-    expect(calls.slice(1)).toEqual([
-      ['browser.click.cdp', {
+    expect(calls[1]).toEqual([
+      'browser.click.cdp', {
         selector: '[data-wmux-ref="field-1"]',
         workspaceId: 'ws-test',
         surfaceId: 'surface-1',
-      }],
+      },
+    ]);
+    // Between the click and the typing: did the click actually take focus?
+    // `selectAll` and `Input.insertText` both act on the DOCUMENT's focused
+    // node, so a selector naming something unfocusable would have overwritten
+    // whichever field the page had focused instead.
+    expect(calls[2][0]).toBe('browser.evaluate');
+    expect(String(calls[2][1].expression)).toContain('activeElement');
+    expect(calls[2][1]).toMatchObject({ workspaceId: 'ws-test', surfaceId: 'surface-1' });
+    expect(calls.slice(3)).toEqual([
       ['browser.evaluate', {
         expression: "document.execCommand('selectAll')",
         workspaceId: 'ws-test',
@@ -87,5 +96,28 @@ describe('browser_fill RPC fallback workspace scope', () => {
     ]);
     expect(result.isError).toBeUndefined();
     expect(result.content[0].text).toBe('Filled 1/1 field(s).');
+  });
+
+  it('types nothing when the click did not take focus, instead of overwriting another field', async () => {
+    mockSendRpc.mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      if (method !== 'browser.evaluate') return {};
+      const expression = String(params.expression ?? '');
+      if (expression.includes('isPasswordField')) return { value: 'no' };
+      if (expression.includes('activeElement')) return { value: 'wmux-caret:lost' };
+      return { value: '' };
+    });
+
+    const result = await fill({
+      fields: [{ ref: 'field-1', value: 'new value' }],
+      surfaceId: 'surface-1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('did not take focus');
+    // The two calls that act on the focused node are the ones that never ran.
+    const sent = mockSendRpc.mock.calls.map(([method, params]) =>
+      `${method}:${String((params as { expression?: string }).expression ?? '')}`);
+    expect(sent.some((c) => c.includes('selectAll'))).toBe(false);
+    expect(sent.some((c) => c.startsWith('browser.type.cdp'))).toBe(false);
   });
 });

--- a/src/mcp/playwright/__tests__/interaction.typeNewline.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.typeNewline.test.ts
@@ -56,6 +56,11 @@ function makePage() {
   const log: string[] = [];
   const page = {
     log,
+    /**
+     * What the caret probe answers, one entry per question, `true` once these
+     * run out. A field that submits on the first Enter answers `false`.
+     */
+    caretAnswers: [] as boolean[],
     url: () => 'https://example.test/compose',
     title: async () => 'Compose',
     innerText: async () => 'body text',
@@ -73,7 +78,12 @@ function makePage() {
         elementHandle: async () => null,
         click: async () => { log.push('click'); },
         fill: async (value: string) => { log.push(`fill(${sel}):${value}`); },
-        evaluate: async () => false,
+        // Two questions arrive on this one method: the password probe (is this
+        // node a credential field) and the caret probe (is it still focused).
+        // They are told apart by the predicate's own source, so the fake can
+        // answer each honestly.
+        evaluate: async (fn: (node: Element) => unknown) =>
+          String(fn).includes('activeElement') ? page.caretAnswers.shift() ?? true : false,
       }),
     }),
     keyboard: {
@@ -163,6 +173,54 @@ describe('browser_type newline mode', () => {
     await type({ selector: '#caption', text: 'one\ntwo', newline: 'enter', surfaceId: 'surf-1' });
 
     expect(ring.all()[0].step.args).toMatchObject({ text: 'one\ntwo', newline: 'enter' });
+  });
+
+  // A composer that SUBMITS on Enter is the common case the mode exists for.
+  // The remaining lines would then be typed into whatever the new page focuses,
+  // and the old receipt reported all eight as delivered.
+  it('stops when the first Enter took the field away, and says how far it got', async () => {
+    const page = makePage();
+    page.caretAnswers = [false];
+    getPage.mockResolvedValue(page);
+
+    const result = await type({
+      selector: '#caption',
+      text: 'one\ntwo\nthree',
+      newline: 'enter',
+      surfaceId: 'surf-1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Typed 1 of 3 lines');
+    // Nothing after the press: the lines that would have gone to another field.
+    expect(page.log).toEqual(['fill(#caption):one', 'press:Enter']);
+    // A partial type is not a step any replay could reproduce.
+    expect(ring.all()).toEqual([]);
+  });
+
+  it('stops on the RPC transport too, at the same place', async () => {
+    getPage.mockResolvedValue(null);
+    let caretAsked = 0;
+    mockSendRpc.mockImplementation(async (method: string, params: Record<string, unknown>) => {
+      if (method !== 'browser.evaluate') return {};
+      const expression = String(params.expression ?? '');
+      if (expression.includes('isPasswordField')) return { value: 'no' };
+      if (expression.includes('activeElement')) {
+        // Held for the fill's own focus check, lost after the first Enter.
+        caretAsked++;
+        return { value: caretAsked === 1 ? 'wmux-caret:held' : 'wmux-caret:lost' };
+      }
+      return { value: '' };
+    });
+
+    const result = await type({ ref: '4', text: 'one\ntwo\nthree', newline: 'enter', surfaceId: 'surf-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Typed 1 of 3 lines');
+    const typed = mockSendRpc.mock.calls
+      .filter(([method]) => method === 'browser.type.cdp')
+      .map(([, params]) => (params as { text: string }).text);
+    expect(typed).toEqual(['one']);
   });
 
   it('splits the same way over the RPC transport', async () => {

--- a/src/mcp/playwright/__tests__/interaction.typeNewline.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.typeNewline.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({
+      getPageForScope: getPage,
+      drainLocalLifecycle: () => [],
+      resolveWorkspaceBackend: async () => 'playwright',
+    }),
+  },
+}));
+
+import { registerInteractionTools } from '../tools/interaction';
+import { ActionRing } from '../../browser-replay/actionRing';
+
+// `Input.insertText` — the only way to type that survives a CJK IME and a
+// React controlled input — puts a `\n` into the field verbatim, where a
+// single-line input drops it and a rich-text editor never sees the keydown it
+// listens for. Instagram's caption came out as one paragraph and the user
+// pressed Enter eight times by hand (dogfood 2026-09-04).
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const ring = new ActionRing();
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test'), actionRing: ring };
+
+const tools = new Map<string, ToolHandler>();
+registerInteractionTools(
+  {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  } as never,
+  browserToolDeps as never,
+);
+
+const type = tools.get('browser_type') as ToolHandler;
+
+/** A page that writes every fill / press / insert into one ordered transcript. */
+function makePage() {
+  const log: string[] = [];
+  const page = {
+    log,
+    url: () => 'https://example.test/compose',
+    title: async () => 'Compose',
+    innerText: async () => 'body text',
+    on: () => undefined,
+    mainFrame: () => ({ id: 'main' }),
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async () => ({})),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    locator: (sel?: string) => ({
+      count: async () => 1,
+      first: () => ({
+        elementHandle: async () => null,
+        click: async () => { log.push('click'); },
+        fill: async (value: string) => { log.push(`fill(${sel}):${value}`); },
+        evaluate: async () => false,
+      }),
+    }),
+    keyboard: {
+      press: async (key: string) => { log.push(`press:${key}`); },
+      insertText: async (text: string) => { log.push(`insert:${text}`); },
+    },
+    mouse: { move: async () => undefined },
+    viewportSize: () => ({ width: 1280, height: 720 }),
+    getByRole: vi.fn(),
+  };
+  return page;
+}
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({});
+  getPage.mockReset();
+  ring.clear();
+});
+
+describe('browser_type newline mode', () => {
+  it('leaves \\n in the text by default, exactly as before', async () => {
+    const page = makePage();
+    getPage.mockResolvedValue(page);
+
+    const result = await type({ selector: '#caption', text: 'one\ntwo', surfaceId: 'surf-1' });
+
+    expect(result.isError).toBeUndefined();
+    expect(page.log).toEqual(['fill(#caption):one\ntwo']);
+  });
+
+  it('presses Enter between the lines and inserts each one after it', async () => {
+    const page = makePage();
+    getPage.mockResolvedValue(page);
+
+    const result = await type({
+      selector: '#caption',
+      text: 'one\ntwo\nthree',
+      newline: 'enter',
+      surfaceId: 'surf-1',
+    });
+
+    expect(page.log).toEqual([
+      'fill(#caption):one',
+      'press:Enter',
+      'insert:two',
+      'press:Enter',
+      'insert:three',
+    ]);
+    // The receipt says how many keypresses were spent, so a caller can tell a
+    // field that swallowed them from one that never got them.
+    expect(result.content[0].text).toContain('as 3 lines (Enter between them)');
+  });
+
+  it('sends Shift+Enter for an editor that submits on a bare Enter', async () => {
+    const page = makePage();
+    getPage.mockResolvedValue(page);
+
+    await type({
+      selector: '#caption',
+      text: 'one\ntwo',
+      newline: 'shift-enter',
+      surfaceId: 'surf-1',
+    });
+
+    expect(page.log).toEqual(['fill(#caption):one', 'press:Shift+Enter', 'insert:two']);
+  });
+
+  it('makes a blank line with the keypress alone, inserting nothing for it', async () => {
+    const page = makePage();
+    getPage.mockResolvedValue(page);
+
+    await type({ selector: '#caption', text: 'a\n\nb', newline: 'enter', surfaceId: 'surf-1' });
+
+    expect(page.log).toEqual([
+      'fill(#caption):a',
+      'press:Enter',
+      'press:Enter',
+      'insert:b',
+    ]);
+  });
+
+  it('records the mode, so a replay of the step splits the text the same way', async () => {
+    const page = makePage();
+    getPage.mockResolvedValue(page);
+
+    await type({ selector: '#caption', text: 'one\ntwo', newline: 'enter', surfaceId: 'surf-1' });
+
+    expect(ring.all()[0].step.args).toMatchObject({ text: 'one\ntwo', newline: 'enter' });
+  });
+
+  it('splits the same way over the RPC transport', async () => {
+    getPage.mockResolvedValue(null);
+    mockSendRpc.mockImplementation(async (method: string) =>
+      method === 'browser.evaluate' ? { value: 'no' } : {},
+    );
+
+    await type({ ref: '4', text: 'one\ntwo', newline: 'enter', surfaceId: 'surf-1' });
+
+    const sent = mockSendRpc.mock.calls
+      .filter(([method]) => method === 'browser.type.cdp' || method === 'browser.press.cdp')
+      .map(([method, params]) => {
+        const p = params as { text?: string; key?: string };
+        return `${method}:${p.text ?? p.key}`;
+      });
+    expect(sent).toEqual([
+      'browser.type.cdp:one',
+      'browser.press.cdp:Enter',
+      'browser.type.cdp:two',
+    ]);
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.typeSmartRef.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.typeSmartRef.test.ts
@@ -108,9 +108,9 @@ function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
     // No data-wmux-ref tags on this page: a browser_snapshot ref resolves to
     // nothing, which is exactly the state a smartRef-only session is in. A
     // caller's own CSS selector is answered from `cssMatches` instead.
-    cssMatches: new Set<string>(),
+    cssMatches: new Map<string, number>(),
     locator: (sel?: string) => ({
-      count: async () => (sel !== undefined && page.cssMatches.has(sel) ? 1 : 0),
+      count: async () => (sel === undefined ? 0 : page.cssMatches.get(sel) ?? 0),
       first: () => ({
         elementHandle: async () => null,
         click: async () => undefined,
@@ -197,7 +197,7 @@ describe('browser_type / browser_fill accept smartRefs', () => {
   // be typeable — that is the whole reason browser_type takes a selector.
   it('types into a CSS selector when neither snapshot gave the element a ref', async () => {
     const page = makePage(tree([{ backendId: 50, role: 'button', name: 'Next' }]));
-    page.cssMatches.add('#title-textbox');
+    page.cssMatches.set('#title-textbox', 1);
     getPage.mockResolvedValue(page);
 
     const result = await tool('browser_type')({
@@ -226,6 +226,89 @@ describe('browser_type / browser_fill accept smartRefs', () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain('No element matches selector: #missing');
     expect(page.filled).toEqual([]);
+  });
+
+  // A selector matching several elements used to type into `.first()` and
+  // record a css-axis step — which the replay runner refuses whenever the count
+  // is not 1. Live success, guaranteed replay failure.
+  it('refuses a selector that matches more than one element, naming the count', async () => {
+    const page = makePage(tree([{ backendId: 60, role: 'button', name: 'Next' }]));
+    page.cssMatches.set('.field', 3);
+    getPage.mockResolvedValue(page);
+
+    const result = await tool('browser_type')({ selector: '.field', text: 'x', surfaceId: 'surf-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('matches 3 elements');
+    expect(page.filled).toEqual([]);
+    expect(ring.all()).toEqual([]);
+  });
+
+  it('refuses the same on the RPC transport, which counts through querySelectorAll', async () => {
+    getPage.mockResolvedValue(null);
+    mockSendRpc.mockImplementation(async (method: string, params: Record<string, unknown>) =>
+      method === 'browser.evaluate' && String(params.expression ?? '').includes('querySelectorAll')
+        ? { value: '2' }
+        : { value: '' },
+    );
+
+    const result = await tool('browser_type')({ selector: '.field', text: 'x', surfaceId: 'surf-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('matches 2 elements');
+    expect(mockSendRpc.mock.calls.some(([m]) => m === 'browser.type.cdp')).toBe(false);
+  });
+
+  // `selector` is CSS on all three lanes: the RPC lane resolves it with
+  // querySelector and a recorded step carries it on the css axis. Playwright's
+  // own locator() would accept these and nothing else would.
+  it('refuses a Playwright engine selector, which only one lane could ever run', async () => {
+    const page = makePage(tree([{ backendId: 61, role: 'button', name: 'Save' }]));
+    getPage.mockResolvedValue(page);
+
+    for (const selector of ['text=Save', '//div[@id="x"]', '#a >> #b']) {
+      const result = await tool('browser_type')({ selector, text: 'x', surfaceId: 'surf-1' });
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('must be a CSS selector');
+    }
+    expect(page.filled).toEqual([]);
+  });
+
+  // The smart-snapshot record lives on the connection, not on the page, so
+  // without a page check the hint pointed at an element from another tab.
+  it('does not name the other ref space when the smart snapshot was taken elsewhere', async () => {
+    const other = makePage(tree([{ backendId: 30, role: 'textbox', name: '제목' }]));
+    getPage.mockResolvedValue(other);
+    await getSmartSnapshot(other as never);
+
+    const current = makePage(tree([{ backendId: 70, role: 'button', name: 'Next' }]));
+    getPage.mockResolvedValue(current);
+
+    const result = await tool('browser_fill')({
+      fields: [{ ref: '1', value: 'x' }],
+      surfaceId: 'surf-1',
+    });
+
+    expect(result.isError).toBe(true);
+    // The generic advice stays; the specific "smartRef 1 IS this element" claim
+    // must not, because it names an element on a page this call cannot reach.
+    expect(result.content[0].text).toContain('Run browser_snapshot to get current refs');
+    expect(result.content[0].text).not.toContain('제목');
+  });
+
+  // `data-wmux-ref` tags are written by browser_snapshot; browser_smart_snapshot
+  // numbers its own, differently-keyed space and tags nothing. Rendering
+  // smartRef=1 as `[data-wmux-ref="1"]` names either nothing or an unrelated
+  // element that an earlier browser_snapshot happened to number 1.
+  it('refuses a smartRef on the RPC transport instead of guessing a tag selector', async () => {
+    getPage.mockResolvedValue(null);
+
+    const result = await tool('browser_type')({ smartRef: 1, text: 'x', surfaceId: 'surf-1' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('cannot be used on this transport');
+    expect(mockSendRpc.mock.calls.some(([m]) => m === 'browser.type.cdp')).toBe(false);
+    expect(ring.all()).toEqual([]);
   });
 
   it('refuses an address that names no element, and one that names two', async () => {

--- a/src/mcp/playwright/__tests__/interaction.typeSmartRef.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.typeSmartRef.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSendRpc, getPage } = vi.hoisted(() => ({
+  mockSendRpc: vi.fn(),
+  getPage: vi.fn(),
+}));
+
+vi.mock('../../wmux-client', () => ({
+  sendRpc: (method: string, ...args: unknown[]) =>
+    (method.startsWith('browser.lease.') || method === 'browser.lifecycle.get')
+      ? Promise.resolve({ token: null })
+      : mockSendRpc(method, ...args),
+}));
+
+vi.mock('../PlaywrightEngine', () => ({
+  PlaywrightEngine: {
+    getInstance: () => ({
+      getPageForScope: getPage,
+      drainLocalLifecycle: () => [],
+      resolveWorkspaceBackend: async () => 'playwright',
+    }),
+  },
+}));
+
+import { registerInteractionTools } from '../tools/interaction';
+import { ActionRing } from '../../browser-replay/actionRing';
+import { clearElementCache, getSmartSnapshot } from '../dom-intelligence';
+
+// browser_type / browser_fill used to accept only browser_snapshot refs, so a
+// number read off browser_smart_snapshot ("[61] textbox") came back as
+// "Element with ref=61 not found" — a valid ref reported as a missing one, with
+// nothing in the message to say the two spaces are different (dogfood
+// 2026-09-04, YouTube Studio).
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}>;
+
+const ring = new ActionRing();
+const browserToolDeps = { resolveWorkspaceId: vi.fn(async () => 'ws-test'), actionRing: ring };
+
+const tools = new Map<string, ToolHandler>();
+registerInteractionTools(
+  {
+    tool: (name: string, _desc: string, _schema: unknown, handler: ToolHandler) => {
+      tools.set(name, handler);
+    },
+  } as never,
+  browserToolDeps as never,
+);
+
+function tool(name: string): ToolHandler {
+  const handler = tools.get(name);
+  if (!handler) throw new Error(`${name} failed to register`);
+  return handler;
+}
+
+interface CdpNode {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+function tree(children: { backendId: number; role: string; name: string }[]): CdpNode[] {
+  const nodes: CdpNode[] = [
+    {
+      nodeId: '1',
+      backendDOMNodeId: 1,
+      role: { type: 'role', value: 'RootWebArea' },
+      name: { type: 'name', value: 'Page' },
+      childIds: children.map((c) => String(c.backendId)),
+    },
+  ];
+  for (const child of children) {
+    nodes.push({
+      nodeId: String(child.backendId),
+      backendDOMNodeId: child.backendId,
+      role: { type: 'role', value: child.role },
+      name: { type: 'name', value: child.name },
+      childIds: [],
+    });
+  }
+  return nodes;
+}
+
+function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
+  const filled: string[] = [];
+  const page = {
+    nodes,
+    filled,
+    currentUrl: url,
+    url: () => page.currentUrl,
+    title: async () => 'Page',
+    innerText: async () => 'body text',
+    on: () => undefined,
+    mainFrame: () => ({ id: 'main' }),
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string) =>
+          method === 'Accessibility.getFullAXTree' ? { nodes: page.nodes } : {},
+        ),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    // No data-wmux-ref tags on this page: a browser_snapshot ref resolves to
+    // nothing, which is exactly the state a smartRef-only session is in.
+    locator: () => ({ count: async () => 0, first: () => ({ elementHandle: async () => null }) }),
+    keyboard: { press: async () => undefined, insertText: async () => undefined },
+    mouse: { move: async () => undefined },
+    viewportSize: () => ({ width: 1280, height: 720 }),
+    getByRole: (r: string, opts?: { name?: string }) => ({
+      count: async () => page.nodes.filter((n) => n.role?.value === r
+        && (opts?.name === undefined || (n.name?.value ?? '') === opts.name)).length,
+      nth: (i: number) => ({
+        boundingBox: async () => ({ x: 100, y: 100, width: 120, height: 40 }),
+        click: async () => undefined,
+        fill: async (value: string) => { filled.push(`${r} ${opts?.name ?? ''}#${i}=${value}`); },
+        evaluate: async () => false,
+      }),
+    }),
+  };
+  return page;
+}
+
+beforeEach(() => {
+  mockSendRpc.mockReset();
+  mockSendRpc.mockResolvedValue({});
+  getPage.mockReset();
+  ring.clear();
+  clearElementCache();
+});
+
+describe('browser_type / browser_fill accept smartRefs', () => {
+  it('types into the element a smartRef names', async () => {
+    const page = makePage(tree([
+      { backendId: 10, role: 'textbox', name: 'Title' },
+      { backendId: 11, role: 'textbox', name: 'Title' },
+    ]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+
+    const result = await tool('browser_type')({ smartRef: 2, text: 'hello', surfaceId: 'surf-1' });
+
+    expect(result.isError).toBeUndefined();
+    expect(page.filled).toEqual(['textbox Title#1=hello']);
+    expect(result.content[0].text).toContain('smartRef=2');
+  });
+
+  it('fills a field addressed by smartRef and records a replayable ref axis', async () => {
+    const page = makePage(tree([{ backendId: 20, role: 'textbox', name: 'Caption' }]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+
+    const result = await tool('browser_fill')({
+      fields: [{ smartRef: 1, value: 'a caption' }],
+      surfaceId: 'surf-1',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(page.filled).toEqual(['textbox Caption#0=a caption']);
+    const [recorded] = ring.all();
+    expect(recorded.step.axis.kind).toBe('ref');
+    expect(recorded.step.axis).toMatchObject({ role: 'textbox', name: 'Caption', via: 'smart' });
+  });
+
+  it('names the other ref space when a smartRef is passed as ref', async () => {
+    const page = makePage(tree([{ backendId: 30, role: 'textbox', name: '제목' }]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+
+    const result = await tool('browser_fill')({
+      fields: [{ ref: '1', value: 'x' }],
+      surfaceId: 'surf-1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('browser_smart_snapshot');
+    expect(result.content[0].text).toContain('smartRef');
+    expect(result.content[0].text).toContain('textbox "제목"');
+    expect(page.filled).toEqual([]);
+  });
+
+  it('refuses an address that names no element, and one that names two', async () => {
+    const page = makePage(tree([{ backendId: 40, role: 'textbox', name: 'Title' }]));
+    getPage.mockResolvedValue(page);
+    await getSmartSnapshot(page as never);
+
+    const none = await tool('browser_type')({ text: 'x', surfaceId: 'surf-1' });
+    expect(none.isError).toBe(true);
+    expect(none.content[0].text).toContain('smartRef');
+
+    const both = await tool('browser_type')({ ref: '1', smartRef: 1, text: 'x', surfaceId: 'surf-1' });
+    expect(both.isError).toBe(true);
+    expect(both.content[0].text).toContain('not both');
+    expect(page.filled).toEqual([]);
+  });
+});

--- a/src/mcp/playwright/__tests__/interaction.typeSmartRef.test.ts
+++ b/src/mcp/playwright/__tests__/interaction.typeSmartRef.test.ts
@@ -106,8 +106,18 @@ function makePage(nodes: CdpNode[], url = 'https://example.test/a') {
       }),
     }),
     // No data-wmux-ref tags on this page: a browser_snapshot ref resolves to
-    // nothing, which is exactly the state a smartRef-only session is in.
-    locator: () => ({ count: async () => 0, first: () => ({ elementHandle: async () => null }) }),
+    // nothing, which is exactly the state a smartRef-only session is in. A
+    // caller's own CSS selector is answered from `cssMatches` instead.
+    cssMatches: new Set<string>(),
+    locator: (sel?: string) => ({
+      count: async () => (sel !== undefined && page.cssMatches.has(sel) ? 1 : 0),
+      first: () => ({
+        elementHandle: async () => null,
+        click: async () => undefined,
+        fill: async (value: string) => { filled.push(`${sel}=${value}`); },
+        evaluate: async () => false,
+      }),
+    }),
     keyboard: { press: async () => undefined, insertText: async () => undefined },
     mouse: { move: async () => undefined },
     viewportSize: () => ({ width: 1280, height: 720 }),
@@ -180,6 +190,41 @@ describe('browser_type / browser_fill accept smartRefs', () => {
     expect(result.content[0].text).toContain('browser_smart_snapshot');
     expect(result.content[0].text).toContain('smartRef');
     expect(result.content[0].text).toContain('textbox "제목"');
+    expect(page.filled).toEqual([]);
+  });
+
+  // A `contenteditable` field that no snapshot handed a number for still has to
+  // be typeable — that is the whole reason browser_type takes a selector.
+  it('types into a CSS selector when neither snapshot gave the element a ref', async () => {
+    const page = makePage(tree([{ backendId: 50, role: 'button', name: 'Next' }]));
+    page.cssMatches.add('#title-textbox');
+    getPage.mockResolvedValue(page);
+
+    const result = await tool('browser_type')({
+      selector: '#title-textbox',
+      text: 'My video',
+      surfaceId: 'surf-1',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(page.filled).toEqual(['#title-textbox=My video']);
+    expect(result.content[0].text).toContain('selector=#title-textbox');
+    // Recorded on the css axis, which replay can run as-is.
+    expect(ring.all()[0].step.axis).toMatchObject({ kind: 'css' });
+  });
+
+  it('says a selector matched nothing instead of spending the auto-wait on it', async () => {
+    const page = makePage(tree([{ backendId: 51, role: 'button', name: 'Next' }]));
+    getPage.mockResolvedValue(page);
+
+    const result = await tool('browser_type')({
+      selector: '#missing',
+      text: 'x',
+      surfaceId: 'surf-1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('No element matches selector: #missing');
     expect(page.filled).toEqual([]);
   });
 

--- a/src/mcp/playwright/__tests__/snapshot.contenteditable.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.contenteditable.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateScopedSnapshot, generateSnapshot } from '../snapshot';
+
+// A rich-text field is a `<div contenteditable>`, and the a11y tree may report
+// it under any role at all. YouTube Studio's title and description came back
+// under no interactive role, so `browser_snapshot({filter:'interactive'})` told
+// an agent the upload dialog had none of the two fields it came for, and
+// `selector: "[role=dialog]"` listed one button (dogfood 2026-09-04). The
+// snapshot now reads `contenteditable` DOM-side and counts the HOST — never its
+// descendants — as interactive.
+
+interface CdpAX {
+  nodeId: string;
+  backendDOMNodeId?: number;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+interface CdpDom {
+  backendNodeId?: number;
+  attributes?: string[];
+  children?: CdpDom[];
+}
+
+const role = (value: string) => ({ type: 'role', value });
+const name = (value: string) => ({ type: 'name', value });
+
+function ax(id: number, r: string, n: string, children: number[] = []): CdpAX {
+  return {
+    nodeId: String(id),
+    backendDOMNodeId: id,
+    role: role(r),
+    name: name(n),
+    childIds: children.map(String),
+  };
+}
+
+// The upload dialog: two contenteditable hosts under a role the interactive
+// filter does not know, each wrapping a paragraph of its own text.
+const UPLOAD_DIALOG: CdpAX[] = [
+  ax(1, 'RootWebArea', 'Upload', [2]),
+  ax(2, 'dialog', 'Upload details', [3, 5, 7, 9]),
+  ax(3, 'generic', '제목', [4]),
+  ax(4, 'paragraph', 'My video'),
+  ax(5, 'generic', '설명', [6]),
+  ax(6, 'paragraph', 'Line one'),
+  ax(7, 'generic', 'Read-only note', [8]),
+  ax(8, 'paragraph', 'Not editable'),
+  ax(9, 'button', 'Next'),
+];
+
+const UPLOAD_DOM: CdpDom[] = [
+  { backendNodeId: 3, attributes: ['id', 'title-textbox', 'contenteditable', 'true'] },
+  { backendNodeId: 5, attributes: ['id', 'description-textbox', 'contenteditable', ''] },
+  { backendNodeId: 7, attributes: ['id', 'note', 'contenteditable', 'false'] },
+  { backendNodeId: 9, attributes: ['id', 'next-button'] },
+];
+
+// selector → backendNodeId, as DOM.querySelector would answer it.
+const SELECTORS: Record<string, number> = { '[role=dialog]': 2 };
+
+function makePage(nodes: CdpAX[], domNodes: CdpDom[]) {
+  const page = {
+    url: () => 'https://studio.example.test/upload',
+    title: async () => 'Upload',
+    innerText: async () => 'body text',
+    on: () => undefined,
+    mainFrame: () => ({ id: 'main' }),
+    context: () => ({
+      newCDPSession: async () => ({
+        send: vi.fn(async (method: string, params?: { selector?: string; nodeId?: number }) => {
+          switch (method) {
+            case 'Accessibility.getFullAXTree':
+              return { nodes };
+            case 'DOM.getDocument':
+              // One answer serves both readers: `nodeId` for the selector
+              // resolution, `children` for the contenteditable pass.
+              return { root: { nodeId: 1, backendNodeId: 0, children: domNodes } };
+            case 'DOM.querySelector':
+              return { nodeId: SELECTORS[params?.selector ?? ''] ?? 0 };
+            case 'DOM.describeNode':
+              return { node: { backendNodeId: params?.nodeId } };
+            default:
+              return {};
+          }
+        }),
+        detach: vi.fn(() => Promise.resolve()),
+      }),
+    }),
+    evaluate: vi.fn(async () => ''),
+    locator: vi.fn(),
+    getByRole: vi.fn(),
+  };
+  return page as never;
+}
+
+describe('contenteditable hosts are interactive', () => {
+  it('keeps both editable fields under filter:"interactive" and gives each a ref', async () => {
+    const out = await generateSnapshot(makePage(UPLOAD_DIALOG, UPLOAD_DOM), {
+      format: 'ai',
+      filter: 'interactive',
+    });
+
+    expect(out).toContain('generic "제목" ref=');
+    // A bare `contenteditable` attribute means true, exactly as in HTML.
+    expect(out).toContain('generic "설명" ref=');
+    expect(out).toContain('button "Next" ref=');
+  });
+
+  it('mints a ref for the host only, not for the text inside it', async () => {
+    const out = await generateSnapshot(makePage(UPLOAD_DIALOG, UPLOAD_DOM), {
+      format: 'ai',
+      filter: 'interactive',
+    });
+
+    // Every paragraph inside a region is `editable` in the a11y tree, so
+    // trusting that would mint one ref per paragraph of a long document. The
+    // text stays visible under its host — it just is not separately addressable.
+    expect(out).not.toMatch(/paragraph[^\n]*ref=/);
+    expect((out.match(/ref="/g) ?? []).length).toBe(3);
+  });
+
+  it('leaves contenteditable="false" out — only an explicit false opts out', async () => {
+    const out = await generateSnapshot(makePage(UPLOAD_DIALOG, UPLOAD_DOM), {
+      format: 'ai',
+      filter: 'interactive',
+    });
+
+    expect(out).not.toContain('Read-only note');
+  });
+
+  it('keeps them inside a scoped snapshot too, which used to list the button alone', async () => {
+    const out = await generateScopedSnapshot(makePage(UPLOAD_DIALOG, UPLOAD_DOM), '[role=dialog]', {
+      format: 'ai',
+      filter: 'interactive',
+    });
+
+    expect(out).toContain('generic "제목" ref=');
+    expect(out).toContain('generic "설명" ref=');
+    expect(out).toContain('button "Next" ref=');
+  });
+});

--- a/src/mcp/playwright/__tests__/snapshot.contenteditable.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.contenteditable.test.ts
@@ -40,7 +40,7 @@ function ax(id: number, r: string, n: string, children: number[] = []): CdpAX {
 // filter does not know, each wrapping a paragraph of its own text.
 const UPLOAD_DIALOG: CdpAX[] = [
   ax(1, 'RootWebArea', 'Upload', [2]),
-  ax(2, 'dialog', 'Upload details', [3, 5, 7, 9]),
+  ax(2, 'dialog', 'Upload details', [3, 5, 7, 9, 10]),
   ax(3, 'generic', '제목', [4]),
   ax(4, 'paragraph', 'My video'),
   ax(5, 'generic', '설명', [6]),
@@ -48,6 +48,8 @@ const UPLOAD_DIALOG: CdpAX[] = [
   ax(7, 'generic', 'Read-only note', [8]),
   ax(8, 'paragraph', 'Not editable'),
   ax(9, 'button', 'Next'),
+  ax(10, 'generic', 'Inherited note', [11]),
+  ax(11, 'paragraph', 'Also not editable'),
 ];
 
 const UPLOAD_DOM: CdpDom[] = [
@@ -55,6 +57,7 @@ const UPLOAD_DOM: CdpDom[] = [
   { backendNodeId: 5, attributes: ['id', 'description-textbox', 'contenteditable', ''] },
   { backendNodeId: 7, attributes: ['id', 'note', 'contenteditable', 'false'] },
   { backendNodeId: 9, attributes: ['id', 'next-button'] },
+  { backendNodeId: 10, attributes: ['id', 'inherited', 'contenteditable', 'inherit'] },
 ];
 
 // selector → backendNodeId, as DOM.querySelector would answer it.
@@ -121,13 +124,25 @@ describe('contenteditable hosts are interactive', () => {
     expect((out.match(/ref="/g) ?? []).length).toBe(3);
   });
 
-  it('leaves contenteditable="false" out — only an explicit false opts out', async () => {
+  it('leaves contenteditable="false" out', async () => {
     const out = await generateSnapshot(makePage(UPLOAD_DIALOG, UPLOAD_DOM), {
       format: 'ai',
       filter: 'interactive',
     });
 
     expect(out).not.toContain('Read-only note');
+  });
+
+  // `inherit` resolves to the PARENT's state, and this one sits inside a
+  // non-editable dialog — so it takes no typed text at all. Treating any
+  // non-"false" value as a host advertised a field that is not there.
+  it('leaves contenteditable="inherit" out — only true, bare and plaintext-only are hosts', async () => {
+    const out = await generateSnapshot(makePage(UPLOAD_DIALOG, UPLOAD_DOM), {
+      format: 'ai',
+      filter: 'interactive',
+    });
+
+    expect(out).not.toContain('Inherited note');
   });
 
   it('keeps them inside a scoped snapshot too, which used to list the button alone', async () => {

--- a/src/mcp/playwright/__tests__/snapshot.frames.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.frames.test.ts
@@ -125,6 +125,12 @@ function makeHarness(
   passwordBackendIds: number[] = [],
   /** What page.evaluate() answers the pageFacts collector with, if anything. */
   pageFacts?: Record<string, unknown>,
+  /**
+   * DOM nodes the MAIN target's `DOM.getDocument` reports, for the
+   * contenteditable pass. Only the main session serves them, which is the
+   * point of the cross-frame case below.
+   */
+  mainDomChildren: { backendNodeId: number; attributes: string[] }[] = [],
 ): Harness {
   const counts = new Map<string, number>();
   const handles: string[] = [];
@@ -190,7 +196,9 @@ function makeHarness(
       if (params?.frameId && target.sameProcess === false) throw new Error('oopif');
       return { nodes: target.ax };
     }
-    if (method === 'DOM.getDocument') return { root: { nodeId: docNodeId(main.frameId) } };
+    if (method === 'DOM.getDocument') {
+      return { root: { nodeId: docNodeId(main.frameId), children: mainDomChildren } };
+    }
     if (method === 'DOM.performSearch') {
       return { searchId: 'pw', resultCount: passwordBackendIds.length };
     }
@@ -550,6 +558,44 @@ describe('a cross-origin frame is read over its own session', () => {
     const out = await generateSnapshot(h.page, { format: 'ai' });
     expect(out).toContain('button "Accept" ref="0"');
     expect(await resolveRef(h.page, '0')).toBe('oop|button Accept#0');
+  });
+});
+
+// The contenteditable pass reads ONE target's DOM, so its backendNodeIds are
+// the main frame's. An out-of-process frame is a different target with its own
+// id space, where the same number is an unrelated element — joining there mints
+// a phantom text field in whichever frame's numbering happens to collide.
+describe('editable hosts stop at the main frame, where their ids mean something', () => {
+  it('does not mint a ref for a cross-origin node whose id collides with an editable host', async () => {
+    const oopif = doc({
+      frameId: 'oop',
+      url: 'https://other-origin.test/ad',
+      // Same backendNodeId as the host page's contenteditable div, in a
+      // different target's id space.
+      ax: tree([{ backendId: 90, role: 'paragraph', name: 'Advertisement copy' }]),
+      sameProcess: false,
+    });
+    const h = makeHarness(
+      doc({
+        frameId: 'main',
+        ax: tree([
+          { backendId: 90, role: 'generic', name: 'Caption' },
+          { backendId: 80, role: 'Iframe', name: 'ad' },
+        ]),
+        iframes: [hostedFrame(80, oopif)],
+      }),
+      [],
+      undefined,
+      [{ backendNodeId: 90, attributes: ['contenteditable', 'true'] }],
+    );
+
+    const out = await generateSnapshot(h.page, { format: 'ai', filter: 'interactive' });
+
+    // The real editing host, in the frame the DOM pass actually read.
+    expect(out).toContain('generic "Caption" ref=');
+    // The collision, which is just prose in someone else's document.
+    expect(out).not.toMatch(/paragraph[^\n]*ref=/);
+    expect(out).not.toContain('Advertisement copy');
   });
 });
 

--- a/src/mcp/playwright/__tests__/snapshot.query.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.query.test.ts
@@ -70,6 +70,58 @@ describe('generateSnapshot q', () => {
     expect(out).toContain('no nodes match');
   });
 
+  // ONE compiled regex is tested against every node, so a flag that carries
+  // `lastIndex` between calls makes a match on one node move the start position
+  // for the next. `g` was already dropped; `y` (sticky) was not, and it both
+  // keeps the index AND anchors there.
+  it('drops a sticky flag, which used to make matches skip the node after each hit', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: '/option/y' });
+
+    expect(out).toContain('option "Germany"');
+    // The one that used to vanish: tested from the index Germany's match left.
+    expect(out).toContain('option "Republic of Korea"');
+    expect(out).toContain('option "United States"');
+  });
+
+  // The pattern is caller text compiled into this process's regex engine.
+  it('refuses a pattern that can backtrack forever, and says it read it literally', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: '/(a+)+b/' });
+
+    expect(out).toContain('q read as literal text');
+    expect(out).toContain('backtrack forever');
+  });
+
+  it('refuses an over-long pattern the same way', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, {
+      format: 'ai',
+      q: `/${'a'.repeat(201)}/`,
+    });
+
+    expect(out).toContain('q read as literal text');
+    expect(out).toContain('longer than 200 characters');
+  });
+
+  // RootWebArea's name is the page title, so matching the root returned the
+  // ENTIRE tree with the "matching nodes and their ancestors only" note still
+  // attached — a whole-page snapshot presented as the answer to a question.
+  it('does not match the root, whose name is only the page title', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: 'Settings' });
+
+    expect(out).toBe('(no nodes match q="Settings")');
+  });
+
+  it('says q was ignored when the a11y tree collapsed to the DOM listing', async () => {
+    // Root-only tree: the DOM listing is the only rendering left, and it is
+    // flat — there is no tree to prune, so `q` cannot be honored on it.
+    const page = makePage([{ nodeId: '1', role: role('RootWebArea'), name: name('Settings') }]);
+    page.evaluate = vi.fn(async () => '[1] button "OK"') as never;
+
+    const out = await generateSnapshot(page as never, { format: 'ai', q: 'korea' });
+
+    expect(out).toContain('q ignored');
+    expect(out).toContain('button "OK"');
+  });
+
   it('says so when nothing matches, instead of returning the whole page', async () => {
     const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: 'Andorra' });
     expect(out).toBe('(no nodes match q="Andorra")');

--- a/src/mcp/playwright/__tests__/snapshot.query.test.ts
+++ b/src/mcp/playwright/__tests__/snapshot.query.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateSnapshot } from '../snapshot';
+
+// `q` — a 250-option listbox costs ~4k tokens every time it is snapshotted, and
+// an agent looking for one country in it pays that to read 249 lines it did not
+// want (dogfood 2026-09-04). Same fake Page harness as snapshot.filter.test.ts.
+
+interface CdpNode {
+  nodeId: string;
+  role?: { type: string; value: string };
+  name?: { type: string; value: string };
+  childIds?: string[];
+}
+
+const role = (value: string) => ({ type: 'role', value });
+const name = (value: string) => ({ type: 'name', value });
+
+const TREE: CdpNode[] = [
+  { nodeId: '1', role: role('RootWebArea'), name: name('Settings'), childIds: ['2', '9'] },
+  { nodeId: '2', role: role('listbox'), name: name('Country'), childIds: ['3', '4', '5'] },
+  { nodeId: '3', role: role('option'), name: name('Germany'), childIds: [] },
+  { nodeId: '4', role: role('option'), name: name('Republic of Korea'), childIds: [] },
+  { nodeId: '5', role: role('option'), name: name('United States'), childIds: [] },
+  { nodeId: '9', role: role('paragraph'), name: name('Choose a country'), childIds: [] },
+];
+
+function makePage(nodes: CdpNode[]) {
+  const client = {
+    send: vi.fn(async (method: string) =>
+      method === 'Accessibility.getFullAXTree' ? { nodes } : {},
+    ),
+    detach: vi.fn(() => Promise.resolve()),
+  };
+  return {
+    context: () => ({ newCDPSession: async () => client }),
+    evaluate: vi.fn(async () => ''),
+    getByRole: vi.fn(),
+    locator: vi.fn(),
+  };
+}
+
+describe('generateSnapshot q', () => {
+  it('keeps the match and its ancestors, and drops the siblings', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: 'korea' });
+
+    // Case-insensitive substring: the ordinary case must not need escaping.
+    expect(out).toContain('option "Republic of Korea"');
+    // The ancestor chain stays, or a ref would come back with no context.
+    expect(out).toContain('listbox "Country"');
+    expect(out).not.toContain('Germany');
+    expect(out).not.toContain('United States');
+    // Never silently: a pruned tree reads as a page that lost those elements.
+    expect(out).toContain('(q="korea": matching nodes and their ancestors only)');
+  });
+
+  it('reads /pattern/ as a regular expression', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, {
+      format: 'ai',
+      q: '/^option (Germany|United)/',
+    });
+
+    expect(out).toContain('option "Germany"');
+    expect(out).toContain('option "United States"');
+    expect(out).not.toContain('Republic of Korea');
+  });
+
+  it('falls back to a substring when the pattern will not compile', async () => {
+    // The caller asked for a smaller tree, not for an error.
+    const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: '/[unclosed/' });
+    expect(out).toContain('no nodes match');
+  });
+
+  it('says so when nothing matches, instead of returning the whole page', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, { format: 'ai', q: 'Andorra' });
+    expect(out).toBe('(no nodes match q="Andorra")');
+  });
+
+  it('composes with filter:"interactive" — the question narrows first', async () => {
+    const out = await generateSnapshot(makePage(TREE) as never, {
+      format: 'ai',
+      filter: 'interactive',
+      q: 'Country',
+    });
+
+    // `q` matched the listbox, which the interactive filter then kept.
+    expect(out).toContain('listbox "Country"');
+    // The prose that mentions "country" is not interactive, so it is gone even
+    // though it matched the query.
+    expect(out).not.toContain('Choose a country');
+  });
+});

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -7,7 +7,7 @@ import {
   getPasswordFieldBackendIds,
 } from './redact';
 import { ancestorContext } from '../../shared/browserReplay/actionTrace';
-import { getOwnAttributeLabels } from './ownAttributes';
+import { getDomFacts } from './ownAttributes';
 
 // ---------------------------------------------------------------------------
 // Shared interactive-element selector
@@ -665,7 +665,7 @@ async function walkInteractiveElements(
     // The element's own identifying attribute, over the same bridge and from
     // the same shared helper snapshot.ts uses — a value read differently here
     // would stop every replay that crosses lanes (see IndexedElement.own).
-    const ownLabels = await getOwnAttributeLabels(
+    const { ownLabels } = await getDomFacts(
       client as unknown as { send: (method: string, params?: unknown) => Promise<unknown> },
     );
 

--- a/src/mcp/playwright/dom-intelligence.ts
+++ b/src/mcp/playwright/dom-intelligence.ts
@@ -939,6 +939,25 @@ export function getSmartElementByRef(ref: number): IndexedElement | null {
 }
 
 /**
+ * The same, but only when the smart snapshot was taken on `page`.
+ *
+ * For the ref-space hint in browser_type / browser_fill: "that number IS live
+ * in the other ref space" is only true of the page the smart snapshot was taken
+ * on. On any other page the record describes a different document, so the hint
+ * would name an element the caller cannot reach and send them to the wrong
+ * parameter. Same first check resolveSmartRefLocator makes, and for the same
+ * reason.
+ *
+ * `record.page === null` is the RPC-lane snapshot, which is page-agnostic by
+ * construction; there is nothing to disagree with, so it is allowed through.
+ */
+export function getSmartElementOnPage(ref: number, page: Page | null): IndexedElement | null {
+  const record = getSnapshotRecord();
+  if (record.page !== null && record.page !== page) return null;
+  return record.elements.find((element) => element.ref === ref) ?? null;
+}
+
+/**
  * Look up a Playwright locator string by the ref number assigned during the
  * most recent smart snapshot.
  *

--- a/src/mcp/playwright/ownAttributes.ts
+++ b/src/mcp/playwright/ownAttributes.ts
@@ -106,17 +106,25 @@ function indexDocument(root: CdpDomNode, facts: DomFacts): void {
 }
 
 /**
- * Does this element declare itself editable?
+ * The `contenteditable` values that make an element an editing host.
  *
  * The bare attribute (`<div contenteditable>`) means true, and so does
- * `plaintext-only`; only an explicit `false` opts out. Inheritance is NOT
- * followed on purpose — see DomFacts.editableRoots.
+ * `plaintext-only`. Everything else — `false`, `inherit`, and any typo — is
+ * NOT a host: `inherit` in particular resolves to the parent's state, so an
+ * element carrying it inside a non-editable ancestor takes no typed text at
+ * all, and minting a ref for it would advertise a field that is not there.
+ */
+const EDITABLE_HOST_VALUES = new Set(['', 'true', 'plaintext-only']);
+
+/**
+ * Does this element declare itself editable?
+ *
+ * Inheritance is NOT followed on purpose — see DomFacts.editableRoots.
  */
 function isEditableHost(attributes: readonly string[]): boolean {
   for (let i = 0; i + 1 < attributes.length; i += 2) {
     if (attributes[i] !== 'contenteditable') continue;
-    const value = attributes[i + 1].trim().toLowerCase();
-    return value !== 'false';
+    return EDITABLE_HOST_VALUES.has(attributes[i + 1].trim().toLowerCase());
   }
   return false;
 }

--- a/src/mcp/playwright/ownAttributes.ts
+++ b/src/mcp/playwright/ownAttributes.ts
@@ -31,32 +31,58 @@ interface CdpDomNode {
   contentDocument?: CdpDomNode;
 }
 
+/** What one DOM pass hands back to the two ref-minting lanes. */
+export interface DomFacts {
+  /** `backendDOMNodeId` → the element's own `attr=value` label. */
+  ownLabels: Map<number, string>;
+  /**
+   * `backendDOMNodeId` of every element that OWNS a `contenteditable` region.
+   *
+   * A rich-text field is a `<div contenteditable="true">`, which the a11y tree
+   * may report under any role at all — YouTube Studio's title and description
+   * never reached `browser_snapshot({filter:'interactive'})`, so an agent that
+   * asked for the actionable elements was told the page had none of the two it
+   * came for (dogfood 2026-09-04). The attribute is the unambiguous statement
+   * that the element takes typed text, so it is read here and joined back
+   * through the same id the labels use.
+   *
+   * The HOST only, never its descendants: `editable` in the a11y tree is
+   * inherited by every node inside the region, so trusting that would mint a
+   * ref for each paragraph of a long document.
+   */
+  editableRoots: Set<number>;
+}
+
+export function emptyDomFacts(): DomFacts {
+  return { ownLabels: new Map(), editableRoots: new Set() };
+}
+
 /**
- * `backendDOMNodeId` → the element's own `attr=value` label, for every element
- * in the document that has one.
+ * Read the DOM-side facts the accessibility tree cannot carry, in one pass.
  *
  * Best-effort in the same way getPasswordFieldBackendIds is: a detached target
  * or a missing DOM domain costs the verifier its extra signal and nothing
  * else, because `own` is verify-only — an absent label abstains rather than
- * stops.
+ * stops. An absent `editableRoots` likewise only returns the enumerator to the
+ * roles it always used.
  *
  * `pierce: true` so a control inside a web component's shadow root is covered.
  * Same-process iframes come back too; their nodes are numbered in this
  * target's id space, so joining them is sound. An OUT-OF-PROCESS frame is a
  * different target with a colliding id space, which is why the caller applies
- * this map to main-frame refs only.
+ * these maps to main-frame refs only.
  */
-export async function getOwnAttributeLabels(client: CdpSender): Promise<Map<number, string>> {
-  const labels = new Map<number, string>();
+export async function getDomFacts(client: CdpSender): Promise<DomFacts> {
+  const facts = emptyDomFacts();
   try {
     const doc = (await client.send('DOM.getDocument', { depth: -1, pierce: true })) as {
       root?: CdpDomNode;
     };
-    if (doc?.root) indexDocument(doc.root, labels);
+    if (doc?.root) indexDocument(doc.root, facts);
   } catch {
     /* no DOM domain / detached target — the verifier abstains */
   }
-  return labels;
+  return facts;
 }
 
 /**
@@ -64,18 +90,35 @@ export async function getOwnAttributeLabels(client: CdpSender): Promise<Map<numb
  * table) is exactly the page this runs on, and blowing the stack here would
  * cost the snapshot its whole result.
  */
-function indexDocument(root: CdpDomNode, labels: Map<number, string>): void {
+function indexDocument(root: CdpDomNode, facts: DomFacts): void {
   const stack: CdpDomNode[] = [root];
   while (stack.length > 0) {
     const node = stack.pop() as CdpDomNode;
     if (node.backendNodeId !== undefined && node.attributes && node.attributes.length > 0) {
       const label = labelFor(node.attributes);
-      if (label.length > 0) labels.set(node.backendNodeId, label);
+      if (label.length > 0) facts.ownLabels.set(node.backendNodeId, label);
+      if (isEditableHost(node.attributes)) facts.editableRoots.add(node.backendNodeId);
     }
     if (node.children) for (const child of node.children) stack.push(child);
     if (node.shadowRoots) for (const shadow of node.shadowRoots) stack.push(shadow);
     if (node.contentDocument) stack.push(node.contentDocument);
   }
+}
+
+/**
+ * Does this element declare itself editable?
+ *
+ * The bare attribute (`<div contenteditable>`) means true, and so does
+ * `plaintext-only`; only an explicit `false` opts out. Inheritance is NOT
+ * followed on purpose — see DomFacts.editableRoots.
+ */
+function isEditableHost(attributes: readonly string[]): boolean {
+  for (let i = 0; i + 1 < attributes.length; i += 2) {
+    if (attributes[i] !== 'contenteditable') continue;
+    const value = attributes[i + 1].trim().toLowerCase();
+    return value !== 'false';
+  }
+  return false;
 }
 
 function labelFor(attributes: readonly string[]): string {

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -48,6 +48,16 @@ function queryFilterNote(q: string): string {
   return `(q=${JSON.stringify(q)}: matching nodes and their ancestors only)`;
 }
 
+/**
+ * Said when `q` reaches a route that cannot honor it.
+ *
+ * The DOM listing is a flat rendering with no tree to prune, so the only two
+ * choices are this note or a full listing the caller reads as a filtered one.
+ * Shared with inspection.ts, which reaches the same listing by two more routes.
+ */
+export const DOM_LISTING_Q_NOTE =
+  '(note: q ignored — the a11y tree was unavailable, returning the unfiltered DOM interactive listing)';
+
 /** CDP Accessibility.AXNode shape (subset of fields we use) */
 interface CdpAXNode {
   nodeId: string;
@@ -939,10 +949,29 @@ export function markDomRefsActive(page: Page): void {
  * YouTube Studio's title and description out of every interactive snapshot
  * (dogfood 2026-09-04). `editableRoots` holds the HOSTS only, so a long
  * document does not mint a ref per paragraph.
+ *
+ * The caller passes NO_EDITABLE_ROOTS for anything outside the main frame —
+ * see editableRootsFor.
  */
 function isInteractive(node: AXNode, editableRoots: ReadonlySet<number>): boolean {
   if (INTERACTIVE_ROLES.has(node.role)) return true;
   return node.backendDOMNodeId !== undefined && editableRoots.has(node.backendDOMNodeId);
+}
+
+/** Stand-in for a frame the DOM facts say nothing about. */
+const NO_EDITABLE_ROOTS: ReadonlySet<number> = new Set<number>();
+
+/**
+ * The editable-host ids that may be joined against nodes in `frame`.
+ *
+ * `getDomFacts` reads ONE target's DOM, so its `backendDOMNodeId`s live in the
+ * main frame's id space. An out-of-process frame is a different target with a
+ * colliding space, where id 41 is some unrelated element — joining there would
+ * mint a phantom textbox ref in the frame whose numbers happened to collide.
+ * Same rule, and the same reason, as RefEntry.own.
+ */
+function editableRootsFor(frame: FrameCoord, roots: ReadonlySet<number>): ReadonlySet<number> {
+  return frame.key === MAIN_FRAME.key ? roots : NO_EDITABLE_ROOTS;
 }
 
 /**
@@ -1025,7 +1054,7 @@ function serializeNode(
   // Build attribute string
   const attrs: string[] = [];
 
-  if (ctx.format === 'ai' && isInteractive(node, ctx.editableRoots)) {
+  if (ctx.format === 'ai' && isInteractive(node, editableRootsFor(frame, ctx.editableRoots))) {
     const ref = assignRef(ctx.identity, frame.key, node.backendDOMNodeId);
     ctx.refs.push({
       role,
@@ -1179,8 +1208,16 @@ function serializeTree(root: AXNode, ctx: SerializeCtx): string {
   return serializeForest(root.children ?? [root], ctx);
 }
 
-function stripNonInteractive(node: AXNode, editableRoots: ReadonlySet<number>): AXNode | null {
-  if (isInteractive(node, editableRoots)) return node;
+function stripNonInteractive(
+  node: AXNode,
+  editableRoots: ReadonlySet<number>,
+  inheritedFrame: FrameCoord = MAIN_FRAME,
+): AXNode | null {
+  // Same frame gate serializeNode applies, and for the same reason: this walk
+  // crosses grafted out-of-process frames, whose ids collide with the main
+  // frame's (editableRootsFor).
+  const frame = frameOf(node, inheritedFrame);
+  if (isInteractive(node, editableRootsFor(frame, editableRoots))) return node;
   // An iframe ALWAYS survives the interactive filter. It is not interactive, so
   // it would otherwise vanish — and its disappearance is exactly the wrong
   // signal in both directions. For a frame that was never read, the controls
@@ -1192,7 +1229,7 @@ function stripNonInteractive(node: AXNode, editableRoots: ReadonlySet<number>): 
   // ran.
   if (IFRAME_ROLES.has(node.role)) {
     const inside = (node.children ?? [])
-      .map((child) => stripNonInteractive(child, editableRoots))
+      .map((child) => stripNonInteractive(child, editableRoots, frame))
       .filter((c): c is AXNode => c !== null);
     if (inside.length > 0) return { ...node, children: inside };
     // Childless here means "nothing interactive in it", which frameBoundaryNote
@@ -1203,7 +1240,7 @@ function stripNonInteractive(node: AXNode, editableRoots: ReadonlySet<number>): 
   if (!node.children) return null;
 
   const filtered = node.children
-    .map((child) => stripNonInteractive(child, editableRoots))
+    .map((child) => stripNonInteractive(child, editableRoots, frame))
     .filter((c): c is AXNode => c !== null);
 
   if (filtered.length === 0) return null;
@@ -1222,24 +1259,108 @@ function stripNonInteractive(node: AXNode, editableRoots: ReadonlySet<number>): 
  * `/pattern/flags` is read as a regular expression, anything else as a
  * case-insensitive substring — the ordinary case must not require escaping, and
  * a caller who wants an anchored or alternating match must not be denied one. A
- * malformed regex falls back to the substring reading rather than failing the
- * snapshot: the caller asked for a smaller tree, not for an error.
+ * pattern this refuses to compile falls back to the substring reading rather
+ * than failing the snapshot: the caller asked for a smaller tree, not for an
+ * error. The fallback is never silent — see QueryPlan.note.
  *
  * Matched against role, name, value and description together, because which of
  * those carries the words on screen is Chrome's decision, not the caller's.
  */
-export function queryMatcher(q: string): (node: AXNode) => boolean {
+export interface QueryPlan {
+  matches: (node: AXNode) => boolean;
+  /**
+   * Non-empty when the `/…/` reading was refused and the literal one used
+   * instead. A caller who wrote an anchored pattern and silently got substring
+   * semantics would read the smaller tree as the answer to the question it
+   * asked, which is the one outcome worse than an error.
+   */
+  note: string;
+}
+
+/**
+ * Longest regex source `q` will compile.
+ *
+ * The pattern is caller text compiled into this process's regex engine, so it
+ * is an untrusted program: the cap plus the nested-quantifier refusal below
+ * keep a snapshot from being turned into an unbounded CPU burn.
+ */
+const MAX_Q_REGEX_SOURCE = 200;
+
+export function queryMatcher(q: string): QueryPlan {
   const asRegex = /^\/(.+)\/([gimsuy]*)$/.exec(q);
+  let refused = '';
   if (asRegex) {
-    try {
-      const re = new RegExp(asRegex[1], asRegex[2].replace(/g/g, ''));
-      return (node) => re.test(searchableText(node));
-    } catch {
-      /* not a usable pattern — fall through to the substring reading */
+    const source = asRegex[1];
+    if (source.length > MAX_Q_REGEX_SOURCE) {
+      refused = `the pattern is longer than ${MAX_Q_REGEX_SOURCE} characters`;
+    } else if (hasNestedQuantifier(source)) {
+      refused = 'the pattern quantifies an already-quantified group, which can backtrack forever';
+    } else {
+      try {
+        // `g` AND `y` are dropped. Both keep `lastIndex` across calls, and this
+        // ONE compiled regex is tested against every node in the tree — with
+        // either flag on, a match on one node moves the start position for the
+        // next one, so nodes further down are silently skipped. `y` also
+        // anchors at that position, which is not what `/x/y` asks for here.
+        const re = new RegExp(source, asRegex[2].replace(/[gy]/g, ''));
+        return {
+          // Belt and braces: no flag left can set lastIndex, but a regex reused
+          // across a whole tree must not depend on that staying true.
+          matches: (node) => {
+            re.lastIndex = 0;
+            return re.test(searchableText(node));
+          },
+          note: '',
+        };
+      } catch {
+        refused = 'the pattern does not compile';
+      }
     }
   }
   const needle = q.toLowerCase();
-  return (node) => searchableText(node).toLowerCase().includes(needle);
+  return {
+    matches: (node) => searchableText(node).toLowerCase().includes(needle),
+    note: refused ? `(note: q read as literal text — ${refused})` : '',
+  };
+}
+
+/**
+ * Is a quantifier applied to a group that already contains one?
+ *
+ * `(a+)+` and friends are the shape whose backtracking is exponential in the
+ * length of the subject. Deliberately conservative — a false positive costs
+ * the caller the regex reading and says so, while a false negative costs the
+ * snapshot process an unbounded loop it cannot be interrupted out of.
+ */
+function hasNestedQuantifier(source: string): boolean {
+  const groupStarts: number[] = [];
+  for (let i = 0; i < source.length; i++) {
+    const c = source[i];
+    if (c === '\\') {
+      i++;
+      continue;
+    }
+    if (c === '[') {
+      // A character class holds no groups and no quantifiers of its own.
+      while (i < source.length && source[i] !== ']') {
+        if (source[i] === '\\') i++;
+        i++;
+      }
+      continue;
+    }
+    if (c === '(') {
+      groupStarts.push(i);
+      continue;
+    }
+    if (c === ')') {
+      const start = groupStarts.pop();
+      if (start === undefined) continue;
+      const after = source[i + 1];
+      if (after !== '*' && after !== '+' && after !== '{') continue;
+      if (/(?:^|[^\\])[*+{]/.test(source.slice(start + 1, i))) return true;
+    }
+  }
+  return false;
 }
 
 function searchableText(node: AXNode): string {
@@ -1257,6 +1378,23 @@ function searchableText(node: AXNode): string {
  */
 function pruneToQuery(node: AXNode, matches: (n: AXNode) => boolean): AXNode | null {
   if (matches(node)) return node;
+  return pruneChildrenToQuery(node, matches);
+}
+
+/**
+ * The same, but the node itself is never a match — only what is under it.
+ *
+ * How the PAGE-level tree is pruned. Its root is the RootWebArea, whose name is
+ * the page title, so a `q` that happens to appear in the title matched the root
+ * and returned the entire tree — with the "matching nodes and their ancestors
+ * only" note still attached, which reads as "this IS the filtered result".
+ * Nothing about the title says anything about which nodes answer the question.
+ *
+ * The scoped path keeps the plain `pruneToQuery`: there the root is the element
+ * the caller selected, which is content, and a `q` naming it asking for its
+ * contents is the documented reading.
+ */
+function pruneChildrenToQuery(node: AXNode, matches: (n: AXNode) => boolean): AXNode | null {
   const kept = (node.children ?? [])
     .map((child) => pruneToQuery(child, matches))
     .filter((c): c is AXNode => c !== null);
@@ -1873,6 +2011,11 @@ export async function generateSnapshot(
       if (format === 'aria') {
         domSnapshot = `(note: aria format unavailable — the a11y tree collapsed, returning the DOM interactive listing)\n${domSnapshot}`;
       }
+      // The listing is flat, with no tree to prune, so `q` cannot be honored on
+      // this route either. Said here for the same reason inspection.ts says it
+      // on its own two DOM-listing branches: a full listing returned to a
+      // caller who asked a question reads as the answer to that question.
+      if (options?.q) domSnapshot = `${DOM_LISTING_Q_NOTE}\n${domSnapshot}`;
       // Leave the refMap empty so resolveRef falls through to the data-wmux-ref
       // locator the DOM expression just tagged.
       setPageRefs(page, []);
@@ -1893,13 +2036,17 @@ export async function generateSnapshot(
   let searched = tree;
   let queryNote = '';
   if (options?.q) {
-    const pruned = pruneToQuery(tree, queryMatcher(options.q));
+    const plan = queryMatcher(options.q);
+    // Children only: the root is the RootWebArea, whose name is the page title
+    // — see pruneChildrenToQuery.
+    const pruned = pruneChildrenToQuery(tree, plan.matches);
     if (!pruned) {
       setPageRefs(page, []);
-      return `(no nodes match q=${JSON.stringify(options.q)})`;
+      const miss = `(no nodes match q=${JSON.stringify(options.q)})`;
+      return plan.note ? `${plan.note}\n${miss}` : miss;
     }
     searched = pruned;
-    queryNote = queryFilterNote(options.q);
+    queryNote = [plan.note, queryFilterNote(options.q)].filter((n) => n.length > 0).join('\n');
   }
 
   // Opt-in interactive-only filter: same strip as the overflow retry below,
@@ -2067,15 +2214,16 @@ export async function generateScopedSnapshot(
   let searched = forest;
   let queryNote = '';
   if (options?.q) {
-    const matches = queryMatcher(options.q);
+    const plan = queryMatcher(options.q);
     searched = forest
-      .map((n) => pruneToQuery(n, matches))
+      .map((n) => pruneToQuery(n, plan.matches))
       .filter((n): n is AXNode => n !== null);
     if (searched.length === 0) {
       setPageRefs(page, [], selector);
-      return `(no nodes match q=${JSON.stringify(options.q)} in this subtree)`;
+      const miss = `(no nodes match q=${JSON.stringify(options.q)} in this subtree)`;
+      return plan.note ? `${plan.note}\n${miss}` : miss;
     }
-    queryNote = queryFilterNote(options.q);
+    queryNote = [plan.note, queryFilterNote(options.q)].filter((n) => n.length > 0).join('\n');
   }
 
   let scoped = searched;

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -26,6 +26,8 @@ export interface SnapshotOptions {
   /** 'interactive' = strip non-interactive nodes up front ('ai' format only),
    *  not just on overflow — the measured-dominant agent usage. */
   filter?: 'interactive';
+  /** Keep only nodes matching this text, plus their ancestors. See queryMatcher. */
+  q?: string;
 }
 
 /**
@@ -36,6 +38,15 @@ export interface SnapshotOptions {
  * notes below already follow (#1082).
  */
 const ARIA_FILTER_NOTE = '(note: filter ignored for aria format — returning the full tree)';
+
+/**
+ * Said on every `q` result. A snapshot that silently dropped most of the page
+ * would read as a page that no longer has those elements, which is the reading
+ * that sends an agent off to fix an imaginary problem.
+ */
+function queryFilterNote(q: string): string {
+  return `(q=${JSON.stringify(q)}: matching nodes and their ancestors only)`;
+}
 
 /** CDP Accessibility.AXNode shape (subset of fields we use) */
 interface CdpAXNode {
@@ -1200,6 +1211,59 @@ function stripNonInteractive(node: AXNode, editableRoots: ReadonlySet<number>): 
   return { ...node, children: filtered };
 }
 
+/**
+ * Compile the `q` argument into a per-node predicate.
+ *
+ * A 250-option listbox costs about 4k tokens every time it is snapshotted, and
+ * an agent looking for one country in it pays that to read 249 lines it did not
+ * want (dogfood 2026-09-04). `q` is the cheap way to ask for the part it came
+ * for.
+ *
+ * `/pattern/flags` is read as a regular expression, anything else as a
+ * case-insensitive substring — the ordinary case must not require escaping, and
+ * a caller who wants an anchored or alternating match must not be denied one. A
+ * malformed regex falls back to the substring reading rather than failing the
+ * snapshot: the caller asked for a smaller tree, not for an error.
+ *
+ * Matched against role, name, value and description together, because which of
+ * those carries the words on screen is Chrome's decision, not the caller's.
+ */
+export function queryMatcher(q: string): (node: AXNode) => boolean {
+  const asRegex = /^\/(.+)\/([gimsuy]*)$/.exec(q);
+  if (asRegex) {
+    try {
+      const re = new RegExp(asRegex[1], asRegex[2].replace(/g/g, ''));
+      return (node) => re.test(searchableText(node));
+    } catch {
+      /* not a usable pattern — fall through to the substring reading */
+    }
+  }
+  const needle = q.toLowerCase();
+  return (node) => searchableText(node).toLowerCase().includes(needle);
+}
+
+function searchableText(node: AXNode): string {
+  return [node.role, node.name, node.value ?? '', node.description ?? ''].join(' ');
+}
+
+/**
+ * Keep the nodes `q` matched and every ancestor above them.
+ *
+ * The ancestors are not decoration: a ref is only usable when the caller can see
+ * which dialog, row or frame the element it names sits in, and dropping the
+ * chain would hand back numbers with no context. A matched node keeps its own
+ * subtree, which is what makes `q` on a container ("[role=dialog]"-shaped
+ * questions) return the container's contents.
+ */
+function pruneToQuery(node: AXNode, matches: (n: AXNode) => boolean): AXNode | null {
+  if (matches(node)) return node;
+  const kept = (node.children ?? [])
+    .map((child) => pruneToQuery(child, matches))
+    .filter((c): c is AXNode => c !== null);
+  if (kept.length === 0) return null;
+  return { ...node, children: kept };
+}
+
 // ---------------------------------------------------------------------------
 // CDP helpers
 // ---------------------------------------------------------------------------
@@ -1823,15 +1887,30 @@ export async function generateSnapshot(
     }
   }
 
+  // `q` runs FIRST, on the whole tree: it is the caller's question, and the
+  // interactive strip below — plus the overflow retry, which re-strips from
+  // this same tree — must not see nodes the question already excluded.
+  let searched = tree;
+  let queryNote = '';
+  if (options?.q) {
+    const pruned = pruneToQuery(tree, queryMatcher(options.q));
+    if (!pruned) {
+      setPageRefs(page, []);
+      return `(no nodes match q=${JSON.stringify(options.q)})`;
+    }
+    searched = pruned;
+    queryNote = queryFilterNote(options.q);
+  }
+
   // Opt-in interactive-only filter: same strip as the overflow retry below,
   // but unconditional — the agent asked for only actionable nodes. Zero
   // interactive nodes must NOT fall back to the full tree (review consensus:
   // the filter would silently invert into maximum output) — say so instead.
-  let effectiveTree = tree;
+  let effectiveTree = searched;
   let filterNote = '';
   if (options?.filter === 'interactive') {
     if (format === 'ai') {
-      const stripped = stripNonInteractive(tree, editableRoots);
+      const stripped = stripNonInteractive(searched, editableRoots);
       if (!stripped) {
         setPageRefs(page, []);
         return '(no interactive elements on this page)';
@@ -1882,7 +1961,7 @@ export async function generateSnapshot(
   // If the output exceeds the budget AND we are in 'ai' mode, strip
   // non-interactive nodes and regenerate.
   if (output.length > budget && format === 'ai') {
-    const trimmed = stripNonInteractive(tree, editableRoots);
+    const trimmed = stripNonInteractive(searched, editableRoots);
     if (trimmed) {
       refs.length = 0;
       // The pool is per rendering, not per call: the first pass spent it, and
@@ -1902,7 +1981,8 @@ export async function generateSnapshot(
   // Store the refMap for this page so resolveRef can use it without re-querying
   setPageRefs(page, refs);
 
-  return filterNote ? `${filterNote}\n${output}` : output;
+  const notes = [queryNote, filterNote].filter((n) => n.length > 0);
+  return notes.length > 0 ? `${notes.join('\n')}\n${output}` : output;
 }
 
 /**
@@ -1982,11 +2062,27 @@ export async function generateScopedSnapshot(
   const { forest, occlusion, ownLabels, editableRoots } = found;
   if (!forest || forest.length === 0) return null;
 
-  let scoped = forest;
+  // Same order as the page-level path: the caller's question narrows the tree
+  // before anything else reads it, including the overflow retry below.
+  let searched = forest;
+  let queryNote = '';
+  if (options?.q) {
+    const matches = queryMatcher(options.q);
+    searched = forest
+      .map((n) => pruneToQuery(n, matches))
+      .filter((n): n is AXNode => n !== null);
+    if (searched.length === 0) {
+      setPageRefs(page, [], selector);
+      return `(no nodes match q=${JSON.stringify(options.q)} in this subtree)`;
+    }
+    queryNote = queryFilterNote(options.q);
+  }
+
+  let scoped = searched;
   let filterNote = '';
   if (options?.filter === 'interactive') {
     if (format === 'ai') {
-      scoped = forest
+      scoped = searched
         .map((n) => stripNonInteractive(n, editableRoots))
         .filter((n): n is AXNode => n !== null);
       if (scoped.length === 0) {
@@ -2020,7 +2116,7 @@ export async function generateScopedSnapshot(
   const budget = Math.max(0, maxLength - note.length);
 
   if (output.length > budget && format === 'ai') {
-    const trimmed = forest
+    const trimmed = searched
       .map((n) => stripNonInteractive(n, editableRoots))
       .filter((n): n is AXNode => n !== null);
     if (trimmed.length > 0) {
@@ -2040,7 +2136,8 @@ export async function generateScopedSnapshot(
   // so resolveRef must count matches inside the same element.
   setPageRefs(page, refs, selector);
 
-  return filterNote ? `${filterNote}\n${output}` : output;
+  const notes = [queryNote, filterNote].filter((n) => n.length > 0);
+  return notes.length > 0 ? `${notes.join('\n')}\n${output}` : output;
 }
 
 export interface ResolveRefOptions {

--- a/src/mcp/playwright/snapshot.ts
+++ b/src/mcp/playwright/snapshot.ts
@@ -10,7 +10,7 @@ import { collectPageFacts, formatPageFactsFooter } from './pageFacts';
 import { peekRecentPendingRequests } from './pageCapture';
 import { evaluateIsolated, isolatedProbeTarget } from './isolated-eval';
 import { ancestorContext } from '../../shared/browserReplay/actionTrace';
-import { getOwnAttributeLabels } from './ownAttributes';
+import { emptyDomFacts, getDomFacts } from './ownAttributes';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -920,8 +920,18 @@ export function markDomRefsActive(page: Page): void {
 }
 
 
-function isInteractive(role: string): boolean {
-  return INTERACTIVE_ROLES.has(role);
+/**
+ * Does this node take input?
+ *
+ * Role first, and then the DOM's own word for it: a `contenteditable` host is
+ * a text field whatever role the a11y tree gives it, and the roles alone left
+ * YouTube Studio's title and description out of every interactive snapshot
+ * (dogfood 2026-09-04). `editableRoots` holds the HOSTS only, so a long
+ * document does not mint a ref per paragraph.
+ */
+function isInteractive(node: AXNode, editableRoots: ReadonlySet<number>): boolean {
+  if (INTERACTIVE_ROLES.has(node.role)) return true;
+  return node.backendDOMNodeId !== undefined && editableRoots.has(node.backendDOMNodeId);
 }
 
 /**
@@ -945,6 +955,8 @@ interface SerializeCtx {
    * caller asked for 'aria' (which mints no refs to carry it).
    */
   ownLabels: Map<number, string>;
+  /** See DomFacts.editableRoots. Empty on the 'aria' path, which mints no refs. */
+  editableRoots: ReadonlySet<number>;
   /**
    * Characters left for frame content — ONE pool for the whole snapshot,
    * drawn down by every grafted frame in it.
@@ -1002,7 +1014,7 @@ function serializeNode(
   // Build attribute string
   const attrs: string[] = [];
 
-  if (ctx.format === 'ai' && isInteractive(role)) {
+  if (ctx.format === 'ai' && isInteractive(node, ctx.editableRoots)) {
     const ref = assignRef(ctx.identity, frame.key, node.backendDOMNodeId);
     ctx.refs.push({
       role,
@@ -1156,8 +1168,8 @@ function serializeTree(root: AXNode, ctx: SerializeCtx): string {
   return serializeForest(root.children ?? [root], ctx);
 }
 
-function stripNonInteractive(node: AXNode): AXNode | null {
-  if (isInteractive(node.role)) return node;
+function stripNonInteractive(node: AXNode, editableRoots: ReadonlySet<number>): AXNode | null {
+  if (isInteractive(node, editableRoots)) return node;
   // An iframe ALWAYS survives the interactive filter. It is not interactive, so
   // it would otherwise vanish — and its disappearance is exactly the wrong
   // signal in both directions. For a frame that was never read, the controls
@@ -1169,7 +1181,7 @@ function stripNonInteractive(node: AXNode): AXNode | null {
   // ran.
   if (IFRAME_ROLES.has(node.role)) {
     const inside = (node.children ?? [])
-      .map(stripNonInteractive)
+      .map((child) => stripNonInteractive(child, editableRoots))
       .filter((c): c is AXNode => c !== null);
     if (inside.length > 0) return { ...node, children: inside };
     // Childless here means "nothing interactive in it", which frameBoundaryNote
@@ -1180,7 +1192,7 @@ function stripNonInteractive(node: AXNode): AXNode | null {
   if (!node.children) return null;
 
   const filtered = node.children
-    .map(stripNonInteractive)
+    .map((child) => stripNonInteractive(child, editableRoots))
     .filter((c): c is AXNode => c !== null);
 
   if (filtered.length === 0) return null;
@@ -1689,18 +1701,19 @@ async function occlusionFor(page: Page, fallback: CdpClient): Promise<OcclusionI
 interface SnapshotSource {
   tree: AXNode | null;
   occlusion: OcclusionInfo | null;
-  /** See SerializeCtx.ownLabels. Empty when `wantOwnLabels` was false. */
+  /** See SerializeCtx.ownLabels / editableRoots. Empty when `wantDomFacts` was false. */
   ownLabels: Map<number, string>;
+  editableRoots: Set<number>;
 }
 
 /**
- * @param wantOwnLabels adds ONE `DOM.getDocument` to the session, which is
+ * @param wantDomFacts adds ONE `DOM.getDocument` to the session, which is
  *   only worth paying for on the 'ai' path — 'aria' mints no RefEntry to hang
- *   the label on.
+ *   the label on and marks nothing interactive.
  */
 async function getAccessibilityTree(
   page: Page,
-  wantOwnLabels: boolean,
+  wantDomFacts: boolean,
 ): Promise<SnapshotSource> {
   // Sessions opened for out-of-process frames during the graft. Detached here
   // rather than inside the walk so one frame's cleanup cannot abort the rest.
@@ -1708,23 +1721,29 @@ async function getAccessibilityTree(
   try {
     return await withCdpSession<SnapshotSource>(
       page,
-      async (client) => ({
-        tree: (await fetchAccessibilityTree(client, { page, extraSessions }))?.root ?? null,
+      async (client) => {
+        const tree = (await fetchAccessibilityTree(client, { page, extraSessions }))?.root ?? null;
         // On the same session as the tree, so the DOM the attributes are read
         // from is the DOM the a11y nodes were computed against. Its own
         // failures are swallowed inside — a missing label abstains.
-        ownLabels: wantOwnLabels ? await getOwnAttributeLabels(client) : new Map(),
-      // After the tree, never instead of it: a thrown occlusion probe must not
-      // cost the caller its snapshot (collectOcclusion swallows its own
-      // failures, and this ordering keeps the tree even if that ever changes).
-        // The probe runs on the module's CACHED per-page session, not on this
-        // short-lived one: Chromium caches an isolated world per (session,
-        // frame, name), so minting one per snapshot would pile them up in the
-        // renderer of a long-lived SPA. Falls back to this session, main
-        // world, exactly as before, when there is no isolated world.
-        occlusion: await occlusionFor(page, client),
-      }),
-      { tree: null, occlusion: null, ownLabels: new Map() },
+        const domFacts = wantDomFacts ? await getDomFacts(client) : emptyDomFacts();
+        return {
+          tree,
+          ownLabels: domFacts.ownLabels,
+          editableRoots: domFacts.editableRoots,
+          // After the tree, never instead of it: a thrown occlusion probe must
+          // not cost the caller its snapshot (collectOcclusion swallows its own
+          // failures, and this ordering keeps the tree even if that ever
+          // changes).
+          // The probe runs on the module's CACHED per-page session, not on this
+          // short-lived one: Chromium caches an isolated world per (session,
+          // frame, name), so minting one per snapshot would pile them up in the
+          // renderer of a long-lived SPA. Falls back to this session, main
+          // world, exactly as before, when there is no isolated world.
+          occlusion: await occlusionFor(page, client),
+        };
+      },
+      { tree: null, occlusion: null, ...emptyDomFacts() },
     );
   } finally {
     for (const extra of extraSessions) {
@@ -1760,7 +1779,10 @@ export async function generateSnapshot(
   // fallthroughs below — stamps the same generation onto the page.
   const identity = beginRefGeneration(page);
 
-  const { tree, occlusion, ownLabels } = await getAccessibilityTree(page, format === 'ai');
+  const { tree, occlusion, ownLabels, editableRoots } = await getAccessibilityTree(
+    page,
+    format === 'ai',
+  );
 
   // A null tree (no CDP session / getFullAXTree threw / zero nodes) OR a root-only
   // tree (the a11y path collapsed — a background surface with no layout, or a page
@@ -1809,7 +1831,7 @@ export async function generateSnapshot(
   let filterNote = '';
   if (options?.filter === 'interactive') {
     if (format === 'ai') {
-      const stripped = stripNonInteractive(tree);
+      const stripped = stripNonInteractive(tree, editableRoots);
       if (!stripped) {
         setPageRefs(page, []);
         return '(no interactive elements on this page)';
@@ -1828,6 +1850,7 @@ export async function generateSnapshot(
     identity,
     occlusion,
     ownLabels,
+    editableRoots,
     frameBudgetRemaining: Math.floor(maxLength * FRAME_BUDGET_SHARE),
   };
   let output = serializeTree(effectiveTree, ctx);
@@ -1859,7 +1882,7 @@ export async function generateSnapshot(
   // If the output exceeds the budget AND we are in 'ai' mode, strip
   // non-interactive nodes and regenerate.
   if (output.length > budget && format === 'ai') {
-    const trimmed = stripNonInteractive(tree);
+    const trimmed = stripNonInteractive(tree, editableRoots);
     if (trimmed) {
       refs.length = 0;
       // The pool is per rendering, not per call: the first pass spent it, and
@@ -1921,32 +1944,42 @@ export async function generateScopedSnapshot(
     forest: AXNode[] | null;
     occlusion: OcclusionInfo | null;
     ownLabels: Map<number, string>;
+    editableRoots: Set<number>;
   }>(
     page,
     async (client) => {
       // Resolve the selector FIRST: a miss costs nothing and must reach the DOM
       // listing, which owns the user-facing "No element matches selector:" error.
       const backendId = await resolveSelectorBackendId(client, selector);
-      if (backendId === null) return { forest: null, occlusion: null, ownLabels: new Map() };
+      if (backendId === null) {
+        return { forest: null, occlusion: null, ...emptyDomFacts() };
+      }
 
       const built = await fetchAccessibilityTree(client);
       if (!built || isRootOnly(built.root)) {
-        return { forest: null, occlusion: null, ownLabels: new Map() };
+        return { forest: null, occlusion: null, ...emptyDomFacts() };
       }
+
+      // Same DOM facts the page-level path reads, and for the same reason: a
+      // `selector: "[role=dialog]"` over YouTube Studio's upload dialog listed
+      // one button and neither contenteditable field, because the scope keeps
+      // whatever the interactive test lets through (dogfood 2026-09-04).
+      const domFacts = format === 'ai' ? await getDomFacts(client) : emptyDomFacts();
 
       return {
         forest: built.byBackendId.get(backendId) ?? null,
-        ownLabels: format === 'ai' ? await getOwnAttributeLabels(client) : new Map(),
+        ownLabels: domFacts.ownLabels,
+        editableRoots: domFacts.editableRoots,
         // Occlusion is a whole-page fact, so it is worth just as much inside a
         // scope — a selector aimed at the page behind an overlay is exactly the
         // case where the agent is about to click something inert.
         occlusion: await occlusionFor(page, client),
       };
     },
-    { forest: null, occlusion: null, ownLabels: new Map() },
+    { forest: null, occlusion: null, ...emptyDomFacts() },
   );
 
-  const { forest, occlusion, ownLabels } = found;
+  const { forest, occlusion, ownLabels, editableRoots } = found;
   if (!forest || forest.length === 0) return null;
 
   let scoped = forest;
@@ -1954,7 +1987,7 @@ export async function generateScopedSnapshot(
   if (options?.filter === 'interactive') {
     if (format === 'ai') {
       scoped = forest
-        .map(stripNonInteractive)
+        .map((n) => stripNonInteractive(n, editableRoots))
         .filter((n): n is AXNode => n !== null);
       if (scoped.length === 0) {
         setPageRefs(page, [], selector);
@@ -1973,6 +2006,7 @@ export async function generateScopedSnapshot(
     identity,
     occlusion,
     ownLabels,
+    editableRoots,
     frameBudgetRemaining: Math.floor(maxLength * FRAME_BUDGET_SHARE),
   };
   // Unlike the page-level tree, the matched element is content, not a container
@@ -1987,7 +2021,7 @@ export async function generateScopedSnapshot(
 
   if (output.length > budget && format === 'ai') {
     const trimmed = forest
-      .map(stripNonInteractive)
+      .map((n) => stripNonInteractive(n, editableRoots))
       .filter((n): n is AXNode => n !== null);
     if (trimmed.length > 0) {
       refs.length = 0;

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -60,6 +60,10 @@ const BROWSER_SNAPSHOT_SHAPE = {
     .enum(['interactive'])
     .optional()
     .describe('Strips non-interactive nodes — much smaller output. Ignored by "aria".'),
+  q: z
+    .string()
+    .optional()
+    .describe('Keep only nodes matching this text (or /regex/), plus their ancestors.'),
   full: z.boolean().optional().describe('Force the complete tree instead of a diff.'),
   surfaceId: optionalSurfaceId,
 };
@@ -212,6 +216,15 @@ function windowFootnote(window: CaptureWindow | undefined, noun: string): string
   return `\n\n[collection started ${since}; ${noun} from before then are not included]`;
 }
 
+/**
+ * Said when `q` reaches a route that cannot honor it.
+ *
+ * The DOM listing is a flat rendering with no tree to prune, so the only two
+ * choices are this note or a full listing the caller reads as a filtered one.
+ */
+const DOM_LISTING_Q_NOTE =
+  '(note: q ignored — the a11y tree was unavailable, returning the unfiltered DOM interactive listing)';
+
 // --- Shared formatters: used by both the Playwright path and the RPC fallback
 // (#106) so console/network render identically regardless of transport. ---
 
@@ -296,7 +309,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
     'browser_snapshot',
     'Accessibility-tree snapshot of the page, with interactive elements annotated with ref numbers. A repeat snapshot of the same page returns a diff against the previous one when that is smaller — pass full:true for the complete tree. Line markers: "focused" on the focused node; while an overlay covers the page, a note names the layer, "overlay" marks it in the tree, and "clickable" marks the only controls still reachable behind it; an iframe line is a boundary — its contents are a separate document, not in this snapshot. Password field values read as "[redacted:password]" (the field is still listed and fillable); an empty field has no value at all, so a redacted one means it IS filled. "ai" drops the duplicate StaticText/InlineTextBox lines Chrome stacks under every piece of text; "aria" keeps them.',
     BROWSER_SNAPSHOT_SHAPE,
-    async ({ format, selector, filter, full, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ format, selector, filter, q, full, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         let text: string;
         // Which route served a SCOPED snapshot. Part of the diff key: an a11y
@@ -317,6 +330,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
             ? await generateScopedSnapshot(page, selector, {
                 format: format ?? 'ai',
                 ...(filter && { filter }),
+                ...(q && { q }),
               }).catch(() => null)
             : null;
 
@@ -350,11 +364,15 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
             if (format === 'aria') {
               text = `(note: aria format unavailable for this selector — the a11y tree could not be scoped, returning the DOM interactive listing)\n${text}`;
             }
+            // The DOM listing has no tree to prune, so `q` cannot be honored
+            // here. Say so rather than return a full listing that looks filtered.
+            if (q) text = `${DOM_LISTING_Q_NOTE}\n${text}`;
           }
         } else if (page) {
           text = await generateSnapshot(page, {
             format: format ?? 'ai',
             ...(filter && { filter }),
+            ...(q && { q }),
           });
         } else {
           // Fallback: extract page structure via RPC evaluation. Tags interactive
@@ -370,6 +388,7 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
           if (format === 'aria') {
             text = `(note: aria format unavailable — no live page, returning the DOM interactive listing)\n${text}`;
           }
+          if (q) text = `${DOM_LISTING_Q_NOTE}\n${text}`;
         }
 
         // What this surface's refs are, for the RPC lane's fail-closed guard.
@@ -393,7 +412,11 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
           currentUrl = /^URL: (.+)$/m.exec(text)?.[1];
         }
         const key = snapshotSurfaceKey(scope.workspaceId, scope.surfaceId);
-        const attrs = `${format ?? 'ai'}|${selector ?? ''}|${filter ?? ''}${scopeRoute}`;
+        // `q` joins the diff key for the same reason the others are in it: a
+        // searched snapshot and a whole one are different renderings, and
+        // diffing one against the other would report the unmatched nodes as
+        // removals.
+        const attrs = `${format ?? 'ai'}|${selector ?? ''}|${filter ?? ''}|${q ?? ''}${scopeRoute}`;
         const baseline = full ? null : getSnapshotBaseline(key, attrs, currentUrl);
         const rendered = formatSnapshotResult(baseline?.text ?? null, text);
         setSnapshotBaseline(key, attrs, text, currentUrl);

--- a/src/mcp/playwright/tools/inspection.ts
+++ b/src/mcp/playwright/tools/inspection.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
 import {
+  DOM_LISTING_Q_NOTE,
   generateScopedSnapshot,
   generateSnapshot,
   browserScopeKey,
@@ -216,15 +217,6 @@ function windowFootnote(window: CaptureWindow | undefined, noun: string): string
   return `\n\n[collection started ${since}; ${noun} from before then are not included]`;
 }
 
-/**
- * Said when `q` reaches a route that cannot honor it.
- *
- * The DOM listing is a flat rendering with no tree to prune, so the only two
- * choices are this note or a full listing the caller reads as a filtered one.
- */
-const DOM_LISTING_Q_NOTE =
-  '(note: q ignored — the a11y tree was unavailable, returning the unfiltered DOM interactive listing)';
-
 // --- Shared formatters: used by both the Playwright path and the RPC fallback
 // (#106) so console/network render identically regardless of transport. ---
 
@@ -416,7 +408,14 @@ export function registerInspectionTools(server: McpServer, deps: BrowserToolDeps
         // searched snapshot and a whole one are different renderings, and
         // diffing one against the other would report the unmatched nodes as
         // removals.
-        const attrs = `${format ?? 'ai'}|${selector ?? ''}|${filter ?? ''}|${q ?? ''}${scopeRoute}`;
+        //
+        // JSON, not a `|` join: `selector` and `q` are caller text that may
+        // contain the separator itself, so the parts run together —
+        // `{selector:"a", q:"b||c"}` and `{selector:"a||b", q:"c"}` both spell
+        // `a||b||c`. Two different renderings then share one baseline, which is
+        // exactly the false "(no changes since previous snapshot)" this key
+        // exists to prevent.
+        const attrs = JSON.stringify([format ?? 'ai', selector ?? '', filter ?? '', q ?? '', scopeRoute]);
         const baseline = full ? null : getSnapshotBaseline(key, attrs, currentUrl);
         const rendered = formatSnapshotResult(baseline?.text ?? null, text);
         setSnapshotBaseline(key, attrs, text, currentUrl);

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { ElementHandle } from 'playwright-core';
+import type { ElementHandle, Page } from 'playwright-core';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
@@ -9,7 +9,12 @@ import {
   isOutstandingFrameRef,
   resolveRef,
 } from '../snapshot';
-import { getLocatorByRef, resolveSmartRefLocator, smartRefAxisEntry } from '../dom-intelligence';
+import {
+  getLocatorByRef,
+  getSmartElementByRef,
+  resolveSmartRefLocator,
+  smartRefAxisEntry,
+} from '../dom-intelligence';
 import { typeHumanlike } from '../human-typing';
 import { evaluateIsolated } from '../isolated-eval';
 import {
@@ -67,7 +72,8 @@ const BROWSER_CLICK_SHAPE = {
 };
 
 const BROWSER_TYPE_SHAPE = {
-  ref: z.string().describe('Ref from browser_snapshot.'),
+  ref: z.string().optional().describe('Ref from browser_snapshot.'),
+  smartRef: z.number().optional().describe('Ref from browser_smart_snapshot.'),
   text: z.string(),
   submit: z
     .boolean()
@@ -84,11 +90,12 @@ const BROWSER_FILL_SHAPE = {
   fields: z
     .array(
       z.object({
-        ref: z.string(),
+        ref: z.string().optional(),
+        smartRef: z.number().optional(),
         value: z.string(),
       }),
     )
-    .describe('{ref, value} pairs to fill.'),
+    .describe('{ref (or smartRef), value} pairs to fill.'),
   surfaceId: optionalSurfaceId,
 };
 
@@ -140,11 +147,32 @@ const BROWSER_SCROLL_SHAPE = {
   surfaceId: optionalSurfaceId,
 };
 
-const REF_NOT_FOUND_HINT =
-  'Element with ref={ref} not found. Run browser_snapshot to get current refs.';
-
+/**
+ * What to say when a `ref` argument resolves to nothing.
+ *
+ * There are TWO ref spaces and both print bare numbers: browser_snapshot mints
+ * `ref="12"` and browser_smart_snapshot lists `[61] textbox "제목"`. A smart ref
+ * passed as `ref` used to come back as "Element with ref=61 not found. Run
+ * browser_snapshot to get current refs" — which names neither the mistake nor
+ * the fix, and sends the caller to re-snapshot a page that was fine (dogfood
+ * 2026-09-04, YouTube Studio). So the message says which space the argument was
+ * read in, and — when the number IS live in the other one — which parameter it
+ * belongs to instead.
+ */
 function refNotFound(ref: string): string {
-  return REF_NOT_FOUND_HINT.replace('{ref}', ref);
+  const smart = /^\d+$/.test(ref) ? getSmartElementByRef(Number(ref)) : null;
+  if (smart) {
+    return (
+      `ref=${ref} is not a browser_snapshot ref, but browser_smart_snapshot lists ${ref} as ` +
+      `${smart.role}${smart.name ? ` "${smart.name}"` : ''} — pass it as smartRef, which ` +
+      `browser_click, browser_type and browser_fill all accept.`
+    );
+  }
+  return (
+    `Element with ref=${ref} not found. This argument is read as a browser_snapshot ref; ` +
+    `a number from browser_smart_snapshot goes in smartRef instead. ` +
+    `Run browser_snapshot to get current refs.`
+  );
 }
 
 /**
@@ -387,6 +415,90 @@ async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): P
   });
 }
 
+// ---------------------------------------------------------------------------
+// Addressing: one element, named three ways
+// ---------------------------------------------------------------------------
+
+/**
+ * How a caller names the element a typing tool should act on.
+ *
+ * browser_click has accepted both ref spaces since smart refs existed; the
+ * typing tools accepted only `ref`, so a smartRef read off browser_smart_snapshot
+ * came back as "not found" and there was no second thing to try (dogfood
+ * 2026-09-04). They now resolve exactly the way browser_click does.
+ */
+interface RefAddress {
+  ref?: string;
+  smartRef?: number;
+}
+
+/**
+ * The slice of ElementHandle / Locator the typing tools use.
+ *
+ * A ref resolves to an ElementHandle and a smartRef to a Locator; both carry
+ * these three methods with the same meaning, so one code path serves both.
+ */
+interface TypeTarget {
+  click(): Promise<void>;
+  fill(value: string): Promise<void>;
+  evaluate(fn: (node: Element) => boolean): Promise<boolean>;
+}
+
+/** Reject an address that names no element, or two. */
+function requireOneTarget(addr: RefAddress, tool: string): void {
+  const given = [addr.ref !== undefined, addr.smartRef !== undefined].filter(Boolean).length;
+  if (given === 0) {
+    throw new Error(
+      `${tool} needs ref (from browser_snapshot) or smartRef (from browser_smart_snapshot).`,
+    );
+  }
+  if (given > 1) {
+    throw new Error(`${tool} takes ref or smartRef, not both — they name one element two ways.`);
+  }
+}
+
+/** Resolve an address on the Playwright lane. Throws with the reason it failed. */
+async function resolveTypeTarget(page: Page, addr: RefAddress): Promise<TypeTarget> {
+  if (addr.smartRef !== undefined) {
+    // Throws StaleSmartRefError rather than typing into a substitute — the same
+    // guarantee browser_click({smartRef}) gives.
+    return (await resolveSmartRefLocator(page, addr.smartRef)) as unknown as TypeTarget;
+  }
+  const el = await resolveRef(page, addr.ref as string);
+  if (!el) throw new Error(refNotFound(addr.ref as string));
+  return el as unknown as TypeTarget;
+}
+
+/** The ref the RPC lane resolves an address through (its only addressing mode). */
+function rpcRefFor(addr: RefAddress): string {
+  return addr.ref ?? String(addr.smartRef);
+}
+
+/** How an address reads back in a tool result. */
+function describeAddress(addr: RefAddress): string {
+  return addr.ref !== undefined ? `ref=${addr.ref}` : `smartRef=${addr.smartRef}`;
+}
+
+/**
+ * How a step addressed this way is recorded, mirroring browser_click.
+ *
+ * A smartRef's stored "locator" is getByRole SOURCE TEXT on the CDP lane, which
+ * `page.locator()` cannot parse — so it is recorded on the ref axis instead, and
+ * only the RPC lane's real CSS selector is recorded as a selector.
+ */
+function targetForRecord(
+  addr: RefAddress,
+): { ref: string } | { refEntry: NonNullable<ReturnType<typeof smartRefAxisEntry>> } | { selector: string } | Record<string, never> {
+  if (addr.ref !== undefined) return { ref: addr.ref };
+  if (addr.smartRef !== undefined) {
+    const entry = smartRefAxisEntry(addr.smartRef);
+    if (entry) return { refEntry: entry };
+    const css = getLocatorByRef(addr.smartRef);
+    if (css) return { selector: css };
+  }
+  return {};
+}
+
 /**
  * Is the element behind `ref` a password field?
  *
@@ -400,7 +512,7 @@ async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): P
  * agent itself just sent is the pre-existing behaviour, whereas a failed lookup
  * must not turn into a failed browser_type.
  */
-async function isPasswordElement(el: ElementHandle): Promise<boolean> {
+async function isPasswordElement(el: TypeTarget | ElementHandle): Promise<boolean> {
   try {
     // Main world, deliberately: the predicate is scoped to an ElementHandle,
     // and a handle belongs to the world it was resolved in — there is no way
@@ -749,10 +861,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
   // -----------------------------------------------------------------------
   server.tool(
     'browser_type',
-    'Type text into an element by ref, replacing any existing value. Typing into a password field echoes "[redacted:password]" back — the text still went in.',
+    'Type text into an element by ref or smartRef, replacing any existing value. Typing into a password field echoes "[redacted:password]" back — the text still went in.',
     BROWSER_TYPE_SHAPE,
-    async ({ ref, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ ref, smartRef, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
+        const addr: RefAddress = { ...(ref !== undefined && { ref }), ...(smartRef !== undefined && { smartRef }) };
+        requireOneTarget(addr, 'browser_type');
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         // Decided BEFORE typing: the field is addressable now, and a submit can
@@ -760,8 +874,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
         let isPassword: boolean;
 
         if (page) {
-          const el = await resolveRef(page, ref);
-          if (!el) throw new Error(refNotFound(ref));
+          const el = await resolveTypeTarget(page, addr);
           isPassword = await isPasswordElement(el);
           if (humanlike) {
             await el.click();
@@ -772,8 +885,9 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           if (submit) await page.keyboard.press('Enter');
         } else {
           // RPC fallback
-          isPassword = await rpcIsPasswordElement(ref, scope);
-          await rpcFill(ref, text, scope);
+          const rpcRef = rpcRefFor(addr);
+          isPassword = await rpcIsPasswordElement(rpcRef, scope);
+          await rpcFill(rpcRef, text, scope);
           if (submit) await rpcPressKey('Enter', scope);
         }
 
@@ -792,7 +906,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           scope,
           tool: 'browser_type',
           page,
-          ref,
+          ...targetForRecord(addr),
           args: isPassword ? {} : { text, ...(submit && { submit: true }) },
           ...(isPassword && { unrecordable: 'password' as const }),
         });
@@ -801,7 +915,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           content: [
             {
               type: 'text' as const,
-              text: `Typed "${echoed}" into element ref=${ref}${submit ? ' and submitted' : ''}`,
+              text: `Typed "${echoed}" into element ${describeAddress(addr)}${submit ? ' and submitted' : ''}`,
             },
           ],
         };
@@ -820,7 +934,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
   // -----------------------------------------------------------------------
   server.tool(
     'browser_fill',
-    'Fill multiple form fields at once, each by ref.',
+    'Fill multiple form fields at once, each by ref or smartRef.',
     BROWSER_FILL_SHAPE,
     async ({ fields, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
@@ -838,15 +952,20 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
         for (let i = 0; i < fields.length; i++) {
           const field = fields[i];
+          const addr: RefAddress = {
+            ...(field.ref !== undefined && { ref: field.ref }),
+            ...(field.smartRef !== undefined && { smartRef: field.smartRef }),
+          };
           try {
+            requireOneTarget(addr, 'browser_fill');
             if (page) {
-              const el = await resolveRef(page, field.ref);
-              if (!el) { errors.push(refNotFound(field.ref)); continue; }
+              const el = await resolveTypeTarget(page, addr);
               isPassword[i] = await isPasswordElement(el);
               await el.fill(field.value);
             } else {
-              isPassword[i] = await rpcIsPasswordElement(field.ref, scope);
-              await rpcFill(field.ref, field.value, scope);
+              const rpcRef = rpcRefFor(addr);
+              isPassword[i] = await rpcIsPasswordElement(rpcRef, scope);
+              await rpcFill(rpcRef, field.value, scope);
             }
             filled++;
           } catch (err) {
@@ -863,7 +982,10 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
               scope,
               tool: 'browser_fill',
               page,
-              ref: fields[i].ref,
+              ...targetForRecord({
+                ...(fields[i].ref !== undefined && { ref: fields[i].ref }),
+                ...(fields[i].smartRef !== undefined && { smartRef: fields[i].smartRef }),
+              }),
               args: credential ? {} : { value: fields[i].value },
               ...(credential && { unrecordable: 'password' as const }),
             });

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import type { ElementHandle, Page } from 'playwright-core';
+import type { Page } from 'playwright-core';
 import { z } from 'zod';
 import { PlaywrightEngine } from '../PlaywrightEngine';
 import { withAutomationLease } from '../automationLease';
@@ -11,7 +11,7 @@ import {
 } from '../snapshot';
 import {
   getLocatorByRef,
-  getSmartElementByRef,
+  getSmartElementOnPage,
   resolveSmartRefLocator,
   smartRefAxisEntry,
 } from '../dom-intelligence';
@@ -77,7 +77,7 @@ const BROWSER_TYPE_SHAPE = {
   selector: z
     .string()
     .optional()
-    .describe('CSS selector, for an element no snapshot gave a ref (e.g. a contenteditable div).'),
+    .describe('CSS only (no text=/xpath=), matching exactly one element no snapshot gave a ref.'),
   text: z.string(),
   newline: z
     .enum(['literal', 'enter', 'shift-enter'])
@@ -166,9 +166,14 @@ const BROWSER_SCROLL_SHAPE = {
  * 2026-09-04, YouTube Studio). So the message says which space the argument was
  * read in, and — when the number IS live in the other one — which parameter it
  * belongs to instead.
+ *
+ * `page` scopes that second half. The smart-snapshot record is per connection,
+ * not per page, so without it a stale record from another tab would name an
+ * element this page does not have and point the caller at a parameter that
+ * cannot work either.
  */
-function refNotFound(ref: string): string {
-  const smart = /^\d+$/.test(ref) ? getSmartElementByRef(Number(ref)) : null;
+function refNotFound(ref: string, page: Page | null): string {
+  const smart = /^\d+$/.test(ref) ? getSmartElementOnPage(Number(ref), page) : null;
   if (smart) {
     return (
       `ref=${ref} is not a browser_snapshot ref, but browser_smart_snapshot lists ${ref} as ` +
@@ -421,6 +426,19 @@ async function rpcFill(selector: string, value: string, scope: BrowserTargetScop
   await sendScopedBrowserRpc('browser.click.cdp', scope, { selector });
   // Small delay for focus
   await new Promise(r => setTimeout(r, 100));
+  // Both steps below act on whatever the DOCUMENT has focused, not on the
+  // selector: `selectAll` works on the current selection and `Input.insertText`
+  // on the focused node. A selector naming something unfocusable — a wrapper
+  // `<div>`, a `<label>`, a disabled control — therefore left the click doing
+  // nothing and overwrote whichever field the page had focused instead. Now
+  // that a caller can pass its own selector, that has to be checked. `unknown`
+  // (a transport that cannot answer) proceeds, exactly as it always did.
+  if ((await rpcCaretState(selector, scope)) === 'lost') {
+    throw new Error(
+      `The element matching "${selector}" did not take focus, so typing would have gone into ` +
+        'whatever else the page has focused. Nothing was typed. Name a focusable field.',
+    );
+  }
   // Select all existing text
   await sendScopedBrowserRpc('browser.evaluate', scope, {
     expression: `document.execCommand('selectAll')`,
@@ -476,7 +494,7 @@ const ADDRESS_MODE_HELP: Record<AddressMode, string> = {
 interface TypeTarget {
   click(): Promise<void>;
   fill(value: string): Promise<void>;
-  evaluate(fn: (node: Element) => boolean): Promise<boolean>;
+  evaluate<R>(fn: (node: Element) => R): Promise<R>;
 }
 
 /** Reject an address that names no element, or more than one. */
@@ -495,6 +513,46 @@ function requireOneTarget(addr: RefAddress, tool: string, accepts: readonly Addr
   }
 }
 
+/**
+ * Refuse a `selector` that is not plain CSS.
+ *
+ * The RPC lane resolves it with `document.querySelector`, and a recorded step
+ * carries it on the `css` axis, which the replay runner also resolves as CSS.
+ * Playwright's own `locator()` would happily accept `text=Save`, `//div` and
+ * `a >> b` — so without this the same argument means one thing live on the
+ * Chrome lane and nothing at all on the other two, which is a tool that works
+ * until the day it is replayed.
+ */
+function requireCssSelector(selector: string): void {
+  const bad = (why: string): never => {
+    throw new Error(`selector must be a CSS selector — ${why}. Got: ${selector}`);
+  };
+  const trimmed = selector.trim();
+  if (selector.includes('>>')) bad('">>" chains Playwright engines, which CSS has no equivalent for');
+  if (trimmed.startsWith('//') || trimmed.startsWith('..')) bad('this is an XPath expression');
+  const engine = /^([a-zA-Z_][a-zA-Z0-9_-]*)\s*=/.exec(trimmed);
+  if (engine) bad(`"${engine[1]}=" names a Playwright engine`);
+}
+
+/**
+ * How many elements a selector matches, refusing anything but exactly one.
+ *
+ * Typing into `.first()` of several matches SUCCEEDS live and then fails on
+ * every replay: the step is recorded on the css axis, and the replay runner
+ * refuses a css axis whose count is not 1. The tool would be reporting a
+ * result the flow cannot reproduce — so it refuses here instead, by the same
+ * uniqueness rule a ref carries.
+ */
+function requireSingleMatch(selector: string, count: number): void {
+  if (count === 0) throw new Error(`No element matches selector: ${selector}`);
+  if (count > 1) {
+    throw new Error(
+      `selector "${selector}" matches ${count} elements — it must match exactly one. ` +
+        'Narrow it, or use a ref from browser_snapshot.',
+    );
+  }
+}
+
 /** Resolve an address on the Playwright lane. Throws with the reason it failed. */
 async function resolveTypeTarget(page: Page, addr: RefAddress): Promise<TypeTarget> {
   if (addr.smartRef !== undefined) {
@@ -503,15 +561,16 @@ async function resolveTypeTarget(page: Page, addr: RefAddress): Promise<TypeTarg
     return (await resolveSmartRefLocator(page, addr.smartRef)) as unknown as TypeTarget;
   }
   if (addr.selector !== undefined) {
+    requireCssSelector(addr.selector);
     // Counted before typing: a selector that matches nothing would otherwise
     // spend Playwright's full auto-wait and come back as a timeout, which reads
-    // like a hung page rather than a selector the caller can fix.
-    const matches = await page.locator(addr.selector).count();
-    if (matches === 0) throw new Error(`No element matches selector: ${addr.selector}`);
+    // like a hung page rather than a selector the caller can fix — and one that
+    // matches several must not be silently narrowed to the first.
+    requireSingleMatch(addr.selector, await page.locator(addr.selector).count());
     return page.locator(addr.selector).first() as unknown as TypeTarget;
   }
   const el = await resolveRef(page, addr.ref as string);
-  if (!el) throw new Error(refNotFound(addr.ref as string));
+  if (!el) throw new Error(refNotFound(addr.ref as string, page));
   return el as unknown as TypeTarget;
 }
 
@@ -520,11 +579,40 @@ async function resolveTypeTarget(page: Page, addr: RefAddress): Promise<TypeTarg
  *
  * Its only addressing mode is a selector, so a ref becomes the `data-wmux-ref`
  * tag the snapshot wrote and a caller's own selector is passed through.
+ *
+ * A smartRef gets NO rendering, deliberately. `data-wmux-ref` tags are written
+ * by browser_snapshot; browser_smart_snapshot keeps its own, differently
+ * numbered ref space and tags nothing. Rendering smartRef=61 as
+ * `[data-wmux-ref="61"]` therefore names either nothing at all or — worse, when
+ * a browser_snapshot ran earlier — whatever unrelated element that snapshot
+ * happened to number 61. An error naming the limit is the only honest answer
+ * this lane has.
  */
 function rpcSelectorFor(addr: RefAddress, scope: BrowserTargetScope): string {
-  if (addr.selector !== undefined) return addr.selector;
-  const safeRef = sanitizeRef(addr.ref ?? String(addr.smartRef), scope);
-  return `[data-wmux-ref="${safeRef}"]`;
+  if (addr.selector !== undefined) {
+    requireCssSelector(addr.selector);
+    return addr.selector;
+  }
+  if (addr.ref === undefined) {
+    throw new Error(
+      `smartRef=${addr.smartRef} cannot be used on this transport: browser_smart_snapshot refs ` +
+        'are not tagged into the page, and this surface has no live Chrome page to resolve them ' +
+        'against. Use a ref from browser_snapshot, or a CSS selector.',
+    );
+  }
+  return `[data-wmux-ref="${sanitizeRef(addr.ref, scope)}"]`;
+}
+
+/** How many elements a selector matches on the RPC lane. */
+async function rpcMatchCount(selector: string, scope: BrowserTargetScope): Promise<number> {
+  const value = await rpcEval(
+    `String(document.querySelectorAll(${jsStringLiteral(selector)}).length)`,
+    scope,
+  );
+  const count = Number(value);
+  // A transport that cannot answer must not block the action — the ambiguity
+  // guard is worth having, but not at the price of a fill that no longer runs.
+  return Number.isFinite(count) ? count : 1;
 }
 
 /**
@@ -549,6 +637,54 @@ function newlineKeyFor(mode: 'literal' | 'enter' | 'shift-enter' | undefined): s
 }
 
 /**
+ * What a between-lines keypress left behind.
+ *
+ * `lost` is the one answer that stops the typing: the field the caller named is
+ * gone from the document, or no longer holds the caret. Anything else — an
+ * `unknown` from a transport or a test double that cannot answer the question —
+ * lets the run continue, because a probe that cannot report is not evidence of
+ * a problem.
+ */
+type CaretState = 'held' | 'lost' | 'unknown';
+
+/**
+ * Is the element still attached, and still holding the caret?
+ *
+ * Asked between the segments of a multi-line type. The first Enter into a
+ * search box or a chat composer SUBMITS: the field empties, the page navigates,
+ * and every remaining line is then inserted into whatever the new page happens
+ * to focus — reported back as a successful eight-line type (review, lane D).
+ * `contains` as well as identity, because a rich-text host keeps the caret in
+ * one of its descendant nodes.
+ */
+async function caretStillOnTarget(el: TypeTarget): Promise<CaretState> {
+  try {
+    const held = await el.evaluate((node: Element) => {
+      if (!node.isConnected) return false;
+      const active = node.ownerDocument?.activeElement ?? null;
+      return active !== null && (active === node || node.contains(active));
+    });
+    // A double that answers something other than a boolean has not answered.
+    if (typeof held !== 'boolean') return 'unknown';
+    return held ? 'held' : 'lost';
+  } catch {
+    // A detached handle throws — which IS the answer, but so is a navigation
+    // that tore down the execution context mid-question. Both mean the element
+    // this was typing into is not there any more.
+    return 'lost';
+  }
+}
+
+/** Thrown when a multi-line type stopped early, carrying how far it got. */
+function partialLinesError(done: number, total: number, key: string): Error {
+  return new Error(
+    `Typed ${done} of ${total} lines, then stopped: the field lost focus after the ${key} ` +
+      '(a submit or a navigation is the usual cause). The remaining lines were NOT typed — ' +
+      'they would have gone into whatever the page focused next.',
+  );
+}
+
+/**
  * Type `text` into an already-resolved element on the Playwright lane.
  *
  * The FIRST segment replaces the field's value — the contract browser_type has
@@ -563,7 +699,12 @@ async function typeIntoTarget(
 ): Promise<string[]> {
   const segments = opts.newlineKey === null ? [text] : text.split('\n');
   for (let i = 0; i < segments.length; i++) {
-    if (i > 0) await page.keyboard.press(opts.newlineKey as string);
+    if (i > 0) {
+      await page.keyboard.press(opts.newlineKey as string);
+      if ((await caretStillOnTarget(el)) === 'lost') {
+        throw partialLinesError(i, segments.length, opts.newlineKey as string);
+      }
+    }
     const segment = segments[i];
     if (i === 0) {
       if (opts.humanlike) {
@@ -591,12 +732,47 @@ async function rpcTypeInto(
 ): Promise<string[]> {
   const segments = newlineKey === null ? [text] : text.split('\n');
   await rpcFill(selector, segments[0], scope);
-  for (const segment of segments.slice(1)) {
+  for (let i = 1; i < segments.length; i++) {
     await rpcPressKey(newlineKey as string, scope);
-    if (segment.length === 0) continue;
-    await sendScopedBrowserRpc('browser.type.cdp', scope, { text: segment });
+    // Same guarantee the Playwright lane gives: a key that submitted the form
+    // must not be followed by lines typed into the next page's focused field.
+    if ((await rpcCaretState(selector, scope)) === 'lost') {
+      throw partialLinesError(i, segments.length, newlineKey as string);
+    }
+    if (segments[i].length === 0) continue;
+    await sendScopedBrowserRpc('browser.type.cdp', scope, { text: segments[i] });
   }
   return segments;
+}
+
+/**
+ * Sentinels the caret probe answers with.
+ *
+ * Distinct strings, not 'yes'/'no': every RPC evaluate on this lane returns a
+ * bare string, and a probe that shared its vocabulary with the password probe
+ * would read another question's answer as its own.
+ */
+const CARET_HELD = 'wmux-caret:held';
+const CARET_LOST = 'wmux-caret:lost';
+
+/**
+ * Does the selector's element still hold the caret, over the RPC transport?
+ *
+ * Anything but the `lost` sentinel is treated as `unknown` — see CaretState.
+ */
+async function rpcCaretState(selector: string, scope: BrowserTargetScope): Promise<CaretState> {
+  try {
+    const value = await rpcEval(`(() => {
+      const el = document.querySelector(${jsStringLiteral(selector)});
+      if (!el) return '${CARET_LOST}';
+      const active = document.activeElement;
+      return active && (active === el || el.contains(active)) ? '${CARET_HELD}' : '${CARET_LOST}';
+    })()`, scope);
+    if (value === CARET_LOST) return 'lost';
+    return value === CARET_HELD ? 'held' : 'unknown';
+  } catch {
+    return 'unknown';
+  }
 }
 
 /** How an address reads back in a tool result. */
@@ -640,7 +816,7 @@ function targetForRecord(
  * agent itself just sent is the pre-existing behaviour, whereas a failed lookup
  * must not turn into a failed browser_type.
  */
-async function isPasswordElement(el: TypeTarget | ElementHandle): Promise<boolean> {
+async function isPasswordElement(el: TypeTarget): Promise<boolean> {
   try {
     // Main world, deliberately: the predicate is scoped to an ElementHandle,
     // and a handle belongs to the world it was resolved in — there is no way
@@ -960,7 +1136,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             if (!ref) throw new Error('Either ref or smartRef must be provided.');
 
             const el = await resolveRef(page, ref);
-            if (!el) throw new Error(refNotFound(ref));
+            if (!el) throw new Error(refNotFound(ref, page));
             const dispatch = await clickWithApproach(
               page as unknown as ApproachPage,
               el,
@@ -1033,6 +1209,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
         } else {
           // RPC fallback
           const rpcSelector = rpcSelectorFor(addr, scope);
+          // A caller's own selector is counted here for the same reason it is
+          // on the Playwright lane: `.first()` semantics that replay refuses.
+          // A data-wmux-ref tag is unique by construction, so it is not asked.
+          if (addr.selector !== undefined) {
+            requireSingleMatch(rpcSelector, await rpcMatchCount(rpcSelector, scope));
+          }
           isPassword = await rpcIsPasswordElement(rpcSelector, scope);
           segments = await rpcTypeInto(rpcSelector, text, scope, newlineKey);
           if (submit) await rpcPressKey('Enter', scope);
@@ -1212,7 +1394,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
         if (page) {
           const el = await resolveRef(page, ref);
-          if (!el) throw new Error(refNotFound(ref));
+          if (!el) throw new Error(refNotFound(ref, page));
           if (hasTouchEmulation(page)) touchNote = TOUCH_HOVER_NOTE;
           await el.hover();
         } else {
@@ -1258,9 +1440,9 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
         if (page) {
           const sourceEl = await resolveRef(page, sourceRef);
-          if (!sourceEl) throw new Error(refNotFound(sourceRef));
+          if (!sourceEl) throw new Error(refNotFound(sourceRef, page));
           const targetEl = await resolveRef(page, targetRef);
-          if (!targetEl) throw new Error(refNotFound(targetRef));
+          if (!targetEl) throw new Error(refNotFound(targetRef, page));
 
           const sourceBox = await sourceEl.boundingBox();
           const targetBox = await targetEl.boundingBox();
@@ -1339,7 +1521,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
         if (page) {
           const el = await resolveRef(page, ref);
-          if (!el) throw new Error(refNotFound(ref));
+          if (!el) throw new Error(refNotFound(ref, page));
           await el.selectOption(values);
         } else {
           // Deliberately still a DOM assignment, unlike hover and drag above.
@@ -1358,7 +1540,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             el.dispatchEvent(new Event('change', { bubbles: true }));
             return 'ok';
           })()`, scope);
-          if (val === 'not_found') throw new Error(refNotFound(ref));
+          if (val === 'not_found') throw new Error(refNotFound(ref, page));
         }
 
         recordAction(deps, {
@@ -1395,7 +1577,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
 
         if (page) {
           const el = await resolveRef(page, ref);
-          if (!el) throw new Error(refNotFound(ref));
+          if (!el) throw new Error(refNotFound(ref, page));
           await el.scrollIntoViewIfNeeded();
         } else {
           const safeRef = sanitizeRef(ref, scope);
@@ -1405,7 +1587,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             el.scrollIntoView({ block: 'center', behavior: 'smooth' });
             return 'ok';
           })()`, scope);
-          if (val === 'not_found') throw new Error(refNotFound(ref));
+          if (val === 'not_found') throw new Error(refNotFound(ref, page));
         }
 
         recordAction(deps, { scope, tool: 'browser_scroll_into_view', page, ref });
@@ -1440,7 +1622,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
         if (page) {
           if (ref) {
             const el = await resolveRef(page, ref);
-            if (!el) throw new Error(refNotFound(ref));
+            if (!el) throw new Error(refNotFound(ref, page));
             // Main world, deliberately: element-scoped, and an ElementHandle
             // cannot be adopted into an isolated context (see isolated-eval.ts).
             await el.evaluate(

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -74,6 +74,10 @@ const BROWSER_CLICK_SHAPE = {
 const BROWSER_TYPE_SHAPE = {
   ref: z.string().optional().describe('Ref from browser_snapshot.'),
   smartRef: z.number().optional().describe('Ref from browser_smart_snapshot.'),
+  selector: z
+    .string()
+    .optional()
+    .describe('CSS selector, for an element no snapshot gave a ref (e.g. a contenteditable div).'),
   text: z.string(),
   submit: z
     .boolean()
@@ -400,9 +404,17 @@ async function rpcClick(
   return res?.dispatch === 'touch' ? 'touch' : 'mouse';
 }
 
-async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): Promise<void> {
+/**
+ * Fill the first element matching a CSS selector, over the RPC transport.
+ *
+ * Takes a selector rather than a ref because the ref lane is only ONE of the
+ * ways a caller can now name an element: `browser_type({selector})` hands its
+ * own selector straight through (rpcSelectorFor), and a ref is rendered as the
+ * `data-wmux-ref` tag the snapshot wrote.
+ */
+async function rpcFill(selector: string, value: string, scope: BrowserTargetScope): Promise<void> {
   // Click on the element first to focus it
-  await rpcClick(ref, scope);
+  await sendScopedBrowserRpc('browser.click.cdp', scope, { selector });
   // Small delay for focus
   await new Promise(r => setTimeout(r, 100));
   // Select all existing text
@@ -430,7 +442,26 @@ async function rpcFill(ref: string, value: string, scope: BrowserTargetScope): P
 interface RefAddress {
   ref?: string;
   smartRef?: number;
+  /**
+   * A CSS selector, for an element NEITHER snapshot handed out a number for.
+   *
+   * YouTube Studio's title and description are `contenteditable` divs; before
+   * the snapshot enumerator learned to count those, an agent that could see
+   * them on screen had no way to name them at all (dogfood 2026-09-04). A
+   * selector is the escape hatch that does not depend on an enumerator noticing
+   * the element first.
+   */
+  selector?: string;
 }
+
+/** The parameters a tool accepts as an address, in the order it lists them. */
+type AddressMode = 'ref' | 'smartRef' | 'selector';
+
+const ADDRESS_MODE_HELP: Record<AddressMode, string> = {
+  ref: 'ref (from browser_snapshot)',
+  smartRef: 'smartRef (from browser_smart_snapshot)',
+  selector: 'selector (a CSS selector)',
+};
 
 /**
  * The slice of ElementHandle / Locator the typing tools use.
@@ -444,16 +475,19 @@ interface TypeTarget {
   evaluate(fn: (node: Element) => boolean): Promise<boolean>;
 }
 
-/** Reject an address that names no element, or two. */
-function requireOneTarget(addr: RefAddress, tool: string): void {
-  const given = [addr.ref !== undefined, addr.smartRef !== undefined].filter(Boolean).length;
-  if (given === 0) {
+/** Reject an address that names no element, or more than one. */
+function requireOneTarget(addr: RefAddress, tool: string, accepts: readonly AddressMode[]): void {
+  const given = accepts.filter((mode) => addr[mode] !== undefined);
+  if (given.length === 0) {
+    const help = accepts.map((mode) => ADDRESS_MODE_HELP[mode]);
     throw new Error(
-      `${tool} needs ref (from browser_snapshot) or smartRef (from browser_smart_snapshot).`,
+      `${tool} needs ${help.slice(0, -1).join(', ')} or ${help[help.length - 1]}.`,
     );
   }
-  if (given > 1) {
-    throw new Error(`${tool} takes ref or smartRef, not both — they name one element two ways.`);
+  if (given.length > 1) {
+    throw new Error(
+      `${tool} takes ${given.join(' or ')}, not both — they name one element more than one way.`,
+    );
   }
 }
 
@@ -464,19 +498,36 @@ async function resolveTypeTarget(page: Page, addr: RefAddress): Promise<TypeTarg
     // guarantee browser_click({smartRef}) gives.
     return (await resolveSmartRefLocator(page, addr.smartRef)) as unknown as TypeTarget;
   }
+  if (addr.selector !== undefined) {
+    // Counted before typing: a selector that matches nothing would otherwise
+    // spend Playwright's full auto-wait and come back as a timeout, which reads
+    // like a hung page rather than a selector the caller can fix.
+    const matches = await page.locator(addr.selector).count();
+    if (matches === 0) throw new Error(`No element matches selector: ${addr.selector}`);
+    return page.locator(addr.selector).first() as unknown as TypeTarget;
+  }
   const el = await resolveRef(page, addr.ref as string);
   if (!el) throw new Error(refNotFound(addr.ref as string));
   return el as unknown as TypeTarget;
 }
 
-/** The ref the RPC lane resolves an address through (its only addressing mode). */
-function rpcRefFor(addr: RefAddress): string {
-  return addr.ref ?? String(addr.smartRef);
+/**
+ * The CSS selector the RPC lane resolves an address through.
+ *
+ * Its only addressing mode is a selector, so a ref becomes the `data-wmux-ref`
+ * tag the snapshot wrote and a caller's own selector is passed through.
+ */
+function rpcSelectorFor(addr: RefAddress, scope: BrowserTargetScope): string {
+  if (addr.selector !== undefined) return addr.selector;
+  const safeRef = sanitizeRef(addr.ref ?? String(addr.smartRef), scope);
+  return `[data-wmux-ref="${safeRef}"]`;
 }
 
 /** How an address reads back in a tool result. */
 function describeAddress(addr: RefAddress): string {
-  return addr.ref !== undefined ? `ref=${addr.ref}` : `smartRef=${addr.smartRef}`;
+  if (addr.ref !== undefined) return `ref=${addr.ref}`;
+  if (addr.smartRef !== undefined) return `smartRef=${addr.smartRef}`;
+  return `selector=${addr.selector}`;
 }
 
 /**
@@ -490,6 +541,7 @@ function targetForRecord(
   addr: RefAddress,
 ): { ref: string } | { refEntry: NonNullable<ReturnType<typeof smartRefAxisEntry>> } | { selector: string } | Record<string, never> {
   if (addr.ref !== undefined) return { ref: addr.ref };
+  if (addr.selector !== undefined) return { selector: addr.selector };
   if (addr.smartRef !== undefined) {
     const entry = smartRefAxisEntry(addr.smartRef);
     if (entry) return { refEntry: entry };
@@ -525,13 +577,31 @@ async function isPasswordElement(el: TypeTarget | ElementHandle): Promise<boolea
   }
 }
 
-/** Same question over the RPC transport, resolved through the data-wmux-ref tag. */
-async function rpcIsPasswordElement(ref: string, scope: BrowserTargetScope): Promise<boolean> {
+/**
+ * A CSS selector as a single-quoted JS string literal.
+ *
+ * The refs this used to carry were `[a-zA-Z0-9_-]+` by sanitizeRef, so quoting
+ * them was a non-question. A caller's own selector reaches the probe now
+ * (browser_type's `selector`), and an apostrophe in one — `[title='x']` — would
+ * otherwise close the literal it sits in.
+ */
+function jsStringLiteral(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+  return `'${escaped}'`;
+}
+
+/** Same question over the RPC transport, resolved through a CSS selector. */
+async function rpcIsPasswordElement(selector: string, scope: BrowserTargetScope): Promise<boolean> {
   try {
-    const safeRef = sanitizeRef(ref, scope);
     const val = await rpcEval(`(() => {
       const isPasswordField = ${PASSWORD_FIELD_PREDICATE_JS};
-      return isPasswordField(document.querySelector('[data-wmux-ref="${safeRef}"]')) ? 'yes' : 'no';
+      return isPasswordField(document.querySelector(${jsStringLiteral(selector)})) ? 'yes' : 'no';
     })()`, scope);
     return val === 'yes';
   } catch {
@@ -861,12 +931,16 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
   // -----------------------------------------------------------------------
   server.tool(
     'browser_type',
-    'Type text into an element by ref or smartRef, replacing any existing value. Typing into a password field echoes "[redacted:password]" back — the text still went in.',
+    'Type text into an element by ref, smartRef or CSS selector, replacing any existing value. Typing into a password field echoes "[redacted:password]" back — the text still went in.',
     BROWSER_TYPE_SHAPE,
-    async ({ ref, smartRef, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ ref, smartRef, selector, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
-        const addr: RefAddress = { ...(ref !== undefined && { ref }), ...(smartRef !== undefined && { smartRef }) };
-        requireOneTarget(addr, 'browser_type');
+        const addr: RefAddress = {
+          ...(ref !== undefined && { ref }),
+          ...(smartRef !== undefined && { smartRef }),
+          ...(selector !== undefined && { selector }),
+        };
+        requireOneTarget(addr, 'browser_type', ['ref', 'smartRef', 'selector']);
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         // Decided BEFORE typing: the field is addressable now, and a submit can
@@ -885,9 +959,9 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           if (submit) await page.keyboard.press('Enter');
         } else {
           // RPC fallback
-          const rpcRef = rpcRefFor(addr);
-          isPassword = await rpcIsPasswordElement(rpcRef, scope);
-          await rpcFill(rpcRef, text, scope);
+          const rpcSelector = rpcSelectorFor(addr, scope);
+          isPassword = await rpcIsPasswordElement(rpcSelector, scope);
+          await rpcFill(rpcSelector, text, scope);
           if (submit) await rpcPressKey('Enter', scope);
         }
 
@@ -957,15 +1031,15 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
             ...(field.smartRef !== undefined && { smartRef: field.smartRef }),
           };
           try {
-            requireOneTarget(addr, 'browser_fill');
+            requireOneTarget(addr, 'browser_fill', ['ref', 'smartRef']);
             if (page) {
               const el = await resolveTypeTarget(page, addr);
               isPassword[i] = await isPasswordElement(el);
               await el.fill(field.value);
             } else {
-              const rpcRef = rpcRefFor(addr);
-              isPassword[i] = await rpcIsPasswordElement(rpcRef, scope);
-              await rpcFill(rpcRef, field.value, scope);
+              const rpcSelector = rpcSelectorFor(addr, scope);
+              isPassword[i] = await rpcIsPasswordElement(rpcSelector, scope);
+              await rpcFill(rpcSelector, field.value, scope);
             }
             filled++;
           } catch (err) {

--- a/src/mcp/playwright/tools/interaction.ts
+++ b/src/mcp/playwright/tools/interaction.ts
@@ -79,6 +79,10 @@ const BROWSER_TYPE_SHAPE = {
     .optional()
     .describe('CSS selector, for an element no snapshot gave a ref (e.g. a contenteditable div).'),
   text: z.string(),
+  newline: z
+    .enum(['literal', 'enter', 'shift-enter'])
+    .optional()
+    .describe('How a \\n is sent: literal (default) or a real keypress between the lines.'),
   submit: z
     .boolean()
     .optional()
@@ -523,6 +527,78 @@ function rpcSelectorFor(addr: RefAddress, scope: BrowserTargetScope): string {
   return `[data-wmux-ref="${safeRef}"]`;
 }
 
+/**
+ * The key that ends a line, or null to leave `\n` in the inserted text.
+ *
+ * `Input.insertText` — what both lanes type with, because it is the only thing
+ * that survives CJK IME composition and React's controlled inputs — puts the
+ * newline character into the field verbatim. A single-line input drops it, and
+ * a rich-text editor that listens for the keydown never sees one either, so
+ * Instagram's caption came out as one paragraph and the user pressed Enter
+ * eight times by hand (dogfood 2026-09-04). Splitting on `\n` and pressing a
+ * real key between the pieces is what the editor is actually listening for.
+ *
+ * Default stays `literal`: a `\n` in a search box has meant a literal newline
+ * since the tool existed, and a caller passing multi-line text to a one-line
+ * field must not suddenly submit it.
+ */
+function newlineKeyFor(mode: 'literal' | 'enter' | 'shift-enter' | undefined): string | null {
+  if (mode === 'enter') return 'Enter';
+  if (mode === 'shift-enter') return 'Shift+Enter';
+  return null;
+}
+
+/**
+ * Type `text` into an already-resolved element on the Playwright lane.
+ *
+ * The FIRST segment replaces the field's value — the contract browser_type has
+ * always had — and every later one is inserted after its key, at the caret the
+ * key left behind.
+ */
+async function typeIntoTarget(
+  page: Page,
+  el: TypeTarget,
+  text: string,
+  opts: { humanlike?: boolean; newlineKey: string | null },
+): Promise<string[]> {
+  const segments = opts.newlineKey === null ? [text] : text.split('\n');
+  for (let i = 0; i < segments.length; i++) {
+    if (i > 0) await page.keyboard.press(opts.newlineKey as string);
+    const segment = segments[i];
+    if (i === 0) {
+      if (opts.humanlike) {
+        await el.click();
+        await typeHumanlike(page, '', segment);
+      } else {
+        await el.fill(segment);
+      }
+      continue;
+    }
+    // An empty segment is a blank line: the keypress above already made it.
+    if (segment.length === 0) continue;
+    if (opts.humanlike) await typeHumanlike(page, '', segment);
+    else await page.keyboard.insertText(segment);
+  }
+  return segments;
+}
+
+/** The same, over the RPC transport, where the caret is the page's own. */
+async function rpcTypeInto(
+  selector: string,
+  text: string,
+  scope: BrowserTargetScope,
+  newlineKey: string | null,
+): Promise<string[]> {
+  const segments = newlineKey === null ? [text] : text.split('\n');
+  await rpcFill(selector, segments[0], scope);
+  for (const segment of segments.slice(1)) {
+    await rpcPressKey(newlineKey as string, scope);
+    if (segment.length === 0) continue;
+    await sendScopedBrowserRpc('browser.type.cdp', scope, { text: segment });
+  }
+  return segments;
+}
+
 /** How an address reads back in a tool result. */
 function describeAddress(addr: RefAddress): string {
   if (addr.ref !== undefined) return `ref=${addr.ref}`;
@@ -933,7 +1009,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
     'browser_type',
     'Type text into an element by ref, smartRef or CSS selector, replacing any existing value. Typing into a password field echoes "[redacted:password]" back — the text still went in.',
     BROWSER_TYPE_SHAPE,
-    async ({ ref, smartRef, selector, text, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
+    async ({ ref, smartRef, selector, text, newline, submit, humanlike, surfaceId }) => withAutomationLease(deps, surfaceId, async (scope) => {
       try {
         const addr: RefAddress = {
           ...(ref !== undefined && { ref }),
@@ -941,27 +1017,24 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           ...(selector !== undefined && { selector }),
         };
         requireOneTarget(addr, 'browser_type', ['ref', 'smartRef', 'selector']);
+        const newlineKey = newlineKeyFor(newline);
         const page = await engine.getPageForScope(scope).catch(allowScopedRpcFallback);
 
         // Decided BEFORE typing: the field is addressable now, and a submit can
         // navigate the page out from under a later lookup.
         let isPassword: boolean;
+        let segments: string[];
 
         if (page) {
           const el = await resolveTypeTarget(page, addr);
           isPassword = await isPasswordElement(el);
-          if (humanlike) {
-            await el.click();
-            await typeHumanlike(page, '', text);
-          } else {
-            await el.fill(text);
-          }
+          segments = await typeIntoTarget(page, el, text, { humanlike, newlineKey });
           if (submit) await page.keyboard.press('Enter');
         } else {
           // RPC fallback
           const rpcSelector = rpcSelectorFor(addr, scope);
           isPassword = await rpcIsPasswordElement(rpcSelector, scope);
-          await rpcFill(rpcSelector, text, scope);
+          segments = await rpcTypeInto(rpcSelector, text, scope, newlineKey);
           if (submit) await rpcPressKey('Enter', scope);
         }
 
@@ -969,6 +1042,12 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
         // field — except when the field is a credential, where the echo would
         // only re-enter the value into the transcript and the logs.
         const echoed = isPassword ? REDACTED_PASSWORD : text;
+        // How many keypresses the newline mode spent, so a caller can tell a
+        // field that swallowed them from one that never got them.
+        const lineNote =
+          newlineKey && segments.length > 1
+            ? ` as ${segments.length} lines (${newlineKey} between them)`
+            : '';
 
         // A password step is recorded as a HOLE, never as a step carrying its
         // own value: the text does not enter the ring, so it cannot reach the
@@ -981,7 +1060,9 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           tool: 'browser_type',
           page,
           ...targetForRecord(addr),
-          args: isPassword ? {} : { text, ...(submit && { submit: true }) },
+          args: isPassword
+            ? {}
+            : { text, ...(newline && { newline }), ...(submit && { submit: true }) },
           ...(isPassword && { unrecordable: 'password' as const }),
         });
 
@@ -989,7 +1070,7 @@ export function registerInteractionTools(server: McpServer, deps: BrowserToolDep
           content: [
             {
               type: 'text' as const,
-              text: `Typed "${echoed}" into element ${describeAddress(addr)}${submit ? ' and submitted' : ''}`,
+              text: `Typed "${echoed}" into element ${describeAddress(addr)}${lineNote}${submit ? ' and submitted' : ''}`,
             },
           ],
         };


### PR DESCRIPTION
## Summary

Browser tool fixes from a YouTube Studio / Instagram upload dogfood session (`plans/orch-w2-lane-d-browser.md`). Findings 1–4 and 6 are fixed; 5, 7 and 8 are analysed below with a concrete proposal each.

- **smartRef accepted everywhere** (1): `browser_type` and `browser_fill` resolve a smartRef exactly like `browser_click`; a not-found error names the ref space it was given and which parameter to use.
- **contenteditable is interactive** (2): `contenteditable` hosts (not descendants, and not `="false"`) get refs in both the page-level and the scoped snapshot, so `filter: 'interactive'` and `selector: "[role=dialog]"` show YouTube Studio's title/description. `browser_type` also takes a `selector`; the RPC lane resolves every address through a CSS selector with a string-literal escape so a caller's apostrophe cannot break the password probe.
- **Multiline input** (3): `browser_type({ newline: 'literal' | 'enter' | 'shift-enter' })`, default `literal` (today's behaviour). Splits on `\n` and presses the key between segments on both lanes; the mode is recorded in the step and honoured by replay.
- **Snapshot text filter** (4): `browser_snapshot({ q })`, case-insensitive substring or `/pattern/flags`; keeps matched subtrees plus ancestors so refs stay usable, runs before the interactive filter and the overflow retry, joins the auto-diff key, works on the scoped path. The DOM-listing fallback says `q` was ignored instead of looking filtered.
- **Live Chrome hint** (6): `LIVE_CHROME_UNAVAILABLE` and `docs/browser-backends.md` name the "Remote debugging" sidebar item; the `#remote-debugging` fragment lands on Devices.

Byte counts: full 77,603 / 78,000 · core 48,241 · commander 52,679. Baseline SHAs refreshed per commit.

### Proposals (not implemented)

- **5 · screenshot DPR vs click CSS px**: add `coordSpace: 'css' | 'screenshot'` to `browser_click` (default `css`); on `screenshot`, divide by the DPR read at click time through the same isolated-world read the screenshot uses, and refuse when it cannot be read. A CSS-px screenshot option would re-encode the image and lose detail.
- **7 · `browser_tabs list` shows one tab**: `ChromeLauncher.listTargets` intersects `/json/list` with the surface registry, so a tab is hidden when (a) its record belongs to another workspace, (b) Chrome swapped the page target inside the tab and the rebinding depends on the env-gated tab-target watcher, or (c) the page opened it itself (`target=_blank`). Fix shape: list unregistered live page targets as an adoptable "unmanaged" section and rebind by tab target.
- **8 · upload allow-list**: turn `validateUploadPath`'s single root into a list (uploads root plus per-session grants). Grants must come from the human (a UI action or config), never from an agent-callable tool; in memory, per workspace, cleared on surface close; both roots named in the refusal.

### Left for a follow-up (outside this lane's files)

- The same wrong `chrome://inspect/#remote-debugging` fragment remains in `src/main/pipe/handlers/browser.rpc.ts` and four locale strings (`chromeProfiles.liveDesc` in en/ko/zh/pl).

## Test plan

- [x] 16 new tests: `snapshot.contenteditable` (4), `interaction.typeNewline` (6), `snapshot.query` (5), plus `interaction.typeSmartRef` (+2), `replayRunner` (+1), `LiveChromeClient.attach` (+1).
- [x] `tsc --noEmit` all tsconfigs, eslint clean on touched files (the 7 `ban-types` / `no-empty-function` errors in `interaction.ts` are byte-identical to main), `npm run build:mcp && npm run probe:mcp` green.
- [x] Owned directories `src/mcp/playwright` + `src/mcp/browser-replay` + `src/main/browser-session`: 1,074 / 1,074. Full `npm test` on this machine has 15 environmental timeouts that reproduce on the untouched main checkout; CI is the clean run.
- [ ] Live re-run of the YouTube Studio title/description flow through `browser_smart_snapshot` → `browser_fill` (tracked as dogfood).

Changelog fragment: `changelog.d/browser-dogfood.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text and regular-expression filtering for browser snapshots.
  * Browser interactions now support smart snapshot references and selector-based typing.
  * Added configurable newline handling for typing: literal, Enter, or Shift+Enter.
  * Contenteditable fields now appear as interactive snapshot elements.
  * Browser replay supports recorded newline typing behavior.

* **Bug Fixes**
  * Updated Chrome remote debugging guidance to direct users to the correct sidebar option.
  * Improved error messages for invalid or missing interaction targets.
  * Prevented typing or filling when the target field does not receive focus.

* **Documentation**
  * Clarified Live Chrome remote debugging setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->