### PR TITLE
fix(orch): a fan-out task workspace never runs a brain of its own

### DIFF
--- a/changelog.d/task-workspace-no-brain.md
+++ b/changelog.d/task-workspace-no-brain.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **A fan-out task workspace no longer spawns an orchestrator brain of its own.** Since the task workspace started inheriting its owner's Deck mode (so the owner's brain may press its approvals), that mode also made it brain-eligible: every worker got a brain that consumed the worker's own stop events before the owner ever saw them, one extra Claude session per worker, held open by the Stop gate. Task workspaces are now brain-less for as long as their task is open — the composer and every ambient driver answer `task_workspace` — and a worker's stop reaches only the owner, tagged with its task.

--- a/src/main/deck/CommanderSessionManager.ts
+++ b/src/main/deck/CommanderSessionManager.ts
@@ -35,12 +35,14 @@ export interface CommanderSendResult {
   /** Present on rejection: `busy` (a turn is running), `disposed`, `empty`,
    *  `invalid_workspace` (handler-level, M1.5 — the send carried no valid
    *  workspaceId to route to an orchestrator), or `mode_off` (handler-level —
-   *  the workspace's agent mode is `off`, so the brain must not run at all).
+   *  the workspace's agent mode is `off`, so the brain must not run at all),
+   *  or `task_workspace` (handler-level — a fan-out task workspace never runs
+   *  a brain of its own; the owner's brain drives it).
    *  Additionally `errored` rides an ok:true result when the turn RAN but the
    *  adapter threw mid-stream — callers that must distinguish "completed" from
    *  "died mid-turn" (the re-examine consume) check it; everyone else keys off
    *  `ok` alone. */
-  code?: 'busy' | 'disposed' | 'empty' | 'invalid_workspace' | 'mode_off' | 'errored';
+  code?: 'busy' | 'disposed' | 'empty' | 'invalid_workspace' | 'mode_off' | 'task_workspace' | 'errored';
 }
 
 export interface CommanderStatusSnapshot {

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -8,7 +8,12 @@
 // Stores are mocked in-memory: the handler's CONTRACT with them is under test;
 // the stores' file behavior is covered by their own suites.
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { TaskLedger } from '../../../../daemon/ledger/TaskLedger';
+import { setTaskLedgerForTests } from '../../../deck/taskLedgerHost';
 
 const captured = new Map<string, (...args: unknown[]) => unknown>();
 
@@ -1078,5 +1083,57 @@ describe("regression — yesterday's frozen fork now composes a resolve-first tu
     const res = await invoke(IPC.DECK_SEND, { workspaceId: 'ws-1', text: 'x' });
     expect(res).toEqual({ ok: false, code: 'mode_off' });
     expect(adapters).toHaveLength(0);
+  });
+});
+
+describe('fan-out task workspaces never run a brain of their own (wave 2 dogfood finding 7)', () => {
+  // A task workspace inherits its owner's mode so the OWNER's brain may press
+  // its approvals. That mode alone made it brain-eligible: every worker got a
+  // brain that swallowed its own stop events before the owner saw them.
+  let ledgerDir: string;
+  let ledger: TaskLedger;
+  beforeEach(async () => {
+    ledgerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-deck-task-ws-'));
+    ledger = new TaskLedger({ dir: ledgerDir });
+    setTaskLedgerForTests(ledger);
+    await ledger.register({ id: 'wtask-1', taskWorkspaceId: 'ws-task', ownerWorkspaceId: 'ws-1', title: 'lane' });
+    mockMode = 'danger';
+  });
+  afterEach(() => {
+    setTaskLedgerForTests(null);
+    fs.rmSync(ledgerDir, { recursive: true, force: true });
+  });
+
+  it("a worker's stop wakes the OWNER's brain, tagged with the task — and spawns nothing on the task workspace", { timeout: 10_000 }, async () => {
+    eventBus.emit({
+      type: 'agent.lifecycle',
+      workspaceId: 'ws-task',
+      ptyId: 'p-worker',
+      kind: 'agent.stop',
+      source: 'hook',
+      agent: 'claude',
+      decision: 'emit',
+    });
+    // The edge path debounces 1.5 s before it flushes; wait past it.
+    await new Promise((r) => setTimeout(r, 1_700));
+    expect(adapters.some((a) => a.workspaceId === 'ws-task')).toBe(false);
+    const owner = adapters.find((a) => a.workspaceId === 'ws-1');
+    expect(owner).toBeDefined();
+    const wake = owner!.sentTexts.find((t) => t.includes('[pane-events]'));
+    expect(wake).toBeDefined();
+    expect(wake).toContain('p-worker');
+    expect(wake).toContain('wtask-1');
+  });
+
+  it('the ambient turn path and the composer both refuse a task workspace, whatever its mode', async () => {
+    expect(await invoke(IPC.DECK_WAKE, { workspaceId: 'ws-task' })).toEqual({ ok: false, code: 'task_workspace' });
+    expect(await invoke(IPC.DECK_SEND, { workspaceId: 'ws-task', text: 'hello' })).toEqual({ ok: false, code: 'task_workspace' });
+    expect(adapters).toHaveLength(0);
+  });
+
+  it('a finished task hands its workspace back: the refusal lifts once the entry is closed', async () => {
+    await ledger.update({ id: 'wtask-1', status: 'cancelled', actor: { kind: 'system', workspaceId: 'daemon' }, expectedRev: 1 });
+    const res = await invoke(IPC.DECK_WAKE, { workspaceId: 'ws-task' });
+    expect(res).not.toEqual({ ok: false, code: 'task_workspace' });
   });
 });

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -1098,6 +1098,19 @@ describe('fan-out task workspaces never run a brain of their own (wave 2 dogfood
     setTaskLedgerForTests(ledger);
     await ledger.register({ id: 'wtask-1', taskWorkspaceId: 'ws-task', ownerWorkspaceId: 'ws-1', title: 'lane' });
     mockMode = 'danger';
+    // The outer beforeEach registered the handler against the previous ledger
+    // instance (its transition listener is bound at registration); re-register
+    // so the handler observes THIS ledger.
+    cleanup?.();
+    captured.clear();
+    adapters = [];
+    cleanup = registerDeckHandler(() => fakeWindow, {
+      createAdapter: (opts) => {
+        const a = new FakeAdapter(opts.workspaceId);
+        adapters.push(a);
+        return a;
+      },
+    });
   });
   afterEach(() => {
     setTaskLedgerForTests(null);
@@ -1131,9 +1144,29 @@ describe('fan-out task workspaces never run a brain of their own (wave 2 dogfood
     expect(adapters).toHaveLength(0);
   });
 
-  it('a finished task hands its workspace back: the refusal lifts once the entry is closed', async () => {
+  it('a finished task hands its workspace back: the refusal lifts, and the inherited autonomy is cleared', async () => {
+    capWrites.length = 0;
     await ledger.update({ id: 'wtask-1', status: 'cancelled', actor: { kind: 'system', workspaceId: 'daemon' }, expectedRev: 1 });
+    await new Promise((r) => setTimeout(r, 10));
     const res = await invoke(IPC.DECK_WAKE, { workspaceId: 'ws-task' });
     expect(res).not.toEqual({ ok: false, code: 'task_workspace' });
+    expect(capWrites).toContainEqual({ ws: 'ws-task', patch: { mode: 'off' } });
+  });
+
+  it("an owner that is itself a task workspace (nested fan-out) has no brain: the event is parked, not pushed", async () => {
+    // ws-1 owns wtask-1 (ws-task); make ws-1 itself a task of ws-root.
+    await ledger.register({ id: 'wtask-0', taskWorkspaceId: 'ws-1', ownerWorkspaceId: 'ws-root', title: 'outer' });
+    eventBus.emit({
+      type: 'agent.lifecycle',
+      workspaceId: 'ws-task',
+      ptyId: 'p-worker',
+      kind: 'agent.stop',
+      source: 'hook',
+      agent: 'claude',
+      decision: 'emit',
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ledger.peekOrphanedEvents('ws-1').length).toBe(1);
+    expect(adapters).toHaveLength(0);
   });
 });

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -672,7 +672,20 @@ export function registerDeckHandler(
    * courtesy, not the enforcement: schedules, loops, the heartbeat and the pipe
    * RPC all start turns without going anywhere near it.
    */
-  const refuseWhenModeOff = (workspaceId: string): { ok: false; code: 'mode_off' } | null => {
+  /** True while `workspaceId` is the task workspace of an OPEN fan-out task.
+   *  A finished task's workspace is an ordinary workspace again. Never throws:
+   *  an unreadable ledger answers false, which is the pre-wave-2 behaviour. */
+  const isTaskWorkspace = (workspaceId: string): boolean => {
+    try {
+      return getTaskLedger().findOpenByTaskWorkspace(workspaceId) !== null;
+    } catch {
+      return false;
+    }
+  };
+
+  const refuseWhenModeOff = (
+    workspaceId: string,
+  ): { ok: false; code: 'mode_off' | 'task_workspace' } | null => {
     let mode: AgentMode;
     try {
       mode = loadWorkspaceMode(workspaceId);
@@ -681,7 +694,16 @@ export function registerDeckHandler(
       // the loader; this catch only covers a throw it cannot itself absorb.
       return { ok: false, code: 'mode_off' };
     }
-    return mode === 'off' ? { ok: false, code: 'mode_off' } : null;
+    if (mode === 'off') return { ok: false, code: 'mode_off' };
+    // A fan-out task workspace never runs a brain of its own, whatever its
+    // mode says. It inherits the owner's mode so the OWNER's brain may press
+    // its approvals (taskAutonomy.ts) — but that same mode made it
+    // brain-eligible here, and the wave 2 dogfood showed the result: one
+    // brain per worker, each consuming its own worker's stop events before
+    // the owner ever saw them (dogfood-orchestrator-2026-09.md, finding 7).
+    // The owner's brain is the only one that drives a task workspace.
+    if (isTaskWorkspace(workspaceId)) return { ok: false, code: 'task_workspace' };
+    return null;
   };
 
   const ensureManager = (
@@ -1688,11 +1710,13 @@ export function registerDeckHandler(
       // prompt can say whether the pane is blocked on a question.
       ...(ev.lastMessage ? { lastMessage: ev.lastMessage } : {}),
     };
-    coalescer?.push(lifecycleInput);
-    // Lane F: a fan-out task workspace has no brain of its own, so ALSO copy
-    // the event to the owning (parent) workspace's coalescer, tagged with the
+    // Lane F: a fan-out task workspace has no brain of its own, so the event
+    // goes ONLY to the owning (parent) workspace's coalescer, tagged with the
     // task. The parent's 'none' wake policy lets tagged events through; an
     // owner with no brain gets it parked in the ledger as an orphan backlog.
+    // Pushing it to the task workspace's own coalescer as well spawned a brain
+    // there once the task inherited the owner's mode (wave 2 finding 7).
+    if (!isTaskWorkspace(ev.workspaceId)) coalescer?.push(lifecycleInput);
     routeWorkerEventToOwner(lifecycleInput, {
       hasBrain: (owner) => managers.has(owner) || loadWorkspaceMode(owner) !== 'off',
       push: (copy) => coalescer?.push(copy),
@@ -1734,7 +1758,9 @@ export function registerDeckHandler(
     const entries = getWorkspaceMirror().getEntries();
     if (entries) {
       for (const e of entries) {
-        if (WORKSPACE_ID_RE.test(e.id) && loadWorkspaceMode(e.id) !== 'off') ids.add(e.id);
+        if (WORKSPACE_ID_RE.test(e.id) && loadWorkspaceMode(e.id) !== 'off' && !isTaskWorkspace(e.id)) {
+          ids.add(e.id);
+        }
       }
     }
     return [...ids];

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -675,10 +675,18 @@ export function registerDeckHandler(
   /** True while `workspaceId` is the task workspace of an OPEN fan-out task.
    *  A finished task's workspace is an ordinary workspace again. Never throws:
    *  an unreadable ledger answers false, which is the pre-wave-2 behaviour. */
+  let taskWorkspaceLookupWarned = false;
   const isTaskWorkspace = (workspaceId: string): boolean => {
     try {
       return getTaskLedger().findOpenByTaskWorkspace(workspaceId) !== null;
-    } catch {
+    } catch (err) {
+      // Fail open (= the pre-wave-2 behaviour) but never silently: an
+      // unreadable ledger is exactly the state in which the per-worker brain
+      // would come back, and the operator needs one line saying why.
+      if (!taskWorkspaceLookupWarned) {
+        taskWorkspaceLookupWarned = true;
+        console.warn(`[deck] task ledger unreadable; task workspaces may run brains until it recovers: ${String(err)}`);
+      }
       return false;
     }
   };
@@ -1542,6 +1550,16 @@ export function registerDeckHandler(
   });
   const disposeLedgerPush = getTaskLedger().onTransition((t) => {
     ledgerPushCoalescer.notify(t.entry.ownerWorkspaceId);
+    // The autonomy a task workspace inherited (taskAutonomy.ts) exists so the
+    // OWNER's brain may press its approvals while the task is open. Once the
+    // task is finished the workspace must not wake up as an autonomous
+    // workspace of its own (heartbeat, schedules, a late worker stop): hand
+    // it the product default again. `off` is what an absent entry means.
+    if (t.to === 'completed' || t.to === 'failed' || t.to === 'cancelled') {
+      void setWorkspaceMode(t.entry.taskWorkspaceId, 'off').catch((err) => {
+        console.warn(`[deck] could not clear the autonomy of finished task workspace ${t.entry.taskWorkspaceId}: ${String(err)}`);
+      });
+    }
   });
   coalescer = new CommanderEventCoalescer({
     runTurn: (workspaceId, prompt) => runTurnForWorkspace(prompt, workspaceId),
@@ -1718,7 +1736,10 @@ export function registerDeckHandler(
     // there once the task inherited the owner's mode (wave 2 finding 7).
     if (!isTaskWorkspace(ev.workspaceId)) coalescer?.push(lifecycleInput);
     routeWorkerEventToOwner(lifecycleInput, {
-      hasBrain: (owner) => managers.has(owner) || loadWorkspaceMode(owner) !== 'off',
+      // A task workspace never has a brain, whatever its mode says — an owner
+      // that is itself a task (nested fan-out) parks the event instead.
+      hasBrain: (owner) =>
+        !isTaskWorkspace(owner) && (managers.has(owner) || loadWorkspaceMode(owner) !== 'off'),
       push: (copy) => coalescer?.push(copy),
       reconcile: reconcileTaskLedger,
     });
@@ -1758,12 +1779,13 @@ export function registerDeckHandler(
     const entries = getWorkspaceMirror().getEntries();
     if (entries) {
       for (const e of entries) {
-        if (WORKSPACE_ID_RE.test(e.id) && loadWorkspaceMode(e.id) !== 'off' && !isTaskWorkspace(e.id)) {
-          ids.add(e.id);
-        }
+        if (WORKSPACE_ID_RE.test(e.id) && loadWorkspaceMode(e.id) !== 'off') ids.add(e.id);
       }
     }
-    return [...ids];
+    // A task workspace is not reviewed, whichever way it got in (a live
+    // manager, a live work record, or the mirror): the owner's brain reviews
+    // it through the tagged worker events instead.
+    return [...ids].filter((id) => !isTaskWorkspace(id));
   };
   // WP3 — the instruction the re-examine wake carries as its ORIGINAL prompt (the
   // stale [decision] block is prepended on the wire by runTurnForWorkspace). Kept


### PR DESCRIPTION
## Summary

Wave 2 dogfood finding 7 (`docs/internal/dogfood-orchestrator-2026-09.md`, PR #1211): since #1206 a task workspace inherits its owner's Deck mode so the owner's brain may press its approvals. That mode also made the task workspace brain-eligible, so every fan-out worker got a Deck brain of its own within a second of spawn. Those brains consumed their worker's stop events (`[pane-events] … kind=stop`) before the owner's coalescer saw them, acted as operators on their own worker, and were held open by the Stop gate for as long as the worker ran (66 turns / 32 tool calls for one worker).

- `refuseWhenModeOff` also refuses an open fan-out task workspace with `task_workspace` — the single kill switch every turn path goes through (composer, wake, heartbeat, loop, scheduler, decision resume).
- The event-push path no longer pushes a task workspace's own lifecycle events to its own coalescer; they go only to the owner, tagged with the task (lane F), exactly as before the inheritance landed.
- The heartbeat's reviewed-workspace list skips task workspaces.
- A closed task hands the workspace back (the refusal reads the ledger's OPEN entry).

## Test plan

- [x] New tests in `deck.handler.loop.test.ts`: a worker's stop wakes the OWNER's brain tagged with the task and spawns nothing on the task workspace; wake and composer both answer `task_workspace`; a cancelled task lifts the refusal.
- [x] `tsc --noEmit` (root + daemon), eslint on touched files, `vitest run src/main/deck src/main/ipc/handlers/__tests__ src/main/worktask` 78 files / 1,232 tests.
- [x] Re-run of the wave 2 brain-side dogfood on the packaged build: no brain spawned for either task workspace, and the owner brain woke and drove its workers once a stale pending decision was answered (docs/internal/dogfood-orchestrator-2026-09.md, wave 3 section, PR #1211).

## Review round (Claude + GLM)

- An owner that is itself a task workspace (nested fan-out) parks its worker events instead of pushing them into a coalescer whose turn is always refused.
- A task reaching completed/failed/cancelled hands its workspace the default mode again (the inherited `danger` no longer outlives the task).
- The heartbeat filters task workspaces from its final set, not only the mirror branch.
- An unreadable ledger warns once instead of silently reviving the per-worker brain.
- Deferred: the first stop arriving before the ledger row exists (fan-out registers the row before the worker starts; only a failed registration is exposed), and a per-workspace index on the ledger lookup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fan-out task workspaces now operate without their own AI brain while tasks are active.
  * Worker stop events are routed to the owning workspace and associated with the relevant task.
  * Task workspaces resume normal operation after tasks finish, fail, or are cancelled.

* **Bug Fixes**
  * Prevented ambient and composer interactions from starting turns in active task workspaces.
  * Improved handling of nested task workspace events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->