### PR TITLE
fix(audit): count only external-wire callers as legacy traffic (#1111)

### DIFF
--- a/changelog.d/1229.md
+++ b/changelog.d/1229.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Legacy-traffic audit now counts only external-wire callers.** The shadow log and trust-DB legacy records exist to show which no-`clientName` integrations are still calling before the grandfather lane closes (#1111, announced for 2026-09-30). They were also counting wmux's own renderer bridge and plugin host, which send no `clientName` by design — on a dogfood box that noise was ~636k of the ~639k recorded calls (`events.poll` 445k, `task.mission.list` 191k), drowning the signal the close decision relies on. Both audit channels now use the same wire-provenance check the permission lanes use, so anything new in `shadow-rejections.log` is a real external caller. (#1229)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -329,7 +329,7 @@ Either default can be overridden explicitly via the config key. The enforcement 
 
 Plugin identity rides the JSON-RPC envelope as `clientName` (and optional `clientVersion`). The MCP server (`src/mcp/index.ts`) populates them from the MCP `InitializeRequest.clientInfo` so the substrate can attribute every call to a declared plugin. Identity is **declared, not verified** — there is no root-of-trust today; threat-model details live in `api/mcp-plugin-spec.md`.
 
-Requests without `clientName` are recorded as `legacy`. That grandfather is now on a deprecation clock: **the lane closes in the first release on or after 2026-09-30** (#1111). After the close, envelope-less requests are refused; `wmux-cli` remains as an honestly-labelled limited lane (curated allowlist, no approval dialog).
+Requests without `clientName` **on the external wire** are recorded as `legacy` — the trusted in-process surfaces (renderer bridge, iframe plugin host) send no `clientName` by design and are not recorded. That grandfather is now on a deprecation clock: **the lane closes in the first release on or after 2026-09-30** (#1111). After the close, envelope-less requests are refused; `wmux-cli` remains as an honestly-labelled limited lane (curated allowlist, no approval dialog).
 
 The trust DB lives at `~/.wmux/plugin-trust.json` (atomic-write, single-process owner = wmux main). Per-plugin record shape (`PluginIdentityRecord` in `src/shared/rpc.ts`):
 

--- a/src/main/audit/shadowRejectionLog.ts
+++ b/src/main/audit/shadowRejectionLog.ts
@@ -38,8 +38,9 @@ import type { RpcMethod, RpcRejection } from '../../shared/rpc';
  * starts with three kinds:
  *
  *   - 'rejection'       — would-be permission rejection (shadow mode)
- *   - 'legacy-traffic'  — per-method legacy (envelope-less) call counts,
- *                          emitted at threshold milestones (1, 10, 100, ...)
+ *   - 'legacy-traffic'  — per-method legacy (external-wire envelope-less)
+ *                          call counts, emitted at threshold milestones
+ *                          (1, 10, 100, ...)
  *   - 'browser-scope'    — a browser target lookup the future caller-scope
  *                          enforcement would refuse (#810)
  *

--- a/src/main/mcp/__tests__/phase-2-1-e2e.test.ts
+++ b/src/main/mcp/__tests__/phase-2-1-e2e.test.ts
@@ -101,9 +101,12 @@ function readDbFromDisk(): {
 
 describe('phase 2.1 production wiring — multi-step RPC sequence', () => {
   it('replays a realistic plugin lifecycle and verifies disk state at each step', async () => {
-    // === Step 1: envelope-less RPC (pre-v2.10 caller or pre-handshake race)
-    // Expected: legacy 'unknown' entry persisted, status === 'legacy'.
-    await router.dispatch({ id: 's1', method: 'pane.list', params: {} });
+    // === Step 1: envelope-less wire RPC (pre-v2.10 caller or pre-handshake
+    // race) Expected: legacy 'unknown' entry persisted, status === 'legacy'.
+    await router.dispatch(
+      { id: 's1', method: 'pane.list', params: {} },
+      { externalWire: true },
+    );
     // Fire-and-forget audit write — let the next tick land it on disk.
     await drainWrites();
     await settle();
@@ -120,7 +123,10 @@ describe('phase 2.1 production wiring — multi-step RPC sequence', () => {
     // record itself because applyContact would advance lastSeen.
     const mtimeAfterStep1 = fs.statSync(dbPath).mtimeMs;
     await settle(10);
-    await router.dispatch({ id: 's2', method: 'pane.list', params: {} });
+    await router.dispatch(
+      { id: 's2', method: 'pane.list', params: {} },
+      { externalWire: true },
+    );
     await drainWrites();
     await settle();
     const mtimeAfterStep2 = fs.statSync(dbPath).mtimeMs;

--- a/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
+++ b/src/main/mcp/__tests__/phase-2-2-dynamic.test.ts
@@ -119,10 +119,13 @@ afterEach(() => {
 
 describe('phase 2.2 dynamic — full plugin lifecycle against real disk', () => {
   it('replays the unconfirmed → trusted → capability-mismatch sequence', async () => {
-    // === Step 1: envelope-less RPC. Legacy path runs — trust DB gets a
+    // === Step 1: envelope-less wire RPC. Legacy path runs — trust DB gets a
     // 'legacy' row, traffic counter ticks (milestone 1 → log entry), but
     // the enforcer ALLOWS legacy so no shadow rejection lands.
-    await router.dispatch({ id: 's1', method: 'pane.list', params: {} });
+    await router.dispatch(
+      { id: 's1', method: 'pane.list', params: {} },
+      { externalWire: true },
+    );
     await drainWrites();
     await settle();
 
@@ -309,14 +312,17 @@ describe('phase 2.2 dynamic — full plugin lifecycle against real disk', () => 
   });
 
   it('produces legacy-traffic milestones at configured thresholds', async () => {
-    // 6 envelope-less RPCs against `pane.list`. With milestones=[1,3,5],
+    // 6 envelope-less wire RPCs against `pane.list`. With milestones=[1,3,5],
     // log gets entries at calls 1, 3, 5 (3 entries).
     for (let i = 0; i < 6; i++) {
-      await router.dispatch({
-        id: `legacy-${i}`,
-        method: 'pane.list',
-        params: {},
-      });
+      await router.dispatch(
+        {
+          id: `legacy-${i}`,
+          method: 'pane.list',
+          params: {},
+        },
+        { externalWire: true },
+      );
     }
     await drainWrites();
     await settle();
@@ -331,9 +337,12 @@ describe('phase 2.2 dynamic — full plugin lifecycle against real disk', () => 
   });
 
   it('counts distinct methods separately', async () => {
-    await router.dispatch({ id: 'a-1', method: 'pane.list', params: {} });
-    await router.dispatch({ id: 'b-1', method: 'input.send', params: { text: 'x' } });
-    await router.dispatch({ id: 'a-2', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'a-1', method: 'pane.list', params: {} }, { externalWire: true });
+    await router.dispatch(
+      { id: 'b-1', method: 'input.send', params: { text: 'x' } },
+      { externalWire: true },
+    );
+    await router.dispatch({ id: 'a-2', method: 'pane.list', params: {} }, { externalWire: true });
     await drainWrites();
     await settle();
 

--- a/src/main/pipe/RpcRouter.ts
+++ b/src/main/pipe/RpcRouter.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../shared/rpc';
 import { sanitizeClientDisplayName } from '../../shared/rpc';
 import { check as enforcerCheck } from '../mcp/PermissionEnforcer';
+import { isLocalExternalWireContext } from '../mcp/rpcProvenance';
 import { commanderTokenWorkspace } from '../deck/commanderTrust';
 import { COMMANDER_TEARDOWN_DENY } from '../../shared/commanderSurface';
 import type { EnforcementMode } from '../mcp/enforcementMode';
@@ -28,10 +29,10 @@ type RpcHandler = (
 ) => Promise<unknown>;
 
 // Optional sink for legacy-contact bookkeeping — wired in main/index.ts
-// to PluginTrustStore.upsertLegacyContact so an envelope-less RPC ends up
-// in plugin-trust.json as a `legacy` record. RpcRouter does not import
-// the trust store directly: it stays storage-agnostic, tests opt in by
-// passing their own recorder, and unit tests stay isolated from the
+// to PluginTrustStore.upsertLegacyContact so an envelope-less wire RPC
+// ends up in plugin-trust.json as a `legacy` record. RpcRouter does not
+// import the trust store directly: it stays storage-agnostic, tests opt
+// in by passing their own recorder, and unit tests stay isolated from the
 // real ~/.wmux state.
 type LegacyContactRecorder = (method: RpcMethod) => void;
 
@@ -440,12 +441,20 @@ export class RpcRouter {
           : { kind: 'stale' };
     }
 
-    // Spec §2.2: requests without `clientName` are recorded as `legacy`.
-    // Two side-channels fire here:
+    // Spec §2.2: external-wire requests without `clientName` are recorded as
+    // `legacy`. The trusted in-process surfaces are excluded: the renderer
+    // bridge (`operator`) and the iframe plugin host (`firstParty`) send no
+    // clientName by design, so counting them here drowned the wire signal in
+    // renderer polling (events.poll alone accounted for ~445k dogfood
+    // entries) — and this counter is the evidence base for the #1111 close
+    // decision, which must see only envelope-less WIRE callers. The in-process
+    // lanes were never the grandfather's audience (#1139 exempts them at the
+    // enforcement points for the same reason). Two side-channels fire here:
     //
     //   1. Process-once trust-DB write (`legacyRecorder`) — one row per
     //      process in `~/.wmux/plugin-trust.json`. Enough to signal "this
-    //      process saw legacy traffic" without disk-pounding on every RPC.
+    //      process saw legacy wire traffic" without disk-pounding on every
+    //      RPC.
     //
     //   2. Per-method counter (`legacyTrafficCounter`, Phase 2.2 pre-commit
     //      4) — every call ticks a counter; threshold milestones flush a
@@ -456,7 +465,11 @@ export class RpcRouter {
     // handlers (which own their own recording) don't double-count. Both
     // are fire-and-forget and wrapped in try/catch — they MUST NOT
     // affect dispatch latency or response.
-    if (!ctx.clientName && !IDENTITY_OWN_METHODS.has(request.method)) {
+    if (
+      isLocalExternalWireContext(ctx) &&
+      !ctx.clientName &&
+      !IDENTITY_OWN_METHODS.has(request.method)
+    ) {
       if (!this.legacyContactPersisted && this.legacyRecorder) {
         this.legacyContactPersisted = true;
         try {

--- a/src/main/pipe/__tests__/RpcRouter.test.ts
+++ b/src/main/pipe/__tests__/RpcRouter.test.ts
@@ -82,14 +82,14 @@ describe('RpcRouter dispatch envelope', () => {
 });
 
 describe('RpcRouter legacy-contact recorder', () => {
-  it('fires once per process when the first envelope-less RPC dispatches', async () => {
+  it('fires once per process when the first envelope-less wire RPC dispatches', async () => {
     const router = makeRouter();
     const recorder = vi.fn();
     router.setLegacyContactRecorder(recorder);
 
-    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
-    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} });
-    await router.dispatch({ id: 'r-3', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} }, { externalWire: true });
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} }, { externalWire: true });
+    await router.dispatch({ id: 'r-3', method: 'pane.list', params: {} }, { externalWire: true });
 
     expect(recorder).toHaveBeenCalledTimes(1);
     expect(recorder).toHaveBeenCalledWith('pane.list');
@@ -100,12 +100,15 @@ describe('RpcRouter legacy-contact recorder', () => {
     const recorder = vi.fn();
     router.setLegacyContactRecorder(recorder);
 
-    await router.dispatch({
-      id: 'r-1',
-      method: 'pane.list',
-      params: {},
-      clientName: 'claude-ai',
-    });
+    await router.dispatch(
+      {
+        id: 'r-1',
+        method: 'pane.list',
+        params: {},
+        clientName: 'claude-ai',
+      },
+      { externalWire: true },
+    );
     expect(recorder).not.toHaveBeenCalled();
   });
 
@@ -116,12 +119,28 @@ describe('RpcRouter legacy-contact recorder', () => {
     const recorder = vi.fn();
     router.setLegacyContactRecorder(recorder);
 
-    await router.dispatch({ id: 'r-1', method: 'mcp.identify', params: {} });
-    await router.dispatch({
-      id: 'r-2',
-      method: 'mcp.declarePermissions',
-      params: {},
-    });
+    await router.dispatch({ id: 'r-1', method: 'mcp.identify', params: {} }, { externalWire: true });
+    await router.dispatch(
+      {
+        id: 'r-2',
+        method: 'mcp.declarePermissions',
+        params: {},
+      },
+      { externalWire: true },
+    );
+    expect(recorder).not.toHaveBeenCalled();
+  });
+
+  it('does not fire for trusted in-process surfaces (operator / firstParty send no clientName)', async () => {
+    // #1111 evidence hygiene: the renderer bridge and the plugin host are
+    // not legacy wire callers. Counting them drowned the shadow log's
+    // legacy-traffic signal in renderer polling.
+    const router = makeRouter();
+    const recorder = vi.fn();
+    router.setLegacyContactRecorder(recorder);
+
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} }, { operator: true });
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} }, { firstParty: true });
     expect(recorder).not.toHaveBeenCalled();
   });
 
@@ -132,11 +151,14 @@ describe('RpcRouter legacy-contact recorder', () => {
     router.setLegacyContactRecorder(() => {
       throw new Error('disk full');
     });
-    const response = await router.dispatch({
-      id: 'r-1',
-      method: 'pane.list',
-      params: {},
-    });
+    const response = await router.dispatch(
+      {
+        id: 'r-1',
+        method: 'pane.list',
+        params: {},
+      },
+      { externalWire: true },
+    );
     expect(response.ok).toBe(true);
   });
 
@@ -144,12 +166,18 @@ describe('RpcRouter legacy-contact recorder', () => {
     const router = makeRouter();
     const first = vi.fn();
     router.setLegacyContactRecorder(first);
-    await router.dispatch({ id: 'r-1', method: 'pane.list' as RpcMethod, params: {} });
+    await router.dispatch(
+      { id: 'r-1', method: 'pane.list' as RpcMethod, params: {} },
+      { externalWire: true },
+    );
     expect(first).toHaveBeenCalledTimes(1);
 
     const second = vi.fn();
     router.setLegacyContactRecorder(second);
-    await router.dispatch({ id: 'r-2', method: 'pane.list' as RpcMethod, params: {} });
+    await router.dispatch(
+      { id: 'r-2', method: 'pane.list' as RpcMethod, params: {} },
+      { externalWire: true },
+    );
     expect(second).toHaveBeenCalledTimes(1);
   });
 });
@@ -332,14 +360,14 @@ describe('RpcRouter shadow-mode enforcement wiring', () => {
 });
 
 describe('RpcRouter legacy traffic counter', () => {
-  it('ticks on every envelope-less RPC (not process-once like the trust recorder)', async () => {
+  it('ticks on every envelope-less wire RPC (not process-once like the trust recorder)', async () => {
     const router = makeRouter();
     const counter = { record: vi.fn() };
     router.setLegacyTrafficCounter(counter);
 
-    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
-    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} });
-    await router.dispatch({ id: 'r-3', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} }, { externalWire: true });
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} }, { externalWire: true });
+    await router.dispatch({ id: 'r-3', method: 'pane.list', params: {} }, { externalWire: true });
 
     expect(counter.record).toHaveBeenCalledTimes(3);
     expect(counter.record.mock.calls.map((c) => c[0])).toEqual([
@@ -354,12 +382,31 @@ describe('RpcRouter legacy traffic counter', () => {
     const counter = { record: vi.fn() };
     router.setLegacyTrafficCounter(counter);
 
-    await router.dispatch({
-      id: 'r-1',
-      method: 'pane.list',
-      params: {},
-      clientName: 'p1',
-    });
+    await router.dispatch(
+      {
+        id: 'r-1',
+        method: 'pane.list',
+        params: {},
+        clientName: 'p1',
+      },
+      { externalWire: true },
+    );
+    expect(counter.record).not.toHaveBeenCalled();
+  });
+
+  it('does NOT tick for trusted in-process surfaces, which send no clientName by design', async () => {
+    // #1111 evidence hygiene — the operator renderer bridge polls
+    // events.poll / task.mission.list all day; those must not land in the
+    // legacy-traffic shadow log as if they were external wire callers.
+    const router = makeRouter();
+    const counter = { record: vi.fn() };
+    router.setLegacyTrafficCounter(counter);
+
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} }, { operator: true });
+    await router.dispatch(
+      { id: 'r-2', method: 'pane.list', params: {} },
+      { firstParty: true, hostedWorkspace: null },
+    );
     expect(counter.record).not.toHaveBeenCalled();
   });
 
@@ -370,12 +417,15 @@ describe('RpcRouter legacy traffic counter', () => {
     const counter = { record: vi.fn() };
     router.setLegacyTrafficCounter(counter);
 
-    await router.dispatch({ id: 'r-1', method: 'mcp.identify', params: {} });
-    await router.dispatch({
-      id: 'r-2',
-      method: 'mcp.declarePermissions',
-      params: {},
-    });
+    await router.dispatch({ id: 'r-1', method: 'mcp.identify', params: {} }, { externalWire: true });
+    await router.dispatch(
+      {
+        id: 'r-2',
+        method: 'mcp.declarePermissions',
+        params: {},
+      },
+      { externalWire: true },
+    );
     expect(counter.record).not.toHaveBeenCalled();
   });
 
@@ -386,12 +436,12 @@ describe('RpcRouter legacy traffic counter', () => {
     router.setLegacyContactRecorder(recorder);
     router.setLegacyTrafficCounter(counter);
 
-    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-1', method: 'pane.list', params: {} }, { externalWire: true });
     expect(recorder).toHaveBeenCalledTimes(1);
     expect(counter.record).toHaveBeenCalledTimes(1);
 
     // Second call: recorder is process-once (silent), counter keeps ticking.
-    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} });
+    await router.dispatch({ id: 'r-2', method: 'pane.list', params: {} }, { externalWire: true });
     expect(recorder).toHaveBeenCalledTimes(1);
     expect(counter.record).toHaveBeenCalledTimes(2);
   });
@@ -403,11 +453,14 @@ describe('RpcRouter legacy traffic counter', () => {
         throw new Error('counter blew up');
       },
     });
-    const response = await router.dispatch({
-      id: 'r-1',
-      method: 'pane.list',
-      params: {},
-    });
+    const response = await router.dispatch(
+      {
+        id: 'r-1',
+        method: 'pane.list',
+        params: {},
+      },
+      { externalWire: true },
+    );
     expect(response.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## What

Pre-close evidence hygiene for the #1111 grandfather-lane close (announced for 2026-09-30, notice #1130).

The legacy contact recorder (`RpcRouter` → `plugin-trust.json`) and the per-method legacy traffic counter (`shadow-rejections.log`) fired for **every** envelope-less dispatch — including the trusted in-process surfaces. The renderer IPC bridge (`operator`) and the iframe plugin host (`firstParty`) send no `clientName` by design, so the audit trail that must answer "which external no-clientName callers still exist?" was dominated by wmux's own UI polling.

Measured on the primary dogfood box (`~/.wmux/shadow-rejections.log`, 2026-06-27 → 2026-09-07):

| method | counted calls | actual source |
|---|---|---|
| `events.poll` | 445,504 | renderer polling (`useRpcBridge`) |
| `task.mission.list` | 191,350 | renderer polling (`AppLayout` mission cache — identical daily-count pattern to `events.poll`, same caller) |
| `a2a.channel.getMembers` / `.list` | ~2.4k | renderer channel surfaces + ad-hoc scripts |
| `hooks.signal` | 1,248 | integrations hook bridge — the one true wire caller, already handled by draft PR #1139's curated hook-bridge lane |

Both side channels now gate on `isLocalExternalWireContext` — the same positive provenance predicate the enforcer lanes use. The in-process surfaces were never the grandfather's audience (#1139 exempts them at the enforcement points for the same reason). After this lands, every new `legacy-traffic` entry in the log is a real external envelope-less wire caller, which is exactly what the 2026-09-30 close decision needs to watch during the remaining notice window.

## Changes

- `src/main/pipe/RpcRouter.ts` — legacy recorder + counter block gated on `isLocalExternalWireContext(ctx)`; comments updated.
- `src/main/pipe/__tests__/RpcRouter.test.ts` — legacy suites dispatch with `{ externalWire: true }`; two regression tests: operator / firstParty lanes never tick either channel.
- `src/main/mcp/__tests__/phase-2-1-e2e.test.ts`, `phase-2-2-dynamic.test.ts` — legacy-path steps dispatch as wire callers.
- `src/main/audit/shadowRejectionLog.ts` — entry-kind doc precision.
- `docs/PROTOCOL.md` §4.1 — recording semantics: wire-only; in-process surfaces not recorded.

Note for draft PR #1139: it will want the same wire-only phrasing when it rebases (its §4.1 rewrite touches the same paragraph).

## Verification

- `vitest run src/main/pipe src/main/mcp src/main/audit` — 64 files, 1427 tests passed.
- `tsc --noEmit` — one pre-existing error on clean `main` (`src/mcp/browser-repl/BrowserReplSession.ts:182`), unrelated to this diff (verified via stash).
- `eslint` on touched files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved legacy-traffic auditing so records reflect external wire requests only.
  - Prevented trusted internal renderer and plugin-host activity from being incorrectly counted as legacy traffic.
  - Improved accuracy of audit thresholds and rejection logs used to evaluate legacy traffic.

- **Documentation**
  - Clarified protocol documentation regarding which requests are classified and recorded as legacy traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->