### PR TITLE
fix(term): repair idle-pane ghost glyphs with a post-settle verify repaint

### DIFF
--- a/changelog.d/1230.md
+++ b/changelog.d/1230.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **An idle pane no longer keeps a ghosted frame until you select its text.**
+  The final repaint after a stream of output could itself race on the GPU and
+  leave stale pixels on rows it had just marked clean — and once the pane went
+  quiet, nothing ever repaired it: focus doesn't re-fire on a pane you're
+  already looking at, and repairs were only scheduled while output flowed or on
+  workspace switches. Selecting the text fixed it instantly (the buffer was
+  always correct), which is what made it so annoying to live with. A pane now
+  schedules one more verification repaint a couple of seconds after output
+  settles, so a raced final paint self-heals instead of haunting the pane — and
+  a pane that gets split or dragged right after a command finishes heals too.

--- a/src/renderer/hooks/__tests__/useTerminal.atlasClear.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.atlasClear.test.ts
@@ -39,4 +39,16 @@ describe('#191 — repaint must not clear the shared texture atlas (source-level
   it('repairs staleness with a full-range refresh instead', () => {
     expect(repaintBlock).toMatch(/terminal\.refresh\(0, terminal\.rows - 1\)/);
   });
+
+  // The repaint's output-driven reasons ('burst' and the idle-tail
+  // 'settle-verify') must stay behind the visibility gate: a hidden pane
+  // cannot show staleness, its reveal is repaired by the `visible` repaint,
+  // and un-gating either reason would put a full-range refresh on every
+  // background agent pane after every output burst / stream settle — the GPU
+  // churn this gate exists to prevent. Pinned at source level like the rest
+  // of this file (the gate is an xterm-bound side effect).
+  it('gates both output-driven repaint reasons on pane visibility', () => {
+    expect(repaintBlock).toMatch(/reason === 'burst' \|\| reason === 'settle-verify'/);
+    expect(repaintBlock).toMatch(/!isVisibleRef\.current\) return/);
+  });
 });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1119,6 +1119,18 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // element is detached at this point (React removed the old container
       // before flushing passive effects), so appending is all that is left.
       container.appendChild(adopted.element);
+      // The previous mount's glyphRepaint scheduler died with its cleanup —
+      // taking any still-armed settle-verify with it — and this mount's fresh
+      // scheduler has no history, so a pane restructured right after a stream
+      // settled (split/drag within ~2s of output ending) would carry a raced
+      // final raster with no self-repair left (#1002 adopt path). One
+      // full-range refresh heals it for exactly the cost the verify would
+      // have paid.
+      try {
+        terminal.refresh(0, terminal.rows - 1);
+      } catch {
+        // terminal may already be disposed — teardown owns cleanup
+      }
     } else {
       // Activate Unicode 11 width tables — required for correct CJK / emoji
       // width. Without this, xterm defaults to v6 and TUI apps that use cursor
@@ -1369,7 +1381,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
 
     // Issue #166 — defensive full-range repaint for the "garbled glyphs until
     // resize" corruption (dirty-region desync). Strategy and trigger rationale
-    // live in terminal/glyphRepaint.ts. Every reason (focus / visible / burst)
+    // live in terminal/glyphRepaint.ts. Every reason (focus / visible / burst /
+    // settle-verify)
     // does a plain full-range refresh; "focus" is throttled because it fires on
     // every keyboard pane-nav / MCP pane.focus via useActivePaneFocus's
     // term.focus(), not just mouse clicks, so the throttle is load-bearing. The
@@ -1382,8 +1395,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         // burst refresh — nobody can see the staleness, and the `visible`
         // repaint on re-show repairs it at the moment it matters. Without
         // this gate, N background agent panes each schedule a full-range
-        // refresh after every output burst.
-        if (reason === 'burst' && !isVisibleRef.current) return;
+        // refresh after every output burst. The idle-tail settle-verify is
+        // gated for the same reason: a hidden pane is repaired by `visible`
+        // on reveal, so its verify would be wasted GPU work.
+        if ((reason === 'burst' || reason === 'settle-verify') && !isVisibleRef.current) return;
         // Do NOT clearTextureAtlas here (#191). xterm shares ONE glyph atlas
         // across every same-config terminal (CharAtlasCache); clearing it from
         // one pane empties it for all of them, and siblings that do not rebuild

--- a/src/renderer/terminal/__tests__/glyphRepaint.test.ts
+++ b/src/renderer/terminal/__tests__/glyphRepaint.test.ts
@@ -7,6 +7,7 @@ import {
   BURST_QUIET_MS_DEFAULT,
   FOCUS_THROTTLE_MS_DEFAULT,
   BURST_STREAM_FLUSH_MS_DEFAULT,
+  SETTLE_VERIFY_MS_DEFAULT,
   type RepaintReason,
 } from '../glyphRepaint';
 
@@ -170,8 +171,12 @@ describe('glyphRepaint scheduler', () => {
 
     it('resets both the window and the settle flag so the next sub-floor stream stays silent', () => {
       let t = 0;
+      // settleVerifyMs: Infinity isolates this test's window/flag-leak assertions
+      // from the idle-tail verify — the first settle arms one at t=2400, and this
+      // test's later time advances (ending t=2300) would race into it.
       const s = createGlyphRepaintScheduler({
-        repaint, activityBytes: 256, burstQuietMs: 300, burstStreamFlushMs: 500, now: () => t,
+        repaint, activityBytes: 256, burstQuietMs: 300, burstStreamFlushMs: 500,
+        settleVerifyMs: Infinity, now: () => t,
       });
       const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
       s.onData(1000);          // t=0 mid flush → windowAccum=0, flushedSinceSettle=true
@@ -230,6 +235,97 @@ describe('glyphRepaint scheduler', () => {
       for (let i = 0; i < 20; i++) { s.onData(30); tick(1000); } // 30 units < 256, 1s apart
       vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT);
       expect(repaints).toEqual([]);
+    });
+  });
+
+  // Idle-tail repair (2026-09-07 opencode ghosting report): the settle flush is
+  // the stream's final repaint, but its own WebGL raster can race and leave
+  // stale pixels on rows it just marked clean. After the stream ends, no other
+  // trigger can fire (pane already focused, no visibility change, no output),
+  // so the ghost persists until the user selects text. One delayed verify
+  // repaint after each settle flush closes that window.
+  describe('post-settle verification repaint (idle-tail repair)', () => {
+    it('fires once more after the settle flush, not before', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstStreamFlushMs: Infinity });
+      s.onData(ACTIVITY_BYTES_DEFAULT);
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT);
+      expect(repaints).toEqual(['burst']); // settle flush
+      vi.advanceTimersByTime(SETTLE_VERIFY_MS_DEFAULT - 1);
+      expect(repaints).toEqual(['burst']); // verify not yet
+      vi.advanceTimersByTime(1);
+      expect(repaints).toEqual(['burst', 'settle-verify']);
+    });
+
+    it('schedules nothing for sub-floor noise that never flushed', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstStreamFlushMs: Infinity });
+      s.onData(ACTIVITY_BYTES_DEFAULT - 1);
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT + SETTLE_VERIFY_MS_DEFAULT * 2);
+      expect(repaints).toEqual([]);
+    });
+
+    it('is not cancelled by sub-floor writes after the settle — the hole stays closed', () => {
+      // A keystroke echo after the stream ends must NOT cancel the pending
+      // verify: that echo never flushes, so its own settle cannot re-arm one.
+      const s = createGlyphRepaintScheduler({ repaint, burstStreamFlushMs: Infinity });
+      s.onData(ACTIVITY_BYTES_DEFAULT);
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT); // settle → verify armed
+      s.onData(30); // sub-floor echo
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT + SETTLE_VERIFY_MS_DEFAULT);
+      expect(repaints).toEqual(['burst', 'settle-verify']);
+    });
+
+    it('re-arms instead of stacking when a second stream settles', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, activityBytes: 10, burstQuietMs: 50,
+        burstStreamFlushMs: Infinity, settleVerifyMs: 100, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(100);
+      tick(50); // settle #1 → verify #1 armed at t=150
+      tick(30); // t=80: a second short stream
+      s.onData(100);
+      tick(50); // t=130: settle #2 re-arms verify (fires at t=230)
+      expect(repaints).toEqual(['burst', 'burst']);
+      tick(100); // t=230
+      expect(repaints).toEqual(['burst', 'burst', 'settle-verify']); // ONE verify, not two
+    });
+
+    it('a mid-stream flush alone does not arm a verify — only the settle does', () => {
+      // Pins WHERE the verify is armed: a refactor moving the arm to every
+      // flush (not just the settle) would fire a redundant verify per cadence
+      // tick during streaming. Default-config timings (finite cadence), which
+      // the other verify tests all disable via burstStreamFlushMs: Infinity.
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, activityBytes: 256, burstQuietMs: 300,
+        burstStreamFlushMs: 500, settleVerifyMs: 100, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(1000);            // t=0: mid flush only
+      expect(repaints).toEqual(['burst']);
+      tick(99);                  // t=99: past midFlush+100 — a misplaced arm would fire here
+      expect(repaints).toEqual(['burst']);
+      tick(201);                 // t=300: settle (flushedSinceSettle)
+      expect(repaints).toEqual(['burst', 'burst']);
+      tick(100);                 // t=400: settle-armed verify fires
+      expect(repaints).toEqual(['burst', 'burst', 'settle-verify']);
+    });
+
+    it('is cancelled by dispose', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstStreamFlushMs: Infinity });
+      s.onData(ACTIVITY_BYTES_DEFAULT);
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT); // settle → verify armed
+      s.dispose();
+      vi.advanceTimersByTime(SETTLE_VERIFY_MS_DEFAULT * 2);
+      expect(repaints).toEqual(['burst']);
+    });
+
+    it('Infinity disables the verify entirely', () => {
+      const s = createGlyphRepaintScheduler({ repaint, burstStreamFlushMs: Infinity, settleVerifyMs: Infinity });
+      s.onData(ACTIVITY_BYTES_DEFAULT);
+      vi.advanceTimersByTime(BURST_QUIET_MS_DEFAULT + 10_000);
+      expect(repaints).toEqual(['burst']);
     });
   });
 

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -25,6 +25,8 @@
 //   - `burst`   — output is actively flowing to a visible pane. Fired on a
 //                 time cadence (see below) so live streaming self-repairs, plus
 //                 once more when the stream finally settles.
+//   - `settle-verify` — one delayed repaint after the trailing settle flush
+//                 (see the "idle tail" note below).
 //
 // --- Why the `burst` gate is an activity-based TIME cadence (issue #318) ---
 //
@@ -69,7 +71,32 @@
 // (Old gate: staleness could persist for the entire multi-second stream — the
 // #318 report.)
 //
-// All three reasons run the same full-range refresh; the caller does not vary
+// --- The idle tail: why the settle flush alone is not enough (`settle-verify`) ---
+//
+// The corruption is non-deterministic at the RASTER level: any single full-range
+// refresh can itself race (WebGL dirty-region upload) and paint stale pixels
+// while marking the rows clean — including the settle flush that is supposed to
+// be the stream's final repair. Once the pane goes idle (agent finished, TUI
+// waiting for input), NO further repaint is ever scheduled: focus is throttled
+// but, worse, never re-fires on a pane that is already focused; `visible` needs
+// a workspace switch; `burst` needs output. The user sees the ghosted/stale
+// frame indefinitely, and repairs it manually by selecting text (selection
+// forces renderRows from the correct buffer) — the exact 2026-09-07 opencode
+// report. The settle-verify repaint closes that window: after every settle
+// flush, one more full-range refresh fires `settleVerifyMs` later — after the
+// settle's own raster has committed — so a raced final paint cannot outlive
+// ~`burstQuietMs + settleVerifyMs`. Cost: at most one extra refresh per stream
+// that flushed (overlapping tails coalesce into a single verify); noise-only
+// trickles (no flush) schedule nothing. A pane that PULSES — ≥ activityBytes
+// on a ≥ settleVerifyMs cadence forever (watch loops, status pollers) — pays
+// one verify per pulse (~0.4 full refreshes/s ceiling), an accepted standing
+// cost for the repair guarantee. The verify is deliberately NOT cancelled by
+// new writes: a sub-floor keystroke echo must not reopen the hole (its own
+// settle won't re-arm the verify because nothing flushed), and a stray verify
+// landing mid-stream is just one more harmless full-range repair on the burst
+// cadence. A later real settle re-arms it.
+//
+// All four reasons run the same full-range refresh; the caller does not vary
 // repaint cost per reason. The refresh never mutates the shared glyph atlas
 // (#191), so it cannot corrupt sibling panes — the burst-visibility gate aside,
 // the only per-reason difference is the throttle on `focus`.
@@ -78,7 +105,7 @@
 // tested without xterm; all rendering side effects live in the caller's
 // `repaint` callback.
 
-export type RepaintReason = 'focus' | 'visible' | 'burst';
+export type RepaintReason = 'focus' | 'visible' | 'burst' | 'settle-verify';
 
 export interface GlyphRepaintScheduler {
   /** Feed PTY write sizes; fires repaint('burst') on the streaming cadence. */
@@ -111,6 +138,9 @@ export interface GlyphRepaintOptions {
    *  without churning a full refresh on every write. Pass Infinity to disable
    *  the mid-stream cadence entirely (the trailing settle flush still runs). */
   burstStreamFlushMs?: number;
+  /** Delay after the trailing settle flush for the one-shot verification
+   *  repaint (see the "idle tail" header note). Pass Infinity to disable. */
+  settleVerifyMs?: number;
   /** Injectable clock for tests. */
   now?: () => number;
 }
@@ -129,6 +159,11 @@ export const FOCUS_THROTTLE_MS_DEFAULT = 1000;
 // the trailing settle flush also remains) at half the GPU cost. If glyph
 // corruption is ever seen lingering mid-stream, drop back toward 750.
 export const BURST_STREAM_FLUSH_MS_DEFAULT = 1000;
+// Idle-tail verification (see header): late enough that the settle flush's own
+// raster has long committed (so the verify genuinely re-rasterizes), early
+// enough that a user watching the pane sees the ghost for ~2s instead of
+// forever.
+export const SETTLE_VERIFY_MS_DEFAULT = 2000;
 
 export function createGlyphRepaintScheduler(
   options: GlyphRepaintOptions,
@@ -139,6 +174,7 @@ export function createGlyphRepaintScheduler(
     burstQuietMs = BURST_QUIET_MS_DEFAULT,
     focusThrottleMs = FOCUS_THROTTLE_MS_DEFAULT,
     burstStreamFlushMs: burstStreamFlushMsRaw = BURST_STREAM_FLUSH_MS_DEFAULT,
+    settleVerifyMs: settleVerifyMsRaw = SETTLE_VERIFY_MS_DEFAULT,
     now = Date.now,
   } = options;
   // Floor the mid-stream cadence at 1ms so a 0/negative value can't turn the
@@ -147,6 +183,8 @@ export function createGlyphRepaintScheduler(
   // Infinity); a non-finite cadence disables the mid-stream flush below.
   const burstStreamFlushMs = Math.max(1, burstStreamFlushMsRaw);
   const midStreamEnabled = Number.isFinite(burstStreamFlushMs);
+  const settleVerifyMs = Math.max(1, settleVerifyMsRaw);
+  const settleVerifyEnabled = Number.isFinite(settleVerifyMsRaw);
 
   let disposed = false;
   // Units written since the last flush of any kind. Reset to 0 at every flush.
@@ -156,6 +194,11 @@ export function createGlyphRepaintScheduler(
   // in a mid flush (that flush ran pre-parse; see the header rationale).
   let flushedSinceSettle = false;
   let quietTimer: ReturnType<typeof setTimeout> | null = null;
+  // One-shot idle-tail verify, armed by each settle flush. Never cancelled by
+  // writes (see header); a later settle clears and re-arms it with a FULL
+  // delay — the latest settle's deadline wins (the verify must postdate the
+  // newest settle's own raster), and one verify is in flight at a time.
+  let settleVerifyTimer: ReturnType<typeof setTimeout> | null = null;
   let lastFocusRepaintAt = -Infinity;
   // Timestamp of the last real flush (mid or trailing). Seeded to -Infinity so
   // the first qualifying write flushes immediately — intentional and harmless.
@@ -201,6 +244,16 @@ export function createGlyphRepaintScheduler(
           windowAccum = 0;
           flushedSinceSettle = false;
           repaint('burst');
+          // Idle-tail verify: this settle flush is the stream's final repair,
+          // but its own raster can race and paint stale pixels. One more
+          // full-range refresh after the raster commits closes that window.
+          if (settleVerifyEnabled) {
+            if (settleVerifyTimer) clearTimeout(settleVerifyTimer);
+            settleVerifyTimer = setTimeout(() => {
+              settleVerifyTimer = null;
+              if (!disposed) repaint('settle-verify');
+            }, settleVerifyMs);
+          }
         } else {
           // Sub-threshold noise that never flushed: drop it so a stale trickle
           // can't leak into a later unrelated stream's first-flush timing. No
@@ -229,6 +282,10 @@ export function createGlyphRepaintScheduler(
       if (quietTimer) {
         clearTimeout(quietTimer);
         quietTimer = null;
+      }
+      if (settleVerifyTimer) {
+        clearTimeout(settleVerifyTimer);
+        settleVerifyTimer = null;
       }
       windowAccum = 0;
       flushedSinceSettle = false;


### PR DESCRIPTION
## Problem

An idle pane can show a ghosted/stale frame indefinitely: the text buffer is correct (selecting the text instantly repairs it), but the pixels on screen are stale. Observed with opencode TUIs — CJK + box-drawing heavy, several agent panes streaming at once — the 2026-09-07 dogfood report of this exact symptom, and the same dirty-region desync class as #166/#318/#319 ("garbled glyphs until resize").

## Root cause

The trailing settle flush is a stream's final full-range repair, but its own WebGL raster can race and paint stale pixels on rows it just marked clean. Once the pane goes idle, no repaint trigger can ever fire again:

- `focus` never re-fires on a pane that is already focused
- `visible` needs a workspace switch
- `burst` needs output

So the raced final paint persists until the user manually selects text (selection forces `renderRows` from the correct buffer).

## Fix

`glyphRepaint` arms a one-shot **`settle-verify`** repaint `settleVerifyMs` (default 2s) after every settle flush — after the settle's own raster has committed — so a raced final paint cannot outlive ~`burstQuietMs + settleVerifyMs`. Cost: at most one extra refresh per stream that flushed (overlapping tails coalesce); noise-only trickles schedule nothing; the periodic-pulse standing cost (~0.4 refresh/s ceiling for `watch`-style panes) is documented and accepted. The verify is deliberately not cancelled by sub-floor writes (a keystroke echo would otherwise reopen the hole), and `dispose()` clears it.

## Review hardening (3 specialists + adversarial pass)

- **Adoption hole fixed (#1002 park/adopt):** the previous mount's scheduler death killed an armed verify; a pane split/drag-restructured within ~2s of stream settle carried the ghost with no self-repair left. The adopting mount now does one full-range refresh.
- Header cost claim corrected ("at most one", not "exactly one"), re-arm semantics comment fixed (latest settle wins).
- A fragile pre-existing test isolated from the new timer; new regression tests pin that only a settle (not a mid-stream flush) arms the verify, and that the useTerminal visibility gate covers both output-driven reasons.

## Verification

- `glyphRepaint.test.ts`: 28 tests (6 → 8 new for the verify path) — all pass
- `useTerminal.atlasClear.test.ts`: gate pin added — all pass
- Full `src/renderer/terminal/__tests__` + `src/renderer/hooks/__tests__` run: 1110 passed; the single failure (`atlasCoherence` I1/I3 patch marker) is pre-existing on `main` (node_modules shipped without the addon-webgl patch — separate infra issue, worth a look)
- eslint clean on changed files (remaining errors pre-exist on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where terminal panes could display stale or ghosted content after output stopped.
  * Added a delayed verification repaint to automatically repair rendering issues in idle panes.
  * Improved terminal rendering when panes are adopted, split, or dragged after command completion.
  * Prevented unnecessary repainting for hidden panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->