### PR TITLE
fix(fanout): a worker's model is wmux's choice, not the operator's shell profile

### DIFF
--- a/changelog.d/fanout-worker-model-env.md
+++ b/changelog.d/fanout-worker-model-env.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A fan-out worker no longer launches on whatever model your shell profile
+  exports.** The worker's command is typed into the pane's interactive login
+  shell, so an `ANTHROPIC_MODEL` exported by `~/.zshrc` (or any other rc file)
+  overrode the environment wmux had set and every worker's first turn came back
+  "There's an issue with the selected model", indistinguishable from an idle
+  worker. A `claude` worker is now launched with that variable neutralised on the
+  command line itself, which is the only place late enough to win. A launch that
+  already names a model — an explicit `--model`, or a role bound to an agent and
+  model in Settings — is left exactly as it is. `ANTHROPIC_BASE_URL` and
+  `ANTHROPIC_AUTH_TOKEN` are deliberately untouched: routing claude through your
+  own proxy is a whole-machine choice, and a worker that quietly bypassed it
+  would be talking to a different endpoint than every other pane you open.
+
+- A fan-out worker whose first turn fails on its model is now reported as
+  `input_required` in the task ledger, with the model it was refused and the
+  `/model` fix, instead of sitting in `working` next to an idle-looking pane.
+  wmux reports that screen rather than typing at it.

--- a/changelog.d/fanout-worker-model-env.md
+++ b/changelog.d/fanout-worker-model-env.md
@@ -5,15 +5,24 @@
   shell, so an `ANTHROPIC_MODEL` exported by `~/.zshrc` (or any other rc file)
   overrode the environment wmux had set and every worker's first turn came back
   "There's an issue with the selected model", indistinguishable from an idle
-  worker. A `claude` worker is now launched with that variable neutralised on the
-  command line itself, which is the only place late enough to win. A launch that
-  already names a model — an explicit `--model`, or a role bound to an agent and
-  model in Settings — is left exactly as it is. `ANTHROPIC_BASE_URL` and
-  `ANTHROPIC_AUTH_TOKEN` are deliberately untouched: routing claude through your
-  own proxy is a whole-machine choice, and a worker that quietly bypassed it
-  would be talking to a different endpoint than every other pane you open.
+  worker. A `claude` worker's launch now unsets that variable in the pane's own
+  shell, which is the only place late enough to win — and it does it without
+  bypassing your shell, so an aliased `claude` (what `claude migrate-installer`
+  leaves behind) still resolves.
+
+  Three things call it off, each because wmux would otherwise be overruling a
+  choice you made: a launch that already passes `--model`; a role bound to an
+  agent and a model in Settings, whose flag is spliced in first; and a shell
+  that routes claude through a gateway (`ANTHROPIC_BASE_URL`), where the model
+  name is exactly what the gateway needs. `ANTHROPIC_BASE_URL` and
+  `ANTHROPIC_AUTH_TOKEN` are never touched — routing claude through your own
+  proxy is a whole-machine choice, and a worker that quietly bypassed it would
+  be talking to a different endpoint than every other pane you open. Panes whose
+  shell is fish, PowerShell or nushell are left alone entirely.
 
 - A fan-out worker whose first turn fails on its model is now reported as
-  `input_required` in the task ledger, with the model it was refused and the
-  `/model` fix, instead of sitting in `working` next to an idle-looking pane.
-  wmux reports that screen rather than typing at it.
+  `input_required` in the task ledger, with the model it was refused and where
+  that model came from, instead of sitting in `working` next to an idle-looking
+  pane. wmux reports that screen rather than typing at it, and looks once more a
+  few seconds after the pane goes quiet — the error only arrives after the agent
+  has painted its composer and been refused.

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -47,12 +47,23 @@ import {
   type FanoutSetupSkipReason,
 } from './fanoutEnvironment';
 import { inheritTaskAutonomy } from './taskAutonomy';
+import { commandChoosesModel } from '../../shared/orchestratorRole';
+import {
+  MODEL_ENV_MARKER,
+  WORKER_GATEWAY_ENV,
+  WORKER_MODEL_ENV,
+  isSimpleLaunchCommand,
+  splitModelEnvMarker,
+} from '../../shared/workerLaunch';
 import {
   clearFirstRunPrompts,
+  detectFirstRunPrompt,
+  FIRST_RUN_MODEL_RECHECK_MS,
   firstRunEnvForAgent,
   launcherStem,
   SUPPORTED_STEMS,
   type FirstRunPort,
+  type FirstRunWatchOptions,
 } from './agentFirstRun';
 
 /**
@@ -232,6 +243,11 @@ export interface FanOutServiceOptions {
   /** A-2 — autonomy inheritance for the task workspace. Injected in tests;
    *  defaults to the deck-autonomy store. */
   autonomy?: (ownerWorkspaceId: string, taskWorkspaceId: string) => Promise<unknown>;
+  /** A-1 — watch tuning. Tests shorten it; production takes the defaults. */
+  firstRunOptions?: FirstRunWatchOptions;
+  /** F15 — how long after a clean watch to look once more for the model error.
+   *  Negative disables the re-check entirely. */
+  firstRunRecheckMs?: number;
 }
 
 /**
@@ -256,6 +272,12 @@ export class FanOutService {
   private readonly firstRun?: FirstRunPort;
   /** A-2 — autonomy inheritance (absent = the real deck-autonomy store). */
   private readonly autonomy?: (owner: string, task: string) => Promise<unknown>;
+  /** A-1 — first-run watch tuning (absent = the module defaults). */
+  private readonly firstRunOptions?: FirstRunWatchOptions;
+  /** F15 — delay before the single late model re-read. */
+  private readonly firstRunRecheckMs: number;
+  /** F15 — deferred re-checks still in flight (tests await them). */
+  private pendingRechecks: Promise<void>[] = [];
 
   /** §2 G1 멱등: 키 → 완료 결과 LRU. 동일 키 재호출은 직전 결과 반환. */
   private readonly results = new Map<string, FanOutResult>();
@@ -269,6 +291,8 @@ export class FanOutService {
     this.project = opts.project;
     this.firstRun = opts.firstRun;
     this.autonomy = opts.autonomy;
+    this.firstRunOptions = opts.firstRunOptions;
+    this.firstRunRecheckMs = opts.firstRunRecheckMs ?? FIRST_RUN_MODEL_RECHECK_MS;
   }
 
   /**
@@ -586,9 +610,7 @@ export class FanOutService {
     //    없으면 인자 없이 agentCmd만(사람이 페인에서 직접 입력). 실제 workspaceId 회수.
     // F15 — and the launch neutralises a shell-exported ANTHROPIC_MODEL, which
     // no spawn env can (the rc files run after it). See workerLaunchCommand.
-    const launch = workerLaunchCommand(ctx.agentCmd, promptPath, {
-      ...(ctx.role ? { role: ctx.role } : {}),
-    });
+    const launch = workerLaunchCommand(ctx.agentCmd, promptPath);
     if (launch.note) console.warn(`[fanout] ${launch.note}`);
     const initialCommand = launch.command;
     base.initialCommand = initialCommand; // F2 재발사 재료(맨 셸 오배선 방지).
@@ -713,31 +735,98 @@ export class FanOutService {
     const ptyId = base.ptyId;
     if (!port || !ptyId) return;
     // The command the renderer ACTUALLY launched (a role binding may have
-    // swapped the agent). Only claude has these screens.
-    if (launcherStem(stripLaunchEnvPrefix(base.initialCommand ?? '')) !== 'claude') return;
+    // swapped the agent). Only claude has these screens. The marker is split
+    // off with the SAME shared constant that attaches it, so the two cannot
+    // drift into a stem this check does not recognise.
+    const { marker, command: launched } = splitModelEnvMarker(base.initialCommand ?? '');
+    if (launcherStem(launched) !== 'claude') return;
+    const neutralisedModelEnv = marker.length > 0;
 
     let outcome: Awaited<ReturnType<typeof clearFirstRunPrompts>>;
     try {
-      outcome = await clearFirstRunPrompts(ptyId, port);
+      outcome = await clearFirstRunPrompts(ptyId, port, this.firstRunOptions ?? {});
     } catch (err) {
       console.warn(`[fanout:first-run] watch failed for pane ${ptyId}: ${String(err)}`);
       return;
     }
-    if (outcome.status === 'clear') return;
+    if (outcome.status === 'clear') {
+      // The model error is the one screen that arrives AFTER the composer, so
+      // the clean-read exit above routinely runs before it: claude has to boot,
+      // paint, send the first turn and be refused. Look once more, later — and
+      // do it off the critical path, because spawnOne is serial and the fan-out
+      // must not pay that wait N times over.
+      this.scheduleModelRecheck(base, ownerWorkspaceId, ptyId, port, neutralisedModelEnv);
+      return;
+    }
     base.firstRunPrompt = outcome.headline;
     if (outcome.status !== 'stuck') return;
     base.firstRunStuck = true;
-    if (!base.taskId) return;
+    await this.markFirstRunStuck(base.taskId, ownerWorkspaceId, outcome, neutralisedModelEnv);
+  }
+
+  /**
+   * F15 — one late re-read for the selected-model error, off the critical path.
+   *
+   * Fire-and-forget on purpose: the task result is already on its way back to
+   * the caller, and the only thing this can still fix is the ledger row that
+   * would otherwise claim `working` beside a dead first turn. Tests await it
+   * through {@link settleFirstRunRechecks}.
+   */
+  private scheduleModelRecheck(
+    base: FanOutTaskResult,
+    ownerWorkspaceId: string,
+    ptyId: string,
+    port: FirstRunPort,
+    neutralisedModelEnv: boolean,
+  ): void {
+    const delay = this.firstRunRecheckMs;
+    if (delay < 0) return;
+    const run = async (): Promise<void> => {
+      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+      let screen = '';
+      try {
+        screen = await port.readScreen(ptyId);
+      } catch {
+        return; // an unreadable viewport is no evidence.
+      }
+      const prompt = detectFirstRunPrompt(screen);
+      if (prompt?.kind !== 'model-error') return;
+      await this.markFirstRunStuck(
+        base.taskId,
+        ownerWorkspaceId,
+        { headline: prompt.headline, reason: 'model', ...(prompt.model ? { model: prompt.model } : {}) },
+        neutralisedModelEnv,
+      );
+    };
+    this.pendingRechecks.push(run().catch(() => { /* best-effort — see above */ }));
+  }
+
+  /** Tests only: settle the deferred model re-checks this run scheduled. */
+  async settleFirstRunRechecks(): Promise<void> {
+    const pending = this.pendingRechecks;
+    this.pendingRechecks = [];
+    await Promise.all(pending);
+  }
+
+  /** Move a task's ledger row to `input_required` with the reason. Best-effort:
+   *  the reconciler mirrors the row on the next look either way. */
+  private async markFirstRunStuck(
+    taskId: string | undefined,
+    ownerWorkspaceId: string,
+    outcome: { headline: string; reason: 'trust' | 'unanswered' | 'send-failed' | 'model'; model?: string },
+    neutralisedModelEnv: boolean,
+  ): Promise<void> {
+    if (!taskId) return;
     try {
       const ledger = getTaskLedger();
-      const entry = ledger.list({ id: base.taskId })[0];
+      const entry = ledger.list({ id: taskId })[0];
       if (!entry) return;
       await ledger.update({
-        id: base.taskId,
+        id: taskId,
         status: 'input_required',
         actor: { kind: 'system', workspaceId: ownerWorkspaceId },
         expectedRev: entry.rev,
-        summary: firstRunStuckSummary(outcome),
+        summary: firstRunStuckSummary(outcome, { neutralisedModelEnv }),
       });
     } catch {
       // best-effort — the result already carries firstRunStuck.
@@ -815,22 +904,7 @@ export function buildInitialCommand(
 
 // ─── F15 — the worker's model is wmux's decision, not the shell's ────────────
 
-/**
- * The env var Claude Code reads to pick its model.
- *
- * NOT scrubbed anywhere else, and deliberately so. `ANTHROPIC_BASE_URL` and
- * `ANTHROPIC_AUTH_TOKEN` stay exactly as the operator's environment sets them:
- * routing every pane's claude through a proxy or a gateway is a legitimate,
- * whole-machine choice, and a fan-out worker that silently bypassed it would be
- * talking to a different endpoint than every other pane the operator opened.
- * Model SELECTION is the one part of that environment wmux owns for a worker,
- * because wmux is the one that decided to launch this agent at all.
- */
-export const CLAUDE_MODEL_ENV = 'ANTHROPIC_MODEL';
-
 export interface WorkerLaunchOptions {
-  /** The orchestrator role bound to this task (absent = unroled). */
-  role?: string;
   /** Platform override — tests only; defaults to the real platform. */
   platform?: NodeJS.Platform;
 }
@@ -838,49 +912,36 @@ export interface WorkerLaunchOptions {
 export interface WorkerLaunch {
   /** The command to fire into the worker pane. */
   command: string;
-  /** Was the shell's `ANTHROPIC_MODEL` neutralised for this launch? */
+  /** Does the command carry the model-env marker? */
   neutralisedModelEnv: boolean;
-  /** Why it was not, when that is worth saying out loud. */
+  /** Why it does not, when that is worth saying out loud. */
   note?: string;
 }
 
-/** Does `agentCmd` already choose a model itself? Split on whitespace is exact
- *  here: `agentCmd` is the launcher line ONLY — the quoted prompt argument is
- *  appended afterwards by {@link buildInitialCommand} — so no token of this
- *  string is ever prose. */
-function carriesModelFlag(agentCmd: string): boolean {
-  return agentCmd
-    .trim()
-    .split(/\s+/)
-    .some((t) => t === '--model' || t === '-m' || t.startsWith('--model=') || t.startsWith('-m='));
-}
-
 /**
- * The command a fan-out worker is actually launched with.
+ * The command a fan-out worker is launched with.
  *
- * Why the neutralisation is on the COMMAND LINE and not in the spawn env: the
- * pane's process is the operator's INTERACTIVE LOGIN SHELL, and this command is
- * typed into it after it boots (see scheduleInitialCommand). By then the shell
- * has already sourced `~/.zshrc`, so anything that file exports has overwritten
- * whatever `resolveSpawnEnv` withheld. Three dogfood runs died exactly there:
- * every worker's first turn came back "There's an issue with the selected model
- * (glm-5.3)" and had to be recovered by hand with `/model opus`. `env -u` runs
- * inside that shell, after the rc files, which is the only place late enough to
- * win.
+ * The marker itself, and the reasons it is spelled the way it is, live in
+ * shared/workerLaunch — the renderer handles the same string. This function
+ * decides only whether THIS launch is eligible for it, and every gate reads the
+ * ORIGINAL `agentCmd` rather than the assembled line, so the prompt argument's
+ * contents can never influence the decision:
  *
- * It is only applied when wmux has no model of its own for this worker:
  *  - a non-`claude` launcher is left alone (`SUPPORTED_STEMS`) — no other agent
- *    reads this variable;
- *  - an `agentCmd` that already carries `--model` has been given one explicitly,
- *    and a CLI flag beats the environment anyway;
- *  - a ROLED task is left alone because the renderer resolves the operator's
- *    role binding (agent + model) against this exact string: `applyRoleAgent`
- *    and `applyRoleBinding` both gate on the launcher stem, and an `env` prefix
- *    would make the stem unrecognisable, silently dropping the binding's agent
- *    AND its model. A bound role is wmux deciding the model, which is the case
- *    this function exists to defer to.
- *  - win32 is skipped with a note: `env -u` is POSIX, and the pane's shell there
- *    is PowerShell (see the Windows branch of buildInitialCommand).
+ *    reads the variable;
+ *  - an `agentCmd` that already names a model was given one explicitly, and a
+ *    CLI flag beats the environment anyway;
+ *  - anything but a single simple command is left alone with a note (see
+ *    {@link isSimpleLaunchCommand});
+ *  - win32 is left alone with a note: the marker is POSIX and the pane's shell
+ *    there is PowerShell (see the Windows branch of buildInitialCommand).
+ *
+ * A ROLE is deliberately NOT a gate here. Main cannot see the operator's role
+ * bindings (they are renderer state), so "has a role" is not "has a model" — an
+ * unbound role, or one bound to an agent with no model, would leave the worker
+ * exactly as exposed as before. The renderer decides that instead, where the
+ * binding actually resolves: it splits the marker off before the role rewrite
+ * and re-attaches it only if the rewritten command still names no model.
  */
 export function workerLaunchCommand(
   agentCmd: string,
@@ -890,42 +951,44 @@ export function workerLaunchCommand(
   const platform = opts.platform ?? process.platform;
   const command = buildInitialCommand(agentCmd, promptPath, platform);
   if (!SUPPORTED_STEMS.has(launcherStem(agentCmd))) return { command, neutralisedModelEnv: false };
-  if (carriesModelFlag(agentCmd)) return { command, neutralisedModelEnv: false };
-  if (opts.role) return { command, neutralisedModelEnv: false };
+  if (commandChoosesModel(agentCmd)) return { command, neutralisedModelEnv: false };
+  if (!isSimpleLaunchCommand(agentCmd)) {
+    return {
+      command,
+      neutralisedModelEnv: false,
+      note: `agentCmd is not a single simple command, so ${WORKER_MODEL_ENV} is left as the shell sets it: ${agentCmd}`,
+    };
+  }
   if (platform === 'win32') {
     return {
       command,
       neutralisedModelEnv: false,
-      note: `${CLAUDE_MODEL_ENV} is not neutralised on win32; bind a role with a model, or unset it in the shell profile.`,
+      note: `${WORKER_MODEL_ENV} is not neutralised on win32 (the marker is POSIX); bind a role with a model, or unset it in the shell profile.`,
     };
   }
-  return { command: `env -u ${CLAUDE_MODEL_ENV} ${command}`, neutralisedModelEnv: true };
-}
-
-/** `env -u FOO -u BAR claude …` → `claude …`.
- *
- *  The recorded `initialCommand` is the line that was really launched (F2 needs
- *  to replay it verbatim), so every reader that wants the AGENT out of it —
- *  `launcherStem`, and anything that follows — has to see past the prefix this
- *  module may have added. Only the exact `env -u NAME` shape is stripped; an
- *  `env` used for anything else is left alone. */
-export function stripLaunchEnvPrefix(command: string): string {
-  const m = /^env(?:\s+-u\s+[A-Za-z_][A-Za-z0-9_]*)+\s+/.exec(command.trim());
-  return m ? command.trim().slice(m[0].length) : command;
+  return { command: MODEL_ENV_MARKER + command, neutralisedModelEnv: true };
 }
 
 /** The `input_required` summary for a worker the first-run watch gave up on.
- *  Split out so the two families read differently: a menu needs a keypress, a
- *  model error needs a different model. */
-export function firstRunStuckSummary(outcome: {
-  headline: string;
-  reason: 'trust' | 'unanswered' | 'send-failed' | 'model';
-  model?: string;
-}): string {
+ *  Split out so the cases read differently: a menu needs a keypress, and a model
+ *  error points somewhere else depending on whether the launch had already
+ *  neutralised the shell's variable — if it had, the shell profile is exonerated
+ *  and the gateway or the role binding is what named that model. */
+export function firstRunStuckSummary(
+  outcome: {
+    headline: string;
+    reason: 'trust' | 'unanswered' | 'send-failed' | 'model';
+    model?: string;
+  },
+  opts: { neutralisedModelEnv?: boolean } = {},
+): string {
   if (outcome.reason === 'model') {
+    const fix = opts.neutralisedModelEnv
+      ? `this launch already unset ${WORKER_MODEL_ENV}, so the model came from ${WORKER_GATEWAY_ENV}'s gateway or from the role's model binding`
+      : `stop the shell profile from exporting ${WORKER_MODEL_ENV}`;
     return (
       `worker's first turn failed on its model${outcome.model ? ` (${outcome.model})` : ''}; ` +
-      `run /model <model> in the pane, or stop the shell profile from exporting ${CLAUDE_MODEL_ENV}`
+      `run /model <model> in the pane — ${fix}`
     );
   }
   return `worker is waiting on Claude Code's ${outcome.headline}; it needs a keypress in the pane`;

--- a/src/main/worktask/FanOutService.ts
+++ b/src/main/worktask/FanOutService.ts
@@ -51,6 +51,7 @@ import {
   clearFirstRunPrompts,
   firstRunEnvForAgent,
   launcherStem,
+  SUPPORTED_STEMS,
   type FirstRunPort,
 } from './agentFirstRun';
 
@@ -583,7 +584,13 @@ export class FanOutService {
     // ③ 렌더러 spawn — 전용 워크스페이스 + 에이전트 페인. cwd=worktreePath,
     //    initialCommand=`{agentCmd} "$(cat '{promptPath}')"`(경로 쿼팅) — 프롬프트가
     //    없으면 인자 없이 agentCmd만(사람이 페인에서 직접 입력). 실제 workspaceId 회수.
-    const initialCommand = buildInitialCommand(ctx.agentCmd, promptPath);
+    // F15 — and the launch neutralises a shell-exported ANTHROPIC_MODEL, which
+    // no spawn env can (the rc files run after it). See workerLaunchCommand.
+    const launch = workerLaunchCommand(ctx.agentCmd, promptPath, {
+      ...(ctx.role ? { role: ctx.role } : {}),
+    });
+    if (launch.note) console.warn(`[fanout] ${launch.note}`);
+    const initialCommand = launch.command;
     base.initialCommand = initialCommand; // F2 재발사 재료(맨 셸 오배선 방지).
     const wsName = `wtask: ${ctx.title.slice(0, 32)}`;
     // A-1 — first-run env for the PANE only (not for the setup hook, which is a
@@ -698,7 +705,8 @@ export class FanOutService {
    * Mutates `base` with what was seen. A screen that is still there moves the
    * task's ledger row to `input_required`, because that is the state the brain
    * reads: an idle worker and a worker frozen on an onboarding menu are
-   * indistinguishable from the outside, and `working` would be a lie.
+   * indistinguishable from the outside, and `working` would be a lie. F15 puts
+   * a first turn that died on its model in the same bucket, for the same reason.
    */
   private async watchFirstRun(base: FanOutTaskResult, ownerWorkspaceId: string): Promise<void> {
     const port = this.firstRun;
@@ -706,7 +714,7 @@ export class FanOutService {
     if (!port || !ptyId) return;
     // The command the renderer ACTUALLY launched (a role binding may have
     // swapped the agent). Only claude has these screens.
-    if (launcherStem(base.initialCommand ?? '') !== 'claude') return;
+    if (launcherStem(stripLaunchEnvPrefix(base.initialCommand ?? '')) !== 'claude') return;
 
     let outcome: Awaited<ReturnType<typeof clearFirstRunPrompts>>;
     try {
@@ -729,7 +737,7 @@ export class FanOutService {
         status: 'input_required',
         actor: { kind: 'system', workspaceId: ownerWorkspaceId },
         expectedRev: entry.rev,
-        summary: `worker is waiting on Claude Code's ${outcome.headline}; it needs a keypress in the pane`,
+        summary: firstRunStuckSummary(outcome),
       });
     } catch {
       // best-effort — the result already carries firstRunStuck.
@@ -788,9 +796,13 @@ function describeErr(err: unknown): string {
  * 빈 인자 처리(무시/에러/빈 프롬프트 전송)가 달라 불확정적이므로, "인자 없음"을 명시적으로
  * 만들어 에이전트가 평소 인터랙티브 기동과 동일하게 뜨도록 한다.
  */
-export function buildInitialCommand(agentCmd: string, promptPath?: string): string {
+export function buildInitialCommand(
+  agentCmd: string,
+  promptPath?: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
   if (promptPath === undefined) return agentCmd;
-  if (process.platform === 'win32') {
+  if (platform === 'win32') {
     // PowerShell 단일따옴표 리터럴: 내부 `'`는 `''`로 이스케이프. -LiteralPath로
     // glob·경로 특수문자 해석까지 봉쇄.
     const escaped = promptPath.replace(/'/g, "''");
@@ -799,4 +811,122 @@ export function buildInitialCommand(agentCmd: string, promptPath?: string): stri
   // POSIX 단일따옴표 리터럴: 내부 `'`는 `'\''`(닫고-이스케이프-열기)로 처리.
   const escaped = promptPath.replace(/'/g, "'\\''");
   return `${agentCmd} "$(cat '${escaped}')"`;
+}
+
+// ─── F15 — the worker's model is wmux's decision, not the shell's ────────────
+
+/**
+ * The env var Claude Code reads to pick its model.
+ *
+ * NOT scrubbed anywhere else, and deliberately so. `ANTHROPIC_BASE_URL` and
+ * `ANTHROPIC_AUTH_TOKEN` stay exactly as the operator's environment sets them:
+ * routing every pane's claude through a proxy or a gateway is a legitimate,
+ * whole-machine choice, and a fan-out worker that silently bypassed it would be
+ * talking to a different endpoint than every other pane the operator opened.
+ * Model SELECTION is the one part of that environment wmux owns for a worker,
+ * because wmux is the one that decided to launch this agent at all.
+ */
+export const CLAUDE_MODEL_ENV = 'ANTHROPIC_MODEL';
+
+export interface WorkerLaunchOptions {
+  /** The orchestrator role bound to this task (absent = unroled). */
+  role?: string;
+  /** Platform override — tests only; defaults to the real platform. */
+  platform?: NodeJS.Platform;
+}
+
+export interface WorkerLaunch {
+  /** The command to fire into the worker pane. */
+  command: string;
+  /** Was the shell's `ANTHROPIC_MODEL` neutralised for this launch? */
+  neutralisedModelEnv: boolean;
+  /** Why it was not, when that is worth saying out loud. */
+  note?: string;
+}
+
+/** Does `agentCmd` already choose a model itself? Split on whitespace is exact
+ *  here: `agentCmd` is the launcher line ONLY — the quoted prompt argument is
+ *  appended afterwards by {@link buildInitialCommand} — so no token of this
+ *  string is ever prose. */
+function carriesModelFlag(agentCmd: string): boolean {
+  return agentCmd
+    .trim()
+    .split(/\s+/)
+    .some((t) => t === '--model' || t === '-m' || t.startsWith('--model=') || t.startsWith('-m='));
+}
+
+/**
+ * The command a fan-out worker is actually launched with.
+ *
+ * Why the neutralisation is on the COMMAND LINE and not in the spawn env: the
+ * pane's process is the operator's INTERACTIVE LOGIN SHELL, and this command is
+ * typed into it after it boots (see scheduleInitialCommand). By then the shell
+ * has already sourced `~/.zshrc`, so anything that file exports has overwritten
+ * whatever `resolveSpawnEnv` withheld. Three dogfood runs died exactly there:
+ * every worker's first turn came back "There's an issue with the selected model
+ * (glm-5.3)" and had to be recovered by hand with `/model opus`. `env -u` runs
+ * inside that shell, after the rc files, which is the only place late enough to
+ * win.
+ *
+ * It is only applied when wmux has no model of its own for this worker:
+ *  - a non-`claude` launcher is left alone (`SUPPORTED_STEMS`) — no other agent
+ *    reads this variable;
+ *  - an `agentCmd` that already carries `--model` has been given one explicitly,
+ *    and a CLI flag beats the environment anyway;
+ *  - a ROLED task is left alone because the renderer resolves the operator's
+ *    role binding (agent + model) against this exact string: `applyRoleAgent`
+ *    and `applyRoleBinding` both gate on the launcher stem, and an `env` prefix
+ *    would make the stem unrecognisable, silently dropping the binding's agent
+ *    AND its model. A bound role is wmux deciding the model, which is the case
+ *    this function exists to defer to.
+ *  - win32 is skipped with a note: `env -u` is POSIX, and the pane's shell there
+ *    is PowerShell (see the Windows branch of buildInitialCommand).
+ */
+export function workerLaunchCommand(
+  agentCmd: string,
+  promptPath: string | undefined,
+  opts: WorkerLaunchOptions = {},
+): WorkerLaunch {
+  const platform = opts.platform ?? process.platform;
+  const command = buildInitialCommand(agentCmd, promptPath, platform);
+  if (!SUPPORTED_STEMS.has(launcherStem(agentCmd))) return { command, neutralisedModelEnv: false };
+  if (carriesModelFlag(agentCmd)) return { command, neutralisedModelEnv: false };
+  if (opts.role) return { command, neutralisedModelEnv: false };
+  if (platform === 'win32') {
+    return {
+      command,
+      neutralisedModelEnv: false,
+      note: `${CLAUDE_MODEL_ENV} is not neutralised on win32; bind a role with a model, or unset it in the shell profile.`,
+    };
+  }
+  return { command: `env -u ${CLAUDE_MODEL_ENV} ${command}`, neutralisedModelEnv: true };
+}
+
+/** `env -u FOO -u BAR claude …` → `claude …`.
+ *
+ *  The recorded `initialCommand` is the line that was really launched (F2 needs
+ *  to replay it verbatim), so every reader that wants the AGENT out of it —
+ *  `launcherStem`, and anything that follows — has to see past the prefix this
+ *  module may have added. Only the exact `env -u NAME` shape is stripped; an
+ *  `env` used for anything else is left alone. */
+export function stripLaunchEnvPrefix(command: string): string {
+  const m = /^env(?:\s+-u\s+[A-Za-z_][A-Za-z0-9_]*)+\s+/.exec(command.trim());
+  return m ? command.trim().slice(m[0].length) : command;
+}
+
+/** The `input_required` summary for a worker the first-run watch gave up on.
+ *  Split out so the two families read differently: a menu needs a keypress, a
+ *  model error needs a different model. */
+export function firstRunStuckSummary(outcome: {
+  headline: string;
+  reason: 'trust' | 'unanswered' | 'send-failed' | 'model';
+  model?: string;
+}): string {
+  if (outcome.reason === 'model') {
+    return (
+      `worker's first turn failed on its model${outcome.model ? ` (${outcome.model})` : ''}; ` +
+      `run /model <model> in the pane, or stop the shell profile from exporting ${CLAUDE_MODEL_ENV}`
+    );
+  }
+  return `worker is waiting on Claude Code's ${outcome.headline}; it needs a keypress in the pane`;
 }

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -12,10 +12,10 @@ import {
   FanOutService,
   buildInitialCommand,
   workerLaunchCommand,
-  stripLaunchEnvPrefix,
   firstRunStuckSummary,
   WORKER_DELIVERY_PREAMBLE,
 } from '../FanOutService';
+import { MODEL_ENV_MARKER, reattachModelEnvMarker, splitModelEnvMarker } from '../../../shared/workerLaunch';
 import type { FanOutDaemonPort, FanOutRendererPort } from '../FanOutService';
 import type { TaskWorktreePlan } from '../TaskWorktreeManager';
 import type { ProjectConfigState } from '../../../shared/wmuxProjectConfig';
@@ -203,25 +203,59 @@ describe('workerLaunchCommand (F15)', () => {
 
   it('neutralises a shell-exported ANTHROPIC_MODEL for a plain claude worker', () => {
     // The command is TYPED into the pane's interactive login shell, so ~/.zshrc
-    // has already re-exported ANTHROPIC_MODEL by then; only `env -u` on the line
+    // has already re-exported ANTHROPIC_MODEL by then; only a prefix on the line
     // itself runs late enough to win.
     const launch = workerLaunchCommand('claude', '/m/prompt.md', POSIX);
-    expect(launch.command).toBe("env -u ANTHROPIC_MODEL claude \"$(cat '/m/prompt.md')\"");
+    expect(launch.command).toBe(`${MODEL_ENV_MARKER}claude "$(cat '/m/prompt.md')"`);
     expect(launch.neutralisedModelEnv).toBe(true);
+  });
+
+  it('uses a same-shell form, so an aliased claude still resolves', () => {
+    // `env -u VAR claude` execs a BINARY: after `claude migrate-installer` many
+    // machines have only `alias claude=~/.claude/local/claude` and that form dies
+    // with "env: claude: No such file or directory".
+    const cmd = workerLaunchCommand('claude', undefined, POSIX).command;
+    expect(cmd.startsWith('env ')).toBe(false);
+    expect(cmd).toContain('unset ANTHROPIC_MODEL; ');
+    // The alias-carrying shell really does expand the word after the `;` — an
+    // `env -u` form would have looked for a BINARY that is not on PATH at all.
+    const script = ['shopt -s expand_aliases', "alias claude='printf ALIASED'", cmd].join('\n');
+    expect(execFileSync('bash', ['-c', script], { encoding: 'utf8' })).toBe('ALIASED');
+  });
+
+  it('stands down when a gateway is routing claude (ANTHROPIC_BASE_URL set)', () => {
+    // A gateway operator NEEDS their model name: unset it and claude asks the
+    // gateway for a default claude-* model it does not serve. The test is in the
+    // PANE's shell, not in main — main's process.env is not the environment that
+    // has the problem (Finder-launched wmux inherits none of it).
+    const cmd = workerLaunchCommand('claude', '/m/prompt.md', POSIX).command.replace(
+      /claude "\$\(cat[^)]*\)"$/,
+      'printf %s "${ANTHROPIC_MODEL-<unset>}"',
+    );
+    const withGateway = execFileSync('sh', ['-c', cmd], {
+      encoding: 'utf8',
+      env: { ...process.env, ANTHROPIC_BASE_URL: 'https://gw.example', ANTHROPIC_MODEL: 'glm-5.3' },
+    });
+    expect(withGateway).toBe('glm-5.3');
+    const withoutGateway = execFileSync('sh', ['-c', cmd], {
+      encoding: 'utf8',
+      env: { ...process.env, ANTHROPIC_BASE_URL: '', ANTHROPIC_MODEL: 'glm-5.3' },
+    });
+    expect(withoutGateway).toBe('<unset>');
   });
 
   it('leaves the quoting of the prompt path byte-identical', () => {
     const nasty = "/a b/it's $x`y.md";
     const launch = workerLaunchCommand('claude', nasty, POSIX);
     expect(launch.command.endsWith(buildInitialCommand('claude', nasty, 'darwin'))).toBe(true);
-    // …and the shell really hands the file body to argv, prefix included.
+    // …and the shell really hands the file body to argv, marker included.
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-launch-'));
     try {
       const promptFile = path.join(dir, "a b/it's $x`y.md");
       fs.mkdirSync(path.dirname(promptFile), { recursive: true });
       const body = 'do the thing "$(rm -rf /)" `boom`';
       fs.writeFileSync(promptFile, body, 'utf8');
-      const cmd = workerLaunchCommand("printf '%s'", promptFile, POSIX).command;
+      const cmd = MODEL_ENV_MARKER + buildInitialCommand("printf '%s'", promptFile, 'darwin');
       expect(execFileSync('sh', ['-c', cmd], { encoding: 'utf8' })).toBe(body);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -231,8 +265,8 @@ describe('workerLaunchCommand (F15)', () => {
   it('leaves a command that already chooses a model alone', () => {
     for (const cmd of ['claude --model opus', 'claude --model=opus', 'claude -m opus']) {
       const launch = workerLaunchCommand(cmd, '/m/prompt.md', POSIX);
-      expect(launch.command.startsWith('env ')).toBe(false);
       expect(launch.neutralisedModelEnv).toBe(false);
+      expect(splitModelEnvMarker(launch.command).marker).toBe('');
     }
   });
 
@@ -242,46 +276,59 @@ describe('workerLaunchCommand (F15)', () => {
     expect(launch.neutralisedModelEnv).toBe(false);
   });
 
-  it('leaves a ROLED task alone so the renderer can still read its launcher stem', () => {
-    // applyRoleAgent/applyRoleBinding both gate on the first token: an `env`
-    // prefix would silently drop the role's agent AND its model.
-    const launch = workerLaunchCommand('claude', '/m/prompt.md', { ...POSIX, role: 'Builder' });
-    expect(launch.command).toBe("claude \"$(cat '/m/prompt.md')\"");
-    expect(launch.neutralisedModelEnv).toBe(false);
+  it('does NOT stand down for a roled task — main cannot see the binding', () => {
+    // "has a role" is not "has a model": an unbound role, or one bound to an
+    // agent with no model, injects no --model at all. The renderer decides,
+    // where the binding actually resolves.
+    const launch = workerLaunchCommand('claude', '/m/prompt.md', POSIX);
+    expect(launch.neutralisedModelEnv).toBe(true);
   });
 
-  it('says so instead of emitting a POSIX-only prefix on win32', () => {
+  it('refuses anything but a single simple command, and says why', () => {
+    // A claude launch the marker would change the meaning of: `unset X; a && b`
+    // leaves `b` running with the variable unset in a way nobody wrote.
+    for (const cmd of ['claude && echo hi', 'claude | tee log', 'claude `hostname`']) {
+      const launch = workerLaunchCommand(cmd, '/m/prompt.md', POSIX);
+      expect(launch.neutralisedModelEnv).toBe(false);
+      expect(splitModelEnvMarker(launch.command).marker).toBe('');
+      expect(launch.note).toContain('simple command');
+    }
+    // …and a form whose first token is not the launcher at all never gets as
+    // far as that question: the stem is `a` / `FOO=1` / `claude;`, none of which
+    // is an agent wmux knows, so the command is left alone with nothing to say.
+    for (const cmd of ['a | claude', 'FOO=1 claude', 'claude; echo hi']) {
+      const launch = workerLaunchCommand(cmd, '/m/prompt.md', POSIX);
+      expect(launch.neutralisedModelEnv).toBe(false);
+      expect(splitModelEnvMarker(launch.command).marker).toBe('');
+    }
+  });
+
+  it('says so instead of emitting a POSIX-only marker on win32', () => {
     const launch = workerLaunchCommand('claude', 'C:\\m\\prompt.md', { platform: 'win32' });
-    expect(launch.command.startsWith('env ')).toBe(false);
     expect(launch.neutralisedModelEnv).toBe(false);
-    expect(launch.note).toContain('ANTHROPIC_MODEL');
+    expect(launch.note).toContain('win32');
   });
 
   it('still works for the "environment only" launch with no prompt file', () => {
-    expect(workerLaunchCommand('claude', undefined, POSIX).command).toBe('env -u ANTHROPIC_MODEL claude');
-  });
-});
-
-describe('stripLaunchEnvPrefix (F15)', () => {
-  it('recovers the agent from a command the launch prefixed', () => {
-    expect(stripLaunchEnvPrefix("env -u ANTHROPIC_MODEL claude \"$(cat '/m/p.md')\"")).toBe(
-      "claude \"$(cat '/m/p.md')\"",
-    );
-    expect(stripLaunchEnvPrefix('env -u A -u B claude')).toBe('claude');
-  });
-
-  it('leaves any other command — and any other use of env — untouched', () => {
-    expect(stripLaunchEnvPrefix('claude --model opus')).toBe('claude --model opus');
-    expect(stripLaunchEnvPrefix('env FOO=1 claude')).toBe('env FOO=1 claude');
+    expect(workerLaunchCommand('claude', undefined, POSIX).command).toBe(`${MODEL_ENV_MARKER}claude`);
   });
 });
 
 describe('firstRunStuckSummary (F15)', () => {
-  it('names the model and the fix for a model error', () => {
+  it('names the model and the shell profile when nothing was neutralised', () => {
     const s = firstRunStuckSummary({ headline: 'selected-model error', reason: 'model', model: 'glm-5.3' });
     expect(s).toContain('glm-5.3');
     expect(s).toContain('/model <model>');
-    expect(s).toContain('ANTHROPIC_MODEL');
+    expect(s).toContain('shell profile');
+  });
+
+  it('exonerates the shell profile when the launch already unset the variable', () => {
+    const s = firstRunStuckSummary(
+      { headline: 'selected-model error', reason: 'model', model: 'glm-5.3' },
+      { neutralisedModelEnv: true },
+    );
+    expect(s).toContain('ANTHROPIC_BASE_URL');
+    expect(s).not.toContain('shell profile');
   });
 
   it('still asks for a keypress on a menu the watch could not clear', () => {
@@ -572,7 +619,7 @@ describe('프리플라이트 거부 — 태스크 생성 0', () => {
     // 태스크 2(프롬프트 없음)는 prompt.md 없이 agentCmd만 그대로 발사된다
     // (F15의 ANTHROPIC_MODEL 중화 접두사만 앞에 붙는다 — POSIX에서).
     const barePane = renderer.spawned.find((s) => !s.initialCommand.includes('prompt.md'));
-    expect(stripLaunchEnvPrefix(barePane?.initialCommand ?? '')).toBe('claude');
+    expect(splitModelEnvMarker(barePane?.initialCommand ?? '').command).toBe('claude');
   });
 
   it('§7: 프롬프트 없는 태스크는 prompt.md를 아예 쓰지 않는다', async () => {
@@ -861,14 +908,24 @@ describe('per-task roles', () => {
     // would bring the task back on the default agent with nothing said.
     const daemon = makeDaemonFake();
     const renderer = makeRendererFake({
-      rewriteCommand: (p) => (p.role === 'Reviewer' ? p.initialCommand.replace(/^claude/, 'codex --model o3') : p.initialCommand),
+      // Mirrors the real renderer: the marker comes OFF before the role rewrite
+      // (both role steps gate on the first token) and goes back on only if the
+      // rewritten command still names no model of its own.
+      rewriteCommand: (p) => {
+        const { marker, command } = splitModelEnvMarker(p.initialCommand);
+        const rewritten = p.role === 'Reviewer' ? command.replace(/^claude/, 'codex --model o3') : command;
+        return reattachModelEnvMarker(marker, rewritten, undefined).command;
+      },
     });
     const worktrees = makeWorktreesFake();
     const svc = new FanOutService({ daemon: daemon.port, renderer: renderer.port, worktrees });
 
     const res = await svc.start(baseReq({ titles: ['Build it', 'Review it'], roles: ['Builder', 'Reviewer'] }));
 
-    expect(res.tasks[0].initialCommand?.startsWith('claude')).toBe(true);
+    // Builder's binding pins no model here, so the neutralisation is KEPT…
+    expect(res.tasks[0].initialCommand).toBe(`${MODEL_ENV_MARKER}${renderer.spawned[0].initialCommand.slice(MODEL_ENV_MARKER.length)}`);
+    expect(splitModelEnvMarker(res.tasks[0].initialCommand ?? '').command.startsWith('claude')).toBe(true);
+    // …and Reviewer's `--model o3` makes it redundant, so it comes off.
     expect(res.tasks[1].initialCommand?.startsWith('codex --model o3')).toBe(true);
     // …and the prompt file argument survived the rewrite either way.
     for (const t of res.tasks) expect(t.initialCommand).toMatch(/prompt\.md/);
@@ -948,7 +1005,7 @@ describe('fan-out worker first run (A-1)', () => {
     if (process.platform === 'win32') {
       expect(launched.startsWith('claude')).toBe(true);
     } else {
-      expect(launched.startsWith('env -u ANTHROPIC_MODEL claude ')).toBe(true);
+      expect(launched.startsWith(`${MODEL_ENV_MARKER}claude `)).toBe(true);
     }
   });
 
@@ -979,8 +1036,8 @@ describe('fan-out worker first run (A-1)', () => {
       });
 
       const res = await svc.start(baseReq({ idempotencyKey: 'fo-key-model', titles: ['Task A'] }));
-      // The watch ran even though the launch carries the `env -u` prefix — a
-      // stem read straight off the recorded command would have said `env`.
+      // The watch ran even though the launch carries the marker — a stem read
+      // straight off the recorded command would have said `[`.
       expect(res.tasks[0].firstRunStuck).toBe(true);
       expect(res.tasks[0].firstRunPrompt).toBe('selected-model error');
       // No blind press: this is not a menu, and wmux does not type at one.
@@ -990,6 +1047,51 @@ describe('fan-out worker first run (A-1)', () => {
       expect(row.status).toBe('input_required');
       expect(row.summary).toContain('glm-5.3');
       expect(row.summary).toContain('/model <model>');
+      // The launch DID neutralise the variable, so the summary must not send
+      // the operator back to their shell profile for a model it did not set.
+      expect(row.summary).toContain('ANTHROPIC_BASE_URL');
+    } finally {
+      setTaskLedgerForTests(null);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('catches a model error that only lands AFTER the composer painted', async () => {
+    // The clean-read exit fires at ~6 s, about when the composer finishes
+    // painting — the error needs the first turn to be sent and refused first,
+    // so the watch would otherwise call this worker healthy and walk away.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-f15-late-'));
+    const ledger = new TaskLedger({ dir });
+    setTaskLedgerForTests(ledger);
+    try {
+      const composer = ['\u276f Try "write a test"', '\u23f5\u23f5 auto mode on'].join('\n');
+      const late = ['> do the thing', '', "There's an issue with the selected model (glm-5.3)"].join('\n');
+      let reads = 0;
+      const svc = new FanOutService({
+        daemon: makeDaemonFake().port,
+        renderer: makeRendererFake().port,
+        worktrees: makeWorktreesFake(),
+        firstRun: {
+          readScreen: async () => {
+            reads += 1;
+            return reads >= 3 ? late : composer;
+          },
+          sendKey: async () => { /* nothing to press on either screen */ },
+        },
+        firstRunOptions: { watchMs: 0, pollMs: 0, deadlineMs: 5, log: () => { /* silent */ } },
+        firstRunRecheckMs: 0,
+      });
+
+      const res = await svc.start(baseReq({ idempotencyKey: 'fo-key-late', titles: ['Task A'] }));
+      // The watch itself saw a healthy pane and did not hold the fan-out up.
+      expect(res.tasks[0].ok).toBe(true);
+      expect(res.tasks[0].firstRunStuck).toBeUndefined();
+      expect(ledger.list({ id: res.tasks[0].taskId as string })[0].status).toBe('working');
+
+      await svc.settleFirstRunRechecks();
+      const row = ledger.list({ id: res.tasks[0].taskId as string })[0];
+      expect(row.status).toBe('input_required');
+      expect(row.summary).toContain('glm-5.3');
     } finally {
       setTaskLedgerForTests(null);
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -8,11 +8,20 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { execFileSync } from 'node:child_process';
-import { FanOutService, buildInitialCommand, WORKER_DELIVERY_PREAMBLE } from '../FanOutService';
+import {
+  FanOutService,
+  buildInitialCommand,
+  workerLaunchCommand,
+  stripLaunchEnvPrefix,
+  firstRunStuckSummary,
+  WORKER_DELIVERY_PREAMBLE,
+} from '../FanOutService';
 import type { FanOutDaemonPort, FanOutRendererPort } from '../FanOutService';
 import type { TaskWorktreePlan } from '../TaskWorktreeManager';
 import type { ProjectConfigState } from '../../../shared/wmuxProjectConfig';
 import { clearFanoutPortReservationsForTest } from '../fanoutEnvironment';
+import { TaskLedger } from '../../../daemon/ledger/TaskLedger';
+import { setTaskLedgerForTests } from '../../deck/taskLedgerHost';
 
 let metaRoot: string;
 beforeEach(() => {
@@ -184,6 +193,101 @@ describe('buildInitialCommand (§4 D4)', () => {
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// ── F15: the worker's model is wmux's decision, not the login shell's ─────────
+
+describe('workerLaunchCommand (F15)', () => {
+  const POSIX = { platform: 'darwin' as NodeJS.Platform };
+
+  it('neutralises a shell-exported ANTHROPIC_MODEL for a plain claude worker', () => {
+    // The command is TYPED into the pane's interactive login shell, so ~/.zshrc
+    // has already re-exported ANTHROPIC_MODEL by then; only `env -u` on the line
+    // itself runs late enough to win.
+    const launch = workerLaunchCommand('claude', '/m/prompt.md', POSIX);
+    expect(launch.command).toBe("env -u ANTHROPIC_MODEL claude \"$(cat '/m/prompt.md')\"");
+    expect(launch.neutralisedModelEnv).toBe(true);
+  });
+
+  it('leaves the quoting of the prompt path byte-identical', () => {
+    const nasty = "/a b/it's $x`y.md";
+    const launch = workerLaunchCommand('claude', nasty, POSIX);
+    expect(launch.command.endsWith(buildInitialCommand('claude', nasty, 'darwin'))).toBe(true);
+    // …and the shell really hands the file body to argv, prefix included.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-launch-'));
+    try {
+      const promptFile = path.join(dir, "a b/it's $x`y.md");
+      fs.mkdirSync(path.dirname(promptFile), { recursive: true });
+      const body = 'do the thing "$(rm -rf /)" `boom`';
+      fs.writeFileSync(promptFile, body, 'utf8');
+      const cmd = workerLaunchCommand("printf '%s'", promptFile, POSIX).command;
+      expect(execFileSync('sh', ['-c', cmd], { encoding: 'utf8' })).toBe(body);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves a command that already chooses a model alone', () => {
+    for (const cmd of ['claude --model opus', 'claude --model=opus', 'claude -m opus']) {
+      const launch = workerLaunchCommand(cmd, '/m/prompt.md', POSIX);
+      expect(launch.command.startsWith('env ')).toBe(false);
+      expect(launch.neutralisedModelEnv).toBe(false);
+    }
+  });
+
+  it('leaves a non-claude launcher alone — no other agent reads the variable', () => {
+    const launch = workerLaunchCommand('codex', '/m/prompt.md', POSIX);
+    expect(launch.command).toBe("codex \"$(cat '/m/prompt.md')\"");
+    expect(launch.neutralisedModelEnv).toBe(false);
+  });
+
+  it('leaves a ROLED task alone so the renderer can still read its launcher stem', () => {
+    // applyRoleAgent/applyRoleBinding both gate on the first token: an `env`
+    // prefix would silently drop the role's agent AND its model.
+    const launch = workerLaunchCommand('claude', '/m/prompt.md', { ...POSIX, role: 'Builder' });
+    expect(launch.command).toBe("claude \"$(cat '/m/prompt.md')\"");
+    expect(launch.neutralisedModelEnv).toBe(false);
+  });
+
+  it('says so instead of emitting a POSIX-only prefix on win32', () => {
+    const launch = workerLaunchCommand('claude', 'C:\\m\\prompt.md', { platform: 'win32' });
+    expect(launch.command.startsWith('env ')).toBe(false);
+    expect(launch.neutralisedModelEnv).toBe(false);
+    expect(launch.note).toContain('ANTHROPIC_MODEL');
+  });
+
+  it('still works for the "environment only" launch with no prompt file', () => {
+    expect(workerLaunchCommand('claude', undefined, POSIX).command).toBe('env -u ANTHROPIC_MODEL claude');
+  });
+});
+
+describe('stripLaunchEnvPrefix (F15)', () => {
+  it('recovers the agent from a command the launch prefixed', () => {
+    expect(stripLaunchEnvPrefix("env -u ANTHROPIC_MODEL claude \"$(cat '/m/p.md')\"")).toBe(
+      "claude \"$(cat '/m/p.md')\"",
+    );
+    expect(stripLaunchEnvPrefix('env -u A -u B claude')).toBe('claude');
+  });
+
+  it('leaves any other command — and any other use of env — untouched', () => {
+    expect(stripLaunchEnvPrefix('claude --model opus')).toBe('claude --model opus');
+    expect(stripLaunchEnvPrefix('env FOO=1 claude')).toBe('env FOO=1 claude');
+  });
+});
+
+describe('firstRunStuckSummary (F15)', () => {
+  it('names the model and the fix for a model error', () => {
+    const s = firstRunStuckSummary({ headline: 'selected-model error', reason: 'model', model: 'glm-5.3' });
+    expect(s).toContain('glm-5.3');
+    expect(s).toContain('/model <model>');
+    expect(s).toContain('ANTHROPIC_MODEL');
+  });
+
+  it('still asks for a keypress on a menu the watch could not clear', () => {
+    expect(firstRunStuckSummary({ headline: 'fullscreen renderer upsell', reason: 'unanswered' })).toContain(
+      'keypress',
+    );
   });
 });
 
@@ -465,9 +569,10 @@ describe('프리플라이트 거부 — 태스크 생성 0', () => {
     const res = await svc.start(baseReq({ prompt: '', taskPrompts: ['only A has one', ''] }));
     expect(res.ok).toBe(true);
     expect(daemon.calls.filter((c) => c.method === 'task.mission.start')).toHaveLength(2);
-    // 태스크 2(프롬프트 없음)는 prompt.md 없이 agentCmd만 그대로 발사된다.
+    // 태스크 2(프롬프트 없음)는 prompt.md 없이 agentCmd만 그대로 발사된다
+    // (F15의 ANTHROPIC_MODEL 중화 접두사만 앞에 붙는다 — POSIX에서).
     const barePane = renderer.spawned.find((s) => !s.initialCommand.includes('prompt.md'));
-    expect(barePane?.initialCommand).toBe('claude');
+    expect(stripLaunchEnvPrefix(barePane?.initialCommand ?? '')).toBe('claude');
   });
 
   it('§7: 프롬프트 없는 태스크는 prompt.md를 아예 쓰지 않는다', async () => {
@@ -823,5 +928,71 @@ describe('fan-out worker first run (A-1)', () => {
     expect(res.tasks[0].firstRunPrompt).toBe('fullscreen renderer upsell');
     // It DID try the dismissal the screen advertises before giving up.
     expect(keys).toEqual(['\x1b', '\x1b', '\x1b']);
+  });
+
+  // ── F15 ────────────────────────────────────────────────────────────────────
+
+  it('records the neutralised command it actually launched', async () => {
+    const daemon = makeDaemonFake();
+    const renderer = makeRendererFake();
+    const svc = new FanOutService({
+      daemon: daemon.port,
+      renderer: renderer.port,
+      worktrees: makeWorktreesFake(),
+    });
+
+    const res = await svc.start(baseReq({ idempotencyKey: 'fo-key-f15', titles: ['Task A'] }));
+    const launched = renderer.spawned[0].initialCommand;
+    // What main recorded for F2 re-fire is what the renderer was told to launch.
+    expect(res.tasks[0].initialCommand).toBe(launched);
+    if (process.platform === 'win32') {
+      expect(launched.startsWith('claude')).toBe(true);
+    } else {
+      expect(launched.startsWith('env -u ANTHROPIC_MODEL claude ')).toBe(true);
+    }
+  });
+
+  it('moves a worker whose first turn died on its model to input_required', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-f15-ledger-'));
+    const ledger = new TaskLedger({ dir });
+    setTaskLedgerForTests(ledger);
+    try {
+      const screen = [
+        '> do the thing',
+        '',
+        "There's an issue with the selected model (glm-5.3)",
+        '',
+      ].join('\n');
+      const keys: string[] = [];
+      const daemon = makeDaemonFake();
+      const renderer = makeRendererFake();
+      const svc = new FanOutService({
+        daemon: daemon.port,
+        renderer: renderer.port,
+        worktrees: makeWorktreesFake(),
+        firstRun: {
+          readScreen: async () => screen,
+          sendKey: async (_p, seq) => {
+            keys.push(seq);
+          },
+        },
+      });
+
+      const res = await svc.start(baseReq({ idempotencyKey: 'fo-key-model', titles: ['Task A'] }));
+      // The watch ran even though the launch carries the `env -u` prefix — a
+      // stem read straight off the recorded command would have said `env`.
+      expect(res.tasks[0].firstRunStuck).toBe(true);
+      expect(res.tasks[0].firstRunPrompt).toBe('selected-model error');
+      // No blind press: this is not a menu, and wmux does not type at one.
+      expect(keys).toEqual([]);
+
+      const row = ledger.list({ id: res.tasks[0].taskId as string })[0];
+      expect(row.status).toBe('input_required');
+      expect(row.summary).toContain('glm-5.3');
+      expect(row.summary).toContain('/model <model>');
+    } finally {
+      setTaskLedgerForTests(null);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -1054,9 +1054,14 @@ describe('fan-out worker first run (A-1)', () => {
       expect(row.status).toBe('input_required');
       expect(row.summary).toContain('glm-5.3');
       expect(row.summary).toContain('/model <model>');
-      // The launch DID neutralise the variable, so the summary must not send
-      // the operator back to their shell profile for a model it did not set.
-      expect(row.summary).toContain('ANTHROPIC_BASE_URL');
+      // On POSIX the launch DID neutralise the variable, so the summary must
+      // not send the operator back to their shell profile for a model it did
+      // not set. win32 attaches no marker, so there the profile IS the cause.
+      if (process.platform === 'win32') {
+        expect(row.summary).toContain('ANTHROPIC_MODEL');
+      } else {
+        expect(row.summary).toContain('ANTHROPIC_BASE_URL');
+      }
     } finally {
       setTaskLedgerForTests(null);
       fs.rmSync(dir, { recursive: true, force: true });

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -922,9 +922,16 @@ describe('per-task roles', () => {
 
     const res = await svc.start(baseReq({ titles: ['Build it', 'Review it'], roles: ['Builder', 'Reviewer'] }));
 
-    // Builder's binding pins no model here, so the neutralisation is KEPT…
-    expect(res.tasks[0].initialCommand).toBe(`${MODEL_ENV_MARKER}${renderer.spawned[0].initialCommand.slice(MODEL_ENV_MARKER.length)}`);
-    expect(splitModelEnvMarker(res.tasks[0].initialCommand ?? '').command.startsWith('claude')).toBe(true);
+    // Builder's binding pins no model here, so the neutralisation is KEPT —
+    // except on win32, where main attaches no marker at all (it is POSIX, and
+    // the pane's shell there is PowerShell), so the recorded line is the bare
+    // Get-Content form the renderer stub echoed back.
+    const builderLaunched = renderer.spawned[0].initialCommand;
+    expect(res.tasks[0].initialCommand).toBe(builderLaunched);
+    expect(splitModelEnvMarker(builderLaunched).marker).toBe(
+      process.platform === 'win32' ? '' : MODEL_ENV_MARKER,
+    );
+    expect(splitModelEnvMarker(builderLaunched).command.startsWith('claude')).toBe(true);
     // …and Reviewer's `--model o3` makes it redundant, so it comes off.
     expect(res.tasks[1].initialCommand?.startsWith('codex --model o3')).toBe(true);
     // …and the prompt file argument survived the rewrite either way.

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -16,6 +16,7 @@ import {
   WORKER_DELIVERY_PREAMBLE,
 } from '../FanOutService';
 import { MODEL_ENV_MARKER, reattachModelEnvMarker, splitModelEnvMarker } from '../../../shared/workerLaunch';
+import { FIRST_RUN_CLEAN_READS } from '../agentFirstRun';
 import type { FanOutDaemonPort, FanOutRendererPort } from '../FanOutService';
 import type { TaskWorktreePlan } from '../TaskWorktreeManager';
 import type { ProjectConfigState } from '../../../shared/wmuxProjectConfig';
@@ -1084,23 +1085,48 @@ describe('fan-out worker first run (A-1)', () => {
         renderer: makeRendererFake().port,
         worktrees: makeWorktreesFake(),
         firstRun: {
+          // The composer for as long as the watch is looking, the error after \u2014
+          // keyed on the clean-read budget rather than a magic number, because
+          // that budget is exactly how many reads the watch below will take.
           readScreen: async () => {
             reads += 1;
-            return reads >= 3 ? late : composer;
+            return reads > FIRST_RUN_CLEAN_READS ? late : composer;
           },
           sendKey: async () => { /* nothing to press on either screen */ },
         },
-        firstRunOptions: { watchMs: 0, pollMs: 0, deadlineMs: 5, log: () => { /* silent */ } },
+        // A FAKE clock and a no-op sleep, not a short real deadline. With the
+        // real one, Windows' ~15 ms timer granularity makes the first
+        // `setTimeout(0)` overshoot a 5 ms deadline, so the watch exits after a
+        // single read and the re-check gets the composer instead of the error.
+        firstRunOptions: {
+          watchMs: 0,
+          pollMs: 0,
+          deadlineMs: 50,
+          sleep: async () => { /* the fake clock is what advances time here */ },
+          now: ((): (() => number) => {
+            let t = 0;
+            return () => (t += 10);
+          })(),
+          log: () => { /* silent */ },
+        },
         firstRunRecheckMs: 0,
       });
 
       const res = await svc.start(baseReq({ idempotencyKey: 'fo-key-late', titles: ['Task A'] }));
-      // The watch itself saw a healthy pane and did not hold the fan-out up.
+      // The WATCH itself saw a healthy pane: `firstRunStuck` is the one signal
+      // only the watch sets, so it stays a fact about the watch no matter when
+      // the detached re-check happens to run. The ledger row is deliberately not
+      // asserted here — with a 0 ms re-check the row may already have moved, and
+      // a test that raced on that would be green or red by machine speed.
       expect(res.tasks[0].ok).toBe(true);
       expect(res.tasks[0].firstRunStuck).toBeUndefined();
-      expect(ledger.list({ id: res.tasks[0].taskId as string })[0].status).toBe('working');
 
       await svc.settleFirstRunRechecks();
+      // Pin the read budget: the whole point is that the error was found by a
+      // read the WATCH never took. FIRST_RUN_CLEAN_READS during the watch, one
+      // after it — a watch that quit early would land here with 2 and still
+      // have gone green on the status assertion below.
+      expect(reads).toBe(FIRST_RUN_CLEAN_READS + 1);
       const row = ledger.list({ id: res.tasks[0].taskId as string })[0];
       expect(row.status).toBe('input_required');
       expect(row.summary).toContain('glm-5.3');

--- a/src/main/worktask/__tests__/agentFirstRun.test.ts
+++ b/src/main/worktask/__tests__/agentFirstRun.test.ts
@@ -45,6 +45,17 @@ const ASK_USER_QUESTION_SCREEN = [
 
 const READY_SCREEN = ['❯ Try "write a test for <filepath>"', '⏵⏵ auto mode on · ← for agents'].join('\n');
 
+/** F15 — the first turn's model rejection, verbatim from the wave 3 dogfood
+ *  (the operator's ~/.zshrc exported ANTHROPIC_MODEL=glm-5.3). No menu, no
+ *  footer, nothing to press: only reportable. */
+const MODEL_ERROR_SCREEN = [
+  '> implement the lane',
+  '',
+  "There's an issue with the selected model (glm-5.3)",
+  '',
+  '❯ ',
+].join('\n');
+
 describe('launcherStem', () => {
   it('reduces a launch command to its agent stem', () => {
     expect(launcherStem('claude')).toBe('claude');
@@ -94,6 +105,20 @@ describe('detectFirstRunPrompt', () => {
   it('does not match a working pane or an empty read', () => {
     expect(detectFirstRunPrompt(READY_SCREEN)).toBeNull();
     expect(detectFirstRunPrompt('')).toBeNull();
+  });
+
+  // F15 — the screen three dogfood runs actually died on.
+  it('recognises the selected-model error and names the model', () => {
+    const found = detectFirstRunPrompt(MODEL_ERROR_SCREEN);
+    expect(found?.kind).toBe('model-error');
+    expect(found?.headline).toBe('selected-model error');
+    expect(found?.model).toBe('glm-5.3');
+  });
+
+  it('recognises the message with no model in parentheses', () => {
+    const found = detectFirstRunPrompt("There's an issue with the selected model");
+    expect(found?.kind).toBe('model-error');
+    expect(found?.model).toBeUndefined();
   });
 });
 
@@ -145,6 +170,13 @@ describe('clearFirstRunPrompts', () => {
     const port = scriptedPort([TRUST_SCREEN]);
     const outcome = await clearFirstRunPrompts('pty-1', port, { ...fastOptions, now: undefined });
     expect(outcome).toMatchObject({ status: 'stuck', reason: 'trust' });
+    expect(port.keys).toEqual([]);
+  });
+
+  it('reports the selected-model error without pressing anything (F15)', async () => {
+    const port = scriptedPort([MODEL_ERROR_SCREEN]);
+    const outcome = await clearFirstRunPrompts('pty-1', port, { ...fastOptions, now: undefined });
+    expect(outcome).toMatchObject({ status: 'stuck', reason: 'model', model: 'glm-5.3' });
     expect(port.keys).toEqual([]);
   });
 

--- a/src/main/worktask/__tests__/agentFirstRun.test.ts
+++ b/src/main/worktask/__tests__/agentFirstRun.test.ts
@@ -120,6 +120,32 @@ describe('detectFirstRunPrompt', () => {
     expect(found?.kind).toBe('model-error');
     expect(found?.model).toBeUndefined();
   });
+
+  it('does NOT read the worker\'s own echoed prompt as the agent speaking', () => {
+    // A fan-out task ABOUT this bug quotes the message verbatim, and the pane
+    // echoes the prompt back — including the continuation lines, which carry no
+    // `>` of their own and are told apart only by their indent.
+    const echoed = [
+      '> Fix the fan-out worker launch: every worker answers',
+      "  There's an issue with the selected model (glm-5.3)",
+      '  and needs /model opus by hand.',
+      '',
+      '⏺ Reading src/main/worktask/FanOutService.ts',
+      '❯ ',
+    ].join('\n');
+    expect(detectFirstRunPrompt(echoed)).toBeNull();
+  });
+
+  it('does not match the phrase quoted mid-sentence', () => {
+    expect(
+      detectFirstRunPrompt('The pane said there\'s an issue with the selected model, so I retried.'),
+    ).toBeNull();
+  });
+
+  it('does not match an error scrolled out of the tail', () => {
+    const old = ["There's an issue with the selected model (glm-5.3)", ...Array(12).fill('working…')].join('\n');
+    expect(detectFirstRunPrompt(old)).toBeNull();
+  });
 });
 
 /** A scripted pane: each read returns the next screen, then the last one repeats. */

--- a/src/main/worktask/agentFirstRun.ts
+++ b/src/main/worktask/agentFirstRun.ts
@@ -71,7 +71,7 @@ export const CLAUDE_SANDBOXED_ENV = 'CLAUDE_CODE_SANDBOXED';
 
 /** Launcher stems this module acts on. Every other agent is left ALONE — a
  *  codex/gemini/opencode pane has neither these screens nor this env. */
-const SUPPORTED_STEMS: ReadonlySet<string> = new Set(['claude']);
+export const SUPPORTED_STEMS: ReadonlySet<string> = new Set(['claude']);
 
 /** Is the first-run handling enabled at all? */
 export function firstRunEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -112,13 +112,19 @@ export function firstRunEnvForAgent(
  *                    means a worker only reaches it when the operator opted out.
  *   - `interstitial` a one-shot onboarding/upsell menu. Answered with ESC, the
  *                    dismissal the screen itself advertises.
+ *   - `model-error`  the first turn came back "There's an issue with the
+ *                    selected model (…)". Not a menu and not answerable by a
+ *                    keystroke — reported, so the row stops claiming `working`.
  */
-export type FirstRunPromptKind = 'trust' | 'interstitial';
+export type FirstRunPromptKind = 'trust' | 'interstitial' | 'model-error';
 
 export interface FirstRunPrompt {
   kind: FirstRunPromptKind;
   /** The headline that matched — logged, so a stuck worker names its screen. */
   headline: string;
+  /** `model-error` only: the model the agent named, when the screen printed it
+   *  in parentheses. Absent when the message carried no name. */
+  model?: string;
 }
 
 /** ESC. The only byte this module ever writes into a worker pane. */
@@ -140,6 +146,23 @@ const INTERSTITIAL_HEADLINES: readonly { re: RegExp; label: string }[] = [
 const CONFIRM_FOOTER = /enter to confirm/i;
 
 /**
+ * The first turn's model rejection, e.g.
+ * `There's an issue with the selected model (glm-5.3)`.
+ *
+ * Not a menu: no options, no confirm footer, nothing to press. It is here
+ * because from the outside it is indistinguishable from an idle worker — the
+ * exact confusion the rest of this module exists to remove — and it was the
+ * failure mode of every fan-out worker in three dogfood runs (the operator's
+ * `~/.zshrc` exported `ANTHROPIC_MODEL`, and the pane's login shell re-exports
+ * it after wmux has set the spawn env). The launch now neutralises that (see
+ * `workerLaunchCommand` in FanOutService), so this detector is the backstop for
+ * every other way a worker can end up on a model it cannot use.
+ *
+ * The apostrophe class covers the typographic `’` a TUI may render.
+ */
+const MODEL_ERROR_HEADLINE = /issue with the selected model(?:\s*\(([^)\n]{1,80})\))?/i;
+
+/**
  * Is `screen` showing a first-run prompt?
  *
  * Three conditions for an interstitial, all required: a known headline, the
@@ -147,9 +170,21 @@ const CONFIRM_FOOTER = /enter to confirm/i;
  * approval pre-write check uses). The trust dialog is matched on its headline
  * plus the footer — its options are `No, exit` / `Yes, I trust this folder`,
  * and it is reported rather than answered anyway.
+ *
+ * The model error is checked FIRST and outside the footer gate: it is an error
+ * line, not a menu, so it renders none of the menu furniture.
  */
 export function detectFirstRunPrompt(screen: string): FirstRunPrompt | null {
   if (!screen) return null;
+  const modelError = MODEL_ERROR_HEADLINE.exec(screen);
+  if (modelError) {
+    const model = modelError[1]?.trim();
+    return {
+      kind: 'model-error',
+      headline: 'selected-model error',
+      ...(model ? { model } : {}),
+    };
+  }
   const rows = screen.split('\n');
   const hasFooter = CONFIRM_FOOTER.test(screen);
   if (!hasFooter) return null;
@@ -193,7 +228,13 @@ export type FirstRunOutcome =
   /** One was seen and dismissed; the pane is free. */
   | { status: 'answered'; headline: string }
   /** Still on screen at the deadline, or a screen we refuse to answer. */
-  | { status: 'stuck'; headline: string; reason: 'trust' | 'unanswered' | 'send-failed' };
+  | {
+      status: 'stuck';
+      headline: string;
+      reason: 'trust' | 'unanswered' | 'send-failed' | 'model';
+      /** `model` only — the model the agent named, when it printed one. */
+      model?: string;
+    };
 
 export interface FirstRunWatchOptions {
   watchMs?: number;
@@ -253,6 +294,24 @@ export async function clearFirstRunPrompts(
           `${CLAUDE_SANDBOXED_ENV}, or accept the folder once by hand.`,
       );
       return { status: 'stuck', headline: prompt.headline, reason: 'trust' };
+    }
+
+    if (prompt?.kind === 'model-error') {
+      // Same no-blind-press rule as the trust dialog, for the same reason: wmux
+      // reports what it sees rather than typing at a screen it did not author.
+      // Returning immediately is deliberate — the error is terminal for that
+      // turn, so waiting out the deadline only delays the report.
+      log(
+        `pane ${ptyId} came back with a selected-model error` +
+          `${prompt.model ? ` (${prompt.model})` : ''}; wmux does not pick a model for you. ` +
+          `Run /model <model> in the pane, or stop the shell rc from exporting one.`,
+      );
+      return {
+        status: 'stuck',
+        headline: prompt.headline,
+        reason: 'model',
+        ...(prompt.model ? { model: prompt.model } : {}),
+      };
     }
 
     if (prompt) {

--- a/src/main/worktask/agentFirstRun.ts
+++ b/src/main/worktask/agentFirstRun.ts
@@ -160,7 +160,55 @@ const CONFIRM_FOOTER = /enter to confirm/i;
  *
  * The apostrophe class covers the typographic `’` a TUI may render.
  */
-const MODEL_ERROR_HEADLINE = /issue with the selected model(?:\s*\(([^)\n]{1,80})\))?/i;
+const MODEL_ERROR_HEADLINE = /^there[''’]s an issue with the selected model(?:\s*\(([^)\n]{1,80})\))?/i;
+
+/** How far back from the bottom of the viewport the error may be. The port
+ *  reads a 40-line tail; the error is the LAST thing the pane printed, and the
+ *  lines above it are the worker's own transcript — including its prompt, which
+ *  for a task ABOUT this bug quotes the message verbatim. */
+const MODEL_ERROR_TAIL_LINES = 6;
+
+/** Box/bullet furniture Claude Code draws to the left of a line. Stripped so
+ *  the headline can still be ANCHORED to the start of the text. */
+const SCREEN_DECORATION = /^[│┃|⎿⏺●\s]{0,4}/;
+
+/** The prefix Claude Code puts on an echoed user message, and on the composer. */
+const ECHO_MARKER = /^[>❯›]/;
+
+/**
+ * Find the model error in the tail of a viewport, refusing to read the worker's
+ * own words as the agent's.
+ *
+ * Three guards, and all three were needed: the phrase is anchored to the start
+ * of a line (a sentence mentioning it mid-line is prose), only the last few
+ * lines are considered, and an echoed user message is skipped — including its
+ * CONTINUATION lines, which carry no `>` of their own and are distinguishable
+ * only by their indent. Without the last one, a worker whose prompt wrapped the
+ * phrase onto a second line reported itself broken.
+ */
+function detectModelError(screen: string): FirstRunPrompt | null {
+  const lines = screen.split('\n');
+  let inEcho = false;
+  for (const raw of lines.slice(Math.max(0, lines.length - MODEL_ERROR_TAIL_LINES))) {
+    if (raw.trim().length === 0) {
+      inEcho = false; // a blank line closes the echoed block.
+      continue;
+    }
+    const indented = /^\s{2,}/.test(raw);
+    const line = raw.replace(SCREEN_DECORATION, '');
+    if (ECHO_MARKER.test(line)) {
+      inEcho = true;
+      continue;
+    }
+    if (inEcho && indented) continue;
+    inEcho = false;
+    const m = MODEL_ERROR_HEADLINE.exec(line);
+    if (!m) continue;
+    const model = m[1]?.trim();
+    return { kind: 'model-error', headline: 'selected-model error', ...(model ? { model } : {}) };
+  }
+  return null;
+}
 
 /**
  * Is `screen` showing a first-run prompt?
@@ -176,15 +224,8 @@ const MODEL_ERROR_HEADLINE = /issue with the selected model(?:\s*\(([^)\n]{1,80}
  */
 export function detectFirstRunPrompt(screen: string): FirstRunPrompt | null {
   if (!screen) return null;
-  const modelError = MODEL_ERROR_HEADLINE.exec(screen);
-  if (modelError) {
-    const model = modelError[1]?.trim();
-    return {
-      kind: 'model-error',
-      headline: 'selected-model error',
-      ...(model ? { model } : {}),
-    };
-  }
+  const modelError = detectModelError(screen);
+  if (modelError) return modelError;
   const rows = screen.split('\n');
   const hasFooter = CONFIRM_FOOTER.test(screen);
   if (!hasFooter) return null;
@@ -214,6 +255,18 @@ export const FIRST_RUN_CLEAN_READS = 2;
 /** At most this many ESCs per worker. A screen that survives three dismissals
  *  is not the family this module knows about. */
 export const FIRST_RUN_MAX_ANSWERS = 3;
+
+/**
+ * F15 — how long after a CLEAN watch to look once more for the model error.
+ *
+ * The watch's clean-read exit fires at ~{@link FIRST_RUN_WATCH_MS}, which is
+ * about when Claude Code finishes painting its composer — and the model error
+ * only arrives after that, once the first turn has been sent and refused. So
+ * the clean exit is routinely too early for this one screen. The caller runs
+ * this re-read OFF the critical path (fan-out spawns are serial; nobody should
+ * pay a longer watch N times over), which is why it can afford to be generous.
+ */
+export const FIRST_RUN_MODEL_RECHECK_MS = 12_000;
 
 export interface FirstRunPort {
   /** Current viewport text of the pane. Fails soft — '' means "nothing read". */

--- a/src/renderer/hooks/__tests__/useRpcBridge.fanoutRole.test.ts
+++ b/src/renderer/hooks/__tests__/useRpcBridge.fanoutRole.test.ts
@@ -55,27 +55,73 @@ describe('useRpcBridge — fan-out task roles', () => {
     // inert twice over: no agent change AND no model flag. Panel review caught
     // exactly this.
     const block = fanoutSpawnBlock();
-    expect(block).toMatch(/applyRoleAgent\(initialCommand, roleBinding\)/);
+    expect(block).toMatch(/applyRoleAgent\(bareCommand, roleBinding\)/);
     // Match the CALLS, not the prose: the comment above the swap names
     // withRoleBinding first, so a plain indexOf compares against the comment.
-    expect(block.search(/applyRoleAgent\(/)).toBeLessThan(block.search(/withRoleBinding\(\n/));
+    expect(block.search(/applyRoleAgent\(/)).toBeLessThan(block.search(/withRoleBinding\(seeded/));
     // …and the swapped command is what gets launched, not the original.
-    expect(block).toMatch(/initialCommand: launchCommand/);
+    expect(block).toMatch(/initialCommand: swap\.command/);
     expect(src).toMatch(/import \{[^}]*applyRoleAgent[^}]*\} from '\.\.\/\.\.\/shared\/orchestratorRole'/);
   });
 
   it('returns the launched command so a re-fire replays the bound one', () => {
-    expect(fanoutSpawnBlock()).toMatch(/return \{ workspaceId: newWsId, ptyId, initialCommand: launchCommand \}/);
+    const block = fanoutSpawnBlock();
+    expect(block).toMatch(/return \{ workspaceId: newWsId, ptyId, initialCommand: launchCommand \}/);
+    // …and that variable is read off the options the PTY was actually created
+    // with, so the role rewrite, the marker decision and the workspace profile
+    // are all already in it.
+    expect(block).toMatch(/const launchCommand = createOptions\.initialCommand \?\? ''/);
+    expect(block).toMatch(/pty\.create\(createOptions\)/);
   });
 
   it('applies the binding to the launch command via withRoleBinding', () => {
     const block = fanoutSpawnBlock();
-    expect(block).toMatch(/withRoleBinding\(/);
     // Order matters: withDefaultShell must run FIRST so there is a command to
     // rewrite, and withWorkspaceProfile stays outermost so the profile's env
     // overlay is applied to whatever command survives the rewrite.
-    expect(block).toMatch(/withWorkspaceProfile\(\s*withRoleBinding\(\s*withDefaultShell\(/);
+    const at = (re: RegExp): number => {
+      const i = block.search(re);
+      expect(i).toBeGreaterThan(-1);
+      return i;
+    };
+    expect(at(/withDefaultShell\(/)).toBeLessThan(at(/withRoleBinding\(seeded/));
+    expect(at(/withRoleBinding\(seeded/)).toBeLessThan(at(/withWorkspaceProfile\(/));
     expect(src).toMatch(/import \{[^}]*withRoleBinding[^}]*\} from '\.\.\/utils\/ptyCreateOptions'/);
+  });
+
+  // ── F15: the model-env marker crosses this handler ─────────────────────────
+
+  it('takes the model-env marker OFF before the role rewrite and back on after', () => {
+    // Both role steps gate on the command's FIRST TOKEN. A marker in front of
+    // the launcher makes the stem unrecognisable, and the binding's agent AND
+    // its model are dropped without a word — the same stem-mismatch trap
+    // applyRoleAgent exists to work around.
+    const block = fanoutSpawnBlock();
+    const at = (re: RegExp): number => {
+      const i = block.search(re);
+      expect(i).toBeGreaterThan(-1);
+      return i;
+    };
+    expect(at(/const \{ marker, command: bareCommand \} = splitModelEnvMarker\(initialCommand\)/)).toBeLessThan(
+      at(/applyRoleAgent\(/),
+    );
+    expect(at(/withRoleBinding\(seeded/)).toBeLessThan(at(/reattachModelEnvMarker\(/));
+    expect(src).toMatch(/import \{[^}]*reattachModelEnvMarker[^}]*\} from '\.\.\/\.\.\/shared\/workerLaunch'/);
+  });
+
+  it('gives the marker decision the bound command AND the pane shell', () => {
+    // Those are the two things main could not see: whether the operator's role
+    // binding ended up naming a model, and whether this pane's shell can even
+    // run the marker (fish has no `unset`).
+    expect(fanoutSpawnBlock()).toMatch(
+      /reattachModelEnvMarker\(marker, bound\.initialCommand, seeded\.shell\)/,
+    );
+  });
+
+  it('says out loud when the neutralisation was dropped', () => {
+    // Losing it silently is how the operator's shell wins again with nobody
+    // noticing — the exact failure mode this whole fix exists for.
+    expect(fanoutSpawnBlock()).toMatch(/model-env marker dropped/);
   });
 
   it('stamps the role on the pane so it survives the first launch', () => {

--- a/src/renderer/hooks/useRpcBridge.ts
+++ b/src/renderer/hooks/useRpcBridge.ts
@@ -11,6 +11,7 @@ import { generateId } from '../../shared/types';
 import { getLeafPanes, getWorkspaceLeafPanes, getWorkspacePtyIds } from '../../shared/paneUtils';
 import { findStashedEntry, paneStashedError, stashedPaneLiveness } from '../../shared/paneStash';
 import { applyRoleAgent, bindingEnforcesModel, normalizeRoleBinding, sanitizeOrchRole } from '../../shared/orchestratorRole';
+import { reattachModelEnvMarker, splitModelEnvMarker } from '../../shared/workerLaunch';
 import { handleCompanyRpc } from '../../company/renderer/rpcHandlers';
 import { formatA2aMessage, formatA2aBroadcast, sanitizeA2aName } from '../utils/a2aFormat';
 import type { A2aPriority } from '../utils/a2aFormat';
@@ -828,14 +829,23 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // assembled `<agent> "$(cat …)"` itself and a Reviewer→codex binding exists
     // precisely so review tasks run on codex. Without the swap first, the stem
     // mismatch made the whole binding inert: no agent change AND no model flag.
-    const swap = applyRoleAgent(initialCommand, roleBinding);
+    // F15 — main prefixed the line with the model-env marker (shared/workerLaunch)
+    // so a worker cannot inherit the operator's shell-exported ANTHROPIC_MODEL.
+    // It has to come OFF before the role rewrite: both steps below gate on the
+    // command's first token, and a marker in front of the launcher makes the stem
+    // unrecognisable — the binding's agent AND its model would be dropped without
+    // a word. It goes back on afterwards, and only if the rewritten command still
+    // names no model of its own, which is the decision main could not make (it
+    // cannot see the bindings — an unbound role, or one bound to an agent with no
+    // model, injects nothing).
+    const { marker, command: bareCommand } = splitModelEnvMarker(initialCommand);
+    const swap = applyRoleAgent(bareCommand, roleBinding);
     if (swap.note) {
       // A refusal (unknown agent, or flags that would not survive the swap) is
       // fail-soft — the task still launches, so the reason must be visible
       // somewhere rather than silently discarded.
       console.warn('[wmux:role-binding] fan-out agent not swapped', { role, note: swap.note });
     }
-    const launchCommand = swap.command;
 
     store.addWorkspace(name);
     const afterAdd = useStore.getState();
@@ -846,28 +856,44 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     const newWsId = newWs.id;
     const paneId = newWs.activePaneId;
 
+    // Unnested so the FINAL command is readable: withDefaultShell first (there
+    // has to be a command to rewrite), then the role binding, then the marker
+    // goes back on, and withWorkspaceProfile stays outermost so the profile's
+    // env overlay lands on whatever command survived.
+    const seeded = withDefaultShell(
+      {
+        workspaceId: newWsId,
+        cwd: cwd || undefined,
+        ...(swap.command ? { initialCommand: swap.command } : {}),
+        ...(Object.keys(taskEnv).length > 0 ? { env: taskEnv } : {}),
+      },
+      useStore.getState().defaultShell,
+    );
+    const bound = withRoleBinding(seeded, roleBinding, role);
+    // `bound.initialCommand` stays undefined for the "environment only" launch,
+    // and it has to: withWorkspaceProfile fills a MISSING command from the
+    // profile's defaultPaneCommand, and an empty string is not missing.
+    const remarked = bound.initialCommand
+      ? reattachModelEnvMarker(marker, bound.initialCommand, seeded.shell)
+      : { command: bound.initialCommand, dropped: undefined };
+    if (remarked.dropped) {
+      // Losing the neutralisation silently is how the operator's shell wins
+      // again with nobody noticing, so name the reason it came off.
+      console.warn('[wmux:worker-launch] model-env marker dropped', { role, reason: remarked.dropped });
+    }
+    const createOptions = withWorkspaceProfile(
+      remarked.command === bound.initialCommand ? bound : { ...bound, initialCommand: remarked.command },
+      // profile.startupCwd = worktreePath 힌트(§1 — 초기 편의). split 상속에
+      // 밀리는 tolerant 힌트라 방어가 아니라 편의로만 계상한다.
+      { ...newWs.profile, startupCwd: cwd || newWs.profile?.startupCwd },
+    );
+    // The line that will really be typed into the pane — after the role rewrite,
+    // after the marker decision, and after the profile has had its say.
+    const launchCommand = createOptions.initialCommand ?? '';
+
     let ptyId: string;
     try {
-      const created = await window.electronAPI.pty.create(
-        withWorkspaceProfile(
-          withRoleBinding(
-            withDefaultShell(
-              {
-                workspaceId: newWsId,
-                cwd: cwd || undefined,
-                ...(launchCommand ? { initialCommand: launchCommand } : {}),
-                ...(Object.keys(taskEnv).length > 0 ? { env: taskEnv } : {}),
-              },
-              useStore.getState().defaultShell,
-            ),
-            roleBinding,
-            role,
-          ),
-          // profile.startupCwd = worktreePath 힌트(§1 — 초기 편의). split 상속에
-          // 밀리는 tolerant 힌트라 방어가 아니라 편의로만 계상한다.
-          { ...newWs.profile, startupCwd: cwd || newWs.profile?.startupCwd },
-        ),
-      );
+      const created = await window.electronAPI.pty.create(createOptions);
       ptyId = created.id;
     } catch (err) {
       const rollback = useStore.getState();
@@ -908,6 +934,8 @@ async function handleRpcMethod(method: string, params: RpcParams): Promise<RpcRe
     // main stores this as the re-fire material, and a re-fire that replayed the
     // pre-binding string would quietly drop the role's agent and model — the
     // task would come back on the default (expensive) one with nothing said.
+    // It carries the model-env marker exactly as launched, so main can tell
+    // whether the neutralisation survived when it reports a stuck worker.
     return { workspaceId: newWsId, ptyId, initialCommand: launchCommand };
   }
 

--- a/src/shared/__tests__/workerLaunch.test.ts
+++ b/src/shared/__tests__/workerLaunch.test.ts
@@ -1,0 +1,101 @@
+// F15 — the marker main attaches and the renderer takes off again. Both
+// processes handle this string, so the contract is tested once, here.
+
+import { describe, it, expect } from 'vitest';
+import {
+  MODEL_ENV_MARKER,
+  WORKER_GATEWAY_ENV,
+  WORKER_MODEL_ENV,
+  isSimpleLaunchCommand,
+  reattachModelEnvMarker,
+  shellSupportsModelEnvMarker,
+  splitModelEnvMarker,
+} from '../workerLaunch';
+
+describe('MODEL_ENV_MARKER', () => {
+  it('unsets the model in the SAME shell, so an aliased launcher still resolves', () => {
+    // `env -u VAR claude` execs a binary; `claude migrate-installer` leaves many
+    // machines with only an alias, and that form dies before claude ever runs.
+    expect(MODEL_ENV_MARKER.startsWith('env ')).toBe(false);
+    expect(MODEL_ENV_MARKER).toContain(`unset ${WORKER_MODEL_ENV}`);
+    expect(MODEL_ENV_MARKER.endsWith('; ')).toBe(true);
+  });
+
+  it('stands down when a gateway is routing claude', () => {
+    // A gateway needs its own model name; unsetting it makes claude ask that
+    // endpoint for a default claude-* model it does not serve.
+    expect(MODEL_ENV_MARKER).toContain(`-n "$${WORKER_GATEWAY_ENV}"`);
+  });
+});
+
+describe('splitModelEnvMarker', () => {
+  it('round-trips the exact marker', () => {
+    const cmd = `${MODEL_ENV_MARKER}claude "$(cat '/m/p.md')"`;
+    expect(splitModelEnvMarker(cmd)).toEqual({
+      marker: MODEL_ENV_MARKER,
+      command: "claude \"$(cat '/m/p.md')\"",
+    });
+  });
+
+  it('leaves a command that never carried one untouched', () => {
+    expect(splitModelEnvMarker('claude --model opus')).toEqual({ marker: '', command: 'claude --model opus' });
+    expect(splitModelEnvMarker('unset SOMETHING_ELSE; claude').marker).toBe('');
+  });
+});
+
+describe('isSimpleLaunchCommand', () => {
+  it('accepts a launcher with flags', () => {
+    expect(isSimpleLaunchCommand('claude')).toBe(true);
+    expect(isSimpleLaunchCommand('/opt/bin/claude --dangerously-skip-permissions')).toBe(true);
+  });
+
+  it('rejects anything the marker would change the meaning of', () => {
+    for (const cmd of ['claude && echo', 'claude; echo', 'a | claude', 'claude `x`', 'claude $(x)', 'FOO=1 claude', 'claude\necho']) {
+      expect(isSimpleLaunchCommand(cmd)).toBe(false);
+    }
+  });
+});
+
+describe('shellSupportsModelEnvMarker', () => {
+  it('accepts the Bourne family, and an absent shell (the platform default)', () => {
+    for (const sh of [undefined, '/bin/zsh', '/bin/bash', '/usr/bin/sh', '/bin/dash']) {
+      expect(shellSupportsModelEnvMarker(sh)).toBe(true);
+    }
+  });
+
+  it('refuses a shell that cannot run it — fish has no `unset` at all', () => {
+    for (const sh of ['/opt/homebrew/bin/fish', '/usr/bin/pwsh', 'C:\\pwsh.exe', '/usr/bin/nu', '/bin/tcsh']) {
+      expect(shellSupportsModelEnvMarker(sh)).toBe(false);
+    }
+  });
+});
+
+describe('reattachModelEnvMarker', () => {
+  it('puts the marker back on a command that still names no model', () => {
+    const r = reattachModelEnvMarker(MODEL_ENV_MARKER, 'claude "$(cat \'/m/p.md\')"', '/bin/zsh');
+    expect(r.command.startsWith(MODEL_ENV_MARKER)).toBe(true);
+    expect(r.dropped).toBeUndefined();
+  });
+
+  it('drops it once the role binding pinned a model — the flag beats the env', () => {
+    const r = reattachModelEnvMarker(MODEL_ENV_MARKER, 'codex --model o3 "$(cat \'/m/p.md\')"', '/bin/zsh');
+    expect(r.command).toBe('codex --model o3 "$(cat \'/m/p.md\')"');
+    expect(r.dropped).toBe('model-bound');
+  });
+
+  it('drops it on a shell whose grammar it is not written in', () => {
+    const r = reattachModelEnvMarker(MODEL_ENV_MARKER, 'claude', '/opt/homebrew/bin/fish');
+    expect(r.command).toBe('claude');
+    expect(r.dropped).toBe('shell');
+  });
+
+  it('does not invent one where main attached none', () => {
+    expect(reattachModelEnvMarker('', 'claude', '/bin/zsh')).toEqual({ command: 'claude' });
+  });
+
+  it('is not fooled by a prompt path that reads like a flag', () => {
+    // The quoted argument is one token; a whitespace split would read its words.
+    const r = reattachModelEnvMarker(MODEL_ENV_MARKER, 'claude "$(cat \'/m/--model opus/p.md\')"', undefined);
+    expect(r.command.startsWith(MODEL_ENV_MARKER)).toBe(true);
+  });
+});

--- a/src/shared/orchestratorRole.ts
+++ b/src/shared/orchestratorRole.ts
@@ -342,6 +342,20 @@ function hasExplicitModelFlag(tokens: ReturnType<typeof tokenize>): boolean {
   return tokens.some((tkn) => isExplicitModelFlagToken(tkn.value));
 }
 
+/**
+ * D-4 as a public question about a whole command line: does this launch already
+ * choose its own model?
+ *
+ * The quote-aware tokenizer is the point — a fan-out launch ends in
+ * `"$(cat '<prompt path>')"`, one quoted argument, and a naive whitespace split
+ * would read a path's words as flags. Exported so the fan-out launch assembly
+ * (shared/workerLaunch) asks the same question this file already answers for
+ * the role rewrite, rather than growing a second, looser copy of it.
+ */
+export function commandChoosesModel(command: string): boolean {
+  return hasExplicitModelFlag(tokenize(command));
+}
+
 /** Sub-commands that may legitimately follow a launcher as a bare word.
  *  `codex resume --last` / `codex exec …` are launches, not prose. */
 const LAUNCH_SUBCOMMANDS: ReadonlySet<string> = new Set(['resume', 'exec', 'e']);

--- a/src/shared/workerLaunch.ts
+++ b/src/shared/workerLaunch.ts
@@ -1,0 +1,129 @@
+// ─── Fan-out worker launch line — the model-env marker (F15) ────────────────
+//
+// A fan-out worker's launch command is not spawned: it is TYPED into the pane's
+// interactive login shell after that shell has booted (scheduleInitialCommand).
+// By then the operator's rc files have run, so an `ANTHROPIC_MODEL` exported by
+// `~/.zshrc` has overwritten whatever environment wmux resolved for the spawn.
+// Three dogfood runs died there — every worker's first turn came back "There's
+// an issue with the selected model (glm-5.3)" — so the neutralisation has to be
+// part of the command line itself, which is the only thing that runs later than
+// the rc files.
+//
+// This module owns the exact text of that prefix, because TWO processes handle
+// it and a drifting private regex in either one silently disarms the fix:
+//
+//   - main (FanOutService) attaches it to an eligible launch;
+//   - the renderer (useRpcBridge, fanout.spawnWorkspace) splits it off before
+//     the operator's role binding is applied — `applyRoleAgent` and
+//     `applyRoleBinding` both gate on the FIRST TOKEN of the command, so a
+//     prefix in front of the launcher would silently drop the role's agent AND
+//     its model — and re-attaches it only if the rewritten command still names
+//     no model of its own.
+//
+// ── Why `unset` and not `env -u` ────────────────────────────────────────────
+//
+// `env -u VAR claude …` execs a BINARY named claude. `claude migrate-installer`
+// leaves many machines with `alias claude="$HOME/.claude/local/claude"` and no
+// `claude` on PATH at all, so that form dies with `env: claude: No such file or
+// directory` — a worker that fails to start is strictly worse than one on the
+// wrong model. `unset VAR; claude …` runs in the shell that owns the alias, and
+// alias expansion applies to the first word of a command after `;`.
+//
+// ── Why the gateway test is in the SHELL, not in main ───────────────────────
+//
+// An operator routing claude through a gateway (`ANTHROPIC_BASE_URL`, e.g. a
+// z.ai/GLM endpoint) NEEDS their `ANTHROPIC_MODEL`: unset it and claude asks
+// that gateway for a default `claude-*` model it does not serve, and every
+// worker dies the same way this fix exists to prevent. So the marker tests for
+// it — and it tests in the PANE's shell rather than in main's `process.env`,
+// because main's environment is not the one that has the problem. The whole
+// finding is that the rc files export variables main never saw (and when wmux
+// is opened from Finder/Dock, main inherits no shell environment at all), so a
+// main-side `process.env.ANTHROPIC_BASE_URL` check would read absent for
+// exactly the gateway operator it is meant to protect.
+
+import { commandChoosesModel } from './orchestratorRole';
+
+/** The variable the launch neutralises. */
+export const WORKER_MODEL_ENV = 'ANTHROPIC_MODEL';
+
+/** The variable whose presence CANCELS the neutralisation (see above). */
+export const WORKER_GATEWAY_ENV = 'ANTHROPIC_BASE_URL';
+
+/**
+ * The prefix, verbatim. Compared and sliced as a literal on both sides — never
+ * re-derived from a regex — so main and the renderer cannot drift apart.
+ *
+ * `ANTHROPIC_AUTH_TOKEN` is deliberately NOT touched here, nor is
+ * `ANTHROPIC_BASE_URL` itself: routing every pane's claude through a proxy is a
+ * legitimate whole-machine choice, and a worker that quietly bypassed it would
+ * be talking to a different endpoint than every other pane the operator opens.
+ * Model SELECTION is the one part of that environment wmux owns for a worker,
+ * because wmux is what decided to launch this agent at all.
+ */
+export const MODEL_ENV_MARKER = `[ -n "$${WORKER_GATEWAY_ENV}" ] || unset ${WORKER_MODEL_ENV}; `;
+
+/** Split a leading {@link MODEL_ENV_MARKER} off a launch command. */
+export function splitModelEnvMarker(command: string): { marker: string; command: string } {
+  return command.startsWith(MODEL_ENV_MARKER)
+    ? { marker: MODEL_ENV_MARKER, command: command.slice(MODEL_ENV_MARKER.length) }
+    : { marker: '', command };
+}
+
+/**
+ * Shell basenames the marker's grammar is written for.
+ *
+ * fish spells this `set -e` and has no `unset` at all; csh/tcsh need `unsetenv`;
+ * PowerShell, nushell, xonsh and elvish share none of the syntax. So a shell the
+ * operator NAMED but this list does not know drops the marker: the worst case
+ * of dropping it is the original bug, and the worst case of keeping it is a
+ * worker that never starts.
+ *
+ * An ABSENT shell is the one case that still gets the marker — it means "the
+ * pane inherits the platform default", and the attaching side has already
+ * refused every platform whose default is not a Bourne shell.
+ */
+const POSIX_MARKER_SHELLS: ReadonlySet<string> = new Set([
+  'sh', 'bash', 'zsh', 'dash', 'ksh', 'ksh93', 'mksh', 'ash', 'busybox',
+]);
+
+/** Can this pane's shell run the marker? `undefined` = the platform default. */
+export function shellSupportsModelEnvMarker(shell: string | undefined): boolean {
+  if (!shell) return true;
+  const base = (shell.split(/[\\/]/).pop() ?? '').replace(/\.exe$/i, '').toLowerCase();
+  return POSIX_MARKER_SHELLS.has(base);
+}
+
+/**
+ * Is `agentCmd` a single simple command the marker can safely precede?
+ *
+ * `unset X; a && b` would leave `b` running with the variable unset in a way the
+ * operator never wrote, and a `VAR=value claude` form puts the assignment where
+ * the marker's `;` would split it off. Neither is a shape wmux assembles — both
+ * would have to come from an explicit `agentCmd` — so the honest answer for one
+ * is to leave the command exactly as written and say why.
+ */
+export function isSimpleLaunchCommand(agentCmd: string): boolean {
+  if (/[;|&\n\r`]/.test(agentCmd)) return false;
+  if (/\$\(/.test(agentCmd)) return false;
+  return !/^\s*[A-Za-z_][A-Za-z0-9_]*=/.test(agentCmd);
+}
+
+/**
+ * Re-attach `marker` to a command the role rewrite has been through.
+ *
+ * Dropped when the rewritten command now names a model itself (the operator's
+ * role binding IS wmux deciding the model, and a CLI flag beats the environment
+ * anyway) or when the pane's shell cannot run the marker. `reason` says which,
+ * so the caller can log a dropped neutralisation rather than lose it silently.
+ */
+export function reattachModelEnvMarker(
+  marker: string,
+  command: string,
+  shell: string | undefined,
+): { command: string; dropped?: 'model-bound' | 'shell' } {
+  if (!marker) return { command };
+  if (commandChoosesModel(command)) return { command, dropped: 'model-bound' };
+  if (!shellSupportsModelEnvMarker(shell)) return { command, dropped: 'shell' };
+  return { command: marker + command };
+}


### PR DESCRIPTION
## Summary

Wave 3 finding 15 (`docs/internal/dogfood-orchestrator-2026-09.md`, second run): every fan-out worker's first turn died with "issue with the selected model (glm-5.3)". The worker command is typed into the pane's interactive login shell after its rc files ran, so an `ANTHROPIC_MODEL` exported by `~/.zshrc` overrides anything the spawn env set. Reproduced three times, recovered by hand each time.

- `workerLaunchCommand` prefixes the launch with `env -u ANTHROPIC_MODEL` on POSIX for a `claude` worker that carries no `--model` and no role. A roled task is left alone on purpose: the prefix would hide the launcher stem from the renderer's role binding (`applyRoleAgent` / `applyRoleBinding`) and drop the binding's agent and model. win32 gets a logged note instead of a prefix.
- `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` are deliberately not scrubbed: routing claude through a proxy for every pane is the operator's call; only the model is wmux's.
- The recorded `initialCommand` is the line actually launched; `stripLaunchEnvPrefix` lets the first-run watch still read the launcher stem through the prefix.
- The first-run detector recognises the model error screen (`issue with the selected model (…)`) as a new kind that is never pressed; the ledger row moves to `input_required` with a summary naming the model and the fix.

## Test plan

- [x] 13 new tests: prefix rules (plain claude, `--model`/`-m` forms, non-claude stem, roled task, win32, environment-only launch), prompt-path quoting with a real `sh -c` round trip, prefix stripping, stuck summary wording, FanOutService records the launched command, model-error screen → `input_required` with zero keys sent, detector on the exact dogfood text.
- [x] `tsc --noEmit` root + daemon, eslint on touched files, vitest over worktask/pty/pipe handlers: 70 files / 1,587 tests.
- [ ] Live: fan-out on the demo instance with the shell profile still exporting `ANTHROPIC_MODEL` (wave 3 third run).

Known gap: a roled task whose binding has no model still launches unprotected (main cannot see renderer-side bindings); the detector is the backstop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fan-out Claude workers now honor the model selected by the application instead of an overriding shell setting.
  - Workers encountering a selected-model error during their first turn are promptly marked as requiring input, with guidance to resolve the issue.
  - Model errors identify the rejected model and its source when available.
  - Existing explicit model selections, role-based configurations, gateway routing, and supported shell behavior remain unchanged.
  - Delayed model errors appearing after the worker screen loads are now detected reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->