### PR TITLE
fix(orch): a pending decision no longer eats delegated wakes silently, refusals read REFUSED, and the ledger names its legal moves

### DIFF
--- a/changelog.d/brain-loop-honesty.md
+++ b/changelog.d/brain-loop-honesty.md
@@ -5,25 +5,34 @@
   deliberate — but until now the events it blocked were dropped without a
   trace, so a decision left over from a previous session ate every fan-out
   worker's "I'm done" and the orchestrator simply looked asleep. The block is
-  now logged once per workspace per minute, naming how many events it held and
-  which delegated tasks they belonged to, and a worker's own events are no
-  longer thrown away: they are held and delivered on the turn that follows the
-  answer. Ambient chatter is still dropped, as before.
+  now logged (once per workspace per minute, and again straight away for a new
+  decision), naming how many events it blocked and which delegated tasks they
+  belonged to. A worker's own events are no longer thrown away either: they are
+  parked in the same durable backlog that already holds events for a workspace
+  with no orchestrator, so they survive an app restart — the decision does —
+  and answering the decision replays them into the turn that follows. Answering
+  also restores the auto-wake budget the wait may have eaten. Ambient chatter is
+  still dropped, as before.
 
 - `fanout_start` now warns you at the moment it accepts when the launching
   workspace has a pending decision, instead of starting workers whose reports
-  will not reach anyone until it is answered.
+  will not reach anyone until it is answered. The warning leads the tool's
+  answer as its own line, not just a field an agent can skim past.
 
 - A refused `task_adopt`, `task_close` or `task_pr` now says so in a sentence
-  before it says so in JSON. The tool answer opens with `REFUSED (<reason>):
+  before it says so in JSON. The answer opens with `REFUSED (<reason>):
   <error>`, states that nothing was adopted / closed / opened, and names the
   one move that clears it — because an orchestrator reading an envelope for a
   commit sha was skimming past `ok: false` and reporting an adopt that had
-  never happened.
+  never happened. Refusals from the permission gate (an approval declined or
+  expired, a task that is not yours) now name their real cause instead of
+  reading as "unknown", and the JSON itself is left untouched so anything that
+  parses it still works.
 
 - The task ledger explains itself when it refuses a status change. An illegal
-  transition now lists the statuses that ARE reachable from the current one,
-  and the `ledger_update` tool text states the whole table in one line — which
-  moves belong to the worker, which to the orchestrator, and that `force` with
-  a reason is the orchestrator's only way past a worker that cannot report for
-  itself.
+  transition now lists the statuses that ARE reachable from the current one —
+  and only the ones the caller is actually allowed to set, so it never suggests
+  a move that would be refused a moment later. The `ledger_update` tool text
+  states the whole table, says plainly that a task can only be completed from
+  `review_requested`, and that an orchestrator may set that itself when the
+  worker cannot — with `force` and a reason as the way past a missing gate.

--- a/changelog.d/brain-loop-honesty.md
+++ b/changelog.d/brain-loop-honesty.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- An unanswered decision no longer silently kills the delegation loop. A
+  workspace with a pending decision is never auto-woken — that part is
+  deliberate — but until now the events it blocked were dropped without a
+  trace, so a decision left over from a previous session ate every fan-out
+  worker's "I'm done" and the orchestrator simply looked asleep. The block is
+  now logged once per workspace per minute, naming how many events it held and
+  which delegated tasks they belonged to, and a worker's own events are no
+  longer thrown away: they are held and delivered on the turn that follows the
+  answer. Ambient chatter is still dropped, as before.
+
+- `fanout_start` now warns you at the moment it accepts when the launching
+  workspace has a pending decision, instead of starting workers whose reports
+  will not reach anyone until it is answered.
+
+- A refused `task_adopt`, `task_close` or `task_pr` now says so in a sentence
+  before it says so in JSON. The tool answer opens with `REFUSED (<reason>):
+  <error>`, states that nothing was adopted / closed / opened, and names the
+  one move that clears it — because an orchestrator reading an envelope for a
+  commit sha was skimming past `ok: false` and reporting an adopt that had
+  never happened.
+
+- The task ledger explains itself when it refuses a status change. An illegal
+  transition now lists the statuses that ARE reachable from the current one,
+  and the `ledger_update` tool text states the whole table in one line — which
+  moves belong to the worker, which to the orchestrator, and that `force` with
+  a reason is the orchestrator's only way past a worker that cannot report for
+  itself.

--- a/docs/internal/orch-o2-tool-contract.md
+++ b/docs/internal/orch-o2-tool-contract.md
@@ -32,24 +32,33 @@ registerGitTools(server, { getSenderPtyId, resolveWorkspaceId });
 | `git_log` | `{ task_id?: z.string().min(1), limit?: z.number().int().min(1).max(50) }` | `task.git.log` |
 | `gh_pr_view` | `{ task_id: z.string().min(1) }` | `task.gh.prView` |
 
-A refusal from `task_adopt`, `task_close` or `task_pr` is PREFIXED with a
-plain-language verdict before the envelope (wave 3, finding 13 — a brain read
-two `ok: false` adopts and reported "adopt finished (ff51d7e)"):
+A refusal from `task_adopt`, `task_close` or `task_pr` answers with **two
+content blocks** (wave 3, finding 13 — a brain read two `ok: false` adopts and
+reported "adopt finished (ff51d7e)"):
 
 ```
-REFUSED (dirty-target): <the server's error>
-Nothing was adopted. Next step: commit or stash the target's changes, …
-
-{ "ok": false, "reason": "dirty-target", … }
+content[0]  REFUSED (dirty-target): <the server's error>
+            Nothing was adopted. Next step: commit or stash the target's changes, …
+content[1]  { "ok": false, "reason": "dirty-target", … }
 ```
 
-`isError: true` is set as before and the JSON still follows whole, so a caller
-that parses the envelope is unaffected — the header is for the caller that
-skims. The next-step text is keyed on the server's own `reason` (`dirty-target`,
+The verdict is its OWN block, never a prefix on the JSON: the envelope block
+must stay parseable, and a caller reading `content[0].text` as JSON would break
+on a prefix. **The envelope is always the LAST block** — read it from the end,
+not from index 0. A success answers with the single JSON block, exactly as
+before, and `isError: true` is set on a refusal as before.
+
+The next-step text is keyed on the server's own `reason` (`dirty-target`,
 `commit-failed`, `conflict`, `needs_rebase`, `empty` for adopt; `unpushed`,
-`dirty` for close; `gh-missing`, `gh-unauth`, `dirty`, `no-origin` for pr) with
-a generic "read `reason` and `error`, fix that, retry" fallback. The gate tools
-are unchanged: a failing gate is a successful CALL, not a refusal.
+`dirty` for close; `gh-missing`, `gh-unauth`, `dirty`, `no-origin` for pr).
+A refusal from the RPC **gate** (origin, identity, ownership, materialization)
+has no `reason` at all — it is `{ ok: false, error: { code, message } }` — so
+the header falls back to `error.code` for the reason and `error.message` for the
+text, with next steps for `NOT_AUTHORIZED` / `FAILED_PRECONDITION` /
+`PERMISSION_DENIED` / `INVALID_ARGUMENT` / `UNAVAILABLE`; anything else gets
+"read `reason` and `error`, fix that, retry". The gate TOOLS
+(`task_gate_run` / `task_gate_cancel`) are unchanged and carry no header: a
+failing gate is a successful CALL, not a refusal.
 
 `task_adopt`'s `commit` defaults to `false` — the staged, uncommitted result this
 lane shipped with. `commit: true` commits the index the `--3way` apply filled

--- a/docs/internal/orch-o2-tool-contract.md
+++ b/docs/internal/orch-o2-tool-contract.md
@@ -32,6 +32,25 @@ registerGitTools(server, { getSenderPtyId, resolveWorkspaceId });
 | `git_log` | `{ task_id?: z.string().min(1), limit?: z.number().int().min(1).max(50) }` | `task.git.log` |
 | `gh_pr_view` | `{ task_id: z.string().min(1) }` | `task.gh.prView` |
 
+A refusal from `task_adopt`, `task_close` or `task_pr` is PREFIXED with a
+plain-language verdict before the envelope (wave 3, finding 13 — a brain read
+two `ok: false` adopts and reported "adopt finished (ff51d7e)"):
+
+```
+REFUSED (dirty-target): <the server's error>
+Nothing was adopted. Next step: commit or stash the target's changes, …
+
+{ "ok": false, "reason": "dirty-target", … }
+```
+
+`isError: true` is set as before and the JSON still follows whole, so a caller
+that parses the envelope is unaffected — the header is for the caller that
+skims. The next-step text is keyed on the server's own `reason` (`dirty-target`,
+`commit-failed`, `conflict`, `needs_rebase`, `empty` for adopt; `unpushed`,
+`dirty` for close; `gh-missing`, `gh-unauth`, `dirty`, `no-origin` for pr) with
+a generic "read `reason` and `error`, fix that, retry" fallback. The gate tools
+are unchanged: a failing gate is a successful CALL, not a refusal.
+
 `task_adopt`'s `commit` defaults to `false` — the staged, uncommitted result this
 lane shipped with. `commit: true` commits the index the `--3way` apply filled
 with the subject `adopt: <title> (<task id>)`, taking the title from the

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -3,7 +3,7 @@
   "profiles": {
     "full": {
       "maxListBytes": 78000,
-      "wireResultSha256": "610525def102b44f92e20c4be2570d539055cfe33780f8c734e2809768f2c7a7",
+      "wireResultSha256": "34c9713e8b5be63b1f4c71a49fdffc7856c96eafd3758230f60627c7bf714741",
       "instructionSha256": "f18849bb1ea62bcf5a1e46a73d633c787b4e08e763cc04b01c4e557df8f833eb",
       "toolNames": [
         "browser_open",
@@ -99,7 +99,7 @@
     },
     "core": {
       "maxListBytes": 49000,
-      "wireResultSha256": "4036aa08b52701b5ecda81d9e264d2859fdc76e193c48af55dd9301469d745be",
+      "wireResultSha256": "16a2affbaa2c48f4f37e06aee89a7b0fcbe73913176b53f3447c677e32eef065",
       "instructionSha256": "0c313d4e88ad9313bb6a51ff00717abbb243ebcdd18f8e226cba2c738e43c95a",
       "toolNames": [
         "terminal_read",
@@ -154,7 +154,7 @@
     },
     "commander": {
       "maxListBytes": 60000,
-      "wireResultSha256": "cd329389d42658747b196446435a4455f276839e803a12b8efd318c2503b7dc0",
+      "wireResultSha256": "2150dd9a1a37c50d8db2fea64e5350041343a1859feca02388042938689df8d8",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",

--- a/scripts/mcp-protocol-baseline.json
+++ b/scripts/mcp-protocol-baseline.json
@@ -154,7 +154,7 @@
     },
     "commander": {
       "maxListBytes": 60000,
-      "wireResultSha256": "58bc3db43ac64959d8178700c11a09978038c054e1703450a6bb4461d9ae8684",
+      "wireResultSha256": "cd329389d42658747b196446435a4455f276839e803a12b8efd318c2503b7dc0",
       "instructionSha256": "5a97f851c892326eba7cbcf46292f6925834d5794172461d1ced997d90ac1deb",
       "toolNames": [
         "terminal_read",

--- a/src/daemon/ledger/TaskLedger.ts
+++ b/src/daemon/ledger/TaskLedger.ts
@@ -43,6 +43,7 @@ import {
   LEDGER_GATE_TAIL_MAX_BYTES,
   LEDGER_SCHEMA_VERSION,
   LEDGER_TERMINAL_RETENTION_MS,
+  LEDGER_TRANSITIONS,
   canActorSet,
   canTransition,
   isLedgerStatus,
@@ -358,7 +359,13 @@ export class TaskLedger {
       return {
         ok: false,
         error: 'illegal_transition',
-        message: `${entry.status} → ${next} is not an allowed transition`,
+        // Name the legal moves. A bare "working → completed is not allowed" told
+        // the brain it was wrong and nothing about what to do instead, and the
+        // move it wanted (`review_requested`) is the WORKER's — not something it
+        // could reach at all (dogfood finding 14).
+        message:
+          `${entry.status} → ${next} is not an allowed transition ` +
+          `(allowed from ${entry.status}: ${LEDGER_TRANSITIONS[entry.status].join(', ') || 'none — terminal'})`,
         entry,
       };
     }

--- a/src/daemon/ledger/TaskLedger.ts
+++ b/src/daemon/ledger/TaskLedger.ts
@@ -130,6 +130,16 @@ export interface LedgerListFilter {
   openOnly?: boolean;
 }
 
+/** The transitions `actor` may actually make from `entry`'s current status, as
+ *  a display string. Empty for a terminal status (nothing is reachable) and for
+ *  an actor the authorization rule bars from every reachable one. */
+function describeLegalMoves(entry: LedgerEntry, actor: LedgerActor): string {
+  const reachable = LEDGER_TRANSITIONS[entry.status as LedgerStatus] ?? [];
+  if (reachable.length === 0) return 'none — terminal';
+  const mine = reachable.filter((to) => canActorSet(actor, entry, to));
+  return mine.length > 0 ? mine.join(', ') : `none — ${actor.kind} may set none of ${reachable.join(', ')}`;
+}
+
 export const OPEN_LEDGER_STATUSES: readonly LedgerStatus[] = [
   'working',
   'input_required',
@@ -359,13 +369,15 @@ export class TaskLedger {
       return {
         ok: false,
         error: 'illegal_transition',
-        // Name the legal moves. A bare "working → completed is not allowed" told
-        // the brain it was wrong and nothing about what to do instead, and the
-        // move it wanted (`review_requested`) is the WORKER's — not something it
-        // could reach at all (dogfood finding 14).
+        // Name the legal moves — and only the ones THIS actor may make, or the
+        // message advertises a transition the authorization check would refuse
+        // one line later. A bare "working → completed is not allowed" told the
+        // caller it was wrong and nothing about what to do instead (finding 14).
+        // `?? []` because the status is replayed from disk: an unknown/legacy
+        // one reaches here (canTransition already refused it) and must not throw.
         message:
           `${entry.status} → ${next} is not an allowed transition ` +
-          `(allowed from ${entry.status}: ${LEDGER_TRANSITIONS[entry.status].join(', ') || 'none — terminal'})`,
+          `(allowed from ${entry.status} for ${input.actor.kind}: ${describeLegalMoves(entry, input.actor)})`,
         entry,
       };
     }

--- a/src/daemon/ledger/__tests__/TaskLedger.test.ts
+++ b/src/daemon/ledger/__tests__/TaskLedger.test.ts
@@ -243,7 +243,23 @@ describe('TaskLedger — transition matrix', () => {
     expect(res).toMatchObject({ ok: false, error: 'illegal_transition' });
     if (res.ok) throw new Error('unreachable');
     expect(res.message).toContain('working → completed is not an allowed transition');
-    expect(res.message).toContain('allowed from working: input_required, review_requested, failed, cancelled');
+    expect(res.message).toContain('allowed from working for brain: input_required, review_requested, failed, cancelled');
+  });
+
+  // The list must not advertise a move the authorization check refuses one line
+  // later: a worker may not cancel its own task, so `cancelled` is not offered
+  // even though the transition table reaches it.
+  it('the legal moves are filtered to what the CALLING actor may set', async () => {
+    const a = open();
+    await seed(a);
+    await driveTo(a, 'wtask-1', 'failed');
+    const cur = a.get('wtask-1')!;
+    const res = await a.update({ id: 'wtask-1', status: 'review_requested', actor: WORKER, expectedRev: cur.rev });
+    expect(res).toMatchObject({ ok: false, error: 'illegal_transition' });
+    if (res.ok) throw new Error('unreachable');
+    // The table says failed → working | cancelled; a worker may only do the first.
+    expect(res.message).toContain('allowed from failed for worker: working');
+    expect(res.message).not.toContain('cancelled');
   });
 
   it('a terminal status says so instead of listing nothing', async () => {
@@ -254,7 +270,7 @@ describe('TaskLedger — transition matrix', () => {
     const res = await a.update({ id: 'wtask-1', status: 'working', actor: SYSTEM, expectedRev: cur.rev });
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('unreachable');
-    expect(res.message).toContain('allowed from cancelled: none — terminal');
+    expect(res.message).toContain('allowed from cancelled for system: none — terminal');
   });
 
   it('refuses an unknown status and a stale rev', async () => {

--- a/src/daemon/ledger/__tests__/TaskLedger.test.ts
+++ b/src/daemon/ledger/__tests__/TaskLedger.test.ts
@@ -234,6 +234,29 @@ describe('TaskLedger — transition matrix', () => {
     }
   }
 
+  // Wave 3, finding 14: the brain tried working → completed and was told only
+  // that it was wrong. The message now names the moves it CAN make from here.
+  it('an illegal transition names the legal moves from the current status', async () => {
+    const a = open();
+    await seed(a);
+    const res = await a.update({ id: 'wtask-1', status: 'completed', actor: BRAIN, expectedRev: 1 });
+    expect(res).toMatchObject({ ok: false, error: 'illegal_transition' });
+    if (res.ok) throw new Error('unreachable');
+    expect(res.message).toContain('working → completed is not an allowed transition');
+    expect(res.message).toContain('allowed from working: input_required, review_requested, failed, cancelled');
+  });
+
+  it('a terminal status says so instead of listing nothing', async () => {
+    const a = open();
+    await seed(a);
+    await driveTo(a, 'wtask-1', 'cancelled');
+    const cur = a.get('wtask-1')!;
+    const res = await a.update({ id: 'wtask-1', status: 'working', actor: SYSTEM, expectedRev: cur.rev });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unreachable');
+    expect(res.message).toContain('allowed from cancelled: none — terminal');
+  });
+
   it('refuses an unknown status and a stale rev', async () => {
     const a = open();
     await seed(a);

--- a/src/main/deck/CommanderEventCoalescer.ts
+++ b/src/main/deck/CommanderEventCoalescer.ts
@@ -201,6 +201,11 @@ interface WsState {
    *  no wake was actually attempted on. Bounded: pruned each flush to only ptyIds
    *  still `complete` in the latest snapshot, so it can't outgrow the live fleet. */
   snapshotSurfacedComplete: Set<string>;
+  /** Our clock at the last pending-decision block we logged for this
+   *  workspace. Rate-limits that line to one per PENDING_DECISION_LOG_MS so a
+   *  chatty fleet (or a held backlog re-examined on every idle) cannot spam
+   *  the log while one decision sits unanswered. */
+  pendingDecisionLoggedAt: number;
 }
 
 /** A running loop's wake-relevant slice (read fresh at every flush). */
@@ -270,6 +275,11 @@ export interface CoalescerDeps {
   peekOrphanBacklog?: (workspaceId: string) => CoalescerInput[];
   /** Lane F: the parked events at or below `upToSeq` reached the brain. */
   ackOrphanBacklog?: (workspaceId: string, upToSeq: number) => void;
+  /** One-line diagnostics sink (default `console.warn`). Used by the pending
+   *  decision gate, which is otherwise a silent kill switch: a wake it blocks
+   *  left no trace anywhere, so "the brain never woke" was indistinguishable
+   *  from "no event ever fired". */
+  log?: (line: string) => void;
 }
 
 const DEFAULT_DEBOUNCE_MS = 1_500;
@@ -284,6 +294,10 @@ const DEFAULT_MAX_WAKES_PER_MIN = 6;
 const RATE_WINDOW_MS = 60_000;
 /** Cap the rendered lines so a fleet-wide storm can't blow the turn context. */
 const MAX_FLUSH_LINES = 20;
+/** Rate limit for the pending-decision block line, per workspace. */
+const PENDING_DECISION_LOG_MS = 60_000;
+/** Task ids named in that line before it is elided (keeps one line one line). */
+const PENDING_DECISION_LOG_MAX_IDS = 5;
 
 export class CommanderEventCoalescer {
   private readonly deps: CoalescerDeps;
@@ -391,8 +405,19 @@ export class CommanderEventCoalescer {
     this.reconcileSurfacedComplete(st, snapshot);
     // Decision gate: a pending decision blocks EVERY wake, snapshot included.
     // Drop the snapshot (the next heartbeat re-reads it); leave buffered edges
-    // untouched for the normal edge path to govern.
-    if (this.safeHasPendingDecision(workspaceId)) return;
+    // untouched for the normal edge path to govern. Logged (rate-limited) for
+    // the same reason the edge path logs: silence here read as "nothing fired".
+    if (this.safeHasPendingDecision(workspaceId)) {
+      const edges = this.collectBuffer(st);
+      this.logPendingDecisionBlock(
+        st,
+        workspaceId,
+        edges.length,
+        edges.filter((e) => e.task !== undefined),
+        { snapshot: true },
+      );
+      return;
+    }
     const loopHint = this.safeGetLoop(workspaceId);
     const loopRunning = loopHint?.running === true;
     const workActive = this.safeHasActiveWork(workspaceId);
@@ -635,6 +660,7 @@ export class CommanderEventCoalescer {
         autoWakesUsed: 0,
         wakeTimestamps: [],
         snapshotSurfacedComplete: new Set(),
+        pendingDecisionLoggedAt: -Infinity,
       };
       this.states.set(workspaceId, st);
     }
@@ -839,6 +865,45 @@ export class CommanderEventCoalescer {
     st.phase = 'idle';
   }
 
+  /** Remove exactly these events from the buffer WITHOUT touching the
+   *  watermark. `consume` cannot be used when part of the buffer is being
+   *  retained: its watermark jump would prune the retained events too, and a
+   *  later replay of them would be dropped as already-flushed. */
+  private dropFromBuffer(st: WsState, events: readonly BufferedEvent[]): void {
+    for (const e of events) {
+      const byKind = st.buffer.get(e.ptyId);
+      if (!byKind) continue;
+      if (byKind.get(e.kind)?.seq === e.seq) byKind.delete(e.kind);
+      if (byKind.size === 0) st.buffer.delete(e.ptyId);
+    }
+  }
+
+  /** ONE line per blocked flush naming the workspace, how many events the
+   *  decision gate blocked and which of them were delegated work. Rate-limited
+   *  per workspace (PENDING_DECISION_LOG_MS); never throws. */
+  private logPendingDecisionBlock(
+    st: WsState,
+    workspaceId: string,
+    total: number,
+    delegated: readonly BufferedEvent[],
+    opts: { snapshot?: boolean } = {},
+  ): void {
+    const now = this.nowFn();
+    if (now - st.pendingDecisionLoggedAt < PENDING_DECISION_LOG_MS) return;
+    st.pendingDecisionLoggedAt = now;
+    const ids = [...new Set(delegated.map((e) => e.task?.taskId ?? '?'))];
+    const shown = ids.slice(0, PENDING_DECISION_LOG_MAX_IDS).join(', ');
+    const more = ids.length > PENDING_DECISION_LOG_MAX_IDS ? `, +${ids.length - PENDING_DECISION_LOG_MAX_IDS} more` : '';
+    const tail = delegated.length > 0 ? ` (${delegated.length} delegated held for replay: ${shown}${more})` : ' (0 delegated)';
+    const what = opts.snapshot ? 'snapshot wake' : 'wake';
+    const line = `[deck] ${what} for ${workspaceId} dropped: pending decision; ${total} events${tail}`;
+    try {
+      (this.deps.log ?? ((l: string) => console.warn(l)))(line);
+    } catch {
+      // diagnostics must never break a flush
+    }
+  }
+
   private attemptFlush(workspaceId: string, st: WsState): void {
     if (this.disposed) return;
     this.clearDebounce(st);
@@ -850,10 +915,27 @@ export class CommanderEventCoalescer {
     // Decision gate: a PENDING decision blocks EVERY wake — even a running loop
     // (unlike the auto-wake switch and mode policy below, which a running loop
     // overrides). The brain raised a decision and must not proceed until a human
-    // answers. Consume (drop) the buffered events: resolving the decision
-    // explicitly kicks a resume turn, so there is nothing to replay here.
+    // answers. Ambient events are consumed (dropped): resolving the decision
+    // explicitly kicks a resume turn, so there is nothing to replay for them.
+    //
+    // DELEGATED events are the exception (dogfood finding 12). A worker's stop
+    // routed to its owner is the owner's own result, not ambient noise, and a
+    // decision left over from a previous app session silently ate every one of
+    // them for twenty minutes. So: keep the task-tagged events BUFFERED (do not
+    // advance the watermark past them) and let the resume turn's onIdle flush
+    // them the moment the decision is answered. Either way the block is logged.
     if (this.safeHasPendingDecision(workspaceId)) {
-      this.consume(st, events);
+      const delegated = events.filter((e) => e.task !== undefined);
+      this.logPendingDecisionBlock(st, workspaceId, events.length, delegated);
+      if (delegated.length === 0) {
+        this.consume(st, events);
+        return;
+      }
+      this.dropFromBuffer(
+        st,
+        events.filter((e) => e.task === undefined),
+      );
+      st.phase = 'buffering';
       return;
     }
     // Global auto-wake switch: OFF suppresses AMBIENT wakes. The buffered
@@ -1203,8 +1285,14 @@ function awaitingVerdict(
   if (!autonomy.approvalPress) return '(NOTIFY ONLY, do NOT approve)';
   // The next-step contract: after the press the worker runs on its own and its
   // own event wakes you, so the turn ends here rather than looping on the pane.
+  // The ledger half of the same contract (dogfood finding 14): the brain kept
+  // trying to move a task straight to `completed`, which the transition table
+  // refuses — `review_requested` is the WORKER's move, and the brain's own is
+  // the hop after it. Say so on the line that already tells it to end the turn.
   const then = target?.taskId
-    ? ` Then END YOUR TURN — task ${target.taskId} runs on and its next event wakes you.`
+    ? ` Then END YOUR TURN — task ${target.taskId} runs on and its next event wakes you.` +
+      ' Your ledger move is review_requested → completed (after task_gate_run, or force with a reason);' +
+      ' review_requested is the worker\'s.'
     : '';
   if (source === 'hook') {
     return (

--- a/src/main/deck/CommanderEventCoalescer.ts
+++ b/src/main/deck/CommanderEventCoalescer.ts
@@ -202,10 +202,13 @@ interface WsState {
    *  still `complete` in the latest snapshot, so it can't outgrow the live fleet. */
   snapshotSurfacedComplete: Set<string>;
   /** Our clock at the last pending-decision block we logged for this
-   *  workspace. Rate-limits that line to one per PENDING_DECISION_LOG_MS so a
-   *  chatty fleet (or a held backlog re-examined on every idle) cannot spam
-   *  the log while one decision sits unanswered. */
+   *  workspace, and the decision it was about. Rate-limits that line to one per
+   *  PENDING_DECISION_LOG_MS so a chatty fleet cannot spam the log while one
+   *  decision sits unanswered — but a DIFFERENT decision id logs immediately
+   *  (it is a new fact, not a repeat), and an accepted flush clears both so the
+   *  next block is announced fresh. */
   pendingDecisionLoggedAt: number;
+  pendingDecisionLoggedId: string | null;
 }
 
 /** A running loop's wake-relevant slice (read fresh at every flush). */
@@ -275,6 +278,18 @@ export interface CoalescerDeps {
   peekOrphanBacklog?: (workspaceId: string) => CoalescerInput[];
   /** Lane F: the parked events at or below `upToSeq` reached the brain. */
   ackOrphanBacklog?: (workspaceId: string, upToSeq: number) => void;
+  /** DURABLY park delegated (task-tagged) events a pending decision blocked,
+   *  through the ledger's orphan backlog — the same store `routeWorkerEventToOwner`
+   *  parks into when an owner has no brain. The in-memory buffer cannot hold
+   *  them: its (ptyId, kind) slot is overwritten by the next same-kind event,
+   *  `notifyHumanSend` clears it, and an app restart loses it — while the
+   *  decision that blocked them is exactly the thing that survives a restart.
+   *  Absent = the events are consumed as before (fail-open, never wedge). */
+  parkDelegated?: (workspaceId: string, events: CoalescerInput[]) => void;
+  /** The id of the workspace's pending decision, for the block log's rate
+   *  limiter: a NEW decision is a new fact and logs immediately instead of
+   *  waiting out the previous one's window. Absent/throwing = no id. */
+  getPendingDecisionId?: (workspaceId: string) => string | null;
   /** One-line diagnostics sink (default `console.warn`). Used by the pending
    *  decision gate, which is otherwise a silent kill switch: a wake it blocks
    *  left no trace anywhere, so "the brain never woke" was indistinguishable
@@ -408,14 +423,22 @@ export class CommanderEventCoalescer {
     // untouched for the normal edge path to govern. Logged (rate-limited) for
     // the same reason the edge path logs: silence here read as "nothing fired".
     if (this.safeHasPendingDecision(workspaceId)) {
-      const edges = this.collectBuffer(st);
-      this.logPendingDecisionBlock(
-        st,
-        workspaceId,
-        edges.length,
-        edges.filter((e) => e.task !== undefined),
-        { snapshot: true },
-      );
+      // Cheap checks first: the heartbeat calls this every interval for the
+      // whole life of the decision, so neither collectBuffer nor the log fires
+      // unless the rate window is actually open AND something was really held.
+      if (this.pendingDecisionLogDue(st, workspaceId).due) {
+        const edges = this.collectBuffer(st);
+        const blockedPanes = snapshot.panes.some((p) => isAttentionStatus(p.agentStatus));
+        if (edges.length > 0 || blockedPanes) {
+          this.logPendingDecisionBlock(
+            st,
+            workspaceId,
+            edges.length,
+            edges.filter((e) => e.task !== undefined),
+            { snapshot: true },
+          );
+        }
+      }
       return;
     }
     const loopHint = this.safeGetLoop(workspaceId);
@@ -517,6 +540,10 @@ export class CommanderEventCoalescer {
         if (r.ok) {
           st.autoWakesUsed += 1;
           this.recordWake(st, this.nowFn());
+          // A wake got through, so the next block is a fresh fact — announce it
+          // rather than swallowing it inside the previous window.
+          st.pendingDecisionLoggedAt = -Infinity;
+          st.pendingDecisionLoggedId = null;
           if (snapshotMaxSeq > st.watermark) st.watermark = snapshotMaxSeq;
           this.pruneBuffer(st, snapshotMaxSeq);
           st.phase = st.buffer.size > 0 ? 'buffering' : 'idle';
@@ -571,6 +598,26 @@ export class CommanderEventCoalescer {
    *  events so the first wake carries them; budgets are untouched. */
   notifyBrainBooted(workspaceId: string): void {
     if (this.disposed) return;
+    this.replayOrphanBacklog(workspaceId);
+  }
+
+  /** A human ANSWERED this workspace's pending decision (DECK_DECISION_RESOLVE).
+   *  Three things follow, and none of them happen anywhere else:
+   *
+   *   - the answer is a human turn, so the consecutive auto-wake budget resets
+   *     (a long-pending decision otherwise let heartbeat re-reviews burn all 5
+   *     and the resume turn arrived budget-blocked);
+   *   - the block log's rate window closes, so the NEXT block is announced;
+   *   - the worker events parked while the gate was shut replay through the
+   *     ordinary push path, exactly as a booting brain's backlog does, so the
+   *     resume turn carries them. Nothing leaves the backlog until a wake
+   *     actually delivered it (ackOrphanBacklog). */
+  notifyDecisionResolved(workspaceId: string): void {
+    if (this.disposed) return;
+    const st = this.ensureState(workspaceId);
+    st.autoWakesUsed = 0;
+    st.pendingDecisionLoggedAt = -Infinity;
+    st.pendingDecisionLoggedId = null;
     this.replayOrphanBacklog(workspaceId);
   }
 
@@ -661,6 +708,7 @@ export class CommanderEventCoalescer {
         wakeTimestamps: [],
         snapshotSurfacedComplete: new Set(),
         pendingDecisionLoggedAt: -Infinity,
+        pendingDecisionLoggedId: null,
       };
       this.states.set(workspaceId, st);
     }
@@ -865,22 +913,40 @@ export class CommanderEventCoalescer {
     st.phase = 'idle';
   }
 
-  /** Remove exactly these events from the buffer WITHOUT touching the
-   *  watermark. `consume` cannot be used when part of the buffer is being
-   *  retained: its watermark jump would prune the retained events too, and a
-   *  later replay of them would be dropped as already-flushed. */
-  private dropFromBuffer(st: WsState, events: readonly BufferedEvent[]): void {
-    for (const e of events) {
-      const byKind = st.buffer.get(e.ptyId);
-      if (!byKind) continue;
-      if (byKind.get(e.kind)?.seq === e.seq) byKind.delete(e.kind);
-      if (byKind.size === 0) st.buffer.delete(e.ptyId);
+  /** Hand the delegated events to the durable backlog. Never throws: a park
+   *  that fails costs this one replay, it must not wedge the flush. */
+  private safeParkDelegated(workspaceId: string, events: readonly BufferedEvent[]): void {
+    if (!this.deps.parkDelegated) return;
+    try {
+      this.deps.parkDelegated(
+        workspaceId,
+        events.map((e) => ({ ...e, workspaceId })),
+      );
+    } catch {
+      // best-effort — the events are consumed either way, as they were before
     }
   }
 
-  /** ONE line per blocked flush naming the workspace, how many events the
-   *  decision gate blocked and which of them were delegated work. Rate-limited
-   *  per workspace (PENDING_DECISION_LOG_MS); never throws. */
+  /** The pending decision's id, never-throw. */
+  private safePendingDecisionId(workspaceId: string): string | null {
+    try {
+      return this.deps.getPendingDecisionId?.(workspaceId) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Is the block line due for this workspace? A DIFFERENT decision id is a new
+   *  fact and logs at once; the same one waits out PENDING_DECISION_LOG_MS. */
+  private pendingDecisionLogDue(st: WsState, workspaceId: string): { due: boolean; id: string | null } {
+    const id = this.safePendingDecisionId(workspaceId);
+    if (id !== null && id !== st.pendingDecisionLoggedId) return { due: true, id };
+    return { due: this.nowFn() - st.pendingDecisionLoggedAt >= PENDING_DECISION_LOG_MS, id };
+  }
+
+  /** ONE line per blocked flush naming the workspace, the decision, how many
+   *  events the gate blocked and which of them were delegated work. Rate-limited
+   *  per workspace and per decision id; never throws. */
   private logPendingDecisionBlock(
     st: WsState,
     workspaceId: string,
@@ -888,15 +954,16 @@ export class CommanderEventCoalescer {
     delegated: readonly BufferedEvent[],
     opts: { snapshot?: boolean } = {},
   ): void {
-    const now = this.nowFn();
-    if (now - st.pendingDecisionLoggedAt < PENDING_DECISION_LOG_MS) return;
-    st.pendingDecisionLoggedAt = now;
+    const { due, id } = this.pendingDecisionLogDue(st, workspaceId);
+    if (!due) return;
+    st.pendingDecisionLoggedAt = this.nowFn();
+    st.pendingDecisionLoggedId = id;
     const ids = [...new Set(delegated.map((e) => e.task?.taskId ?? '?'))];
     const shown = ids.slice(0, PENDING_DECISION_LOG_MAX_IDS).join(', ');
     const more = ids.length > PENDING_DECISION_LOG_MAX_IDS ? `, +${ids.length - PENDING_DECISION_LOG_MAX_IDS} more` : '';
-    const tail = delegated.length > 0 ? ` (${delegated.length} delegated held for replay: ${shown}${more})` : ' (0 delegated)';
+    const tail = delegated.length > 0 ? ` (${delegated.length} delegated parked for replay: ${shown}${more})` : ' (0 delegated)';
     const what = opts.snapshot ? 'snapshot wake' : 'wake';
-    const line = `[deck] ${what} for ${workspaceId} dropped: pending decision; ${total} events${tail}`;
+    const line = `[deck] ${what} for ${workspaceId} dropped: pending decision${id ? ` ${id}` : ''}; ${total} events${tail}`;
     try {
       (this.deps.log ?? ((l: string) => console.warn(l)))(line);
     } catch {
@@ -921,21 +988,18 @@ export class CommanderEventCoalescer {
     // DELEGATED events are the exception (dogfood finding 12). A worker's stop
     // routed to its owner is the owner's own result, not ambient noise, and a
     // decision left over from a previous app session silently ate every one of
-    // them for twenty minutes. So: keep the task-tagged events BUFFERED (do not
-    // advance the watermark past them) and let the resume turn's onIdle flush
-    // them the moment the decision is answered. Either way the block is logged.
+    // them for twenty minutes. So: PARK the task-tagged events durably in the
+    // ledger's orphan backlog — the same place a brain-less owner's events go —
+    // and let the resume turn the resolve kicks replay them. Parking, not
+    // holding in the buffer: the buffer keeps ONE event per (pane, kind), is
+    // cleared by a human send, and dies with the process, while the decision
+    // that blocked the wake is precisely what outlives a restart. Either way
+    // the watermark advances normally and the block is logged.
     if (this.safeHasPendingDecision(workspaceId)) {
       const delegated = events.filter((e) => e.task !== undefined);
       this.logPendingDecisionBlock(st, workspaceId, events.length, delegated);
-      if (delegated.length === 0) {
-        this.consume(st, events);
-        return;
-      }
-      this.dropFromBuffer(
-        st,
-        events.filter((e) => e.task === undefined),
-      );
-      st.phase = 'buffering';
+      if (delegated.length > 0) this.safeParkDelegated(workspaceId, delegated);
+      this.consume(st, events);
       return;
     }
     // Global auto-wake switch: OFF suppresses AMBIENT wakes. The buffered
@@ -1041,6 +1105,10 @@ export class CommanderEventCoalescer {
         if (r.ok) {
           st.autoWakesUsed += 1;
           this.recordWake(st, this.nowFn());
+          // A wake got through, so the next block is a fresh fact — announce it
+          // rather than swallowing it inside the previous window.
+          st.pendingDecisionLoggedAt = -Infinity;
+          st.pendingDecisionLoggedId = null;
           if (snapshotMaxSeq > st.watermark) st.watermark = snapshotMaxSeq;
           this.pruneBuffer(st, snapshotMaxSeq);
           this.ackReplayed(workspaceId, flushEvents);
@@ -1287,12 +1355,13 @@ function awaitingVerdict(
   // own event wakes you, so the turn ends here rather than looping on the pane.
   // The ledger half of the same contract (dogfood finding 14): the brain kept
   // trying to move a task straight to `completed`, which the transition table
-  // refuses — `review_requested` is the WORKER's move, and the brain's own is
-  // the hop after it. Say so on the line that already tells it to end the turn.
+  // refuses — completed is reachable only from review_requested. Say so on the
+  // line that already tells it to end the turn, in the same words the tool
+  // description and the ledger's refusal use.
   const then = target?.taskId
     ? ` Then END YOUR TURN — task ${target.taskId} runs on and its next event wakes you.` +
-      ' Your ledger move is review_requested → completed (after task_gate_run, or force with a reason);' +
-      ' review_requested is the worker\'s.'
+      ' Ledger: completed is reachable only from review_requested — the worker normally reports that,' +
+      ' set it yourself only if it cannot; then task_gate_run, then ledger_update completed.'
     : '';
   if (source === 'hook') {
     return (

--- a/src/main/deck/__tests__/CommanderEventCoalescer.approvalPress.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.approvalPress.test.ts
@@ -41,6 +41,10 @@ describe('the awaiting_input verdict', () => {
     // The next-step contract: press, then stop — the worker's own event wakes
     // the brain again, so it must not sit on the pane burning the turn.
     expect(prompt).toContain('END YOUR TURN — task wtask-7 runs on');
+    // Wave 3, finding 14: the same contract names WHICH ledger transition is
+    // the brain's, because it kept trying to make the worker's one.
+    expect(prompt).toContain('Your ledger move is review_requested → completed');
+    expect(prompt).toContain("review_requested is the worker's");
     // And the move it replaces is gone from this verdict.
     expect(prompt).not.toContain('press it with terminal_send_key');
   });

--- a/src/main/deck/__tests__/CommanderEventCoalescer.approvalPress.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.approvalPress.test.ts
@@ -43,8 +43,8 @@ describe('the awaiting_input verdict', () => {
     expect(prompt).toContain('END YOUR TURN — task wtask-7 runs on');
     // Wave 3, finding 14: the same contract names WHICH ledger transition is
     // the brain's, because it kept trying to make the worker's one.
-    expect(prompt).toContain('Your ledger move is review_requested → completed');
-    expect(prompt).toContain("review_requested is the worker's");
+    expect(prompt).toContain('completed is reachable only from review_requested');
+    expect(prompt).toContain('the worker normally reports that');
     // And the move it replaces is gone from this verdict.
     expect(prompt).not.toContain('press it with terminal_send_key');
   });

--- a/src/main/deck/__tests__/CommanderEventCoalescer.pendingDecision.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.pendingDecision.test.ts
@@ -1,0 +1,161 @@
+// Wave 3, finding 12 — a pending decision was a SILENT kill switch.
+//
+// A decision left unanswered from a previous app session blocked every wake of
+// the owner workspace for twenty minutes. Nothing said so: no log line, and the
+// worker stops routed to the owner (tagged `task`) were consumed on the way in,
+// so they were gone even after the human answered. Two properties are pinned
+// here: the block is announced exactly once per rate window, and delegated work
+// SURVIVES the block and reaches the brain on the resume turn.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CommanderEventCoalescer, type CoalescerInput } from '../CommanderEventCoalescer';
+import { DEFAULT_AUTONOMY } from '../deckAutonomyStore';
+import type { FleetSnapshot } from '../../../shared/workspaceMirror';
+
+const settle = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function mk(opts: { pending: () => boolean }) {
+  const prompts: { ws: string; prompt: string }[] = [];
+  const logs: string[] = [];
+  let clock = 0;
+  const c = new CommanderEventCoalescer({
+    runTurn: async (ws, prompt) => {
+      prompts.push({ ws, prompt });
+      return { ok: true };
+    },
+    isBusy: () => false,
+    getAutonomy: () => ({ ...DEFAULT_AUTONOMY }),
+    hasPendingDecision: opts.pending,
+    log: (line) => logs.push(line),
+    now: () => clock,
+    debounceMs: 1_000,
+  });
+  return { c, prompts, logs, tick: (ms: number) => { clock += ms; } };
+}
+
+function stop(over: Partial<CoalescerInput> = {}): CoalescerInput {
+  return {
+    workspaceId: 'ws-owner',
+    ptyId: 'pty-worker',
+    kind: 'agent.stop',
+    source: 'hook',
+    agent: 'claude',
+    seq: 1,
+    ts: 0,
+    ...over,
+  };
+}
+
+const TASK = { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' };
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('the pending-decision gate logs what it blocked', () => {
+  it('names the workspace, the event count and the delegated task ids', async () => {
+    const { c, prompts, logs } = mk({ pending: () => true });
+    c.push(stop({ seq: 1, ptyId: 'pty-a', task: TASK }));
+    c.push(stop({ seq: 2, ptyId: 'pty-b' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+
+    expect(prompts).toHaveLength(0);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain('[deck] wake for ws-owner dropped: pending decision');
+    expect(logs[0]).toContain('2 events');
+    expect(logs[0]).toContain('1 delegated held for replay: wtask-1');
+  });
+
+  it('says "0 delegated" when only ambient noise was dropped', async () => {
+    const { c, logs } = mk({ pending: () => true });
+    c.push(stop({ seq: 1 }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain('(0 delegated)');
+  });
+
+  it('rate-limits the line to one per minute per workspace', async () => {
+    const { c, logs, tick } = mk({ pending: () => true });
+    c.push(stop({ seq: 1, ptyId: 'pty-a' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    tick(30_000);
+    c.push(stop({ seq: 2, ptyId: 'pty-b' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(logs).toHaveLength(1);
+
+    tick(31_000);
+    c.push(stop({ seq: 3, ptyId: 'pty-c' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(logs).toHaveLength(2);
+  });
+
+  it('logs a blocked level snapshot too', () => {
+    const { c, logs } = mk({ pending: () => true });
+    const snapshot: FleetSnapshot = {
+      workspaceId: 'ws-owner',
+      ts: 0,
+      panes: [{ ptyId: 'pty-a', agentName: 'claude', agentStatus: 'complete', isActivePane: true }],
+    };
+    c.flushSnapshot('ws-owner', snapshot);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain('[deck] snapshot wake for ws-owner dropped: pending decision');
+  });
+});
+
+describe('delegated work survives a pending decision', () => {
+  it('holds the task-tagged events and flushes them once the decision is answered', async () => {
+    let pending = true;
+    const { c, prompts, logs } = mk({ pending: () => pending });
+    c.push(stop({ seq: 1, ptyId: 'pty-worker', task: TASK }));
+    c.push(stop({ seq: 2, ptyId: 'pty-shell' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(0);
+    expect(logs).toHaveLength(1);
+
+    // The human answers; the resolve kicks a resume turn whose onIdle is this.
+    pending = false;
+    c.notifyIdle('ws-owner');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].prompt).toContain('worker-task=wtask-1');
+    // The ambient stop was still consumed — only delegated work is held.
+    expect(prompts[0].prompt).not.toContain('pty-shell');
+  });
+
+  it('does not advance the watermark past a held delegated event', async () => {
+    const { c } = mk({ pending: () => true });
+    c.push(stop({ seq: 4, ptyId: 'pty-worker', task: TASK }));
+    c.push(stop({ seq: 9, ptyId: 'pty-shell' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    // Consuming seq 9 would have pruned the held seq 4 with it.
+    expect(c.getWatermark('ws-owner')).toBeLessThan(4);
+    expect(c.getPhase('ws-owner')).toBe('buffering');
+  });
+
+  it('is unchanged when nothing was delegated: the buffer is consumed', async () => {
+    let pending = true;
+    const { c, prompts } = mk({ pending: () => pending });
+    c.push(stop({ seq: 1 }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(c.getWatermark('ws-owner')).toBe(1);
+
+    pending = false;
+    c.notifyIdle('ws-owner');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(0);
+  });
+});

--- a/src/main/deck/__tests__/CommanderEventCoalescer.pendingDecision.test.ts
+++ b/src/main/deck/__tests__/CommanderEventCoalescer.pendingDecision.test.ts
@@ -4,8 +4,10 @@
 // the owner workspace for twenty minutes. Nothing said so: no log line, and the
 // worker stops routed to the owner (tagged `task`) were consumed on the way in,
 // so they were gone even after the human answered. Two properties are pinned
-// here: the block is announced exactly once per rate window, and delegated work
-// SURVIVES the block and reaches the brain on the resume turn.
+// here: the block is announced (once per window, and again for a NEW decision),
+// and delegated work is PARKED DURABLY rather than dropped or held in RAM —
+// the buffer keeps one event per (pane, kind), a human send clears it, and the
+// decision that blocked the wake is exactly what outlives a restart.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CommanderEventCoalescer, type CoalescerInput } from '../CommanderEventCoalescer';
@@ -17,9 +19,18 @@ const settle = async () => {
   await Promise.resolve();
 };
 
-function mk(opts: { pending: () => boolean }) {
+interface Opts {
+  pending: () => boolean;
+  decisionId?: () => string | null;
+  backlog?: CoalescerInput[];
+}
+
+function mk(opts: Opts) {
   const prompts: { ws: string; prompt: string }[] = [];
   const logs: string[] = [];
+  const parked: CoalescerInput[] = [];
+  const acks: number[] = [];
+  const backlog = opts.backlog ?? [];
   let clock = 0;
   const c = new CommanderEventCoalescer({
     runTurn: async (ws, prompt) => {
@@ -27,13 +38,32 @@ function mk(opts: { pending: () => boolean }) {
       return { ok: true };
     },
     isBusy: () => false,
-    getAutonomy: () => ({ ...DEFAULT_AUTONOMY }),
+    // 'all' so an UNTAGGED event is a real wake here: these tests are about the
+    // decision gate, which sits above the wake policy, and the fail-closed
+    // default ('none') would consume the ambient events for a second reason.
+    getAutonomy: () => ({ ...DEFAULT_AUTONOMY, wakePolicy: 'all' as const }),
     hasPendingDecision: opts.pending,
+    getPendingDecisionId: opts.decisionId ?? (() => 'dec-1'),
+    // The real port is durable (the ledger's orphan backlog); here it is the
+    // same list `peekOrphanBacklog` reads, so a park is observable as a replay.
+    parkDelegated: (_ws, events) => {
+      for (const e of events) {
+        if (!backlog.some((b) => b.seq === e.seq)) {
+          parked.push(e);
+          backlog.push(e);
+        }
+      }
+    },
+    peekOrphanBacklog: () => [...backlog],
+    ackOrphanBacklog: (_ws, upToSeq) => {
+      acks.push(upToSeq);
+      for (let i = backlog.length - 1; i >= 0; i--) if (backlog[i].seq <= upToSeq) backlog.splice(i, 1);
+    },
     log: (line) => logs.push(line),
     now: () => clock,
     debounceMs: 1_000,
   });
-  return { c, prompts, logs, tick: (ms: number) => { clock += ms; } };
+  return { c, prompts, logs, parked, backlog, acks, tick: (ms: number) => { clock += ms; } };
 }
 
 function stop(over: Partial<CoalescerInput> = {}): CoalescerInput {
@@ -55,7 +85,7 @@ beforeEach(() => vi.useFakeTimers());
 afterEach(() => vi.useRealTimers());
 
 describe('the pending-decision gate logs what it blocked', () => {
-  it('names the workspace, the event count and the delegated task ids', async () => {
+  it('names the workspace, the decision, the event count and the delegated task ids', async () => {
     const { c, prompts, logs } = mk({ pending: () => true });
     c.push(stop({ seq: 1, ptyId: 'pty-a', task: TASK }));
     c.push(stop({ seq: 2, ptyId: 'pty-b' }));
@@ -64,9 +94,9 @@ describe('the pending-decision gate logs what it blocked', () => {
 
     expect(prompts).toHaveLength(0);
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toContain('[deck] wake for ws-owner dropped: pending decision');
+    expect(logs[0]).toContain('[deck] wake for ws-owner dropped: pending decision dec-1');
     expect(logs[0]).toContain('2 events');
-    expect(logs[0]).toContain('1 delegated held for replay: wtask-1');
+    expect(logs[0]).toContain('1 delegated parked for replay: wtask-1');
   });
 
   it('says "0 delegated" when only ambient noise was dropped', async () => {
@@ -97,65 +127,163 @@ describe('the pending-decision gate logs what it blocked', () => {
     expect(logs).toHaveLength(2);
   });
 
-  it('logs a blocked level snapshot too', () => {
+  it('logs a DIFFERENT decision immediately, without waiting out the window', async () => {
+    let id = 'dec-1';
+    const { c, logs, tick } = mk({ pending: () => true, decisionId: () => id });
+    c.push(stop({ seq: 1, ptyId: 'pty-a' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(logs).toHaveLength(1);
+
+    tick(1_000);
+    id = 'dec-2';
+    c.push(stop({ seq: 2, ptyId: 'pty-b' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(logs).toHaveLength(2);
+    expect(logs[1]).toContain('pending decision dec-2');
+  });
+
+  it('an accepted flush re-arms the line, so the next block is announced', async () => {
+    let pending = true;
+    const { c, logs, tick } = mk({ pending: () => pending });
+    c.push(stop({ seq: 1, ptyId: 'pty-a' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(logs).toHaveLength(1);
+
+    pending = false;
+    c.push(stop({ seq: 2, ptyId: 'pty-b' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+
+    pending = true;
+    tick(1_000);
+    c.push(stop({ seq: 3, ptyId: 'pty-c' }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(logs).toHaveLength(2);
+  });
+
+  it('logs a blocked level snapshot, but says nothing when nothing was blocked', () => {
     const { c, logs } = mk({ pending: () => true });
-    const snapshot: FleetSnapshot = {
+    const snap = (agentStatus: 'complete' | 'running'): FleetSnapshot => ({
       workspaceId: 'ws-owner',
       ts: 0,
-      panes: [{ ptyId: 'pty-a', agentName: 'claude', agentStatus: 'complete', isActivePane: true }],
-    };
-    c.flushSnapshot('ws-owner', snapshot);
+      panes: [{ ptyId: 'pty-a', agentName: 'claude', agentStatus, isActivePane: true }],
+    });
+
+    // A quiescent fleet with an empty buffer is not a blocked wake — no line,
+    // and no rate-limit slot burned on it.
+    c.flushSnapshot('ws-owner', snap('running'));
+    expect(logs).toHaveLength(0);
+
+    c.flushSnapshot('ws-owner', snap('complete'));
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toContain('[deck] snapshot wake for ws-owner dropped: pending decision');
+    expect(logs[0]).toContain('[deck] snapshot wake for ws-owner dropped: pending decision dec-1');
   });
 });
 
-describe('delegated work survives a pending decision', () => {
-  it('holds the task-tagged events and flushes them once the decision is answered', async () => {
-    let pending = true;
-    const { c, prompts, logs } = mk({ pending: () => pending });
-    c.push(stop({ seq: 1, ptyId: 'pty-worker', task: TASK }));
-    c.push(stop({ seq: 2, ptyId: 'pty-shell' }));
+describe('delegated work is parked durably, not dropped', () => {
+  it('parks the task-tagged events, consumes the ambient ones, and advances the watermark', async () => {
+    const { c, prompts, parked } = mk({ pending: () => true });
+    c.push(stop({ seq: 4, ptyId: 'pty-worker', task: TASK }));
+    c.push(stop({ seq: 9, ptyId: 'pty-shell' }));
     vi.advanceTimersByTime(1_000);
     await settle();
-    expect(prompts).toHaveLength(0);
-    expect(logs).toHaveLength(1);
 
-    // The human answers; the resolve kicks a resume turn whose onIdle is this.
+    expect(prompts).toHaveLength(0);
+    expect(parked.map((e) => e.seq)).toEqual([4]);
+    expect(parked[0].task).toEqual(TASK);
+    expect(parked[0].workspaceId).toBe('ws-owner');
+    // Normal consume: nothing is left half-in the buffer.
+    expect(c.getWatermark('ws-owner')).toBe(9);
+    expect(c.getPhase('ws-owner')).toBe('idle');
+  });
+
+  it('the resume after a resolve delivers the parked event exactly once and acks it', async () => {
+    let pending = true;
+    const { c, prompts, backlog, acks } = mk({ pending: () => pending });
+    c.push(stop({ seq: 4, ptyId: 'pty-worker', task: TASK }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(backlog).toHaveLength(1);
+
+    // The human answers: DECK_DECISION_RESOLVE calls this before the resume turn.
     pending = false;
-    c.notifyIdle('ws-owner');
+    c.notifyDecisionResolved('ws-owner');
     vi.advanceTimersByTime(1_000);
     await settle();
 
     expect(prompts).toHaveLength(1);
     expect(prompts[0].prompt).toContain('worker-task=wtask-1');
-    // The ambient stop was still consumed — only delegated work is held.
-    expect(prompts[0].prompt).not.toContain('pty-shell');
-  });
+    expect(acks).toEqual([4]);
+    expect(backlog).toHaveLength(0);
 
-  it('does not advance the watermark past a held delegated event', async () => {
-    const { c } = mk({ pending: () => true });
-    c.push(stop({ seq: 4, ptyId: 'pty-worker', task: TASK }));
-    c.push(stop({ seq: 9, ptyId: 'pty-shell' }));
-    vi.advanceTimersByTime(1_000);
-    await settle();
-    // Consuming seq 9 would have pruned the held seq 4 with it.
-    expect(c.getWatermark('ws-owner')).toBeLessThan(4);
-    expect(c.getPhase('ws-owner')).toBe('buffering');
-  });
-
-  it('is unchanged when nothing was delegated: the buffer is consumed', async () => {
-    let pending = true;
-    const { c, prompts } = mk({ pending: () => pending });
-    c.push(stop({ seq: 1 }));
-    vi.advanceTimersByTime(1_000);
-    await settle();
-    expect(c.getWatermark('ws-owner')).toBe(1);
-
-    pending = false;
+    // And it is not delivered a second time on the next idle.
     c.notifyIdle('ws-owner');
     vi.advanceTimersByTime(1_000);
     await settle();
+    expect(prompts).toHaveLength(1);
+  });
+
+  it('a human send between the park and the resolve does not lose it', async () => {
+    let pending = true;
+    const { c, prompts, backlog, parked } = mk({ pending: () => pending });
+    c.push(stop({ seq: 4, ptyId: 'pty-worker', task: TASK }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
+
+    // A human send clears the buffer and advances the watermark — which is why
+    // the buffer could never have been the holding place. The backlog survives,
+    // and re-parking it does not duplicate the row.
+    c.notifyHumanSend('ws-owner');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(backlog).toHaveLength(1);
+    expect(parked).toHaveLength(1);
+
+    pending = false;
+    c.notifyDecisionResolved('ws-owner');
+    vi.advanceTimersByTime(1_000);
+    await settle();
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0].prompt).toContain('worker-task=wtask-1');
+  });
+
+  it('resolving resets the auto-wake budget a long-pending decision burned', async () => {
+    let pending = false;
+    const { c } = mk({ pending: () => pending });
+    // Five accepted ambient wakes exhaust the default budget.
+    for (let seq = 1; seq <= 5; seq++) {
+      c.push(stop({ seq, ptyId: `pty-${seq}` }));
+      vi.advanceTimersByTime(1_000);
+      await settle();
+    }
+    expect(c.getWakeBudgetRemaining('ws-owner')).toBe(0);
+
+    pending = true;
+    pending = false;
+    c.notifyDecisionResolved('ws-owner');
+    expect(c.getWakeBudgetRemaining('ws-owner')).toBe(5);
+  });
+
+  it('is a no-op without a park port: the events are consumed as before', async () => {
+    const prompts: string[] = [];
+    const c = new CommanderEventCoalescer({
+      runTurn: async (_ws, p) => {
+        prompts.push(p);
+        return { ok: true };
+      },
+      isBusy: () => false,
+      getAutonomy: () => ({ ...DEFAULT_AUTONOMY }),
+      hasPendingDecision: () => true,
+      debounceMs: 1_000,
+    });
+    c.push(stop({ seq: 1, task: TASK }));
+    vi.advanceTimersByTime(1_000);
+    await settle();
     expect(prompts).toHaveLength(0);
+    expect(c.getWatermark('ws-owner')).toBe(1);
   });
 });

--- a/src/main/deck/__tests__/taskLedgerHost.test.ts
+++ b/src/main/deck/__tests__/taskLedgerHost.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { TaskLedger } from '../../../daemon/ledger/TaskLedger';
 import {
   routeWorkerEventToOwner,
+  parkDelegatedEvents,
   peekOrphanBacklog,
   ackOrphanBacklog,
   noteWorkTaskClosed,
@@ -203,5 +204,46 @@ describe('ledger → mission channel emitter (step 5)', () => {
       summary: 'need the "API key"',
     });
     expect(quoted).toBe('[ledger] wtask-9 working→input_required worker@ws-t worker: "need the ”API key”"');
+  });
+});
+
+// Wave 3, finding 12 — the events a PENDING DECISION blocks go to the same
+// durable backlog a brain-less owner's do. Durable is the whole point: the
+// decision that shut the gate is precisely the thing that survives a restart,
+// so an in-memory hold would lose exactly the events the operator came back for.
+describe('parkDelegatedEvents', () => {
+  const blocked = (seq: number): CoalescerInput =>
+    ev({ workspaceId: 'ws-parent', seq, task: { taskId: 'wtask-1', taskWorkspaceId: 'ws-task' } });
+
+  it('parks to disk: a FRESH ledger over the same dir replays the event', async () => {
+    parkDelegatedEvents('ws-parent', [blocked(7)]);
+    await ledger.flush();
+    const reopened = new TaskLedger({ dir });
+    const parked = reopened.peekOrphanedEvents('ws-parent');
+    expect(parked).toHaveLength(1);
+    expect(parked[0].seq).toBe(7);
+    expect((parked[0].payload as CoalescerInput).task?.taskId).toBe('wtask-1');
+  });
+
+  it('is readable through the same peek the brain-boot replay uses', async () => {
+    parkDelegatedEvents('ws-parent', [blocked(7), blocked(8)]);
+    await ledger.flush();
+    expect(peekOrphanBacklog('ws-parent').map((e) => e.seq)).toEqual([7, 8]);
+    await ackOrphanBacklog('ws-parent', 8);
+    expect(peekOrphanBacklog('ws-parent')).toHaveLength(0);
+  });
+
+  it('does not duplicate a seq already parked (a human send re-parks the replay)', async () => {
+    parkDelegatedEvents('ws-parent', [blocked(7)]);
+    await ledger.flush();
+    parkDelegatedEvents('ws-parent', [blocked(7), blocked(9)]);
+    await ledger.flush();
+    expect(peekOrphanBacklog('ws-parent').map((e) => e.seq)).toEqual([7, 9]);
+  });
+
+  it('never throws when the ledger is unusable', () => {
+    setTaskLedgerForTests(null);
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(() => parkDelegatedEvents('ws-parent', [blocked(7)])).not.toThrow();
   });
 });

--- a/src/main/deck/taskLedgerHost.ts
+++ b/src/main/deck/taskLedgerHost.ts
@@ -116,6 +116,35 @@ export function peekOrphanBacklog(workspaceId: string, instance?: TaskLedger): C
   return out;
 }
 
+/**
+ * Park worker events a PENDING DECISION blocked (finding 12). Same store and
+ * same shape as the brain-less-owner park above, so one replay path drains
+ * both — but deduplicated against what is already parked: a human send between
+ * the park and the resolve replays the backlog into the coalescer, which parks
+ * whatever the still-shut gate blocks again, and an un-deduplicated re-park
+ * would deliver the same stop twice. Never throws.
+ */
+export function parkDelegatedEvents(
+  workspaceId: string,
+  events: readonly CoalescerInput[],
+  instance?: TaskLedger,
+): void {
+  const l = instance ?? getTaskLedger();
+  let parked: Set<number>;
+  try {
+    parked = new Set(l.peekOrphanedEvents(workspaceId).map((o) => o.seq));
+  } catch {
+    return;
+  }
+  for (const ev of events) {
+    if (parked.has(ev.seq)) continue;
+    parked.add(ev.seq);
+    l.recordOrphanedEvent({ ownerWorkspaceId: workspaceId, seq: ev.seq, payload: ev }).catch((err) =>
+      console.warn(`[deck] could not park a blocked worker event for ${workspaceId}: ${String(err)}`),
+    );
+  }
+}
+
 /** Acknowledge parked events at or below `upToSeq` — they reached the brain. */
 export function ackOrphanBacklog(workspaceId: string, upToSeq: number, instance?: TaskLedger): Promise<void> {
   const l = instance ?? getTaskLedger();

--- a/src/main/ipc/handlers/deck.handler.ts
+++ b/src/main/ipc/handlers/deck.handler.ts
@@ -56,6 +56,7 @@ import {
   routeWorkerEventToOwner,
   peekOrphanBacklog,
   ackOrphanBacklog,
+  parkDelegatedEvents,
   createWorkTaskReconciler,
   readLedgerGateInput,
   installLedgerChannelEmitter,
@@ -1569,6 +1570,10 @@ export function registerDeckHandler(
     ackOrphanBacklog: (workspaceId, upToSeq) => {
       void ackOrphanBacklog(workspaceId, upToSeq).catch(() => undefined);
     },
+    // Finding 12: a pending decision blocks every wake, so the worker events it
+    // blocks go to the SAME durable backlog a brain-less owner's events go to —
+    // the buffer cannot hold them across a restart, and the decision can.
+    parkDelegated: (workspaceId, events) => parkDelegatedEvents(workspaceId, events),
     isBusy: (workspaceId) =>
       managers.get(workspaceId)?.manager.getStatus().status === 'busy',
     // Fail-closed autonomy caps (summarize on, dangerous caps off by default).
@@ -1594,6 +1599,12 @@ export function registerDeckHandler(
     // A PENDING decision gate blocks every wake for this workspace (even a
     // running loop) until the human resolves it. Read fresh at each flush.
     hasPendingDecision: (workspaceId) => hasPendingDecision(workspaceId),
+    // Which decision, for the block log's rate limiter — a new decision is a new
+    // fact and is announced at once rather than inside the old one's window.
+    getPendingDecisionId: (workspaceId) => {
+      const d = loadWorkspaceDecision(workspaceId);
+      return d && d.status === 'pending' ? d.id : null;
+    },
     // maxWakesPerMin: left to the coalescer's built-in default (6 accepted wakes
     // per 60s window) — the single unconditional rate ceiling. No store knob
     // yet, so nothing to thread here.
@@ -2483,6 +2494,12 @@ export function registerDeckHandler(
       // or a model that no-ops the answer and stops slips through a cap-out
       // suppression recorded before the decision was even raised.
       clearGateCapOut(workspaceId);
+      // Finding 12: the gate that was shut until this instant parked the worker
+      // events it blocked. Replay them BEFORE the resume turn so that turn (or
+      // its onIdle flush) is the one that carries them, and reset the auto-wake
+      // budget a long-pending decision may have burned through — a human just
+      // answered, which is what resets it everywhere else.
+      coalescer?.notifyDecisionResolved(workspaceId);
       // Un-blocked now (hasPendingDecision is false). Kick a resume turn; a busy
       // reject is fine — the resolution rides withLoopContext on the next turn
       // (event / schedule / human) and is consumed then. Fire-and-forget: the

--- a/src/main/pipe/handlers/__tests__/fanout.rpc.test.ts
+++ b/src/main/pipe/handlers/__tests__/fanout.rpc.test.ts
@@ -28,9 +28,11 @@ import { CHANNEL_TOPIC_MAX, HUMAN_WORKSPACE_ID } from '../../../../shared/channe
 
 vi.mock('../_bridge', () => ({ sendToRenderer: vi.fn() }));
 vi.mock('../../../git/git', () => ({ git: vi.fn() }));
+vi.mock('../../../deck/deckDecisionStore', () => ({ loadWorkspaceDecision: vi.fn(() => null) }));
 
 import { sendToRenderer } from '../_bridge';
 import { git } from '../../../git/git';
+import { loadWorkspaceDecision } from '../../../deck/deckDecisionStore';
 import { registerFanOutRpc, FANOUT_WIRE_AGENT_CMD, FANOUT_IDEMPOTENCY_KEY_MAX_BYTES } from '../fanout.rpc';
 import type { FanOutRequest, FanOutResult, FanOutService, FanOutStatus } from '../../../worktask/FanOutService';
 import type { RpcRouter } from '../../RpcRouter';
@@ -1083,5 +1085,54 @@ describe('FanOutService is constructed exactly once in main', () => {
     expect(src).toMatch(/const fanOutService = createFanOutService\(/);
     expect(src).toMatch(/registerFanOutRpc\(rpcRouter, fanOutService,/);
     expect(src).toMatch(/registerFanOutHandler\(fanOutService\)/);
+  });
+});
+
+// ── the accept's warnings ─────────────────────────────────────────────────
+//
+// Wave 3, finding 12: the owner workspace carried an unanswered decision from a
+// previous app session, which blocks EVERY wake. The fan-out was accepted, the
+// workers ran and finished, and nothing ever reached the brain. The accept is
+// the one moment the caller is reading a reply, so it says so there.
+describe('the accepted reply warns about a pending decision on the owner', () => {
+  it('carries the warning naming the workspace and the decision id', async () => {
+    vi.mocked(loadWorkspaceDecision).mockReturnValue({
+      id: 'dec-9',
+      question: 'resume?',
+      options: [],
+      context: '',
+      status: 'pending',
+      raisedAt: 0,
+    });
+    const h = setup();
+    const res = await h.call(goodParams());
+    expect(res).toMatchObject({ ok: true, status: 'accepted' });
+    const warnings = res['warnings'] as string[];
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(`owner workspace ${CALLER_WS} has a pending decision dec-9`);
+    expect(warnings[0]).toContain('worker events will not wake the brain until it is answered');
+  });
+
+  it('omits the field entirely when there is no pending decision', async () => {
+    vi.mocked(loadWorkspaceDecision).mockReturnValue(null);
+    const h = setup();
+    expect(await h.call(goodParams())).not.toHaveProperty('warnings');
+  });
+
+  it('a resolved decision is not a warning, and a torn store is not an error', async () => {
+    vi.mocked(loadWorkspaceDecision).mockReturnValue({
+      id: 'dec-1',
+      question: 'q',
+      options: [],
+      context: '',
+      status: 'resolved',
+      raisedAt: 0,
+    });
+    expect(await setup().call(goodParams())).not.toHaveProperty('warnings');
+
+    vi.mocked(loadWorkspaceDecision).mockImplementation(() => {
+      throw new Error('torn store');
+    });
+    expect(await setup().call(goodParams())).toMatchObject({ ok: true, status: 'accepted' });
   });
 });

--- a/src/main/pipe/handlers/fanout.rpc.ts
+++ b/src/main/pipe/handlers/fanout.rpc.ts
@@ -85,9 +85,35 @@ import { ORCH_ROLES } from '../../../shared/orchestratorRole';
 import { sendToRenderer } from './_bridge';
 import { resolvePtyOwnerWorkspace } from '../../workspace/ptyOwnership';
 import { git as runGit } from '../../git/git';
+import { loadWorkspaceDecision } from '../../deck/deckDecisionStore';
 import type { FanOutRequest, FanOutService } from '../../worktask/FanOutService';
 
 type GetWindow = () => BrowserWindow | null;
+
+/**
+ * Additive `warnings` on the accepted reply: conditions that do not refuse the
+ * fan-out but WILL break the loop it starts.
+ *
+ * The only one so far is the pending decision gate (dogfood finding 12). A
+ * workspace with an unanswered decision — including one raised in a previous
+ * app session and never seen — cannot be auto-woken at all, so every worker
+ * stop routed back to it is held rather than delivered. Fanning out from such
+ * a workspace looks perfectly healthy and then never reports anything, so the
+ * accept says so at the one moment the caller is reading a reply.
+ * Never throws: a torn decision store yields no warning, not a failed fan-out.
+ */
+function acceptWarnings(ownerWorkspaceId: string): string[] {
+  try {
+    const decision = loadWorkspaceDecision(ownerWorkspaceId);
+    if (!decision || decision.status !== 'pending') return [];
+    return [
+      `owner workspace ${ownerWorkspaceId} has a pending decision ${decision.id}; ` +
+        'worker events will not wake the brain until it is answered',
+    ];
+  } catch {
+    return [];
+  }
+}
 
 /**
  * R1 — the agent command wire callers get, always. NEVER read from params:
@@ -802,6 +828,7 @@ export function registerFanOutRpc(router: RpcRouter, service: FanOutService, get
       }
     })();
 
+    const warnings = acceptWarnings(callerWorkspaceId);
     return {
       ok: true as const,
       status: 'accepted' as const,
@@ -809,6 +836,7 @@ export function registerFanOutRpc(router: RpcRouter, service: FanOutService, get
       taskCount: parsed.titles.length,
       repoPath: callerRepoRoot,
       workspaceId: callerWorkspaceId,
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
   });
 }

--- a/src/mcp/__tests__/fanout.test.ts
+++ b/src/mcp/__tests__/fanout.test.ts
@@ -286,3 +286,33 @@ describe('fanout_start: result envelope', () => {
     expect(res.content[0].text).toContain('RPC timeout');
   });
 });
+
+// Wave 3, finding 12 — a fan-out from a workspace with an unanswered decision
+// runs fine and reports to nobody. The accept carries `warnings`; a JSON key is
+// skippable, so it also leads the content as its own WARNING block.
+describe('fanout_start: accept warnings', () => {
+  it('leads with a WARNING block and keeps the envelope as the last block, parseable', async () => {
+    mockSendRpc.mockResolvedValue({
+      ok: true,
+      status: 'accepted',
+      taskCount: 1,
+      warnings: ['owner workspace ws-1 has a pending decision dec-9; worker events will not wake the brain until it is answered'],
+    });
+    const res = await fanoutStart({ idempotency_key: 'kw1', titles: ['t'] });
+    expect(res.isError).toBeUndefined();
+    expect(res.content).toHaveLength(2);
+    expect(res.content[0].text.startsWith('WARNING: owner workspace ws-1 has a pending decision dec-9')).toBe(true);
+    expect(JSON.parse(res.content[res.content.length - 1].text)).toMatchObject({ status: 'accepted' });
+  });
+
+  it('adds no block when there are no warnings, or when the field is malformed', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted' });
+    expect((await fanoutStart({ idempotency_key: 'kw2', titles: ['t'] })).content).toHaveLength(1);
+
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted', warnings: 'nope' });
+    expect((await fanoutStart({ idempotency_key: 'kw3', titles: ['t'] })).content).toHaveLength(1);
+
+    mockSendRpc.mockResolvedValue({ ok: true, status: 'accepted', warnings: ['', '  ', 7] });
+    expect((await fanoutStart({ idempotency_key: 'kw4', titles: ['t'] })).content).toHaveLength(1);
+  });
+});

--- a/src/mcp/__tests__/ledger.test.ts
+++ b/src/mcp/__tests__/ledger.test.ts
@@ -20,26 +20,30 @@ const mockSendRpc = sendRpc as unknown as ReturnType<typeof vi.fn>;
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<{ content: { type: 'text'; text: string }[]; isError?: boolean }>;
 
-function collect(): { tools: Map<string, ToolHandler>; shapes: Map<string, Record<string, unknown>> } {
+function collect(): { tools: Map<string, ToolHandler>; shapes: Map<string, Record<string, unknown>>; descs: Map<string, string> } {
   const tools = new Map<string, ToolHandler>();
   const shapes = new Map<string, Record<string, unknown>>();
-  const tool = (name: string, _d: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+  const descs = new Map<string, string>();
+  const tool = (name: string, d: string, schema: Record<string, unknown>, handler: ToolHandler) => {
     tools.set(name, handler);
     shapes.set(name, schema);
+    descs.set(name, d);
   };
   registerLedgerUpdateTool({ tool } as never, { getSenderPtyId: () => 'pty-mine', resolveWorkspaceId: async () => 'ws-mine' });
   registerLedgerListTool(tool as never);
-  return { tools, shapes };
+  return { tools, shapes, descs };
 }
 
-function collectBrain(): { tools: Map<string, ToolHandler>; shapes: Map<string, Record<string, unknown>> } {
+function collectBrain(): { tools: Map<string, ToolHandler>; shapes: Map<string, Record<string, unknown>>; descs: Map<string, string> } {
   const tools = new Map<string, ToolHandler>();
   const shapes = new Map<string, Record<string, unknown>>();
-  registerLedgerBrainUpdateTool(((name: string, _d: string, schema: Record<string, unknown>, handler: ToolHandler) => {
+  const descs = new Map<string, string>();
+  registerLedgerBrainUpdateTool(((name: string, d: string, schema: Record<string, unknown>, handler: ToolHandler) => {
     tools.set(name, handler);
     shapes.set(name, schema);
+    descs.set(name, d);
   }) as never);
-  return { tools, shapes };
+  return { tools, shapes, descs };
 }
 
 beforeEach(() => mockSendRpc.mockReset());
@@ -103,5 +107,27 @@ describe('ledger_list (commander-only)', () => {
     expect(COMMANDER_ONLY_TOOLS).toContain('ledger_list');
     expect(CORE_TOOL_SURFACE).not.toContain('ledger_list');
     expect(COMMANDER_RPC_METHODS.has('ledger.list')).toBe(true);
+  });
+});
+
+// Wave 3, finding 14 — the brain tried working → completed, was refused, and
+// had nothing in the contract text telling it whose move review_requested is.
+describe('the transition contract is in the tool text', () => {
+  it('the brain variant states the table and names force as its only exit', () => {
+    const desc = collectBrain().descs.get('ledger_update') ?? '';
+    expect(desc).toContain('worker: working → review_requested | input_required');
+    expect(desc).toContain('brain: review_requested → completed');
+    expect(desc).toContain('system: gate records');
+    expect(desc).toContain("review_requested, which is the WORKER's move");
+    expect(desc).toContain('force: { reason } is the ONLY brain-side exit');
+  });
+
+  // The WORKER variant is deliberately left alone: it rides the `full` profile,
+  // whose tools/list budget is the tight one, and it already says the two things
+  // a worker needs — review_requested is its move, completed is the brain's.
+  it('the worker variant keeps its own short contract', () => {
+    const desc = collect().descs.get('ledger_update') ?? '';
+    expect(desc).toContain('the brain marks completed');
+    expect(desc).not.toContain('system: gate records');
   });
 });

--- a/src/mcp/__tests__/ledger.test.ts
+++ b/src/mcp/__tests__/ledger.test.ts
@@ -115,11 +115,13 @@ describe('ledger_list (commander-only)', () => {
 describe('the transition contract is in the tool text', () => {
   it('the brain variant states the table and names force as its only exit', () => {
     const desc = collectBrain().descs.get('ledger_update') ?? '';
-    expect(desc).toContain('worker: working → review_requested | input_required');
-    expect(desc).toContain('brain: review_requested → completed');
-    expect(desc).toContain('system: gate records');
-    expect(desc).toContain("review_requested, which is the WORKER's move");
-    expect(desc).toContain('force: { reason } is the ONLY brain-side exit');
+    expect(desc).toContain('working → review_requested | input_required | failed | cancelled');
+    expect(desc).toContain('review_requested → completed');
+    expect(desc).toContain('completed is therefore reachable ONLY from review_requested');
+    // Honest about the escape hatch the ledger actually allows: an owner MAY
+    // set review_requested itself. Saying "that is the worker's" hid it.
+    expect(desc).toContain('you may set it yourself when the worker cannot');
+    expect(desc).toContain('force: { reason }, the only exit without one');
   });
 
   // The WORKER variant is deliberately left alone: it rides the `full` profile,

--- a/src/mcp/__tests__/worktask.test.ts
+++ b/src/mcp/__tests__/worktask.test.ts
@@ -106,12 +106,18 @@ describe('the wire call', () => {
   });
 });
 
+/** The envelope still follows the refusal header verbatim — parse it back. */
+function envelope(text: string): Record<string, unknown> {
+  const at = text.indexOf('{');
+  return JSON.parse(at === -1 ? '{}' : text.slice(at)) as Record<string, unknown>;
+}
+
 describe('the answer', () => {
   it('keeps the refusal envelope whole and flags it as an error', async () => {
     mockSendRpc.mockResolvedValue({ ok: false, taskId: 'wtask-1', reason: 'unpushed', aheadCount: 2 });
     const res = await tools.get('task_close')?.({ task_id: 'wtask-1' });
     expect(res?.isError).toBe(true);
-    const parsed = JSON.parse(res?.content[0]?.text ?? '{}') as Record<string, unknown>;
+    const parsed = envelope(res?.content[0]?.text ?? '{}');
     expect(parsed['reason']).toBe('unpushed');
     expect(parsed['aheadCount']).toBe(2);
   });
@@ -129,5 +135,54 @@ describe('the answer', () => {
     const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
     expect(res?.isError).toBe(true);
     expect(res?.content[0]?.text).toContain('wmux is not running');
+  });
+});
+
+// Wave 3, finding 13 — the brain reported "adopt finished (ff51d7e)" after two
+// refusals. The envelope was right; a JSON blob is just skimmable past. A
+// refusal now LEADS with the verdict.
+describe('a refusal cannot be read as a success', () => {
+  it('a refused adopt starts with REFUSED, is isError, and names the next step', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, taskId: 'wtask-1', reason: 'dirty-target', error: 'target has uncommitted changes' });
+    const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
+    expect(res?.isError).toBe(true);
+    const text = res?.content[0]?.text ?? '';
+    expect(text.startsWith('REFUSED (dirty-target): target has uncommitted changes')).toBe(true);
+    expect(text).toContain('Nothing was adopted. Next step: commit or stash');
+    expect(envelope(text)['reason']).toBe('dirty-target');
+  });
+
+  it('spells out the commit-failed recovery (the applied paths were restored)', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, reason: 'commit-failed', error: 'hook refused', files: ['a.ts'] });
+    const text = (await tools.get('task_adopt')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
+    expect(text.startsWith('REFUSED (commit-failed): hook refused')).toBe(true);
+    expect(text).toContain('the applied paths were restored; inspect the target with git_status and retry');
+  });
+
+  it('falls back to a generic next step for a reason it does not know', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, reason: 'no-repo' });
+    const text = (await tools.get('task_adopt')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
+    expect(text.startsWith('REFUSED (no-repo): the server refused the call (no message)')).toBe(true);
+    expect(text).toContain('then call task_adopt again');
+  });
+
+  it('close and pr share the shape with their own wording', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, reason: 'unpushed', error: '2 commits ahead' });
+    const closed = (await tools.get('task_close')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
+    expect(closed.startsWith('REFUSED (unpushed): 2 commits ahead')).toBe(true);
+    expect(closed).toContain('Nothing was closed; the worktree is intact.');
+
+    mockSendRpc.mockResolvedValue({ ok: false, reason: 'gh-missing', error: 'gh not found' });
+    const pr = (await tools.get('task_pr')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
+    expect(pr.startsWith('REFUSED (gh-missing): gh not found')).toBe(true);
+    expect(pr).toContain('No pull request was opened.');
+  });
+
+  it('leaves a SUCCESS untouched — no header, plain JSON', async () => {
+    mockSendRpc.mockResolvedValue({ ok: true, commit: 'ff51d7e' });
+    const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
+    expect(res?.isError).toBeUndefined();
+    expect(res?.content[0]?.text.startsWith('{')).toBe(true);
+    expect(res?.content[0]?.text).not.toContain('REFUSED');
   });
 });

--- a/src/mcp/__tests__/worktask.test.ts
+++ b/src/mcp/__tests__/worktask.test.ts
@@ -106,10 +106,17 @@ describe('the wire call', () => {
   });
 });
 
-/** The envelope still follows the refusal header verbatim — parse it back. */
-function envelope(text: string): Record<string, unknown> {
-  const at = text.indexOf('{');
-  return JSON.parse(at === -1 ? '{}' : text.slice(at)) as Record<string, unknown>;
+/** The envelope is always the LAST content block, untouched and parseable —
+ *  a refusal header rides in its own block ahead of it. */
+function envelope(res?: { content: { type: 'text'; text: string }[] }): Record<string, unknown> {
+  const blocks = res?.content ?? [];
+  return JSON.parse(blocks[blocks.length - 1]?.text ?? '{}') as Record<string, unknown>;
+}
+
+/** The refusal header block, or '' when the answer carries none. */
+function header(res?: { content: { type: 'text'; text: string }[] }): string {
+  const blocks = res?.content ?? [];
+  return blocks.length > 1 ? blocks[0].text : '';
 }
 
 describe('the answer', () => {
@@ -117,9 +124,11 @@ describe('the answer', () => {
     mockSendRpc.mockResolvedValue({ ok: false, taskId: 'wtask-1', reason: 'unpushed', aheadCount: 2 });
     const res = await tools.get('task_close')?.({ task_id: 'wtask-1' });
     expect(res?.isError).toBe(true);
-    const parsed = envelope(res?.content[0]?.text ?? '{}');
+    const parsed = envelope(res);
     expect(parsed['reason']).toBe('unpushed');
     expect(parsed['aheadCount']).toBe(2);
+    // The JSON block itself is untouched — a caller that JSON.parses it works.
+    expect(() => JSON.parse(res?.content[res.content.length - 1]?.text ?? '')).not.toThrow();
   });
 
   it('does not flag a successful gate run, whatever the exit code says', async () => {
@@ -142,47 +151,82 @@ describe('the answer', () => {
 // refusals. The envelope was right; a JSON blob is just skimmable past. A
 // refusal now LEADS with the verdict.
 describe('a refusal cannot be read as a success', () => {
-  it('a refused adopt starts with REFUSED, is isError, and names the next step', async () => {
+  it('a refused adopt leads with REFUSED in its OWN block, is isError, and names the next step', async () => {
     mockSendRpc.mockResolvedValue({ ok: false, taskId: 'wtask-1', reason: 'dirty-target', error: 'target has uncommitted changes' });
     const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
     expect(res?.isError).toBe(true);
-    const text = res?.content[0]?.text ?? '';
-    expect(text.startsWith('REFUSED (dirty-target): target has uncommitted changes')).toBe(true);
-    expect(text).toContain('Nothing was adopted. Next step: commit or stash');
-    expect(envelope(text)['reason']).toBe('dirty-target');
+    expect(res?.content).toHaveLength(2);
+    expect(header(res).startsWith('REFUSED (dirty-target): target has uncommitted changes')).toBe(true);
+    expect(header(res)).toContain('Nothing was adopted. Next step: commit or stash');
+    // The envelope block stays pure JSON.
+    expect(envelope(res)['reason']).toBe('dirty-target');
   });
 
   it('spells out the commit-failed recovery (the applied paths were restored)', async () => {
     mockSendRpc.mockResolvedValue({ ok: false, reason: 'commit-failed', error: 'hook refused', files: ['a.ts'] });
-    const text = (await tools.get('task_adopt')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
-    expect(text.startsWith('REFUSED (commit-failed): hook refused')).toBe(true);
-    expect(text).toContain('the applied paths were restored; inspect the target with git_status and retry');
+    const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
+    expect(header(res).startsWith('REFUSED (commit-failed): hook refused')).toBe(true);
+    expect(header(res)).toContain('the applied paths were restored; inspect the target with git_status and retry');
+  });
+
+  // The RPC GATE refuses before any service runs, and its shape has no `reason`
+  // at all: { ok: false, error: { code, message } }. Keying only on `reason`
+  // printed "REFUSED (unknown): the server refused the call (no message)" over
+  // the one fact that mattered — the human declined the approval.
+  it('falls back to the gate error code and message when there is no reason', async () => {
+    mockSendRpc.mockResolvedValue({
+      ok: false,
+      error: { code: 'NOT_AUTHORIZED', message: 'the approval was declined' },
+    });
+    const res = await tools.get('task_close')?.({ task_id: 'wtask-1' });
+    expect(res?.isError).toBe(true);
+    expect(header(res).startsWith('REFUSED (NOT_AUTHORIZED): the approval was declined')).toBe(true);
+    expect(header(res)).toContain('the approval was declined or expired, or the task is not yours');
+    expect(envelope(res)['ok']).toBe(false);
+  });
+
+  it('names the precondition recovery for a task with no worktree', async () => {
+    mockSendRpc.mockResolvedValue({
+      ok: false,
+      error: { code: 'FAILED_PRECONDITION', message: 'task has no worktree' },
+    });
+    const res = await tools.get('task_pr')?.({ task_id: 'wtask-1' });
+    expect(header(res).startsWith('REFUSED (FAILED_PRECONDITION): task has no worktree')).toBe(true);
+    expect(header(res)).toContain('check it with ledger_list / git_status first');
   });
 
   it('falls back to a generic next step for a reason it does not know', async () => {
     mockSendRpc.mockResolvedValue({ ok: false, reason: 'no-repo' });
-    const text = (await tools.get('task_adopt')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
-    expect(text.startsWith('REFUSED (no-repo): the server refused the call (no message)')).toBe(true);
-    expect(text).toContain('then call task_adopt again');
+    const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
+    expect(header(res).startsWith('REFUSED (no-repo): the server refused the call (no message)')).toBe(true);
+    expect(header(res)).toContain('then call task_adopt again');
   });
 
   it('close and pr share the shape with their own wording', async () => {
     mockSendRpc.mockResolvedValue({ ok: false, reason: 'unpushed', error: '2 commits ahead' });
-    const closed = (await tools.get('task_close')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
-    expect(closed.startsWith('REFUSED (unpushed): 2 commits ahead')).toBe(true);
-    expect(closed).toContain('Nothing was closed; the worktree is intact.');
+    const closed = await tools.get('task_close')?.({ task_id: 'wtask-1' });
+    expect(header(closed).startsWith('REFUSED (unpushed): 2 commits ahead')).toBe(true);
+    expect(header(closed)).toContain('Nothing was closed; the worktree is intact.');
 
     mockSendRpc.mockResolvedValue({ ok: false, reason: 'gh-missing', error: 'gh not found' });
-    const pr = (await tools.get('task_pr')?.({ task_id: 'wtask-1' }))?.content[0]?.text ?? '';
-    expect(pr.startsWith('REFUSED (gh-missing): gh not found')).toBe(true);
-    expect(pr).toContain('No pull request was opened.');
+    const pr = await tools.get('task_pr')?.({ task_id: 'wtask-1' });
+    expect(header(pr).startsWith('REFUSED (gh-missing): gh not found')).toBe(true);
+    expect(header(pr)).toContain('No pull request was opened.');
   });
 
-  it('leaves a SUCCESS untouched — no header, plain JSON', async () => {
+  it('leaves a SUCCESS untouched — one block, plain JSON', async () => {
     mockSendRpc.mockResolvedValue({ ok: true, commit: 'ff51d7e' });
     const res = await tools.get('task_adopt')?.({ task_id: 'wtask-1' });
     expect(res?.isError).toBeUndefined();
-    expect(res?.content[0]?.text.startsWith('{')).toBe(true);
+    expect(res?.content).toHaveLength(1);
+    expect(envelope(res)['commit']).toBe('ff51d7e');
     expect(res?.content[0]?.text).not.toContain('REFUSED');
+  });
+
+  it('a refused GATE tool keeps the plain envelope (no refusal copy)', async () => {
+    mockSendRpc.mockResolvedValue({ ok: false, error: { code: 'NOT_AUTHORIZED', message: 'no' } });
+    const res = await tools.get('task_gate_run')?.({ task_id: 'wtask-1' });
+    expect(res?.isError).toBe(true);
+    expect(res?.content).toHaveLength(1);
   });
 });

--- a/src/mcp/fanout.ts
+++ b/src/mcp/fanout.ts
@@ -91,6 +91,13 @@ const FANOUT_START_SHAPE = {
 };
 
 /** Register the fan-out tool on the given MCP server. */
+/** The accept's `warnings`, defensively: an unknown shape yields none. */
+function readWarnings(result: unknown): string[] {
+  const w = (result as { warnings?: unknown } | null | undefined)?.warnings;
+  if (!Array.isArray(w)) return [];
+  return w.filter((x): x is string => typeof x === 'string' && x.trim().length > 0);
+}
+
 export function registerFanOutTools(server: McpServer, deps: FanOutToolDeps): void {
   // Captured per registration, not a module global: the broker hosts many
   // servers in one process, and a global would stamp every connection's
@@ -106,7 +113,8 @@ export function registerFanOutTools(server: McpServer, deps: FanOutToolDeps): vo
       // themselves, which is the same answer.
       'Returns { status: "accepted" } immediately: spawning outlasts one RPC, so poll with the SAME idempotency_key, or watch each mission channel appear in your channel list. ' +
       'The user must approve first and that prompt is never auto-approved; unanswered, a poll reports { status: "denied", reason: "timeout" } rather than leaving you waiting. ' +
-      'Repository, owning workspace and agent command all come from your verified identity — fan-out runs in YOUR repository, the tasks are owned by you, and it is refused without that identity.',
+      'Repository, owning workspace and agent command all come from your verified identity — fan-out runs in YOUR repository, the tasks are owned by you, and it is refused without that identity. ' +
+      'An accept may carry `warnings` (also printed as a WARNING line): the fan-out ran, but something will stop its reports reaching you — act on it.',
     FANOUT_START_SHAPE,
     async ({ idempotency_key, titles, prompt, task_prompts, roles }) => {
       const params: Record<string, unknown> = {
@@ -147,8 +155,17 @@ export function registerFanOutTools(server: McpServer, deps: FanOutToolDeps): vo
         // "the user declined" from "the 30s prompt expired with nobody at the
         // keyboard" from "this key already ran and its result aged out" — which
         // is half of what the async contract exists to report.
+        // A warning is not a refusal — the fan-out IS running — but it names a
+        // condition that will break the loop it started (an unanswered decision
+        // on the owner workspace holds every worker report). A JSON key is
+        // skippable; a first line is not, so it is surfaced as its own content
+        // block ahead of the untouched envelope.
+        const warnings = readWarnings(result);
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) }],
+          content: [
+            ...warnings.map((w) => ({ type: 'text' as const, text: `WARNING: ${w}` })),
+            { type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) },
+          ],
           ...(result && result.ok === false ? { isError: true as const } : {}),
         };
       } catch (err) {

--- a/src/mcp/ledger.ts
+++ b/src/mcp/ledger.ts
@@ -101,7 +101,7 @@ export function registerLedgerUpdateTool(server: McpServer, deps: LedgerToolDeps
 export function registerLedgerBrainUpdateTool(register: McpServer['tool']): void {
   register(
     'ledger_update',
-    'Move one of YOUR tasks in the task ledger. Transitions — worker: working → review_requested | input_required; brain: review_requested → completed; system: gate records. So completed is reachable only from review_requested, which is the WORKER\'s move: mark completed after review_requested AND a passing gate recorded by the gate runner (task_gate_run). force: { reason } is the ONLY brain-side exit when the worker cannot report it itself (the reason is logged on the entry). Bounce a review back with input_required, or close a task as failed / cancelled. Carry the rev you read.',
+    'Move one of YOUR tasks in the task ledger. Transitions: working → review_requested | input_required | failed | cancelled; review_requested → completed | working | input_required | failed | cancelled; completed and cancelled are terminal. completed is therefore reachable ONLY from review_requested. The worker normally reports review_requested when its own gate passed; you may set it yourself when the worker cannot (no ledger tool, or it stalled). Then completed needs a passing gate the gate runner recorded (task_gate_run) — or force: { reason }, the only exit without one, logged on the entry. Bounce a review back with input_required, or close a task as failed / cancelled. Carry the rev you read.',
     LEDGER_BRAIN_UPDATE_SHAPE,
     async ({ task_id, status, expected_rev, summary, force, reason }) => {
       const params: Record<string, unknown> = { taskId: task_id, status, expectedRev: expected_rev };

--- a/src/mcp/ledger.ts
+++ b/src/mcp/ledger.ts
@@ -101,7 +101,7 @@ export function registerLedgerUpdateTool(server: McpServer, deps: LedgerToolDeps
 export function registerLedgerBrainUpdateTool(register: McpServer['tool']): void {
   register(
     'ledger_update',
-    'Move one of YOUR tasks in the task ledger. Mark completed only after review_requested AND a passing gate recorded by the gate runner (task_gate_run) — the server refuses otherwise; force + reason is the logged exception. Bounce a review back with input_required, or close a task as failed / cancelled. Carry the rev you read.',
+    'Move one of YOUR tasks in the task ledger. Transitions — worker: working → review_requested | input_required; brain: review_requested → completed; system: gate records. So completed is reachable only from review_requested, which is the WORKER\'s move: mark completed after review_requested AND a passing gate recorded by the gate runner (task_gate_run). force: { reason } is the ONLY brain-side exit when the worker cannot report it itself (the reason is logged on the entry). Bounce a review back with input_required, or close a task as failed / cancelled. Carry the rev you read.',
     LEDGER_BRAIN_UPDATE_SHAPE,
     async ({ task_id, status, expected_rev, summary, force, reason }) => {
       const params: Record<string, unknown> = { taskId: task_id, status, expectedRev: expected_rev };

--- a/src/mcp/worktask.ts
+++ b/src/mcp/worktask.ts
@@ -34,15 +34,85 @@ const TASK_ID = z
   .describe('The task id (wtask-…) from fanout_start or your mission list. Must be a task your workspace owns.');
 
 /**
+ * A refusal is easy to misread as a success (dogfood finding 13: both
+ * `task_adopt` calls answered `ok: false` and the brain's summary still said
+ * "adopt finished (ff51d7e)"). The envelope was correct; the SHAPE was not —
+ * a JSON blob whose second key is `ok: false` reads, to a model skimming for a
+ * sha, like a result. So a refused call leads with a sentence that cannot be
+ * skimmed past, and only then the envelope.
+ *
+ * `nothing` states what did NOT happen; `next` maps the server's own `reason`
+ * to the one concrete move that clears it.
+ */
+interface RefusalCopy {
+  nothing: string;
+  next: Record<string, string>;
+  fallback: string;
+}
+
+const ADOPT_REFUSAL: RefusalCopy = {
+  nothing: 'Nothing was adopted.',
+  next: {
+    'dirty-target':
+      "commit or stash the target's changes, or adopt with commit:true only after the target is clean",
+    'commit-failed':
+      'the applied paths were restored; inspect the target with git_status and retry',
+    conflict: 'the parent was left untouched; rebase the task branch on the parent, then adopt again',
+    needs_rebase: 'the two share no commit; rebase the task branch onto the parent, then adopt again',
+    empty: 'the task produced no changes; read its mission channel before closing it',
+  },
+  fallback: 'read `reason` and `error` below, fix that, then call task_adopt again',
+};
+
+const CLOSE_REFUSAL: RefusalCopy = {
+  nothing: 'Nothing was closed; the worktree is intact.',
+  next: {
+    unpushed: 'the branch has commits nobody has pushed; harvest with task_pr or task_adopt first',
+    dirty: 'the worktree has uncommitted changes; harvest them with task_adopt first',
+  },
+  fallback: 'read `reason` and `error` below, fix that, then call task_close again',
+};
+
+const PR_REFUSAL: RefusalCopy = {
+  nothing: 'No pull request was opened.',
+  next: {
+    'gh-missing': 'the GitHub CLI is not installed on this machine; this is a human step',
+    'gh-unauth': 'the GitHub CLI is not authenticated; this is a human step',
+    dirty: "the worktree has uncommitted changes — they would not be in the PR; have the worker commit them",
+    'no-origin': 'the repository has no origin remote; this is a human step',
+  },
+  fallback: 'read `reason` and `error` below, fix that, then call task_pr again',
+};
+
+/** `REFUSED (<reason>): <error>` + the next step, or null when the envelope is
+ *  not a refusal. Defensive about shape: the reason/error are read off an
+ *  arbitrary object, because a malformed envelope must still surface AS a
+ *  refusal rather than throw. */
+function refusalHeader(result: unknown, copy: RefusalCopy): string | null {
+  const r = result as { ok?: unknown; reason?: unknown; error?: unknown } | null | undefined;
+  if (!r || typeof r !== 'object' || r.ok !== false) return null;
+  const reason = typeof r.reason === 'string' && r.reason ? r.reason : 'unknown';
+  const error =
+    typeof r.error === 'string' && r.error.trim()
+      ? r.error.trim()
+      : 'the server refused the call (no message)';
+  const next = copy.next[reason] ?? copy.fallback;
+  return `REFUSED (${reason}): ${error}\n${copy.nothing} Next step: ${next}\n`;
+}
+
+/**
  * One call shape for all four tools: resolve identity, attach the verified
  * ptyId, send, hand the envelope back whole. The envelope is never collapsed to
  * a message — `reason` fields ('dirty', 'unpushed', 'busy', 'deps_missing') are
- * how an unattended caller tells "refused, fix this" from "failed".
+ * how an unattended caller tells "refused, fix this" from "failed" — but when
+ * `refusal` copy is supplied, a refusal is PREFIXED with a plain-language
+ * verdict so it cannot be read as a success. The JSON still follows it whole.
  */
 async function callTask(
   method: string,
   params: Record<string, unknown>,
   deps: WorktaskToolDeps,
+  refusal?: RefusalCopy,
 ): Promise<{ content: { type: 'text'; text: string }[]; isError?: true }> {
   if (deps.resolveWorkspaceId) {
     try {
@@ -56,8 +126,11 @@ async function callTask(
   if (pty) wire['senderPtyId'] = pty;
   try {
     const result = (await sendRpc(method as unknown as RpcMethod, wire)) as { ok?: boolean } | undefined;
+    const header = refusal ? refusalHeader(result, refusal) : null;
     return {
-      content: [{ type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) }],
+      content: [
+        { type: 'text' as const, text: `${header ?? ''}${JSON.stringify(result ?? {}, null, 2)}` },
+      ],
       ...(result && result.ok === false ? { isError: true as const } : {}),
     };
   } catch (err) {
@@ -109,7 +182,7 @@ export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps)
         ),
     },
     async ({ task_id, commit }) =>
-      callTask('task.adopt', { taskId: task_id, ...(commit !== undefined ? { commit } : {}) }, deps),
+      callTask('task.adopt', { taskId: task_id, ...(commit !== undefined ? { commit } : {}) }, deps, ADOPT_REFUSAL),
   );
 
   server.tool(
@@ -117,7 +190,7 @@ export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps)
     'Close a task and remove its git worktree. Destructive and deliberately picky: it refuses ({ reason: "unpushed" }) while the branch has commits nobody has pushed, and refuses ({ reason: "dirty" }, preserving the worktree) while there are uncommitted changes — so a close never silently destroys work. ' +
       'Harvest first (task_adopt, or task_pr), then close. Only tasks your own workspace owns can be closed.',
     { task_id: TASK_ID },
-    async ({ task_id }) => callTask('task.close', { taskId: task_id }, deps),
+    async ({ task_id }) => callTask('task.close', { taskId: task_id }, deps, CLOSE_REFUSAL),
   );
 
   server.tool(
@@ -132,6 +205,6 @@ export function registerWorktaskTools(server: McpServer, deps: WorktaskToolDeps)
         .describe('PR body. Omit for a one-line default naming the task.'),
     },
     async ({ task_id, body }) =>
-      callTask('task.pr', { taskId: task_id, ...(body !== undefined ? { body } : {}) }, deps),
+      callTask('task.pr', { taskId: task_id, ...(body !== undefined ? { body } : {}) }, deps, PR_REFUSAL),
   );
 }

--- a/src/mcp/worktask.ts
+++ b/src/mcp/worktask.ts
@@ -84,20 +84,42 @@ const PR_REFUSAL: RefusalCopy = {
   fallback: 'read `reason` and `error` below, fix that, then call task_pr again',
 };
 
+/** Next steps for the refusals the RPC GATE makes, before any service runs.
+ *  These arrive as `{ ok: false, error: { code, message } }` with NO `reason`
+ *  (see the deny() helper in worktask.rpc.ts), so a header keyed only on
+ *  `reason` printed "REFUSED (unknown): …" over the one thing the caller needed
+ *  — that a human declined the approval, or that the task is not yours. */
+const GATE_NEXT: Record<string, string> = {
+  NOT_AUTHORIZED:
+    'the approval was declined or expired, or the task is not yours — re-read your tasks with ledger_list and ask the operator before retrying',
+  FAILED_PRECONDITION:
+    'the task is not in a state this call can act on (often: no worktree on disk) — check it with ledger_list / git_status first',
+  PERMISSION_DENIED: 'this surface may not make that call; the operator has to do it',
+  INVALID_ARGUMENT: 'the arguments were rejected; re-read the tool schema and send a valid task id',
+  UNAVAILABLE: 'wmux could not reach the service; retry once, then tell the operator',
+};
+
 /** `REFUSED (<reason>): <error>` + the next step, or null when the envelope is
- *  not a refusal. Defensive about shape: the reason/error are read off an
- *  arbitrary object, because a malformed envelope must still surface AS a
- *  refusal rather than throw. */
+ *  not a refusal. Defensive about shape: reason, error and error.code/.message
+ *  are read off an arbitrary object, because a malformed envelope must still
+ *  surface AS a refusal rather than throw. */
 function refusalHeader(result: unknown, copy: RefusalCopy): string | null {
   const r = result as { ok?: unknown; reason?: unknown; error?: unknown } | null | undefined;
   if (!r || typeof r !== 'object' || r.ok !== false) return null;
-  const reason = typeof r.reason === 'string' && r.reason ? r.reason : 'unknown';
+  const errObj =
+    r.error && typeof r.error === 'object' ? (r.error as { code?: unknown; message?: unknown }) : null;
+  const code = typeof errObj?.code === 'string' && errObj.code ? errObj.code : null;
+  // The service's own `reason`, else the gate's error code — never "unknown"
+  // while either is on the wire.
+  const reason = typeof r.reason === 'string' && r.reason ? r.reason : (code ?? 'unknown');
   const error =
     typeof r.error === 'string' && r.error.trim()
       ? r.error.trim()
-      : 'the server refused the call (no message)';
-  const next = copy.next[reason] ?? copy.fallback;
-  return `REFUSED (${reason}): ${error}\n${copy.nothing} Next step: ${next}\n`;
+      : typeof errObj?.message === 'string' && errObj.message.trim()
+        ? errObj.message.trim()
+        : 'the server refused the call (no message)';
+  const next = copy.next[reason] ?? GATE_NEXT[reason] ?? copy.fallback;
+  return `REFUSED (${reason}): ${error}\n${copy.nothing} Next step: ${next}`;
 }
 
 /**
@@ -105,8 +127,9 @@ function refusalHeader(result: unknown, copy: RefusalCopy): string | null {
  * ptyId, send, hand the envelope back whole. The envelope is never collapsed to
  * a message — `reason` fields ('dirty', 'unpushed', 'busy', 'deps_missing') are
  * how an unattended caller tells "refused, fix this" from "failed" — but when
- * `refusal` copy is supplied, a refusal is PREFIXED with a plain-language
- * verdict so it cannot be read as a success. The JSON still follows it whole.
+ * `refusal` copy is supplied, a refusal is PRECEDED by its own content block
+ * carrying a plain-language verdict, so it cannot be read as a success. The
+ * JSON block itself is untouched and stays the LAST block.
  */
 async function callTask(
   method: string,
@@ -127,9 +150,13 @@ async function callTask(
   try {
     const result = (await sendRpc(method as unknown as RpcMethod, wire)) as { ok?: boolean } | undefined;
     const header = refusal ? refusalHeader(result, refusal) : null;
+    // The header is its OWN content block, ahead of the envelope. Prefixing the
+    // JSON text made content[0].text unparseable for every caller that reads it
+    // as JSON — the verdict has to be unmissable, not the envelope unusable.
     return {
       content: [
-        { type: 'text' as const, text: `${header ?? ''}${JSON.stringify(result ?? {}, null, 2)}` },
+        ...(header ? [{ type: 'text' as const, text: header }] : []),
+        { type: 'text' as const, text: JSON.stringify(result ?? {}, null, 2) },
       ],
       ...(result && result.ok === false ? { isError: true as const } : {}),
     };


### PR DESCRIPTION
## Summary

Wave 3 findings 12–14 (`docs/internal/dogfood-orchestrator-2026-09.md`).

- **F12 — pending decision as a silent kill switch.** The coalescer now logs one line per workspace per minute when a wake is dropped for a pending decision, naming how many events and which delegated task ids. Delegated (task-tagged) events are **held in the buffer** instead of consumed: `resolveDecision` kicks a resume turn without the human-send / brain-boot hooks, so a ledger park would never replay — the held events flush on the resume turn's idle instead. `fanout_start`'s accepted reply gains an additive `warnings` array when the owner workspace already has a pending decision.
- **F13 — refusals misread as success.** A refused `task_adopt` / `task_close` / `task_pr` now starts `REFUSED (<reason>): <error>` followed by `Nothing was adopted. Next step: …` (per reason), with the JSON after it; `isError` stays true. Gate tools are untouched (a failing gate is a successful call).
- **F14 — ILLEGAL_TRANSITION.** The ledger error appends `(allowed from <from>: <list>)`; the brain-side `ledger_update` description states the transition table in one line and names `force: { reason }` as the only brain-side exit; the task-tagged wake contract says which move is the brain's. The worker-side description is unchanged (the `full` profile has 398 B of headroom).

Byte counts: full 77,602 / 78,000 (unchanged), core 48,241, commander 55,698 / 60,000.

## Test plan

- [x] 7 new coalescer tests (log content and rate limit, snapshot path, hold-then-flush on resume, watermark not advanced, ambient consume unchanged), 3 fanout warning tests, 5 worktask refusal tests + 1 updated, 2 ledger message tests, 2 description tests, 2 contract assertions.
- [x] `tsc` root + daemon + mcp, eslint on 13 touched files, `build:mcp && probe:mcp` green, vitest over deck/mcp/ledger/pipe: 172 files / 2,941 tests.
- [ ] Live: refused adopt text and the pending-decision warning on the demo brain (wave 3 dogfood re-run).

Left: the fan-out warning is computed at accept time only; a decision raised afterwards is covered by the coalescer log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending decisions now clearly indicate when worker events are being held, while delegated task events are preserved for later delivery.
  * Fan-out confirmations warn when the workspace has an unresolved decision.
  * Refused task adoption, closure, and pull-request actions now show a clear refusal reason and next step while preserving structured details.
  * Ledger errors now list valid next transitions, and ledger guidance documents the complete transition rules.

* **Bug Fixes**
  * Improved handling and diagnostics for blocked events and unresolved decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->