### PR TITLE
fix(scripts): postinstall verifies the xterm patch landed instead of skipping silently

### DIFF
--- a/changelog.d/1235.md
+++ b/changelog.d/1235.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **A broken local install now fails loudly at install time instead of sabotaging you days later.** When patch-package was missing from node_modules — the signature of a partially stripped install — the postinstall hook skipped wmux's xterm.js patches with a console warning nobody reads. The unpatched terminal renderer and stale type packages then surfaced as a confusing scatter of test failures and phantom type errors, far from the cause. The hook now checks that the patch actually landed and fails the install on the spot with the recovery command, while genuine production installs (`npm ci --omit=dev`) keep passing exactly as before.

--- a/scripts/__tests__/apply-patches-verify.test.mjs
+++ b/scripts/__tests__/apply-patches-verify.test.mjs
@@ -1,0 +1,86 @@
+// Unit tests for the postinstall patch probe (scripts/lib/patch-verify.mjs).
+//
+// The 2026-09-07 incident: a hybrid node_modules (dev deps present,
+// patch-package missing) let the postinstall hook skip patch application
+// silently; the damage surfaced days later as an atlasCoherence failure and
+// phantom tsc errors. These tests pin the probe's four verdicts so the
+// hook's failure-mode selection (in apply-patches.mjs) always has truthful
+// input. The script-level branching is exercised by the dogfood procedure in
+// the PR description; here we stub the fs surface with a fabricated tree.
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  verifyPatchState,
+  PATCH_PROBE_FILE,
+  PATCH_PROBE_MARKER,
+  DEV_INSTALL_SENTINEL,
+} from '../lib/patch-verify.mjs';
+
+function makeTree({ probeContent, devInstall }) {
+  const root = mkdtempSync(path.join(tmpdir(), 'patch-verify-'));
+  if (probeContent !== undefined) {
+    const probe = path.join(root, PATCH_PROBE_FILE);
+    mkdirSync(path.dirname(probe), { recursive: true });
+    writeFileSync(probe, probeContent, 'utf8');
+  }
+  if (devInstall) {
+    const sentinel = path.join(root, DEV_INSTALL_SENTINEL);
+    mkdirSync(path.dirname(sentinel), { recursive: true });
+    writeFileSync(sentinel, 'stub', 'utf8');
+  }
+  return root;
+}
+
+describe('verifyPatchState', () => {
+
+  it('reports patched when the marker is present', () => {
+    const root = makeTree({ probeContent: `garbage ${PATCH_PROBE_MARKER} garbage`, devInstall: true });
+    try {
+      expect(verifyPatchState(fs, root)).toEqual({ state: 'patched', ok: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('passes when the probe target is absent (scoped/partial install)', () => {
+    const root = makeTree({ probeContent: undefined, devInstall: false });
+    try {
+      expect(verifyPatchState(fs, root)).toEqual({ state: 'target-absent', ok: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails an unpatched tree and flags a dev install (the hybrid incident state)', () => {
+    const root = makeTree({ probeContent: 'pristine upstream bundle', devInstall: true });
+    try {
+      expect(verifyPatchState(fs, root)).toEqual({ state: 'unpatched', ok: false, devInstall: true });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('fails an unpatched production-style tree without the devInstall flag', () => {
+    const root = makeTree({ probeContent: 'pristine upstream bundle', devInstall: false });
+    try {
+      expect(verifyPatchState(fs, root)).toEqual({ state: 'unpatched', ok: false, devInstall: false });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('treats an unreadable probe file as unpatched, never as a silent pass', () => {
+    const deps = {
+      existsSync: () => true,
+      readFileSync: () => {
+        throw new Error('EACCES');
+      },
+    };
+    // existsSync always true also fakes the sentinel; what matters is the
+    // verdict: a probe we cannot read must not verify as patched.
+    expect(verifyPatchState(deps, '/nonexistent-root')).toMatchObject({ state: 'unpatched', ok: false });
+  });
+});

--- a/scripts/apply-patches.mjs
+++ b/scripts/apply-patches.mjs
@@ -1,28 +1,78 @@
 #!/usr/bin/env node
 /**
- * Run patch-package after install. Kept out of `dependencies` so the
- * production license/notices closure does not grow a build-tool tree
- * (jsonify@0.0.1 declares "Public Domain" with no LICENSE file).
+ * Run patch-package after install, then VERIFY the patch actually landed.
+ * Kept out of `dependencies` so the production license/notices closure does
+ * not grow a build-tool tree (jsonify@0.0.1 declares "Public Domain" with no
+ * LICENSE file).
  *
- * `npm ci --omit=dev` has no patch-package binary; skip rather than
- * fail the hook. Full `npm ci` (CI, packaging) still applies the patch,
- * and atlasCoherence.test.ts fails if the installed addon is unpatched.
+ * Verification (scripts/lib/patch-verify.mjs): probe the installed
+ * @xterm/addon-webgl bundle for the patch marker. An unpatched install fails
+ * the hook EXCEPT in the one legitimate unpatched state — `npm ci --omit=dev`
+ * has neither patch-package nor devDependencies, and that flow must keep
+ * passing. The two failure modes the probe distinguishes:
+ *
+ *   • HYBRID install (dev deps present, patch-package missing) — a broken
+ *     local node_modules that previously skipped SILENTLY and surfaced days
+ *     later as phantom test/tsc failures (2026-09-07 incident). Now a hard
+ *     error with the recovery command.
+ *   • PATCH DRIFT (patch-package ran but the marker is still absent) — the
+ *     patch no longer applies to the installed version; needs a human, so it
+ *     fails regardless of install flavor.
+ *
+ * Full `npm ci` (CI, packaging) still applies the patch, and
+ * atlasCoherence.test.ts fails in CI if the installed addon is unpatched.
  */
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { verifyPatchState } from './lib/patch-verify.mjs';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
 
-let bin;
+let bin = null;
 try {
   bin = path.join(path.dirname(require.resolve('patch-package/package.json')), 'index.js');
 } catch {
-  console.warn('[apply-patches] patch-package not installed (omit-dev?). Skipping.');
+  bin = null;
+}
+
+const hadPatcher = bin !== null;
+if (hadPatcher) {
+  const result = spawnSync(process.execPath, [bin], { cwd: root, stdio: 'inherit' });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+} else {
+  console.warn('[apply-patches] patch-package not installed (omit-dev?). Verifying installed state instead.');
+}
+
+const verdict = verifyPatchState(undefined, root);
+if (verdict.ok) process.exit(0);
+
+if (verdict.state === 'unpatched' && !verdict.devInstall && !hadPatcher) {
+  // The one legitimate unpatched state: a production (--omit=dev) install.
+  // Legacy behavior preserved — packaging flows must not fail here.
+  console.warn(
+    '[apply-patches] patches are NOT applied (production install without patch-package). ' +
+      'Packaged builds install with a full `npm ci`, which applies them.',
+  );
   process.exit(0);
 }
 
-const result = spawnSync(process.execPath, [bin], { cwd: root, stdio: 'inherit' });
-process.exit(result.status ?? 1);
+if (verdict.state === 'unpatched' && verdict.devInstall && !hadPatcher) {
+  console.error(
+    '[apply-patches] node_modules is inconsistent: dev dependencies are installed but ' +
+      'patch-package is missing, so the @xterm patches were never applied. ' +
+      'Symptoms appear later as atlasCoherence test failures and phantom tsc errors. ' +
+      'Fix: run `npm ci`.',
+  );
+  process.exit(1);
+}
+
+// patch-package ran (or was expected) yet the marker is absent: patch drift.
+console.error(
+  '[apply-patches] patch verification FAILED — the @xterm/addon-webgl patch marker is ' +
+    'absent after patch-package ran. The patch in patches/ likely no longer applies to the ' +
+    'installed version. Regenerate it: npx patch-package @xterm/addon-webgl',
+);
+process.exit(1);

--- a/scripts/lib/patch-verify.mjs
+++ b/scripts/lib/patch-verify.mjs
@@ -1,0 +1,65 @@
+// Patch-state verification for the postinstall hook (apply-patches.mjs).
+//
+// Patch application is load-bearing: the shipped @xterm/addon-webgl has a
+// glyph-atlas bug (xterm.js #4480 page-merge) that wmux's patches/ fix repairs,
+// and atlasCoherence.test.ts fails in CI when the patch is absent. But nothing
+// guarded the LOCAL case: a hybrid node_modules — dev dependencies present,
+// patch-package missing (an --omit=dev-style install layered over a full one) —
+// made the postinstall hook skip silently, and the broken state surfaced days
+// later as a phantom test failure plus phantom tsc errors (2026-09-07 incident).
+//
+// This module is the probe: read the installed addon-webgl bundle and check for
+// the patch marker. It is the CANARY for patch application generally — when
+// patch-package never ran, every patch in patches/ is missing, so probing the
+// one marker atlasCoherence already guards detects the whole class. Pure and
+// dependency-injected so the postinstall script and the unit tests share one
+// implementation with no fs mocking frameworks.
+
+import path from 'node:path';
+import fs from 'node:fs';
+
+/** Bundle file the addon-webgl patch rewrites, relative to the repo root. */
+export const PATCH_PROBE_FILE = path.join('node_modules', '@xterm', 'addon-webgl', 'lib', 'addon-webgl.js');
+
+/** Marker the patch's I1 hunk leaves in the bundle
+ *  (grep-identical to the string atlasCoherence.test.ts asserts). */
+export const PATCH_PROBE_MARKER = 'I1 — clearTexture is total';
+
+/** A devDependency that exists in every FULL install but never in an
+ *  --omit=dev install. Its presence with an unpatched probe file means the
+ *  install is a broken hybrid, not a deliberate production install. */
+export const DEV_INSTALL_SENTINEL = path.join('node_modules', 'typescript');
+
+/**
+ * Probe the installed tree and classify the patch state.
+ *
+ * @param {object} [deps] injectable fs surface (defaults to node:fs) so tests
+ *   can stub existence/content without touching a real node_modules.
+ * @param {string} [root] repo root to probe (defaults to cwd). apply-patches
+ *   passes its own module-derived root; tests pass a fabricated tree.
+ * @returns {{
+ *   state: 'patched' | 'target-absent' | 'unpatched',
+ *   ok: boolean,
+ *   devInstall?: boolean,
+ * }} `ok` is the verdict for THIS hook run: 'patched' and 'target-absent'
+ *   (nothing installed to verify — e.g. a scoped install) pass; 'unpatched'
+ *   fails and carries `devInstall` so the caller can choose the failure mode.
+ */
+export function verifyPatchState(deps = fs, root = process.cwd()) {
+  const { existsSync, readFileSync } = deps;
+  const probePath = path.join(root, PATCH_PROBE_FILE);
+  if (!existsSync(probePath)) return { state: 'target-absent', ok: true };
+  let content;
+  try {
+    content = readFileSync(probePath, 'utf8');
+  } catch {
+    // Unreadable probe file: treat as unpatched rather than silently passing.
+    return { state: 'unpatched', ok: false, devInstall: existsSync(path.join(root, DEV_INSTALL_SENTINEL)) };
+  }
+  if (content.includes(PATCH_PROBE_MARKER)) return { state: 'patched', ok: true };
+  return {
+    state: 'unpatched',
+    ok: false,
+    devInstall: existsSync(path.join(root, DEV_INSTALL_SENTINEL)),
+  };
+}


### PR DESCRIPTION
## Problem

The postinstall hook ran patch-package only when it was installed; when `patch-package` was absent it printed a `console.warn` and exited 0. That skip had one legitimate consumer (`npm ci --omit=dev`) but also silently masked a broken local state: a **hybrid node_modules** (dev deps present, patch-package missing — an `--omit=dev`-style install layered over a full one) skipped patch application with a warning nobody reads.

Observed fallout (2026-09-07 incident): the unpatched `@xterm/addon-webgl` made `atlasCoherence.test.ts` fail, and the partially-stripped type packages produced phantom `tsc` errors — poisoning every later diagnosis for days. Both vanished with a clean `npm ci`.

## Fix

`apply-patches.mjs` now verifies the patch actually landed after running (or skipping) patch-package, via `scripts/lib/patch-verify.mjs` — a probe of the installed addon-webgl bundle for the patch marker (the same string `atlasCoherence.test.ts` asserts; when patch-package never ran, EVERY patch is missing, so one marker detects the whole class):

| installed state | verdict |
|---|---|
| patched / probe target absent | pass |
| unpatched + dev deps present + no patcher (**the incident**) | **exit 1** with `npm ci` recovery hint |
| patcher ran but marker absent (patch drift) | **exit 1** with `npx patch-package @xterm/addon-webgl` hint |
| unpatched + genuinely `--omit=dev` | legacy skip preserved (packaging flows keep passing) |

## Verification (dogfooded)

- Unit tests: `scripts/__tests__/apply-patches-verify.test.mjs` — 5 tests over a fabricated fs tree (patched / absent / hybrid / prod / unreadable-probe)
- End-to-end dogfood in fabricated roots, all four states:
  - healthy full install → patches apply ✔, exit 0
  - hybrid (incident reproduction) → exit 1 + `Fix: run npm ci`
  - omit=dev → exit 0 + legacy warn
  - patch drift → exit 1 + regenerate hint
- Full `scripts/__tests__` suite: 345 passed, 1 skipped (pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install setup now verifies that required terminal-rendering patches were applied successfully.
  * Partially stripped development installs and patch failures now stop immediately with recovery guidance.
  * Production installs without development dependencies continue to complete successfully, with an appropriate warning.

* **Tests**
  * Added coverage for patched, missing-target, partially installed, production, and unreadable-install scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->