### PR TITLE
feat(codex): map the measured PermissionRequest hook to agent.awaiting_input (#1107)

### DIFF
--- a/changelog.d/1231.md
+++ b/changelog.d/1231.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Codex approval pauses are now reported by a hook instead of a screenshot guess.** The one Codex lifecycle event wmux could never measure — `PermissionRequest`, the moment a Codex pane stops and shows "would you like to run this command?" — finally fired under a lab rig (interactive TUI driven in a PTY against a stub model endpoint), and the hooks bridge now maps it to the same "needs a human" state the approval screen-regexes produce. A pane whose operator has trusted the hook gets the fact; the regexes stay as the fallback for everyone else. The captured payload confirmed Codex even names the tool the way Claude does, and the user-facing justification it carries never leaves the bridge. (#1231)

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -8,7 +8,7 @@ different routes, and you want **one** of them, not both.
 | Registered as | `notify = [...]` in `config.toml` | `[[hooks.<Event>]]` in `config.toml` |
 | Payload arrives | last argv token | stdin |
 | Codex floor | any | **0.141.0** |
-| Reports | turn complete | turn complete, turn start, session start |
+| Reports | turn complete | turn complete, turn start, session start, approval pause |
 | Needs operator approval | no | **yes** (trust gate) |
 | Installed by wmux | yes (`lifecycleIntegrations`) | no — see *Installation* |
 
@@ -42,8 +42,11 @@ entirely local.
 `SubagentStart`, `SubagentStop`, `Stop`, `Interrupt`.
 
 **Measured firing** — `SessionStart`, `UserPromptSubmit`, `Stop`, `SessionEnd`,
-`PreToolUse`. Everything else is an enum member nobody has watched fire, and
-none of those is mapped. An unmeasured event is not a signal.
+`PreToolUse` (2026-08-31); `PostToolUse`, `PermissionRequest` (2026-09-07,
+codex-cli 0.153.4, PTY-driven interactive TUI — the only way to see an
+approval pause, since `codex exec` forces `approval: never`). Everything else
+is an enum member nobody has watched fire, and none of those is mapped. An
+unmeasured event is not a signal.
 
 **`Stop` is a turn boundary, not a session one.** This was the question the
 whole spike existed to answer. Across two turns of one session, `Stop` fired
@@ -107,16 +110,43 @@ parse `[[hooks.*]]` without complaint — and both fire nothing. Bisected:
 Only the version distinguishes them, which is why `codexSupportsHooks()` gates
 on the version and fails closed on anything it cannot parse.
 
-### Not verified
+### PermissionRequest, measured 2026-09-07
 
-`PermissionRequest` is the event that would let wmux retire the three
-transcribed approval regexes in `AgentDetector.ts`, and it is the one that could
-not be measured: `codex exec` forces `approval: never`, so no approval pause can
-occur in a non-interactive run, and no amount of config overrides it
-(`approval_policy = "untrusted"` is rejected outright in 0.151.0). Confirming it
-needs an interactive TUI session. Until then the event is unmapped and the
-screen regexes stay — mapping it now would mean guessing at its field names, and
-a wrong `awaiting_permission` is worse than none.
+The event that lets wmux stop screen-scraping Codex approval pauses was finally
+observed. `codex exec` forces `approval: never` and no config overrides it, so
+the measurement drove the **interactive TUI** in a PTY (node-pty) against the
+stub Responses endpoint, returning an `exec_command` call with
+`sandbox_permissions: "require_escalated"` — the model-side request for an
+unsandboxed run, which is what raises the TUI approval dialog.
+
+Firing order for one gated call, all events carrying the same `turn_id`:
+
+```
+PreToolUse → PermissionRequest → (operator approves in the TUI) → PostToolUse → Stop
+```
+
+A captured `PermissionRequest` (elided):
+
+```json
+{"session_id":"01a07ba6-…","turn_id":"01a07ba7-…","transcript_path":"…/rollout-….jsonl",
+ "cwd":"/spike/work","hook_event_name":"PermissionRequest","model":"stub-1",
+ "permission_mode":"default","tool_name":"Bash",
+ "tool_input":{"command":"echo proof > /tmp/…","description":"write the spike proof file outside the sandbox"}}
+```
+
+Three facts that matter for the mapping:
+
+- **`tool_name` is Claude-normalized** ("Bash"), like every tool event.
+- **`tool_input.description` is the call's user-facing `justification`** —
+  content, never forwarded (the bridge is metadata-only).
+- **No `tool_use_id`**, unlike the `PreToolUse`/`PostToolUse` events firing
+  around it.
+
+The spike also surfaced two TUI-only dialogs the driver had to get past, worth
+recording for the next person to drive this thing: a fresh cwd raises a
+*directory trust* dialog (pre-answerable in config: `[projects."<abs path>"]`
+with `trust_level = "trusted"`), and a version-update nag whose default option
+runs `npm install -g @openai/codex` — pick Skip when driving a spike.
 
 ## What the bridge reports
 
@@ -125,16 +155,24 @@ a wrong `awaiting_permission` is worse than none.
 | `SessionStart` | `agent.session_start` (with `source`) |
 | `UserPromptSubmit` | `agent.user_prompt_submit` |
 | `Stop` | `agent.stop` |
+| `PermissionRequest` | `agent.awaiting_input` |
+
+`PermissionRequest` maps to `agent.awaiting_input` — the same pane state the
+three transcribed approval regexes in `AgentDetector.ts` produce — and **not**
+to `agent.awaiting_permission`, which is reserved for wmux's own blocking
+permission gate (#783: the daemon holding the bridge RPC open until a phone
+resolves it), not the agent's local TUI dialog. The regexes stay as the
+fallback for panes without a trusted hook; a pane with this bridge gets the
+fact instead of the screenshot guess.
 
 Deliberately unmapped, each for its own reason — the full argument is in the
 `EVENT_TO_KIND` comment in the bridge:
 
 - `PreToolUse` / `PostToolUse` — a spawn per tool call for a signal the server
-  already throttles. And `PreToolUse` must **not** become `awaiting_input` the
-  way Claude's does: Codex fires it on every tool call, gated or not, and has a
-  separate `PermissionRequest` for the approval pause. Conflating them is the
-  mistake #898 punished.
-- `PermissionRequest` — unverified, see above.
+  already throttles. And `PreToolUse` must **not** become `awaiting_input`
+  the way Claude's does: Codex fires it on every tool call, gated or not, and
+  has a separate `PermissionRequest` for the approval pause. Conflating them
+  is the mistake #898 punished.
 - `SessionEnd` — measured, but there is no `AgentSignalKind` for "session
   over", and `agent.stop` would be a lie.
 - `SubagentStart` / `SubagentStop` / `PreCompact` / `PostCompact` / `Interrupt`
@@ -210,7 +248,7 @@ means widening the lane in `hookBridge.ts` deliberately.
 Both bridges are covered by `scripts/lib/hookHarmlessness.mjs`, which runs each
 one against a fake daemon and requires it to classify identically to a no-op
 hook: byte-empty stdout, exit 0, no surviving process, inside the latency
-budget. The hooks bridge is exercised on all five measured events, including the
+budget. The hooks bridge is exercised on all six measured events, including the
 two it ignores — "ignored" has to mean silent and fast, not a slow no-op, and
 `PreToolUse` fires on every tool call so a slow ignore there would be the most
 expensive kind.

--- a/integrations/codex/__tests__/codexHookEnvelope.test.ts
+++ b/integrations/codex/__tests__/codexHookEnvelope.test.ts
@@ -48,6 +48,25 @@ const PRE_TOOL_USE_PAYLOAD = {
   tool_input: { command: 'rm -rf /secret' },
   tool_use_id: 'call_1',
 };
+// Measured 2026-09-07 (codex-cli 0.153.4, PTY-driven interactive TUI against
+// a stub Responses endpoint returning a require_escalated exec_command). Note
+// what this payload does NOT carry: no tool_use_id, unlike the PreToolUse /
+// PostToolUse events firing around it. `tool_input.description` is the call's
+// user-facing `justification` — content, never forwarded.
+const PERMISSION_REQUEST_PAYLOAD = {
+  session_id: '01a07ba6-cd03-7183-a616-5a523fa50a98',
+  turn_id: '01a07ba7-0b34-7902-a924-1d09a2a89e71',
+  transcript_path: 'C:\\codex\\sessions\\rollout-01a07ba6.jsonl',
+  cwd: 'D:\\work\\proj',
+  hook_event_name: 'PermissionRequest',
+  model: 'gpt-5.6-sol',
+  permission_mode: 'default',
+  tool_name: 'Bash',
+  tool_input: {
+    command: 'echo proof > /tmp/wmux-permspike-proof.txt',
+    description: 'write the spike proof file outside the sandbox',
+  },
+};
 
 const baseEnv = {
   WMUX_PTY_ID: 'pty-123',
@@ -108,8 +127,29 @@ describe('buildCodexHookEnvelope', () => {
       .toBe('agent.user_prompt_submit');
   });
 
+  // The approval pause. Same pane state the three transcribed approval
+  // regexes in AgentDetector.ts produce — NOT agent.awaiting_permission,
+  // which is wmux's own blocking permission gate (#783), not the agent's
+  // local TUI approval dialog.
+  it('maps PermissionRequest to agent.awaiting_input, metadata-only', () => {
+    const envelope = buildCodexHookEnvelope(PERMISSION_REQUEST_PAYLOAD, { env: baseEnv, now: 1 });
+    expect(envelope?.kind).toBe('agent.awaiting_input');
+    expect(envelope?.agentSessionId).toBe(PERMISSION_REQUEST_PAYLOAD.session_id);
+    expect(envelope?.payload).toEqual({
+      turn_id: PERMISSION_REQUEST_PAYLOAD.turn_id,
+      transcript_path: PERMISSION_REQUEST_PAYLOAD.transcript_path,
+    });
+    // tool_name / tool_input (including the justification in `description`)
+    // are content and must not survive.
+    const serialized = JSON.stringify(envelope);
+    expect(serialized).not.toContain('Bash');
+    expect(serialized).not.toContain('proof');
+    expect(serialized).not.toContain('justification');
+    expect(serialized).not.toContain('description');
+  });
+
   it('produces an envelope the wmux daemon accepts', () => {
-    for (const payload of [STOP_PAYLOAD, SESSION_START_PAYLOAD, PROMPT_PAYLOAD]) {
+    for (const payload of [STOP_PAYLOAD, SESSION_START_PAYLOAD, PROMPT_PAYLOAD, PERMISSION_REQUEST_PAYLOAD]) {
       expect(isAgentSignal(buildCodexHookEnvelope(payload, { env: baseEnv, now: 1 }))).toBe(true);
     }
   });
@@ -143,15 +183,16 @@ describe('buildCodexHookEnvelope', () => {
     expect(buildCodexHookEnvelope(STOP_PAYLOAD, { env: { WMUX_PTY_ID: '' }, now: 1 })).toBeNull();
   });
 
-  // Every one of these is a real member of Codex's HookEventName enum. Three
-  // were measured firing (PreToolUse, SessionEnd) or are documented as
-  // unmeasured (PermissionRequest, the rest) — none is mapped, each for a
-  // reason recorded in the bridge's EVENT_TO_KIND comment. Pinning them keeps
-  // a later "while we're here" mapping from landing unnoticed.
+  // Every one of these is a real member of Codex's HookEventName enum.
+  // PermissionRequest used to sit here; it was promoted to a mapping on
+  // 2026-09-07 when it was finally measured firing (see the payload above).
+  // The rest stay unmapped, each for a reason recorded in the bridge's
+  // EVENT_TO_KIND comment. Pinning them keeps a later "while we're here"
+  // mapping from landing unnoticed.
   it('ignores events wmux has no faithful mapping for', () => {
     expect(buildCodexHookEnvelope(PRE_TOOL_USE_PAYLOAD, { env: baseEnv, now: 1 })).toBeNull();
     for (const event of [
-      'PreToolUse', 'PermissionRequest', 'PostToolUse', 'PreCompact', 'PostCompact',
+      'PreToolUse', 'PostToolUse', 'PreCompact', 'PostCompact',
       'SessionEnd', 'SubagentStart', 'SubagentStop', 'Interrupt', 'SomethingNew',
     ]) {
       expect(

--- a/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
+++ b/integrations/codex/bin/wmux-codex-hooks-bridge.mjs
@@ -29,8 +29,10 @@
 //     PreCompact, PostCompact, SessionStart, SessionEnd, UserPromptSubmit,
 //     SubagentStart, SubagentStop, Stop, Interrupt.
 //   * MEASURED FIRING: SessionStart, UserPromptSubmit, Stop, SessionEnd,
-//     PreToolUse. The rest are enum members this bridge has NOT seen fire, and
-//     none of them is mapped below — an unmeasured event is not a signal.
+//     PreToolUse (2026-08-31); PostToolUse, PermissionRequest (2026-09-07,
+//     PTY-driven interactive TUI). The rest are enum members this bridge has
+//     NOT seen fire, and none of them is mapped below — an unmeasured event
+//     is not a signal.
 //   * `Stop` is a TURN boundary, not a session one. Measured across two turns
 //     of one session: `Stop` fired once per turn carrying that turn's
 //     `turn_id`, and `SessionEnd` fired separately, once, with no `turn_id`.
@@ -87,7 +89,8 @@ import { randomUUID } from 'node:crypto';
 const HOOK_TIMEOUT_MS = 2000; // hard cap so we never stall a Codex turn
 // Stamped on every codex-hooks.log line; bump on behavior changes.
 //   0.1.0 — initial: SessionStart + UserPromptSubmit + Stop, metadata-only.
-const BRIDGE_VERSION = '0.1.0';
+//   0.2.0 — PermissionRequest → agent.awaiting_input, measured 2026-09-07.
+const BRIDGE_VERSION = '0.2.0';
 const CONNECT_RETRY_BACKOFFS_MS = [100, 250];
 const TRANSIENT_CONNECT_CODES = new Set([
   'EPERM', 'ECONNREFUSED', 'ECONNRESET', 'EPIPE', 'ETIMEDOUT', 'EBUSY', 'EAGAIN',
@@ -126,20 +129,29 @@ const MAX_STDIN_BYTES = 256 * 1024;
 //     EVERY tool call, gated or not, and has a separate PermissionRequest
 //     event for the approval pause. Conflating them is the mistake #898
 //     punished.
-//   * PermissionRequest — the event that would retire the screen-scraped
-//     approval regexes in AgentDetector.ts, and the one this bridge could NOT
-//     measure: `codex exec` forces `approval: never`, so no approval pause can
-//     occur in a non-interactive run. It is in the enum; it has not been seen
-//     to fire, or its payload observed. Mapping it now would be guessing at
-//     the field names, and a wrong awaiting_permission is worse than none.
 //   * SessionEnd — measured firing, but there is no AgentSignalKind for
 //     "session over"; agent.stop would be a lie (it is not a turn boundary).
 //   * SubagentStart / SubagentStop / PreCompact / PostCompact / Interrupt —
 //     enum members never observed firing.
+//
+// PermissionRequest maps to agent.awaiting_input — the same pane state the
+// three transcribed approval regexes in AgentDetector.ts produce, not
+// agent.awaiting_permission, which is reserved for wmux's own blocking
+// permission gate (#783: the daemon holds the bridge RPC open until a phone
+// resolves it). Measured live 2026-09-07, codex-cli 0.153.4, PTY-driven TUI
+// against a stub Responses endpoint returning an `exec_command` call with
+// `sandbox_permissions: "require_escalated"`: the firing order for one gated
+// call is PreToolUse → PermissionRequest → (operator approves in the TUI) →
+// PostToolUse → Stop, all carrying the same turn_id. The payload carries the
+// Claude-normalized `tool_name` ("Bash"), a `tool_input` whose `description`
+// field is the call's user-facing `justification`, and NO `tool_use_id`
+// (unlike PreToolUse/PostToolUse). tool_name/tool_input are content and are
+// not read — the envelope allowlist below is the enforcement.
 const EVENT_TO_KIND = {
   SessionStart: 'agent.session_start',
   UserPromptSubmit: 'agent.user_prompt_submit',
   Stop: 'agent.stop',
+  PermissionRequest: 'agent.awaiting_input',
 };
 
 // ----- Path helpers (Node built-ins only) ---------------------------------

--- a/integrations/codex/hooks/wmuxHooks.mjs
+++ b/integrations/codex/hooks/wmuxHooks.mjs
@@ -50,8 +50,13 @@ export const CODEX_HOOK_TIMEOUT_MS = 2500;
  * The events wmux registers. Kept in lockstep with EVENT_TO_KIND in
  * bin/wmux-codex-hooks-bridge.mjs — registering an event the bridge drops
  * would spawn a process per occurrence to do nothing.
+ *
+ * PermissionRequest joined on 2026-09-07 when it was finally measured firing
+ * (PTY-driven interactive TUI, codex-cli 0.153.4): it is the hook equivalent
+ * of the approval regexes in AgentDetector.ts, which had been the only way to
+ * see an approval pause because `codex exec` forces `approval: never`.
  */
-export const CODEX_HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'Stop'];
+export const CODEX_HOOK_EVENTS = ['SessionStart', 'UserPromptSubmit', 'Stop', 'PermissionRequest'];
 
 /**
  * Build the `hooks` value for config.toml as plain JS data.

--- a/scripts/lib/hookHarmlessness.mjs
+++ b/scripts/lib/hookHarmlessness.mjs
@@ -376,6 +376,18 @@ export function buildCases(payloadOpts) {
       hook_event_name: 'UserPromptSubmit',
       prompt: 'the user typed this',
     }],
+    // Measured 2026-09-07 (codex-cli 0.153.4). Carries content — the approval
+    // justification rides in tool_input.description — which the bridge must
+    // never forward, so the harness exercises the real shape.
+    ['PermissionRequest', {
+      session_id: codexSession,
+      turn_id: 'harness-turn',
+      transcript_path: codexTranscript,
+      cwd: codexCwd,
+      hook_event_name: 'PermissionRequest',
+      tool_name: 'Bash',
+      tool_input: { command: 'echo proof > /tmp/x', description: 'write outside the sandbox' },
+    }],
     // Events wmux deliberately does not map. "Ignored" must still mean silent
     // and fast, not a slow no-op — and PreToolUse fires on EVERY Codex tool
     // call, so a slow ignore there would be the most expensive kind.

--- a/src/main/pty/AgentDetector.ts
+++ b/src/main/pty/AgentDetector.ts
@@ -292,11 +292,11 @@ const AGENT_PATTERNS: AgentPattern[] = [
       // exempts these from hook-authority veto for exactly that reason.
       //
       // #1107: codex-cli >= 0.141.0 also has a `PermissionRequest` lifecycle
-      // hook, which would replace these three regexes outright. It is NOT
-      // wired up: it is the one event the 2026-08-31 measurement could not
-      // make fire, because `codex exec` forces `approval: never` and an
-      // approval pause needs an interactive TUI. Confirming it is what would
-      // let these go; see integrations/codex/README.md.
+      // hook, measured firing 2026-09-07 and now mapped to
+      // agent.awaiting_input by the hooks bridge. These regexes are the
+      // FALLBACK, not the primary: a pane with a trusted hook gets the fact,
+      // and these cover panes whose operator never approved the hook (the
+      // trust gate is silent, so an uninstalled bridge is the common case).
       //
       // Anchored to the whole line: the question occupies its own line in
       // the TUI (two-space indent, no box-drawing frame in Codex), whereas


### PR DESCRIPTION
## What

Closes the biggest remaining gap of #1107: `PermissionRequest` — the Codex lifecycle event that lets wmux stop screen-scraping Codex approval pauses — is now **measured and mapped**.

### The measurement

`codex exec` forces `approval: never`, so the 2026-08-31 spike could never fire it. This one drove the **interactive TUI in a PTY** (node-pty) against a stub Responses endpoint returning an `exec_command` call with `sandbox_permissions: "require_escalated"` — the model-side request for an unsandboxed run, which is what raises the TUI approval dialog. codex-cli 0.153.4, isolated `CODEX_HOME`, `--dangerously-bypass-hook-trust` for the measurement only.

Firing order for one gated call, all events carrying the same `turn_id`:

```
PreToolUse → PermissionRequest → (operator approves in the TUI) → PostToolUse → Stop
```

Captured payload (elided):

```json
{"session_id":"…","turn_id":"…","transcript_path":"…","cwd":"…",
 "hook_event_name":"PermissionRequest","model":"stub-1","permission_mode":"default",
 "tool_name":"Bash",
 "tool_input":{"command":"echo proof > /tmp/…","description":"write the spike proof file outside the sandbox"}}
```

Three facts that shaped the mapping: `tool_name` is Claude-normalized; `tool_input.description` is the call's user-facing `justification` (content — never forwarded, the envelope allowlist is the enforcement, asserted on the serialized envelope); and there is **no `tool_use_id`**, unlike the tool events around it.

### The mapping

`PermissionRequest` → `agent.awaiting_input` — the same pane state the three transcribed approval regexes in `AgentDetector.ts` produce — **not** `agent.awaiting_permission`, which is reserved for wmux's own blocking permission gate (#783: daemon holds the bridge RPC open until a phone resolves it), not the agent's local TUI dialog. The regexes stay as the fallback for panes whose operator never trusted the hook (the trust gate is silent, so that stays the common case).

### Changes

- Bridge `EVENT_TO_KIND` + `CODEX_HOOK_EVENTS`: `PermissionRequest` registered and mapped; `BRIDGE_VERSION` → 0.2.0.
- `codexHookEnvelope.test.ts`: measured payload fixture, mapping + metadata-only assertions; removed from the pinned unmapped list.
- `hookHarmlessness.mjs`: the real PermissionRequest payload (content fields included) added to the exercised events.
- README: "Not verified" section replaced with the measurement; firing-order, payload, and the two TUI dialogs the driver had to get past (directory trust — pre-answerable via `[projects."<path>"] trust_level = "trusted"` — and the update nag whose default runs a global npm install).
- `AgentDetector.ts`: the #1107 comment on the three regexes updated — hook is primary, regexes are the fallback.

## Verification

- `vitest run integrations/codex` — 35 passed.
- `vitest run src/main/pty/__tests__/AgentDetector.test.ts src/shared/hooks` — 182 passed.
- `hookHarmlessness.runtime.test.mjs` (runs the bridge against a fake daemon) — 18 passed, including the new PermissionRequest case.
- eslint on touched files clean (one pre-existing `no-control-regex` in `AgentDetector.ts:429` exists on clean `main`).

## What remains on #1107

- Install flow honesty (approve-then-verify in `lifecycleIntegrations`).
- Adding this bridge to `hookBridge.lockstep.test.ts`'s `BRIDGES` list when #1111 lands.