### PR TITLE
fix: Dvorak Ctrl+C, Codex Shift+Enter, and stale agent slug after exit

### DIFF
--- a/changelog.d/1228.md
+++ b/changelog.d/1228.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Ctrl+C on Dvorak (and other non-QWERTY layouts) now interrupts the pane.** xterm.js encoded Ctrl+letter from the physical QWERTY key position, so a Dvorak Ctrl+C arrived as Ctrl+I and Claude would not shut down. The control byte is now taken from the letter you typed. Hangul / IME copy still matches the physical C key when the IME has mangled the letter. (#1228, #1227)
+
+- **Shift+Enter in a Codex pane on Windows inserts a newline.** wmux always sent the kitty form of Shift+Enter, which Codex does not speak — it asks for win32-input-mode instead, and the kitty byte landed as Escape plus junk. The pane's own output is now watched for that negotiation, and Shift+Enter is encoded the way Codex asked. Claude Code is unchanged: it never announces kitty, and still gets the kitty byte it already understood. (#1228, #1152)
+
+- **Pasting an image into a shell that used to be Claude no longer silently drops it.** Leaving a Claude session kept the pane labelled as Claude, so the default image-paste route sent Claude's own paste key into readline and the screenshot vanished. Auto now takes the file-path route once the TUI has left the screen (or the agent process is known dead), and the stale agent name is cleared. (#1228, #1210)

--- a/src/daemon/__tests__/x6ResumeDurability.test.ts
+++ b/src/daemon/__tests__/x6ResumeDurability.test.ts
@@ -133,14 +133,21 @@ describe('X6 ② reboot-survival durability', () => {
     // (the bug that made the pill invisible after every reboot). The handler must
     // exclude those reports so only real input retracts the offer.
     const utPath = path.join(__dirname, '..', '..', 'renderer', 'hooks', 'useTerminal.ts');
-    const src = fs.readFileSync(utPath, 'utf-8');
+    const src = fs.readFileSync(utPath, 'utf8');
     const idx = src.indexOf('terminal.onData((data)');
     expect(idx).toBeGreaterThan(-1);
     const body = src.slice(idx, idx + 1400);
-    expect(body).toMatch(/clearResumeHint/);
+    // #1228 C2 restructure: the clear itself moved into the shared
+    // noteUserKeystroke helper (so direct-write bytes get the same side
+    // effects), but the contract is unchanged — only real input retracts.
+    expect(body).toMatch(/noteUserKeystroke\(data\)/);
     // focus reports must be excluded from the clear path
     expect(body).toMatch(/\\x1b\[I/);
     expect(body).toMatch(/\\x1b\[O/);
+    // the helper is where clearResumeHint now lives — real input reaches it.
+    const helperIdx = src.indexOf('const noteUserKeystroke =');
+    expect(helperIdx).toBeGreaterThan(-1);
+    expect(src.slice(helperIdx, helperIdx + 400)).toMatch(/clearResumeHint/);
   });
 
   it('bridge cwd handler has a change-guard so the immediate write only fires on real cd', () => {

--- a/src/daemon/web/__tests__/copyPasteKeys.test.ts
+++ b/src/daemon/web/__tests__/copyPasteKeys.test.ts
@@ -21,7 +21,7 @@ type KeyLike = {
   isComposing?: boolean;
 };
 
-type Decide = (ev: KeyLike, opts: { isMac?: boolean; hasSelection?: boolean; readOnly?: boolean; remoteAcceptsCsiU?: boolean }) => {
+type Decide = (ev: KeyLike, opts: { isMac?: boolean; hasSelection?: boolean; readOnly?: boolean; remoteAcceptsCsiU?: boolean; remoteWin32Input?: boolean }) => {
   action: string;
   data?: string;
 } | null;
@@ -55,6 +55,23 @@ describe('newline keys', () => {
     expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), { remoteAcceptsCsiU: true })).toEqual({
       action: 'newline',
       data: '\x1b[13;2u',
+    });
+  });
+
+  it('Shift+Enter emits the win32-input-mode pair when the pane negotiated ?9001h', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), { remoteWin32Input: true })).toEqual({
+      action: 'newline',
+      data: '\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_',
+    });
+  });
+
+  it('Shift+Enter prefers win32-input-mode over kitty', () => {
+    expect(decideWebKey(kd({ key: 'Enter', code: 'Enter', shiftKey: true }), {
+      remoteAcceptsCsiU: true,
+      remoteWin32Input: true,
+    })).toEqual({
+      action: 'newline',
+      data: '\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_',
     });
   });
 

--- a/src/daemon/web/__tests__/keyboardProtocol.test.ts
+++ b/src/daemon/web/__tests__/keyboardProtocol.test.ts
@@ -10,14 +10,12 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { runInNewContext } from 'node:vm';
 
-type Fold = (prev: { kitty: boolean; modifyOtherKeys: number }, bytes: Uint8Array | string) => {
-  kitty: boolean;
-  modifyOtherKeys: number;
-};
+type KbState = { kitty: boolean; modifyOtherKeys: number; win32Input: boolean };
+type Fold = (prev: KbState, bytes: Uint8Array | string) => KbState;
 
 let fold: Fold;
 let acceptsCsiU: (state: { kitty: boolean }) => boolean;
-let INITIAL_STATE: { kitty: boolean; modifyOtherKeys: number };
+let INITIAL_STATE: KbState;
 
 const frontend = (name: string) => join(__dirname, '..', 'frontend', name);
 
@@ -30,12 +28,12 @@ beforeAll(() => {
   const mod = sandbox.wmuxKeyboardProtocol as Record<string, unknown>;
   fold = mod.foldRemoteKeyboardState as Fold;
   acceptsCsiU = mod.acceptsCsiU as (state: { kitty: boolean }) => boolean;
-  INITIAL_STATE = mod.INITIAL_STATE as { kitty: boolean; modifyOtherKeys: number };
+  INITIAL_STATE = mod.INITIAL_STATE as KbState;
 });
 
 describe('initial state', () => {
   it('starts not negotiated', () => {
-    expect(INITIAL_STATE).toEqual({ kitty: false, modifyOtherKeys: 0 });
+    expect(INITIAL_STATE).toEqual({ kitty: false, modifyOtherKeys: 0, win32Input: false });
   });
 
   it('does not accept CSI-u before any negotiation', () => {
@@ -99,5 +97,17 @@ describe('robustness', () => {
   it('a string input is accepted as well as bytes', () => {
     const next = fold(INITIAL_STATE, '\x1b[>1u' as string);
     expect(next.kitty).toBe(true);
+  });
+});
+
+describe('win32-input-mode (?9001h)', () => {
+  it('turns on for CSI ? 9001 h and off for l', () => {
+    const on = fold(INITIAL_STATE, bytes('\x1b[?9001h'));
+    expect(on.win32Input).toBe(true);
+    expect(fold(on, bytes('\x1b[?9001l')).win32Input).toBe(false);
+  });
+
+  it('picks 9001 out of a combined DECSET', () => {
+    expect(fold(INITIAL_STATE, bytes('\x1b[?1;9001h')).win32Input).toBe(true);
   });
 });

--- a/src/daemon/web/frontend/app.js
+++ b/src/daemon/web/frontend/app.js
@@ -303,12 +303,19 @@
   function paneAcceptsCsiU(sessionId) {
     // Claude Code (and any other detected agent) accepts CSI-u by contract —
     // it is why the desktop sends the byte unconditionally. A shell's claim is
-    // decided by the kitty fold instead.
+    // decided by the kitty fold instead. Codex on Windows is the exception:
+    // it negotiates win32-input-mode, and paneAcceptsWin32 wins in decideWebKey.
     var s = sessions.filter(function (x) { return x.id === sessionId; })[0];
     if (s && s.agent) return true;
     var kb = window.wmuxKeyboardProtocol;
     if (!kb) return false;
     return kb.acceptsCsiU(keyboardStates[sessionId] || kb.INITIAL_STATE);
+  }
+
+  function paneAcceptsWin32(sessionId) {
+    var kb = window.wmuxKeyboardProtocol;
+    if (!kb || !kb.acceptsWin32Input) return false;
+    return kb.acceptsWin32Input(keyboardStates[sessionId] || kb.INITIAL_STATE);
   }
 
   /**
@@ -325,8 +332,10 @@
    * @param {function(): boolean} acceptsCsiU whether THIS pane negotiated the
    *        kitty keyboard protocol (drives the Shift+Enter byte; see
    *        keyboardProtocol.js). A tile must query ITS session's state.
+   * @param {function(): boolean} [acceptsWin32] whether THIS pane negotiated
+   *        win32-input-mode (`?9001h`). Wins over CSI-u for Shift+Enter.
    */
-  function attachTerminalKeys(term, send, readOnly, acceptsCsiU) {
+  function attachTerminalKeys(term, send, readOnly, acceptsCsiU, acceptsWin32) {
     // xterm exposes the custom key handler as a METHOD, not a constructor
     // option. Wired here so Ctrl+C-with-a-selection copies instead of SIGINT,
     // Shift+Enter / Ctrl+Enter insert a newline, and Ctrl+V / Ctrl+D fall back
@@ -338,7 +347,8 @@
           isMac: isMac,
           hasSelection: term.hasSelection(),
           readOnly: readOnly,
-          remoteAcceptsCsiU: acceptsCsiU ? acceptsCsiU() : false
+          remoteAcceptsCsiU: acceptsCsiU ? acceptsCsiU() : false,
+          remoteWin32Input: acceptsWin32 ? acceptsWin32() : false
         });
         if (!decision) return true;
         // Copy: an explicit Ctrl+C must cancel any pending debounced auto-copy.
@@ -419,7 +429,7 @@
         if (termRepaints > 0) return; // parser reply to a replayed query
         sendInput(d);
       });
-      attachTerminalKeys(term, sendInput, !allowInput, function () { return paneAcceptsCsiU(currentSession); });
+      attachTerminalKeys(term, sendInput, !allowInput, function () { return paneAcceptsCsiU(currentSession); }, function () { return paneAcceptsWin32(currentSession); });
       // Auto-focus so typing and Ctrl+V work without a click first — a browser
       // only delivers the paste event to the focused xterm textarea.
       if (allowInput) term.focus();
@@ -1576,7 +1586,7 @@
     // OUTSIDE `if (allowInput)`: a read-only split tile still needs copy —
     // select-to-copy and Ctrl+C-with-selection must work there, only typing is
     // gated on allowInput (the readOnly flag passed here decides newline/paste).
-    attachTerminalKeys(tile.term, function (d) { sendTo(tile.sessionId, d); }, !allowInput, function () { return paneAcceptsCsiU(tile.sessionId); });
+    attachTerminalKeys(tile.term, function (d) { sendTo(tile.sessionId, d); }, !allowInput, function () { return paneAcceptsCsiU(tile.sessionId); }, function () { return paneAcceptsWin32(tile.sessionId); });
     renderTileHead(tile);
     el.addEventListener('pointerdown', function () { focusTile(tile); });
 

--- a/src/daemon/web/frontend/copyPasteKeys.js
+++ b/src/daemon/web/frontend/copyPasteKeys.js
@@ -32,7 +32,7 @@
    *
    * @param ev KeyboardEvent-like ({ type, key, code, ctrlKey, shiftKey, altKey,
    *            metaKey, isComposing })
-   * @param opts { isMac, hasSelection, readOnly, remoteAcceptsCsiU }
+   * @param opts { isMac, hasSelection, readOnly, remoteAcceptsCsiU, remoteWin32Input }
    * @returns null to pass through to xterm/browser; or
    *          { action: 'copy' } — copy the selection to the clipboard;
    *          { action: 'paste' } — decline the key so xterm neither encodes
@@ -53,13 +53,17 @@
     // Un-negotiated, hand the key back to xterm and let it encode the legacy
     // CR (mirrorInput.ts does the same for the attach mirror, #924).
     var remoteAcceptsCsiU = !!opts.remoteAcceptsCsiU;
+    var remoteWin32Input = !!opts.remoteWin32Input;
+    // Keep in lockstep with newlineKeys.ts SHIFT_ENTER_WIN32.
+    var WIN32_SHIFT_ENTER = '\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_';
 
-    // Shift+Enter → CSI u (`ESC [ 13 ; 2 u`): kitty-protocol apps (Claude Code,
-    // codex) insert a newline instead of submitting. Same byte #924's mirror
-    // sends; a read-only host takes nothing; a non-negotiating pane gets the
-    // legacy CR from xterm instead of a byte it would misread.
+    // Shift+Enter. Encoding depends on what the pane negotiated: win32-input-
+    // mode (Codex on Windows, #1152) first, then kitty CSI-u. A pane that
+    // never negotiated gets the legacy CR from xterm instead of a byte it
+    // would misread (bash/vim).
     if (ev.key === 'Enter' && ev.shiftKey && !ev.ctrlKey && !ev.altKey && !ev.metaKey && !ev.isComposing) {
       if (readOnly) return { action: 'swallow' };
+      if (remoteWin32Input) return { action: 'newline', data: WIN32_SHIFT_ENTER };
       if (!remoteAcceptsCsiU) return null;
       return { action: 'newline', data: '\x1b[13;2u' };
     }

--- a/src/daemon/web/frontend/keyboardProtocol.js
+++ b/src/daemon/web/frontend/keyboardProtocol.js
@@ -35,9 +35,10 @@
   var KITTY_PUSH_OR_SET = new RegExp('\\x1b\\[[>=](\\d*)(?:;\\d+)?u', 'g');
   var KITTY_POP = new RegExp('\\x1b\\[<\\d*u', 'g');
   var MODIFY_OTHER_KEYS = new RegExp('\\x1b\\[>4;([0-2])m', 'g');
+  var DECSET_PRIVATE = new RegExp('\\x1b\\[\\?([\\d;]+)([hl])', 'g');
   /* eslint-enable no-control-regex */
 
-  var INITIAL_STATE = { kitty: false, modifyOtherKeys: 0 };
+  var INITIAL_STATE = { kitty: false, modifyOtherKeys: 0, win32Input: false };
 
   /**
    * Fold one chunk of pane output into the keyboard state.
@@ -66,6 +67,7 @@
 
     var kitty = prev.kitty;
     var modifyOtherKeys = prev.modifyOtherKeys;
+    var win32Input = prev.win32Input;
     var events = [];
 
     // Walk in order so a push followed by a pop inside one chunk lands on the
@@ -85,13 +87,23 @@
       var level = Number(m[1]);
       events.push({ index: m.index, apply: function () { modifyOtherKeys = level; } });
     }
+    DECSET_PRIVATE.lastIndex = 0;
+    while ((m = DECSET_PRIVATE.exec(chunk)) !== null) {
+      if (m[1].split(';').indexOf('9001') < 0) continue;
+      // Capture per-match: a var in this while would be shared across apply().
+      (function (enable, index) {
+        events.push({ index: index, apply: function () { win32Input = enable; } });
+      })(m[2] === 'h', m.index);
+    }
 
     if (events.length === 0) return prev;
     events.sort(function (a, b) { return a.index - b.index; });
     for (var i = 0; i < events.length; i++) events[i].apply();
 
-    var changed = kitty !== prev.kitty || modifyOtherKeys !== prev.modifyOtherKeys;
-    return changed ? { kitty: kitty, modifyOtherKeys: modifyOtherKeys } : prev;
+    var changed = kitty !== prev.kitty
+      || modifyOtherKeys !== prev.modifyOtherKeys
+      || win32Input !== prev.win32Input;
+    return changed ? { kitty: kitty, modifyOtherKeys: modifyOtherKeys, win32Input: win32Input } : prev;
   }
 
   /**
@@ -108,9 +120,14 @@
     return state.kitty;
   }
 
+  function acceptsWin32Input(state) {
+    return !!state.win32Input;
+  }
+
   return {
     INITIAL_STATE: INITIAL_STATE,
     foldRemoteKeyboardState: foldRemoteKeyboardState,
-    acceptsCsiU: acceptsCsiU
+    acceptsCsiU: acceptsCsiU,
+    acceptsWin32Input: acceptsWin32Input
   };
 });

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -1610,6 +1610,11 @@ export default function AppLayout() {
             // flight — setSurfaceAgent keeps existing names, but skip the
             // principal round-trip in that case entirely.
             if (store.surfaceAgent[ptyId]?.name) return;
+            // #1210: the agent may have died while resolveAgent was in
+            // flight. Re-stamping would undo clearSurfaceAgentsKnownGone
+            // until the next 15s poll.
+            if (store.agentAliveByPtyId[ptyId] === false) return;
+            if (store.commandRunningByPtyId[ptyId] === false) return;
             store.setSurfaceAgent(ptyId, name, undefined, asAgentSlug(name));
             // R2: freshly-identified panes register into the principal
             // registry exactly like the live-detection path (debounced

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -88,6 +88,20 @@ interface ReconcilePtySession extends DeadPaneSessionSnapshot {
   createdAt?: string;
 }
 
+/** #1210 — drop a pane's detected agent identity once we know the TUI is gone. */
+function clearSurfaceAgentsKnownGone(
+  agentAlive: Record<string, boolean>,
+  commandRunning: Record<string, boolean>,
+): void {
+  const store = useStore.getState();
+  for (const [id, alive] of Object.entries(agentAlive)) {
+    if (alive === false) store.clearSurfaceAgent(id);
+  }
+  for (const [id, running] of Object.entries(commandRunning)) {
+    if (running === false) store.clearSurfaceAgent(id);
+  }
+}
+
 /**
  * Fix 0 — startup reconcile timeout.
  *
@@ -1568,6 +1582,12 @@ export default function AppLayout() {
         useStore.getState().hydrateResumeBindings(resumeBindingSnapshot);
         useStore.getState().hydrateCommandRunning(commandRunningSnapshot);
         useStore.getState().hydrateAgentAlive(agentAliveSnapshot);
+        // #1210: the slug is stamped on detect and was never cleared on
+        // agent exit. Process-truth `false` and OSC 133 "back at a prompt"
+        // are the two signals that the TUI is gone — drop the identity so
+        // auto-name, image-paste `auto`, and the principal registry stop
+        // treating the leftover shell as Claude.
+        clearSurfaceAgentsKnownGone(agentAliveSnapshot, commandRunningSnapshot);
         // 4d (channels): seed agent identity for panes the user has NOT
         // visited yet, so recovered agents show up as invite/mention
         // candidates right after boot instead of only after a visit.
@@ -1576,7 +1596,7 @@ export default function AppLayout() {
         const seedTargets = planAgentCandidateSeed(
           sessions.map((s) => s.id),
           useStore.getState().surfaceAgent,
-        );
+        ).filter((id) => agentAliveSnapshot[id] !== false && commandRunningSnapshot[id] !== false);
         for (const ptyId of seedTargets) {
           void window.electronAPI.metadata.resolveAgent(ptyId).then((name) => {
             // Attempted either way — a null answer means "not an agent pane
@@ -1638,6 +1658,7 @@ export default function AppLayout() {
         useStore.getState().hydrateResumeBindings(snapshot);
         useStore.getState().hydrateCommandRunning(cmdSnapshot);
         useStore.getState().hydrateAgentAlive(agentAliveSnapshot);
+        clearSurfaceAgentsKnownGone(agentAliveSnapshot, cmdSnapshot);
       }).catch(() => { /* transient list failure — the next tick self-heals */ });
     };
     const id = window.setInterval(refreshBindings, 15_000);

--- a/src/renderer/components/Layout/__tests__/appLayout.clearSurfaceAgents.test.ts
+++ b/src/renderer/components/Layout/__tests__/appLayout.clearSurfaceAgents.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Source-level regression lock (#1228 review, C3): the #1210 dead-slug fix's
+ * AppLayout wiring — hydrate, dead-pane exclusion, and the in-flight
+ * resolveAgent re-check — was untested (deleting it passed the suite). These
+ * locks pin the wiring, following the appLayout.deadPaneRecovery convention.
+ */
+
+const source = fs.readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/components/Layout/AppLayout.tsx'),
+  'utf8',
+);
+
+describe('AppLayout clearSurfaceAgents wiring (#1210 / #1228)', () => {
+  it('hydrate runs clearSurfaceAgentsKnownGone after hydrateAgentAlive in both flows', () => {
+    // daemon:connected hydrate AND the 15s refreshBindings poll — two call
+    // sites, each stamped after the liveness maps they read are hydrated.
+    const hydrates = [
+      ...source.matchAll(/hydrateAgentAlive\(agentAliveSnapshot\);/g),
+    ].map((m) => m.index ?? -1);
+    expect(hydrates.length).toBe(2);
+    for (const at of hydrates) {
+      const window = source.slice(at, at + 500);
+      const clearAt = window.indexOf('clearSurfaceAgentsKnownGone(');
+      expect(clearAt).toBeGreaterThan(-1);
+    }
+    expect(source).toMatch(
+      /clearSurfaceAgentsKnownGone\(agentAliveSnapshot, commandRunningSnapshot\)/,
+    );
+    expect(source).toMatch(
+      /clearSurfaceAgentsKnownGone\(agentAliveSnapshot, cmdSnapshot\)/,
+    );
+  });
+
+  it('the agent-seed filter excludes panes known dead', () => {
+    expect(source).toMatch(
+      /\)\.filter\(\(id\) => agentAliveSnapshot\[id\] !== false && commandRunningSnapshot\[id\] !== false\);/,
+    );
+  });
+
+  it('resolveAgent re-checks liveness before stamping the slug', () => {
+    // The agent may die while resolveAgent is in flight; re-stamping would
+    // undo clearSurfaceAgentsKnownGone until the next 15s poll.
+    const then = source.indexOf('resolveAgent(ptyId).then((name)');
+    const agentGone = source.indexOf('store.agentAliveByPtyId[ptyId] === false', then);
+    const cmdGone = source.indexOf('store.commandRunningByPtyId[ptyId] === false', agentGone);
+    const stamp = source.indexOf('setSurfaceAgent(ptyId, name', cmdGone);
+    expect(then).toBeGreaterThan(-1);
+    expect(agentGone).toBeGreaterThan(then);
+    expect(cmdGone).toBeGreaterThan(agentGone);
+    expect(stamp).toBeGreaterThan(cmdGone);
+  });
+});

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -5,7 +5,7 @@ import { sanitizeTitle } from '../../../main/pty/titleDetect';
 import { applyUnicodeWidthModel } from '../../../shared/terminalUnicode';
 import { computeMirrorFontSize, mirrorFitKey, MAX_FIT_PASSES } from './mirrorFit';
 import { decideMirrorKeyWithRepeat } from './mirrorInput';
-import { foldRemoteKeyboardState, acceptsCsiU, INITIAL_REMOTE_KEYBOARD_STATE } from './keyboardProtocol';
+import { foldRemoteKeyboardState, INITIAL_REMOTE_KEYBOARD_STATE } from './keyboardProtocol';
 import { useStore } from '../../stores';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
 import { createAutoSelectionCopy } from '../../utils/autoSelectionCopy';
@@ -435,7 +435,7 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly, onTitl
         isMac,
         hasSelection: term.hasSelection(),
         readOnly: readOnlyRef.current === true,
-        remoteAcceptsCsiU: acceptsCsiU(remoteKeyboardRef.current),
+        protocol: remoteKeyboardRef.current,
         hasCustomCtrlJBinding: useStore.getState().customKeybindings.some(
           (kb) => kb.key === 'Ctrl+J',
         ),

--- a/src/renderer/components/Remote/__tests__/keyboardProtocol.test.ts
+++ b/src/renderer/components/Remote/__tests__/keyboardProtocol.test.ts
@@ -69,4 +69,15 @@ describe('foldRemoteKeyboardState', () => {
     // A pane printing documentation about the protocol has no ESC in it.
     expect(acceptsCsiU(foldRemoteKeyboardState(INIT, 'send CSI [>1u to enable'))).toBe(false);
   });
+
+  it('recognises win32-input-mode (?9001h) and follows the reset', () => {
+    const on = foldRemoteKeyboardState(INIT, '\x1b[?9001h');
+    expect(on.win32Input).toBe(true);
+    expect(acceptsCsiU(on)).toBe(false);
+    expect(foldRemoteKeyboardState(on, '\x1b[?9001l').win32Input).toBe(false);
+  });
+
+  it('picks 9001 out of a combined DECSET list', () => {
+    expect(foldRemoteKeyboardState(INIT, '\x1b[?1;9001h').win32Input).toBe(true);
+  });
 });

--- a/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
+++ b/src/renderer/components/Remote/__tests__/mirrorInput.test.ts
@@ -55,9 +55,17 @@ describe('decideMirrorKey — the four conveniences #895 asked for', () => {
   it('sends the CSI-u newline on Shift+Enter once the remote has asked for it', () => {
     const d = decideMirrorKey(
       key({ key: 'Enter', code: 'Enter', shiftKey: true }),
-      opts({ remoteAcceptsCsiU: true }),
+      opts({ protocol: { kitty: true } }),
     );
     expect(d).toEqual({ kind: 'write', data: '\x1b[13;2u' });
+  });
+
+  it('sends the win32-input-mode pair when the remote negotiated ?9001h', () => {
+    const d = decideMirrorKey(
+      key({ key: 'Enter', code: 'Enter', shiftKey: true }),
+      opts({ protocol: { win32Input: true } }),
+    );
+    expect(d).toEqual({ kind: 'write', data: '\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_' });
   });
 
   it('hands Shift+Enter back to xterm when the remote never negotiated', () => {

--- a/src/renderer/components/Remote/keyboardProtocol.ts
+++ b/src/renderer/components/Remote/keyboardProtocol.ts
@@ -8,8 +8,8 @@
  * that leaves insert and runs the remainder as normal-mode input.
  *
  * xterm.js parses DECSET 2004 for us (`term.modes.bracketedPasteMode`) but
- * exposes nothing about keyboard protocols, so this watches the remote's own
- * output for the two negotiations that matter. Same idea as the bracketed-paste
+ * exposes nothing about keyboard protocols, so this watches the pane's own
+ * output for the negotiations that matter. Same idea as the bracketed-paste
  * read, one layer lower.
  *
  * Deliberately conservative: unknown state means NOT negotiated, so the mirror
@@ -42,6 +42,12 @@ const KITTY_POP = new RegExp('\\x1b\\[<\\d*u', 'g');
  * something" state is not silently conflated with "negotiated kitty".
  */
 const MODIFY_OTHER_KEYS = new RegExp('\\x1b\\[>4;([0-2])m', 'g');
+/**
+ * win32-input-mode (Microsoft private mode 9001). Codex on Windows requests
+ * this and then expects Shift+Enter as a KEY_EVENT_RECORD, not CSI-u.
+ * Combined DECSET (`CSI ? 1 ; 9001 h`) is matched by walking the mode list.
+ */
+const DECSET_PRIVATE = new RegExp('\\x1b\\[\\?([\\d;]+)([hl])', 'g');
 /* eslint-enable no-control-regex */
 
 export interface RemoteKeyboardState {
@@ -49,11 +55,14 @@ export interface RemoteKeyboardState {
   kitty: boolean;
   /** The remote's modifyOtherKeys level, 0 when off. */
   modifyOtherKeys: 0 | 1 | 2;
+  /** The app enabled win32-input-mode (`CSI ? 9001 h`) and has not disabled it. */
+  win32Input: boolean;
 }
 
 export const INITIAL_REMOTE_KEYBOARD_STATE: RemoteKeyboardState = {
   kitty: false,
   modifyOtherKeys: 0,
+  win32Input: false,
 };
 
 /**
@@ -83,6 +92,7 @@ export function foldRemoteKeyboardState(
 
   let kitty = prev.kitty;
   let modifyOtherKeys = prev.modifyOtherKeys;
+  let win32Input = prev.win32Input;
   let changed = false;
 
   // Walk in order so a push followed by a pop inside one chunk lands on the
@@ -106,13 +116,23 @@ export function foldRemoteKeyboardState(
     const index = m.index;
     events.push({ index, apply: () => { modifyOtherKeys = level; } });
   }
+  DECSET_PRIVATE.lastIndex = 0;
+  for (let m = DECSET_PRIVATE.exec(chunk); m; m = DECSET_PRIVATE.exec(chunk)) {
+    const modes = m[1].split(';');
+    if (!modes.includes('9001')) continue;
+    const enable = m[2] === 'h';
+    const index = m.index;
+    events.push({ index, apply: () => { win32Input = enable; } });
+  }
 
   if (events.length === 0) return prev;
   events.sort((a, b) => a.index - b.index);
   for (const e of events) e.apply();
 
-  changed = kitty !== prev.kitty || modifyOtherKeys !== prev.modifyOtherKeys;
-  return changed ? { kitty, modifyOtherKeys } : prev;
+  changed = kitty !== prev.kitty
+    || modifyOtherKeys !== prev.modifyOtherKeys
+    || win32Input !== prev.win32Input;
+  return changed ? { kitty, modifyOtherKeys, win32Input } : prev;
 }
 
 /**
@@ -124,4 +144,9 @@ export function foldRemoteKeyboardState(
  */
 export function acceptsCsiU(state: RemoteKeyboardState): boolean {
   return state.kitty;
+}
+
+/** Whether the pane asked for win32-input-mode key events (`?9001h`). */
+export function acceptsWin32Input(state: RemoteKeyboardState): boolean {
+  return state.win32Input;
 }

--- a/src/renderer/components/Remote/mirrorInput.ts
+++ b/src/renderer/components/Remote/mirrorInput.ts
@@ -19,7 +19,11 @@
  * `newlineKeys.ts` already use.
  */
 
-import { resolveNewlineKeyByte, type NewlineKeyEventLike } from '../../terminal/newlineKeys';
+import {
+  resolveNewlineKeyByte,
+  type KeyboardProtocolHint,
+  type NewlineKeyEventLike,
+} from '../../terminal/newlineKeys';
 
 export interface MirrorKeyEventLike extends NewlineKeyEventLike {
   /** Only `keydown` decides anything; keyup/keypress always pass. */
@@ -37,12 +41,11 @@ export interface MirrorKeyOptions {
   /** The user bound Ctrl+J themselves — see newlineKeys.ts. */
   hasCustomCtrlJBinding?: boolean;
   /**
-   * The remote app asked for kitty CSI-u key encodings (observed in its own
-   * output — see keyboardProtocol.ts). Defaults to false, which is the
-   * conservative side: an app that never negotiated gets what xterm would
-   * have encoded.
+   * Keyboard-protocol negotiation observed in the remote's own output
+   * (keyboardProtocol.ts). Defaults to nothing negotiated, which is the
+   * conservative side: Shift+Enter is handed back to xterm.
    */
-  remoteAcceptsCsiU?: boolean;
+  protocol?: KeyboardProtocolHint;
 }
 
 export type MirrorKeyDecision =
@@ -78,24 +81,21 @@ export function decideMirrorKey(
   // Shift+Enter / Ctrl+Enter / Ctrl+J. Same resolver the local pane uses, so a
   // remote Claude Code gets the same newline byte a local one does instead of
   // whatever xterm's legacy keyCode path happens to produce under an IME.
+  // A read-only host takes no bytes at all. Shift+Enter is swallowed even
+  // when the resolver returns null (un-negotiated → would otherwise `pass`
+  // to xterm, which would encode a CR and send it).
+  if (opts.readOnly && e.key === 'Enter' && e.shiftKey && !e.ctrlKey && !e.altKey) {
+    return { kind: 'swallow' };
+  }
   const newlineByte = resolveNewlineKeyByte(e, {
     hasCustomCtrlJBinding: opts.hasCustomCtrlJBinding,
+    protocol: opts.protocol,
+    // A mirror never negotiated with the app it is watching. CSI-u is
+    // Escape + garbage there unless the app asked for kitty (or win32).
+    shiftEnterFallback: 'xterm',
   });
   if (newlineByte !== null) {
-    // A read-only host takes no bytes at all, negotiated or not — decided here
-    // rather than left to the write path so the table says so.
     if (opts.readOnly) return { kind: 'swallow' };
-    // The CSI-u byte only means "newline" to an app that asked for kitty
-    // encodings. A local pane can send it blind because it and the TUI share
-    // this xterm; a mirror is talking to an app it never negotiated with, and
-    // there `\x1b[13;2u` reads as Escape followed by normal-mode input — in
-    // vim's insert mode that leaves insert and runs the rest as commands.
-    // Un-negotiated, hand the key back to xterm and let it encode the legacy
-    // CR: what the mirror did before it had a key table at all.
-    //
-    // Ctrl+Enter and Ctrl+J are unaffected — a bare LF needs no negotiation.
-    const isCsiU = newlineByte.startsWith('\x1b');
-    if (isCsiU && !opts.remoteAcceptsCsiU) return { kind: 'pass' };
     return { kind: 'write', data: newlineByte };
   }
 

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -286,6 +286,7 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
         ptyId,
         write: (d) => window.electronAPI.pty.write(ptyId, d),
         bracketedPasteMode: !!modes?.bracketedPasteMode,
+        screenIsAlternate: terminal?.buffer.active.type === 'alternate',
       });
     })();
   }, [ptyId, terminalRef]);

--- a/src/renderer/hooks/__tests__/useTerminal.ctrlLetterEncoding.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.ctrlLetterEncoding.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Source-level regression locks for the #1228 review fixes (C1 + C2):
+ *
+ * C1 — keyboard-protocol negotiation state is liveness-scoped and survives
+ * pane park/re-adoption. A terminal adopted after a restructure must seed
+ * `keyboardRef` from the state its previous mount parked (else a live Codex
+ * falls back to CSI-u, #1152), and the state must reset when process-truth /
+ * OSC 133 says the foreground command died (else a Codex that armed win32
+ * input mode without resetting it leaves junk encoding for the next app,
+ * same staleness class as #1210).
+ *
+ * C2 — every directly-written control byte (newline, IME Escape, disabled
+ * shortcut ctrl, catch-all ctrl) feeds `noteUserKeystroke`, so the interrupt
+ * observer, resume-hint retraction, and input scheduler all see it. Before
+ * this, direct writes fed only the dead-input watchdog and a directly-written
+ * Ctrl+C skipped the renderer interrupt edge.
+ *
+ * jsdom can't faithfully run xterm's custom key handler, so like the
+ * macCtrlPassthrough lock we pin the source.
+ */
+
+const SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+const handlerStart = SRC.indexOf('attachCustomKeyEventHandler');
+const handlerEnd = SRC.indexOf('// Right-click behavior', handlerStart);
+const HANDLER = SRC.slice(handlerStart, handlerEnd);
+
+describe('useTerminal ctrl-letter encoding + keyboard-state lifecycle (source-level lock)', () => {
+  it('locates the custom key event handler', () => {
+    expect(handlerStart).toBeGreaterThan(-1);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+  });
+
+  it('Ctrl+C copy branch is matched before the catch-all SIGINT encoder', () => {
+    // Copy-with-selection must win: if the catch-all resolveCtrlLetterByte ran
+    // first, a selected Ctrl+C would send 0x03 and never copy.
+    const copyBranch = HANDLER.indexOf("resolveCtrlLetterByte(e) === '\\x03'");
+    const catchAll = HANDLER.indexOf('const ctrlByte = resolveCtrlLetterByte(e)');
+    expect(copyBranch).toBeGreaterThan(-1);
+    expect(catchAll).toBeGreaterThan(-1);
+    expect(copyBranch).toBeLessThan(catchAll);
+  });
+
+  it('the catch-all ctrl write runs the keystroke side effects', () => {
+    // #1228 C2: the SIGINT path (Dvorak Ctrl+C, #1227) must feed the
+    // interrupt observer via noteUserKeystroke, not just the watchdog.
+    expect(HANDLER).toMatch(
+      /if \(ctrlByte\) \{\s*e\.preventDefault\(\);\s*window\.electronAPI\.pty\.write\(ptyId, ctrlByte\);\s*noteUserKeystroke\(ctrlByte\);\s*return false;/,
+    );
+  });
+
+  it('disabled-shortcut branch encodes the logical ctrl byte before returning true', () => {
+    // #1152: a combo disabled in Settings must reach the PTY as a control
+    // byte, not bubble dead. resolveCtrlLetterByte runs before the return.
+    const guard = SRC.indexOf('matchesDisabledShortcut(');
+    const encode = SRC.indexOf('const disabledCtrl = resolveCtrlLetterByte(e);', guard);
+    const passThrough = SRC.indexOf('return true;', encode);
+    expect(guard).toBeGreaterThan(-1);
+    expect(encode).toBeGreaterThan(guard);
+    expect(passThrough).toBeGreaterThan(encode);
+  });
+
+  it('all four direct-write sites feed noteUserKeystroke (C2)', () => {
+    // Helper definition lives before attachCustomKeyEventHandler, so exactly
+    // the four call sites (newline, IME Escape, disabled ctrl, catch-all
+    // ctrl) are inside the handler slice.
+    const calls = HANDLER.match(/noteUserKeystroke\(/g) ?? [];
+    expect(calls.length).toBe(4);
+    expect(HANDLER).toMatch(/noteUserKeystroke\(newlineByte\);/);
+    expect(HANDLER).toMatch(/noteUserKeystroke\('\\x1b'\);/);
+    expect(HANDLER).toMatch(/noteUserKeystroke\(disabledCtrl\);/);
+    expect(HANDLER).toMatch(/noteUserKeystroke\(ctrlByte\);/);
+  });
+
+  it('an adopted terminal seeds keyboard state from the parked WeakMap (C1)', () => {
+    expect(SRC).toMatch(
+      /adopted\s*\?\s*parkedKeyboardByTerminal\.get\(terminal\) \?\? INITIAL_REMOTE_KEYBOARD_STATE/,
+    );
+    expect(SRC).toMatch(/parkedKeyboardByTerminal\.set\(terminal, keyboardRef\.current\)/);
+  });
+
+  it('keyboard state resets when the foreground command or agent dies (C1)', () => {
+    // Process-truth (agentAliveByPtyId) and OSC 133 (commandRunningByPtyId)
+    // alive→dead edges are the same ones #1210 clears agent identity on.
+    expect(SRC).toMatch(
+      /commandRunningByPtyId\[ptyId\], prev\.commandRunningByPtyId\[ptyId\]/,
+    );
+    expect(SRC).toMatch(
+      /agentAliveByPtyId\[ptyId\], prev\.agentAliveByPtyId\[ptyId\]/,
+    );
+    expect(SRC).toMatch(/parkedKeyboardByTerminal\.delete\(terminal\)/);
+  });
+
+  it('the liveness subscription is torn down on unmount, park or dispose (C1)', () => {
+    const park = SRC.indexOf('parkTerminal(ptyId, terminal, parkElement, disposeTerminal);');
+    const unsub = SRC.indexOf('unsubscribeKeyboardLiveness();', park);
+    const tail = SRC.indexOf('terminalRef.current = null;', unsub);
+    expect(park).toBeGreaterThan(-1);
+    expect(unsub).toBeGreaterThan(park);
+    expect(tail).toBeGreaterThan(unsub);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.ctrlLetterEncoding.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.ctrlLetterEncoding.test.ts
@@ -80,8 +80,18 @@ describe('useTerminal ctrl-letter encoding + keyboard-state lifecycle (source-le
   });
 
   it('an adopted terminal seeds keyboard state from the parked WeakMap (C1)', () => {
+    // Seeding is refused when the pane's foreground command is known dead at
+    // adopt time — the alive→dead edge can fire inside the park→adopt window
+    // where no subscription observes it, so the seed keys on the same
+    // liveness the reset uses.
     expect(SRC).toMatch(
-      /adopted\s*\?\s*parkedKeyboardByTerminal\.get\(terminal\) \?\? INITIAL_REMOTE_KEYBOARD_STATE/,
+      /const parkedKnownGone = seedState\.agentAliveByPtyId\[ptyId\] === false/,
+    );
+    expect(SRC).toMatch(
+      /\|\| seedState\.commandRunningByPtyId\[ptyId\] === false/,
+    );
+    expect(SRC).toMatch(
+      /adopted && !parkedKnownGone\s*\n\s*\? parkedKeyboardByTerminal\.get\(terminal\) \?\? INITIAL_REMOTE_KEYBOARD_STATE/,
     );
     expect(SRC).toMatch(/parkedKeyboardByTerminal\.set\(terminal, keyboardRef\.current\)/);
   });

--- a/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.daemonModeRaceCancel.test.ts
@@ -26,8 +26,12 @@ describe('A6 — useTerminal async restore race cancel (source-level)', () => {
   it('scrollback.load().then(content) guards on isDaemonModeActive() before writing', () => {
     const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
     expect(loadIdx).toBeGreaterThan(0);
-    // Slice forward enough lines to capture the then handler body.
-    const body = src.slice(loadIdx, loadIdx + 4000);
+    // Slice forward enough lines to capture the then handler body. 6000, not
+    // 4000: a CRLF checkout (Windows runner) costs one extra char per line,
+    // and the trailing `for (const payload of pendingData` flush sat at 4020
+    // CRLF chars — one comment growth away from silently falling out of the
+    // window again. The regexes themselves are \s*-based and CRLF-safe.
+    const body = src.slice(loadIdx, loadIdx + 6000);
     // The guard substitutes the .txt content with null when daemon-mode
     // activated during the IPC round-trip.
     expect(body).toMatch(/isDaemonModeActive\(\)\s*\?\s*null\s*:\s*content/);
@@ -40,7 +44,7 @@ describe('A6 — useTerminal async restore race cancel (source-level)', () => {
 
   it('still flushes pending PTY data after the daemon-mode skip', () => {
     const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
-    const body = src.slice(loadIdx, loadIdx + 4000);
+    const body = src.slice(loadIdx, loadIdx + 6000);
     // pendingData.length > 0 check happens whether or not restored ran.
     expect(body).toMatch(/scrollbackLoaded\s*=\s*true/);
     expect(body).toMatch(/for\s*\(\s*const\s+payload\s+of\s+pendingData/);
@@ -57,7 +61,7 @@ describe('A6 — useTerminal async restore race cancel (source-level)', () => {
     expect(src).toMatch(/let\s+removeDaemonConnectedForRestore/);
     // Inside the restore branch, the flag flips true and the listener arms.
     const loadIdx = src.indexOf('scrollback.load(scrollbackFile)');
-    const body = src.slice(loadIdx, loadIdx + 4000);
+    const body = src.slice(loadIdx, loadIdx + 6000);
     expect(body).toMatch(/didRestoreTxt\s*=\s*true/);
     expect(body).toMatch(/window\.electronAPI\.daemon\.onConnected\(/);
     // The listener resets the terminal and clears the flag.

--- a/src/renderer/hooks/__tests__/useTerminal.imeCopyPaste.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.imeCopyPaste.test.ts
@@ -34,10 +34,14 @@ describe('useTerminal copy/paste survives a CJK IME (source-level lock)', () => 
   });
 
   it('Ctrl+C copy matches physical KeyC, not only e.key', () => {
+    // Windows/Linux copy uses resolveCtrlLetterByte (logical letter, IME
+    // fallback on KeyC). macOS copy is still Cmd+C with the KeyC fallback.
+    expect(HANDLER).toMatch(/!isMac && resolveCtrlLetterByte\(e\) === '\\x03'/);
     expect(HANDLER).toMatch(/e\.key === 'c' \|\| e\.code === 'KeyC'/);
   });
 
   it('Ctrl+V paste matches physical KeyV, not only e.key', () => {
+    expect(HANDLER).toMatch(/!isMac && resolveCtrlLetterByte\(e\) === '\\x16'/);
     expect(HANDLER).toMatch(/e\.key === 'v' \|\| e\.code === 'KeyV'/);
   });
 

--- a/src/renderer/hooks/__tests__/useTerminal.macCtrlPassthrough.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.macCtrlPassthrough.test.ts
@@ -53,14 +53,13 @@ describe('useTerminal macOS Ctrl passthrough (source-level lock)', () => {
   });
 
   it('Ctrl+C copy interception is non-mac only — mac is always SIGINT', () => {
-    expect(HANDLER).toMatch(
-      /!isMac && e\.ctrlKey && !e\.shiftKey && \(e\.key === 'c' \|\| e\.code === 'KeyC'\)/,
-    );
+    // #1227: copy is still Windows/Linux-only (`!isMac`). The letter match
+    // moved to resolveCtrlLetterByte so Dvorak logical C is SIGINT, with
+    // the physical-KeyC IME fallback inside that helper.
+    expect(HANDLER).toMatch(/!isMac && resolveCtrlLetterByte\(e\) === '\\x03'/);
   });
 
   it('Ctrl+V paste interception is non-mac only — mac passes through to the PTY as quoted-insert', () => {
-    expect(HANDLER).toMatch(
-      /!isMac && e\.ctrlKey && !e\.shiftKey && \(e\.key === 'v' \|\| e\.code === 'KeyV'\)/,
-    );
+    expect(HANDLER).toMatch(/!isMac && resolveCtrlLetterByte\(e\) === '\\x16'/);
   });
 });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1586,8 +1586,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // (kitty / win32-input-mode / modifyOtherKeys). Shift+Enter encoding
     // reads it; unknown = the historical local CSI-u default. An adopted
     // terminal keeps the state its previous mount parked (#1228 review:
-    // otherwise a workspace switch makes a live Codex fall back to CSI-u).
-    const keyboardRef = { current: adopted
+    // otherwise a workspace switch makes a live Codex fall back to CSI-u) —
+    // unless the pane's foreground command died while it was parked: the
+    // alive→dead edge can fire inside the park→adopt window where no
+    // subscription observes it, so the seed refuses the same liveness the
+    // reset below keys on.
+    const seedState = useStore.getState();
+    const parkedKnownGone = seedState.agentAliveByPtyId[ptyId] === false
+      || seedState.commandRunningByPtyId[ptyId] === false;
+    const keyboardRef = { current: adopted && !parkedKnownGone
       ? parkedKeyboardByTerminal.get(terminal) ?? INITIAL_REMOTE_KEYBOARD_STATE
       : INITIAL_REMOTE_KEYBOARD_STATE };
     const noteKeyboard = (data: string | Uint8Array) => {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -28,7 +28,7 @@ import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
 import { resolveCtrlLetterByte } from '../terminal/ctrlLetterKeys';
-import { foldRemoteKeyboardState, INITIAL_REMOTE_KEYBOARD_STATE } from '../components/Remote/keyboardProtocol';
+import { foldRemoteKeyboardState, INITIAL_REMOTE_KEYBOARD_STATE, type RemoteKeyboardState } from '../components/Remote/keyboardProtocol';
 import { attachImeAnchor } from '../terminal/imeAnchor';
 import { attachImeResidueGuard } from '../terminal/imeResidueGuard';
 import { attachImeStormGuard } from '../terminal/imeStormGuard';
@@ -64,6 +64,11 @@ import { adoptTerminal, parkTerminal, restoreParkedViewport, type ParkedTerminal
 // One detector for every pane in this renderer: the ESC-pair state is keyed by
 // ptyId, and a per-mount instance would lose a double-tap split across a remount.
 const interruptKeystrokes = new InterruptKeystrokeDetector();
+
+// #1228 review — keyboard-protocol state parked with the Terminal instance so
+// a restructure-driven unmount/remount (park → adopt, #1002) keeps the
+// negotiation a live TUI armed. Keyed weakly: final disposal drops it.
+const parkedKeyboardByTerminal = new WeakMap<Terminal, RemoteKeyboardState>();
 
 // Module-level terminal registry for scrollback persistence
 const terminalRegistry = new Map<string, Terminal>();
@@ -1579,10 +1584,47 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     // Keyboard-protocol negotiation folded from this pane's own output
     // (kitty / win32-input-mode / modifyOtherKeys). Shift+Enter encoding
-    // reads it; unknown = the historical local CSI-u default.
-    const keyboardRef = { current: INITIAL_REMOTE_KEYBOARD_STATE };
+    // reads it; unknown = the historical local CSI-u default. An adopted
+    // terminal keeps the state its previous mount parked (#1228 review:
+    // otherwise a workspace switch makes a live Codex fall back to CSI-u).
+    const keyboardRef = { current: adopted
+      ? parkedKeyboardByTerminal.get(terminal) ?? INITIAL_REMOTE_KEYBOARD_STATE
+      : INITIAL_REMOTE_KEYBOARD_STATE };
     const noteKeyboard = (data: string | Uint8Array) => {
       keyboardRef.current = foldRemoteKeyboardState(keyboardRef.current, data);
+      parkedKeyboardByTerminal.set(terminal, keyboardRef.current);
+    };
+    // #1228 review (C1): the fold is liveness-scoped. When process-truth or
+    // OSC 133 says the pane's foreground command is gone, any negotiation it
+    // armed (?9001h / kitty push) is stale — the next app in the pane starts
+    // from a clean slate, not the dead app's encoding. Same edges #1210 uses.
+    const unsubscribeKeyboardLiveness = useStore.subscribe((state, prev) => {
+      const gone = (now: boolean | undefined, was: boolean | undefined) =>
+        now === false && was !== false;
+      if (
+        gone(state.commandRunningByPtyId[ptyId], prev.commandRunningByPtyId[ptyId])
+        || gone(state.agentAliveByPtyId[ptyId], prev.agentAliveByPtyId[ptyId])
+      ) {
+        keyboardRef.current = INITIAL_REMOTE_KEYBOARD_STATE;
+        parkedKeyboardByTerminal.delete(terminal);
+      }
+    });
+
+    // Side effects every real user keystroke owes the pane, whichever path
+    // writes the byte. terminal.onData runs these for xterm-encoded keys; the
+    // direct-write branches in the custom key handler run them for bytes we
+    // encode ourselves. Before this, direct writes fed only the dead-input
+    // watchdog, so a directly-written Ctrl+C (0x03) skipped the interrupt
+    // observer and the running dot waited on main's round-trip — the exact
+    // latency the renderer half exists to avoid (Claude 2.1.236 fires no Stop
+    // hook on Ctrl+C).
+    const noteUserKeystroke = (data: string) => {
+      useStore.getState().clearResumeHint(ptyId);
+      deadInputWatchdog.onData();
+      noteTerminalInput(terminal);
+      if (interruptKeystrokes.observe(ptyId, data)) {
+        useStore.getState().clearSurfaceTurnOpen(ptyId);
+      }
     };
 
     // Clipboard + shortcut handling
@@ -1609,7 +1651,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (newlineByte !== null) {
         e.preventDefault();
         window.electronAPI.pty.write(ptyId, newlineByte);
-        deadInputWatchdog.onData(); // direct write bypasses terminal.onData
+        noteUserKeystroke(newlineByte);
         return false;
       }
 
@@ -1628,7 +1670,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (e.code === 'Escape' && !e.isComposing && e.keyCode === 229) {
         e.preventDefault();
         window.electronAPI.pty.write(ptyId, '\x1b');
-        deadInputWatchdog.onData(); // direct write bypasses terminal.onData
+        noteUserKeystroke('\x1b');
         return false;
       }
 
@@ -1658,7 +1700,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         if (disabledCtrl) {
           e.preventDefault();
           window.electronAPI.pty.write(ptyId, disabledCtrl);
-          deadInputWatchdog.onData();
+          noteUserKeystroke(disabledCtrl);
           return false;
         }
         return true;
@@ -1850,7 +1892,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (ctrlByte) {
         e.preventDefault();
         window.electronAPI.pty.write(ptyId, ctrlByte);
-        deadInputWatchdog.onData();
+        noteUserKeystroke(ctrlByte);
         return false;
       }
 
@@ -1991,21 +2033,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // Focus reports are the only non-input bytes observed here; real keys,
       // pastes, and IME commits all still clear as intended.
       if (data !== '\x1b[I' && data !== '\x1b[O') {
-        useStore.getState().clearResumeHint(ptyId);
-        // Real user input reached the app — clear the dead-input watchdog.
-        deadInputWatchdog.onData();
-        // Open the interactive window so this terminal's imminent echo / redraw
-        // takes the zero-latency direct-write path in the output scheduler.
-        // (Focus reports above are excluded — they are not user input.)
-        noteTerminalInput(terminal);
-      }
-      // The interrupt edge, renderer half. Live finding (Claude Code 2.1.236):
-      // Ctrl+C / ESC ESC ends the turn with NO Stop hook, and `claude` stays the
-      // foreground command so OSC 133 never reports the shell back at its
-      // prompt. Main settles the pane from the same bytes; dropping the latch
-      // here flips the dot without waiting for that round-trip. A pane with no
-      // latch is untouched — the delete is a no-op.
-      if (interruptKeystrokes.observe(ptyId, data)) {
+        noteUserKeystroke(data);
+      } else if (interruptKeystrokes.observe(ptyId, data)) {
+        // Not user input, but the interrupt detector still consumes every
+        // chunk: a focus report between two ESC taps is "something else" and
+        // must cancel the double-tap. (Pre-#1228 this observe ran
+        // unconditionally — the split keeps that contract while the pill /
+        // watchdog / scheduler side effects stay gated on real input.)
         useStore.getState().clearSurfaceTurnOpen(ptyId);
       }
       void chunkOnDataIfNeeded(
@@ -2622,6 +2656,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       } else {
         disposeTerminal();
       }
+      unsubscribeKeyboardLiveness();
       terminalRef.current = null;
       fitAddonRef.current = null;
       searchAddonRef.current = null;

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -27,6 +27,8 @@ import {
 import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
+import { resolveCtrlLetterByte } from '../terminal/ctrlLetterKeys';
+import { foldRemoteKeyboardState, INITIAL_REMOTE_KEYBOARD_STATE } from '../components/Remote/keyboardProtocol';
 import { attachImeAnchor } from '../terminal/imeAnchor';
 import { attachImeResidueGuard } from '../terminal/imeResidueGuard';
 import { attachImeStormGuard } from '../terminal/imeStormGuard';
@@ -1575,6 +1577,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
     });
 
+    // Keyboard-protocol negotiation folded from this pane's own output
+    // (kitty / win32-input-mode / modifyOtherKeys). Shift+Enter encoding
+    // reads it; unknown = the historical local CSI-u default.
+    const keyboardRef = { current: INITIAL_REMOTE_KEYBOARD_STATE };
+    const noteKeyboard = (data: string | Uint8Array) => {
+      keyboardRef.current = foldRemoteKeyboardState(keyboardRef.current, data);
+    };
+
     // Clipboard + shortcut handling
     terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true;
@@ -1590,6 +1600,11 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         hasCustomCtrlJBinding: useStore.getState().customKeybindings.some(
           (kb) => kb.key === 'Ctrl+J',
         ),
+        protocol: keyboardRef.current,
+        // Local pane: Claude Code never emits a kitty push but understands
+        // CSI-u. Keep sending it unless the pane asked for win32-input-mode
+        // (Codex on Windows, #1152).
+        shiftEnterFallback: 'csi-u',
       });
       if (newlineByte !== null) {
         e.preventDefault();
@@ -1636,6 +1651,16 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (matchesDisabledShortcut(
         useStore.getState().disabledShortcuts, e, isMac ? 'darwin' : 'win32',
       )) {
+        // #1227 — xterm encodes Ctrl+letter from keyCode (QWERTY position).
+        // Write the logical control byte ourselves so a disabled Ctrl+T on
+        // Dvorak still delivers 0x14 instead of whatever physical keyCode says.
+        const disabledCtrl = resolveCtrlLetterByte(e);
+        if (disabledCtrl) {
+          e.preventDefault();
+          window.electronAPI.pty.write(ptyId, disabledCtrl);
+          deadInputWatchdog.onData();
+          return false;
+        }
         return true;
       }
       const bubbleKeys = isMac
@@ -1723,21 +1748,19 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
             ptyId,
             write: (d) => window.electronAPI.pty.write(ptyId, d),
             bracketedPasteMode: !!imgModes?.bracketedPasteMode,
+            screenIsAlternate: terminal.buffer.active.type === 'alternate',
           });
         })().catch(() => {});
         return false;
       }
 
-      // Ctrl+C: copy if selection exists, otherwise send SIGINT. Match physical
-      // `code` (KeyC) too — under a CJK IME xterm derives Ctrl+<letter> from the
-      // deprecated keyCode, which becomes 229 ("Process"), so `e.key` is the
-      // composed jamo ('ㅊ') or 'Process' rather than 'c'. Without the code
-      // fallback the copy silently falls through to SIGINT (the reported "Ctrl+C
-      // copy broken in Hangul mode" bug). Same IME class as the Ctrl+J / Escape
-      // handlers above.
+      // Ctrl+C: copy if selection exists, otherwise fall through so the
+      // layout-correct encoder below writes SIGINT. Match the LOGICAL letter
+      // (Dvorak C is physical I — #1227) with an IME fallback on physical
+      // KeyC when `key` is mangled to Process/jamo (Hangul copy).
       // macOS는 복사가 Cmd+C 전담(위 분기)이므로 Ctrl+C는 항상 SIGINT — 선택영역이
       // 남아 있어도 인터럽트를 가로채지 않는다(owner-reported 2026-07-19).
-      if (!isMac && e.ctrlKey && !e.shiftKey && (e.key === 'c' || e.code === 'KeyC')) {
+      if (!isMac && resolveCtrlLetterByte(e) === '\x03') {
         const sel = terminal.getSelection();
         if (sel) {
           // main now throws on clipboard failure — await + catch so the
@@ -1745,14 +1768,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           void copySelectionWithFeedback(terminal, sel);
           return false;
         }
-        return true; // no selection → SIGINT
+        // no selection → SIGINT via resolveCtrlLetterByte at the end of this handler
       }
 
       // Ctrl+V: paste from clipboard (use our IPC clipboard, block event
       // so xterm doesn't also paste via browser's native paste event)
       // mac은 Cmd+V가 붙여넣기 전담(위 분기) — Ctrl+V는 readline quoted-insert
       // (verbatim)이므로 PTY로 통과시킨다.
-      if (!isMac && e.ctrlKey && !e.shiftKey && (e.key === 'v' || e.code === 'KeyV')) {
+      if (!isMac && resolveCtrlLetterByte(e) === '\x16') {
         e.preventDefault();
         // isMac 게이트: blockNativePaste 리스너가 비-macOS에선 등록조차 안 되므로(위 참고)
         // 스탬프도 macOS에서만 찍는다 — 안 그러면 나중에 등록 게이트를 넓힐 때 값이 이미
@@ -1777,6 +1800,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
             ptyId,
             write: (d) => window.electronAPI.pty.write(ptyId, d),
             bracketedPasteMode: !!imgModes?.bracketedPasteMode,
+            screenIsAlternate: terminal.buffer.active.type === 'alternate',
           });
         })().catch(() => {});
         return false;
@@ -1812,8 +1836,21 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
             ptyId,
             write: (d) => window.electronAPI.pty.write(ptyId, d),
             bracketedPasteMode: !!imgModes?.bracketedPasteMode,
+            screenIsAlternate: terminal.buffer.active.type === 'alternate',
           });
         })().catch(() => {});
+        return false;
+      }
+
+      // #1227 — remaining Ctrl+letters (SIGINT, EOF, Ctrl+Z, …). xterm encodes
+      // these from keyCode, which is the QWERTY position, so a Dvorak Ctrl+C
+      // became Ctrl+I. Write the logical control byte ourselves. App shortcuts
+      // and clipboard chords already returned above.
+      const ctrlByte = resolveCtrlLetterByte(e);
+      if (ctrlByte) {
+        e.preventDefault();
+        window.electronAPI.pty.write(ptyId, ctrlByte);
+        deadInputWatchdog.onData();
         return false;
       }
 
@@ -1922,6 +1959,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           ptyId,
           write: (d) => window.electronAPI.pty.write(ptyId, d),
           bracketedPasteMode: !!modes?.bracketedPasteMode,
+          screenIsAlternate: terminal.buffer.active.type === 'alternate',
         });
       })().catch((err) => console.error('[wmux:clipboard] right-click error:', err));
     };
@@ -2122,6 +2160,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       deliverPtyData({ ...payload, data: restingCursor.process(payload.data) });
     };
     const deliverPtyData = (payload: PtyDataPayload) => {
+      // Fold before the resync buffer so a ?9001h that arrives mid-resync
+      // still arms Shift+Enter encoding (#1152).
+      noteKeyboard(payload.data);
       const st = resyncRef.current;
       if (st.pending) {
         st.buffer.push(payload);
@@ -2263,6 +2304,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // Restored scrollback is the oldest replay of all — bytes from a
           // previous run of this pane. Muted (#998).
           writeReplayed(terminal, restored, replayMuteRef.current);
+          noteKeyboard(restored);
           // #952: the fresh PTY about to connect starts from an empty ConPTY
           // whose absolute coordinates begin at row 1 — restored rows left in
           // the viewport get overdrawn by its first absolute repaint

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -2304,7 +2304,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // Restored scrollback is the oldest replay of all — bytes from a
           // previous run of this pane. Muted (#998).
           writeReplayed(terminal, restored, replayMuteRef.current);
-          noteKeyboard(restored);
+          // Do not fold restored scrollback into keyboardRef: those bytes
+          // are from a previous run. A leftover ?9001h would make Shift+Enter
+          // send win32-input-mode to the fresh shell (#1228 review). Live
+          // PTY data still folds through deliverPtyData.
           // #952: the fresh PTY about to connect starts from an empty ConPTY
           // whose absolute coordinates begin at row 1 — restored rows left in
           // the viewport get overdrawn by its first absolute repaint

--- a/src/renderer/stores/slices/paneSlice.ts
+++ b/src/renderer/stores/slices/paneSlice.ts
@@ -187,7 +187,8 @@ export interface PaneSlice {
   // detected agent name + last status for the life of the PTY so a2a_discover /
   // surface_list / pane_list can label each pane individually — one workspace
   // can host >1 agent (gaps 1/3/8). Populated from METADATA_UPDATE in
-  // useNotificationListener; cleared when the owning surface/pane closes.
+  // useNotificationListener; cleared when the owning surface/pane closes
+  // OR when process-truth / OSC 133 say the agent has left (#1210).
   // Transient — never persisted (buildSessionData allowlist excludes it).
   surfaceAgent: Record<string, { name: string; status: AgentStatus; slug?: AgentSlug }>;
   setSurfaceAgent: (ptyId: string, name: string | undefined, status: AgentStatus | undefined, slug?: AgentSlug) => void;

--- a/src/renderer/terminal/__tests__/ctrlLetterKeys.test.ts
+++ b/src/renderer/terminal/__tests__/ctrlLetterKeys.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCtrlLetterByte, type CtrlLetterEventLike } from '../ctrlLetterKeys';
+
+function ev(partial: Partial<CtrlLetterEventLike>): CtrlLetterEventLike {
+  return {
+    key: '',
+    code: '',
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    isComposing: false,
+    ...partial,
+  };
+}
+
+describe('resolveCtrlLetterByte — Dvorak / logical key (#1227)', () => {
+  it('emits SIGINT (0x03) from logical C even when the physical key is I', () => {
+    // Dvorak: the key that types "c" sits where QWERTY I is. keyCode would be
+    // 73, and xterm would emit Ctrl+I (tab). We encode from e.key instead.
+    expect(resolveCtrlLetterByte(ev({ key: 'c', code: 'KeyI', ctrlKey: true }))).toBe('\x03');
+  });
+
+  it('emits Ctrl+J (LF) from logical J on the physical C key, not SIGINT', () => {
+    // The IME fallback must NOT treat physical KeyC as C when the layout
+    // already reported a Latin letter — that is how Dvorak J would steal copy.
+    expect(resolveCtrlLetterByte(ev({ key: 'j', code: 'KeyC', ctrlKey: true }))).toBe('\n');
+  });
+
+  it('emits Ctrl+Z from logical Z', () => {
+    expect(resolveCtrlLetterByte(ev({ key: 'z', code: 'KeySlash', ctrlKey: true }))).toBe('\x1a');
+  });
+});
+
+describe('resolveCtrlLetterByte — IME fallback', () => {
+  it('falls back to physical KeyC when the IME mangles key to Process', () => {
+    expect(resolveCtrlLetterByte(ev({ key: 'Process', code: 'KeyC', ctrlKey: true }))).toBe('\x03');
+  });
+
+  it('falls back to physical KeyC when the IME reports a Hangul jamo', () => {
+    expect(resolveCtrlLetterByte(ev({ key: 'ㅊ', code: 'KeyC', ctrlKey: true }))).toBe('\x03');
+  });
+});
+
+describe('resolveCtrlLetterByte — guards', () => {
+  it('ignores Shift/Alt/Meta and an active IME composition', () => {
+    expect(resolveCtrlLetterByte(ev({ key: 'c', code: 'KeyC', ctrlKey: true, shiftKey: true }))).toBeNull();
+    expect(resolveCtrlLetterByte(ev({ key: 'c', code: 'KeyC', ctrlKey: true, altKey: true }))).toBeNull();
+    expect(resolveCtrlLetterByte(ev({ key: 'c', code: 'KeyC', ctrlKey: true, metaKey: true }))).toBeNull();
+    expect(resolveCtrlLetterByte(ev({ key: 'c', code: 'KeyC', ctrlKey: true, isComposing: true }))).toBeNull();
+  });
+
+  it('ignores a bare C (no Ctrl) and non-letter keys', () => {
+    expect(resolveCtrlLetterByte(ev({ key: 'c', code: 'KeyC' }))).toBeNull();
+    expect(resolveCtrlLetterByte(ev({ key: 'Enter', code: 'Enter', ctrlKey: true }))).toBeNull();
+  });
+});

--- a/src/renderer/terminal/__tests__/newlineKeys.test.ts
+++ b/src/renderer/terminal/__tests__/newlineKeys.test.ts
@@ -66,8 +66,40 @@ describe('resolveNewlineKeyByte — Ctrl+J', () => {
 });
 
 describe('resolveNewlineKeyByte — Shift+Enter (preserved behavior)', () => {
-  it('emits CSI u for Shift+Enter', () => {
+  it('emits CSI u for Shift+Enter on a local pane (default fallback)', () => {
     expect(resolveNewlineKeyByte(ev({ key: 'Enter', shiftKey: true }))).toBe('\x1b[13;2u');
+  });
+
+  it('emits the win32-input-mode pair when the pane negotiated ?9001h (#1152)', () => {
+    expect(
+      resolveNewlineKeyByte(ev({ key: 'Enter', shiftKey: true }), {
+        protocol: { win32Input: true },
+      }),
+    ).toBe('\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_');
+  });
+
+  it('prefers win32-input-mode over kitty when both were seen', () => {
+    // Codex on Windows requests 9001; a stray kitty sequence must not win.
+    expect(
+      resolveNewlineKeyByte(ev({ key: 'Enter', shiftKey: true }), {
+        protocol: { win32Input: true, kitty: true },
+      }),
+    ).toBe('\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_');
+  });
+
+  it('hands Shift+Enter back to xterm when a mirror/web viewer saw no protocol', () => {
+    expect(
+      resolveNewlineKeyByte(ev({ key: 'Enter', shiftKey: true }), { shiftEnterFallback: 'xterm' }),
+    ).toBeNull();
+  });
+
+  it('emits CSI u for a mirror once the remote asked for kitty', () => {
+    expect(
+      resolveNewlineKeyByte(ev({ key: 'Enter', shiftKey: true }), {
+        protocol: { kitty: true },
+        shiftEnterFallback: 'xterm',
+      }),
+    ).toBe('\x1b[13;2u');
   });
 
   it('ignores plain Enter', () => {

--- a/src/renderer/terminal/ctrlLetterKeys.ts
+++ b/src/renderer/terminal/ctrlLetterKeys.ts
@@ -1,0 +1,53 @@
+/**
+ * Layout-correct Ctrl+<letter> encoding for the terminal input path.
+ *
+ * xterm.js derives Ctrl+A…Ctrl+Z from the deprecated `KeyboardEvent.keyCode`
+ * (it looks for 65–90 and emits `String.fromCharCode(keyCode - 64)`). keyCode
+ * is the physical QWERTY position, so on Dvorak the logical C key is physical
+ * I: xterm emits Ctrl+I (0x09) instead of SIGINT (0x03). That is #1227 —
+ * "Ctrl+C does not interrupt Claude until I switch back to QWERTY."
+ *
+ * The rest of wmux already matches *logical* `event.key` for Enter and the
+ * *physical* `event.code` as an IME fallback (Hangul / Pinyin report
+ * `key === 'Process'` / a jamo, while `code` stays `KeyC`). This helper
+ * applies that same split to control letters:
+ *
+ *   1. A Latin `key` (`a`–`z`) wins. Dvorak/Colemak get the letter they typed.
+ *   2. Otherwise, a `KeyA`–`KeyZ` `code` is the IME fallback. Physical C on
+ *      Dvorak is the letter J, but that path is not taken — `key` is already
+ *      Latin, so step 1 fires.
+ *
+ * Returns `null` when the event is not a bare Ctrl+letter (other modifiers,
+ * composition, non-letter keys). Callers then defer to xterm or to a more
+ * specific handler (copy, app shortcut, …).
+ */
+
+export interface CtrlLetterEventLike {
+  key: string;
+  code: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  isComposing: boolean;
+}
+
+const LATIN = /^[a-z]$/;
+const PHYSICAL_LETTER = /^Key([A-Z])$/;
+
+function ctrlByteForLetter(letter: string): string {
+  // 'a' → 0x01, 'c' → 0x03, 'z' → 0x1a. Same formula xterm uses on keyCode.
+  return String.fromCharCode(letter.toUpperCase().charCodeAt(0) - 64);
+}
+
+export function resolveCtrlLetterByte(e: CtrlLetterEventLike): string | null {
+  if (!e.ctrlKey || e.shiftKey || e.altKey || e.metaKey || e.isComposing) return null;
+
+  const latin = e.key.length === 1 ? e.key.toLowerCase() : '';
+  if (LATIN.test(latin)) return ctrlByteForLetter(latin);
+
+  const physical = PHYSICAL_LETTER.exec(e.code);
+  if (physical) return ctrlByteForLetter(physical[1]);
+
+  return null;
+}

--- a/src/renderer/terminal/newlineKeys.ts
+++ b/src/renderer/terminal/newlineKeys.ts
@@ -18,9 +18,9 @@
  *   regardless of IME state.
  *
  * Returned byte:
- *   - Shift+Enter → CSI u (`ESC [ 13 ; 2 u`): Claude Code / kitty-protocol
- *     apps insert a newline instead of submitting. (Pre-existing behavior,
- *     moved here verbatim.)
+ *   - Shift+Enter → protocol-aware (see encodeShiftEnter): kitty CSI-u,
+ *     win32-input-mode (`?9001h`, Codex on Windows — #1152), or xterm's
+ *     own encoding when the caller says the app never negotiated.
  *   - Ctrl+Enter → LF (`\n`): same intent as Ctrl+J. With no extended keyboard
  *     protocol enabled, xterm sends a bare CR for Ctrl+Enter — byte-identical
  *     to plain Enter — so an in-pane TUI submits instead of inserting a
@@ -46,6 +46,27 @@ export interface NewlineKeyEventLike {
   isComposing: boolean;
 }
 
+/**
+ * What the pane's app asked the terminal to send for modified keys.
+ *
+ * Folded from the pane's own output (keyboardProtocol.ts). Unknown fields
+ * are treated as "not negotiated."
+ */
+export interface KeyboardProtocolHint {
+  kitty?: boolean;
+  win32Input?: boolean;
+  modifyOtherKeys?: 0 | 1 | 2;
+}
+
+/**
+ * When no keyboard protocol is negotiated, a local pane still sends CSI-u
+ * (Claude Code never emits a kitty push, yet understands the byte — the
+ * historical newlineKeys behaviour). A mirror / web viewer must not: the
+ * app on the other side never negotiated with this xterm, so CSI-u is
+ * Escape + garbage. Those callers pass `'xterm'` and we return null.
+ */
+export type ShiftEnterFallback = 'csi-u' | 'xterm';
+
 export interface NewlineKeyOptions {
   /**
    * Whether the user has bound Ctrl+J to a custom keybinding. When true we
@@ -55,17 +76,58 @@ export interface NewlineKeyOptions {
    * but we must not actively override it with an LF.)
    */
   hasCustomCtrlJBinding?: boolean;
+  /** Observed keyboard-protocol negotiation. Absent = nothing observed. */
+  protocol?: KeyboardProtocolHint;
+  /**
+   * What to send for Shift+Enter when `protocol` names no encoding.
+   * Defaults to `'csi-u'` (local pane). Remote/web pass `'xterm'`.
+   */
+  shiftEnterFallback?: ShiftEnterFallback;
+}
+
+/** Kitty CSI-u Shift+Enter. Claude Code inserts a newline instead of submitting. */
+export const SHIFT_ENTER_CSI_U = '\x1b[13;2u';
+
+/**
+ * win32-input-mode Shift+Enter (`CSI Vk;Sc;Uc;Kd;Cs;Rc _`).
+ *
+ * VK_RETURN=13, scan 0x1C=28, Unicode CR=13, key-down, SHIFT_PRESSED=0x10,
+ * repeat 1 — then the matching key-up (Unicode 0, key-down 0). Codex on
+ * Windows negotiates `?9001h` and does not understand CSI-u (#1152).
+ */
+export const SHIFT_ENTER_WIN32 =
+  '\x1b[13;28;13;1;16;1_\x1b[13;28;0;0;16;1_';
+
+/** xterm modifyOtherKeys mode 2: CSI 27 ; 2 ; 13 ~ */
+export const SHIFT_ENTER_MODIFY_OTHER_KEYS = '\x1b[27;2;13~';
+
+/**
+ * Encode Shift+Enter for the protocol the pane actually asked for.
+ *
+ * Win32-input-mode wins over kitty: Codex on Windows requests `?9001h` and
+ * will misread CSI-u as Escape + `[13;2u`. modifyOtherKeys mode 2 is the
+ * other non-CSI-u encoding we know how to produce. Everything else follows
+ * `fallback`.
+ */
+export function encodeShiftEnter(
+  protocol: KeyboardProtocolHint | undefined,
+  fallback: ShiftEnterFallback,
+): string | null {
+  if (protocol?.win32Input) return SHIFT_ENTER_WIN32;
+  if (protocol?.kitty) return SHIFT_ENTER_CSI_U;
+  if (protocol?.modifyOtherKeys === 2) return SHIFT_ENTER_MODIFY_OTHER_KEYS;
+  return fallback === 'csi-u' ? SHIFT_ENTER_CSI_U : null;
 }
 
 export function resolveNewlineKeyByte(
   e: NewlineKeyEventLike,
   opts?: NewlineKeyOptions,
 ): string | null {
-  // Shift+Enter → CSI u so Claude Code inserts a newline instead of submitting.
-  // Kitty keyboard protocol: ESC [ 13 ; 2 u. (metaKey intentionally not
-  // constrained — preserves the original inline handler's exact predicate.)
+  // Shift+Enter. Encoding depends on what the pane negotiated (kitty CSI-u,
+  // win32-input-mode, modifyOtherKeys). metaKey is intentionally not
+  // constrained — preserves the original inline handler's exact predicate.
   if (e.key === 'Enter' && e.shiftKey && !e.ctrlKey && !e.altKey) {
-    return '\x1b[13;2u';
+    return encodeShiftEnter(opts?.protocol, opts?.shiftEnterFallback ?? 'csi-u');
   }
 
   // Ctrl+Enter → LF, same intent as Ctrl+J: insert a newline without

--- a/src/renderer/utils/__tests__/imagePaste.test.ts
+++ b/src/renderer/utils/__tests__/imagePaste.test.ts
@@ -29,6 +29,19 @@ beforeEach(() => {
 });
 
 describe('pasteClipboardImage', () => {
+  it('auto + Claude pane after the TUI has left: path route, not the native key (#1210)', async () => {
+    const readImage = stubClipboard({ hasImage: true, imagePath: '/tmp/x.png' });
+    useStore.getState().setSurfaceAgent(PTY, 'Claude Code', 'running', 'claude');
+    const write = vi.fn();
+
+    await pasteClipboardImage({
+      ptyId: PTY, write, bracketedPasteMode: false, screenIsAlternate: false,
+    });
+
+    expect(write).toHaveBeenCalledWith('/tmp/x.png');
+    expect(readImage).toHaveBeenCalledWith(PTY);
+  });
+
   it('auto + Claude pane: sends the agent its own paste key and writes no temp file', async () => {
     const readImage = stubClipboard({ hasImage: true, imagePath: '/tmp/x.png' });
     useStore.getState().setSurfaceAgent(PTY, 'Claude Code', 'running', 'claude');

--- a/src/renderer/utils/imagePaste.ts
+++ b/src/renderer/utils/imagePaste.ts
@@ -28,19 +28,18 @@ export async function pasteClipboardImage(opts: {
   ptyId: string;
   write: (data: string) => void;
   bracketedPasteMode: boolean;
+  /** xterm alternate-screen bit. `false` means a shell, not a TUI (#1210). */
+  screenIsAlternate?: boolean;
 }): Promise<boolean> {
   const { ptyId, write, bracketedPasteMode } = opts;
 
   const state = useStore.getState();
-  // Known limit of the auto route: a pane's detected agent slug is retained
-  // after the agent exits (nothing clears surfaceAgent), so pasting an image
-  // into the plain shell left behind by a finished Claude session sends the
-  // key to readline, where it is quoted-insert and the image is dropped. The
-  // 'path' setting is the escape hatch until agent-exit detection clears the
-  // slug.
   const strategy = resolveImagePasteStrategy({
     mode: state.imagePasteMode,
     agentSlug: state.surfaceAgent[ptyId]?.slug,
+    screenIsAlternate: opts.screenIsAlternate,
+    agentProcessAlive: state.agentAliveByPtyId[ptyId],
+    commandRunning: state.commandRunningByPtyId[ptyId],
   });
 
   // No platform means no way to know WHICH key the agent listens on, and the

--- a/src/shared/__tests__/imagePaste.test.ts
+++ b/src/shared/__tests__/imagePaste.test.ts
@@ -18,6 +18,22 @@ describe('resolveImagePasteStrategy (#1196)', () => {
     expect(resolveImagePasteStrategy({ mode: 'auto', agentSlug: undefined })).toBe('path');
   });
 
+  it('auto does not trust a stale slug once the TUI has left (#1210)', () => {
+    expect(resolveImagePasteStrategy({
+      mode: 'auto', agentSlug: 'claude', screenIsAlternate: false,
+    })).toBe('path');
+    expect(resolveImagePasteStrategy({
+      mode: 'auto', agentSlug: 'claude', agentProcessAlive: false,
+    })).toBe('path');
+    expect(resolveImagePasteStrategy({
+      mode: 'auto', agentSlug: 'claude', commandRunning: false,
+    })).toBe('path');
+    // Unknown liveness still trusts the slug — the TUI may be up.
+    expect(resolveImagePasteStrategy({
+      mode: 'auto', agentSlug: 'claude', screenIsAlternate: true,
+    })).toBe('native');
+  });
+
   it('explicit modes ignore the detected agent', () => {
     expect(resolveImagePasteStrategy({ mode: 'native', agentSlug: undefined })).toBe('native');
     expect(resolveImagePasteStrategy({ mode: 'path', agentSlug: 'claude' })).toBe('path');

--- a/src/shared/imagePaste.ts
+++ b/src/shared/imagePaste.ts
@@ -68,16 +68,37 @@ export interface ImagePasteStrategyInput {
   mode: ImagePasteMode;
   /** Detected agent slug for the target PTY, if any. */
   agentSlug?: string | null;
+  /**
+   * Whether the pane's xterm buffer is the alternate screen (a full-screen
+   * TUI). `false` means the agent has left and a shell prompt is showing —
+   * the slug is then a lie (#1210).
+   */
+  screenIsAlternate?: boolean;
+  /** Process-truth liveness from AgentProcessTracker. `false` = observed dead. */
+  agentProcessAlive?: boolean;
+  /** OSC 133: `false` = the shell is back at a prompt. */
+  commandRunning?: boolean;
 }
 
 /** Which route an image-only clipboard takes for this pane. */
 export function resolveImagePasteStrategy({
   mode,
   agentSlug,
+  screenIsAlternate,
+  agentProcessAlive,
+  commandRunning,
 }: ImagePasteStrategyInput): 'native' | 'path' {
   if (mode === 'path') return 'path';
   if (mode === 'native') return 'native';
-  return agentSupportsNativeImagePaste(agentSlug) ? 'native' : 'path';
+  if (!agentSupportsNativeImagePaste(agentSlug)) return 'path';
+  // #1210: the slug is stamped on detect and was never cleared on exit, so a
+  // finished Claude session still looks like Claude. Negative liveness — left
+  // the alt screen, process died, or OSC 133 says the shell is back — means
+  // the native key would land in readline as quoted-insert and drop the image.
+  if (screenIsAlternate === false) return 'path';
+  if (agentProcessAlive === false) return 'path';
+  if (commandRunning === false) return 'path';
+  return 'native';
 }
 
 /** Windows-side WSL tooling that is not a shell — a /mnt path there is wrong. */


### PR DESCRIPTION
Production bugs that actually break users today. Three related input/identity misses, one PR because they all sit on the local pane's key path.

## What

**#1227 Dvorak Ctrl+C never interrupts.** xterm.js encodes Ctrl+letter from `keyCode` (QWERTY position). On Dvorak the logical C key is physical I, so the PTY got Ctrl+I (tab) instead of SIGINT. We now write the control byte from logical `e.key`, and only fall back to physical `KeyA`–`KeyZ` when an IME has mangled `key` to Process/jamo.

**#1152 remaining: Codex Shift+Enter on Windows.** Local panes always sent kitty CSI-u `\x1b[13;2u`. Codex negotiates win32-input-mode (`?9001h`) and does not understand that byte. Keyboard-protocol fold now tracks 9001 the same way it already tracks kitty, and Shift+Enter is encoded as the KEY_EVENT_RECORD pair when that is what the app asked for. Claude still gets CSI-u — it never emits a kitty push, which is why the local default stays CSI-u.

**#1210 pane keeps its agent slug after the agent exits.** `clearSurfaceAgent` had no production caller, so a finished Claude session still looked like Claude. Image-paste `auto` then sent the native key into readline and dropped the screenshot. The native route now refuses a slug once the TUI has left the alt screen, the agent process is known dead, or OSC 133 says the shell is back. The identity map is cleared on those same edges.

## Not in this PR

- **#1111** grandfather-lane close — draft #1139, calendar lock until 2026-09-30.
- **#1107** remaining Codex `PermissionRequest` mapping — needs an interactive TUI session.
- Features / P3 polish.

Also closed as not actionable from this side:

- **#936** Win10 Codex wheel — deadline 2026-09-04 passed, no reporter readouts.
- **#901** Kimi IME — #888 shipped in 3.43/3.44, no retest.

Closes #1227
Closes #1152
Closes #1210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ctrl+C and other Ctrl+letter shortcuts now work correctly with Dvorak and other keyboard layouts while preserving IME behavior.
  - Shift+Enter in Codex panes on Windows now uses the negotiated input format for reliable submission.
  - Shift+Enter in remote and mirrored terminals now respects the active keyboard protocol.
  - Pasting images after an agent exits its TUI now correctly inserts the image file path.
  - Stale agent detection is cleared when the agent process or command is no longer running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-ups

Merged after a full review (4 specialists + red team + adversarial). Criticals fixed on-branch: keyboard-protocol state is liveness-scoped and survives pane park/re-adoption; every direct-write control byte now feeds the interrupt observer; the #1210 AppLayout wiring and the ctrl-letter encoding are source-locked. Also repaired a pre-existing windows-latest-only source-lock failure (CRLF window drift) that had this branch CI-red before the review-fix commits.
