### PR TITLE
fix(term): repair stale frames on OS window refocus (#1234)

### DIFF
--- a/changelog.d/1239.md
+++ b/changelog.d/1239.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Terminal corruption after alt-tabbing away and back** (#1234): a stale/garbled frame could persist after refocusing the OS window — clicking into the pane or typing repaired nothing, only scrolling did. Refocusing the window now triggers an immediate full-pane repair (plus one delayed verification pass), without waiting for output or a workspace switch.

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1382,7 +1382,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Issue #166 — defensive full-range repaint for the "garbled glyphs until
     // resize" corruption (dirty-region desync). Strategy and trigger rationale
     // live in terminal/glyphRepaint.ts. Every reason (focus / visible / burst /
-    // settle-verify)
+    // settle-verify / window-focus)
     // does a plain full-range refresh; "focus" is throttled because it fires on
     // every keyboard pane-nav / MCP pane.focus via useActivePaneFocus's
     // term.focus(), not just mouse clicks, so the throttle is load-bearing. The
@@ -1422,6 +1422,23 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     const onTextareaFocus = () => glyphRepaint.onFocus();
     // terminal.textarea exists once open() has run (above).
     terminal.textarea?.addEventListener('focus', onTextareaFocus);
+
+    // #1234 — the OS window regained focus. Alt-tab out/back never blurs the
+    // textarea in Electron, so the pane `focus` reason cannot fire; the pane
+    // stays `visible`; an idle pane emits no `burst`. Without this listener a
+    // stale frame survives until the user scrolls. Two signals announce the
+    // same refocus (DOM window focus + visibilitychange — the latter is inert
+    // on Windows, #882); the scheduler's dedup window coalesces them. Gated on
+    // pane visibility: a hidden pane's repair is the `visible` repaint on
+    // reveal, so its refocus repaint would be wasted GPU work.
+    const onWindowRefocus = () => {
+      if (isVisibleRef.current) glyphRepaint.onWindowFocus();
+    };
+    window.addEventListener('focus', onWindowRefocus);
+    const onDocVisibility = () => {
+      if (document.visibilityState === 'visible') onWindowRefocus();
+    };
+    document.addEventListener('visibilitychange', onDocVisibility);
 
     // Shared-atlas page-merge guard (2026-08-01 report) — see atlasGuard.ts
     // for the root cause. glyphRepaint's refresh() above never touches the
@@ -2581,6 +2598,8 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       if (isMac) { container.removeEventListener('paste', blockNativePaste, true); }
       detachAltScreenWheel();
       terminal.textarea?.removeEventListener('focus', onTextareaFocus);
+      window.removeEventListener('focus', onWindowRefocus);
+      document.removeEventListener('visibilitychange', onDocVisibility);
       terminal.textarea?.removeEventListener('keydown', onWatchdogKeyDown);
       terminal.element?.removeEventListener('contextmenu', onTerminalContextMenu);
       glyphRepaint.dispose();

--- a/src/renderer/terminal/__tests__/glyphRepaint.test.ts
+++ b/src/renderer/terminal/__tests__/glyphRepaint.test.ts
@@ -8,6 +8,7 @@ import {
   FOCUS_THROTTLE_MS_DEFAULT,
   BURST_STREAM_FLUSH_MS_DEFAULT,
   SETTLE_VERIFY_MS_DEFAULT,
+  WINDOW_FOCUS_DEDUP_MS_DEFAULT,
   type RepaintReason,
 } from '../glyphRepaint';
 
@@ -356,6 +357,68 @@ describe('glyphRepaint scheduler', () => {
       s.onVisible();
       s.onVisible();
       expect(repaints).toEqual(['visible', 'visible']);
+    });
+  });
+
+  describe('window-focus repaint (#1234 — alt-tab repair)', () => {
+    it('fires an immediate repair plus one delayed verify', () => {
+      const s = createGlyphRepaintScheduler({ repaint });
+      s.onWindowFocus();
+      expect(repaints).toEqual(['window-focus']);
+      vi.advanceTimersByTime(SETTLE_VERIFY_MS_DEFAULT - 1);
+      expect(repaints).toEqual(['window-focus']);
+      vi.advanceTimersByTime(1);
+      expect(repaints).toEqual(['window-focus', 'settle-verify']);
+    });
+
+    it('coalesces the focus + visibilitychange pair into one repair', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({ repaint, now: () => t });
+      s.onWindowFocus(); // DOM window focus
+      s.onWindowFocus(); // visibilitychange, same tick — deduped
+      expect(repaints).toEqual(['window-focus']);
+      t += WINDOW_FOCUS_DEDUP_MS_DEFAULT; // past the dedup window
+      s.onWindowFocus();
+      expect(repaints).toEqual(['window-focus', 'window-focus']);
+      // One verify in flight, not one per signal.
+      vi.advanceTimersByTime(SETTLE_VERIFY_MS_DEFAULT + 1);
+      expect(repaints.filter((r) => r === 'settle-verify')).toHaveLength(1);
+    });
+
+    it('is deliberately NOT throttled by the pane-focus window', () => {
+      // A pane-focus repaint may have fired moments BEFORE the occlusion that
+      // caused the staleness — sharing that throttle would skip the repair on
+      // exactly the #1234 flow.
+      let t = 0;
+      const s = createGlyphRepaintScheduler({ repaint, now: () => t });
+      s.onFocus(); // pane focused at t=0
+      t += 100; // well inside FOCUS_THROTTLE_MS_DEFAULT
+      s.onWindowFocus();
+      expect(repaints).toEqual(['focus', 'window-focus']);
+    });
+
+    it('shares the verify timer with the settle path (latest deadline wins)', () => {
+      let t = 0;
+      const s = createGlyphRepaintScheduler({
+        repaint, activityBytes: 10, burstQuietMs: 50,
+        burstStreamFlushMs: Infinity, settleVerifyMs: 100, now: () => t,
+      });
+      const tick = (ms: number) => { t += ms; vi.advanceTimersByTime(ms); };
+      s.onData(100);
+      tick(50); // settle at t=50 arms verify for t=150
+      tick(40); // t=90: refocus re-arms the verify for t=190
+      s.onWindowFocus();
+      expect(repaints).toEqual(['burst', 'window-focus']);
+      tick(100); // t=190
+      expect(repaints).toEqual(['burst', 'window-focus', 'settle-verify']); // once
+    });
+
+    it('is cancelled by dispose', () => {
+      const s = createGlyphRepaintScheduler({ repaint });
+      s.onWindowFocus();
+      s.dispose();
+      vi.advanceTimersByTime(SETTLE_VERIFY_MS_DEFAULT * 2);
+      expect(repaints).toEqual(['window-focus']);
     });
   });
 

--- a/src/renderer/terminal/glyphRepaint.ts
+++ b/src/renderer/terminal/glyphRepaint.ts
@@ -27,6 +27,16 @@
 //                 once more when the stream finally settles.
 //   - `settle-verify` — one delayed repaint after the trailing settle flush
 //                 (see the "idle tail" note below).
+//   - `window-focus` — the OS window itself regained focus (#1234). Alt-tab
+//                 away and back leaves the textarea's DOM focus untouched (it
+//                 never blurs in Electron), so no pane `focus` fires; the pane
+//                 stays `visible`; and an idle pane produces no output, so no
+//                 `burst`. Nothing else can repair the frame — the reporter's
+//                 "only scrolling fixes it". Fires an immediate repair plus the
+//                 same delayed verify as settle (a single refresh can itself
+//                 race; see the idle-tail note), coalesced to one repaint per
+//                 refocus across the DOM `focus` and `visibilitychange` signals
+//                 that both announce it (the latter is inert on Windows, #882).
 //
 // --- Why the `burst` gate is an activity-based TIME cadence (issue #318) ---
 //
@@ -105,7 +115,7 @@
 // tested without xterm; all rendering side effects live in the caller's
 // `repaint` callback.
 
-export type RepaintReason = 'focus' | 'visible' | 'burst' | 'settle-verify';
+export type RepaintReason = 'focus' | 'visible' | 'burst' | 'settle-verify' | 'window-focus';
 
 export interface GlyphRepaintScheduler {
   /** Feed PTY write sizes; fires repaint('burst') on the streaming cadence. */
@@ -114,6 +124,11 @@ export interface GlyphRepaintScheduler {
   onFocus(): void;
   /** The terminal became visible again; immediate repaint('visible'). */
   onVisible(): void;
+  /** The OS window regained focus (#1234); immediate repaint('window-focus')
+   *  plus one coalesced delayed verify. Cheap to call from both the DOM
+   *  `focus` and `visibilitychange` handlers — the dedup window collapses
+   *  them into a single repair. */
+  onWindowFocus(): void;
   /** Cancel pending timers; all further calls become no-ops. */
   dispose(): void;
 }
@@ -164,6 +179,11 @@ export const BURST_STREAM_FLUSH_MS_DEFAULT = 1000;
 // enough that a user watching the pane sees the ghost for ~2s instead of
 // forever.
 export const SETTLE_VERIFY_MS_DEFAULT = 2000;
+// Coalescing window for `window-focus`: the DOM `focus` event and (on macOS)
+// `visibilitychange` can both announce the same refocus within one tick, and a
+// rapid alt-tab round should not repaint per signal. Human-scale refocus rates
+// are far below 4/s, so this costs nothing real.
+export const WINDOW_FOCUS_DEDUP_MS_DEFAULT = 250;
 
 export function createGlyphRepaintScheduler(
   options: GlyphRepaintOptions,
@@ -199,7 +219,18 @@ export function createGlyphRepaintScheduler(
   // delay — the latest settle's deadline wins (the verify must postdate the
   // newest settle's own raster), and one verify is in flight at a time.
   let settleVerifyTimer: ReturnType<typeof setTimeout> | null = null;
+  // Re-arms `settleVerifyTimer` with a full delay. Shared by the settle path
+  // and `window-focus` so their verifies coalesce (the latest deadline wins).
+  const armVerify = (): void => {
+    if (!settleVerifyEnabled) return;
+    if (settleVerifyTimer) clearTimeout(settleVerifyTimer);
+    settleVerifyTimer = setTimeout(() => {
+      settleVerifyTimer = null;
+      if (!disposed) repaint('settle-verify');
+    }, settleVerifyMs);
+  };
   let lastFocusRepaintAt = -Infinity;
+  let lastWindowFocusAt = -Infinity;
   // Timestamp of the last real flush (mid or trailing). Seeded to -Infinity so
   // the first qualifying write flushes immediately — intentional and harmless.
   // Only ever advanced when a flush actually fires (never on a dropped tail).
@@ -247,13 +278,7 @@ export function createGlyphRepaintScheduler(
           // Idle-tail verify: this settle flush is the stream's final repair,
           // but its own raster can race and paint stale pixels. One more
           // full-range refresh after the raster commits closes that window.
-          if (settleVerifyEnabled) {
-            if (settleVerifyTimer) clearTimeout(settleVerifyTimer);
-            settleVerifyTimer = setTimeout(() => {
-              settleVerifyTimer = null;
-              if (!disposed) repaint('settle-verify');
-            }, settleVerifyMs);
-          }
+          armVerify();
         } else {
           // Sub-threshold noise that never flushed: drop it so a stale trickle
           // can't leak into a later unrelated stream's first-flush timing. No
@@ -275,6 +300,22 @@ export function createGlyphRepaintScheduler(
     onVisible(): void {
       if (disposed) return;
       repaint('visible');
+    },
+
+    onWindowFocus(): void {
+      if (disposed) return;
+      const t = now();
+      // Coalesce the focus + visibilitychange pair (and rapid alt-tab rounds).
+      // Deliberately NOT the pane-focus throttle: a pane-focus repaint may
+      // have fired seconds BEFORE the occlusion that caused the staleness, so
+      // sharing it would skip the repair on exactly the #1234 flow.
+      if (t - lastWindowFocusAt < WINDOW_FOCUS_DEDUP_MS_DEFAULT) return;
+      lastWindowFocusAt = t;
+      repaint('window-focus');
+      // Same lesson as the idle tail: one full-range refresh can itself race,
+      // and after a refocus there is usually no further repaint coming (idle
+      // pane, focus already held). Arm the shared verify.
+      armVerify();
     },
 
     dispose(): void {


### PR DESCRIPTION
## What

Fixes #1234 (same corruption class as #879/#166/#318/#1230, on the alt-tab path).

**Why the existing triggers miss it.** Alt-tab away and back:
- the textarea never loses DOM focus in Electron → no `focus` repaint (clicking back into the pane also does not refire it — matches the report that focusing/typing does nothing);
- the pane never left the visible state → no `visible` repaint;
- an idle pane emits no output → no `burst`/`settle`.

The stale frame survived until the user scrolled — the one path that forces a full re-render.

**Fix.** New `window-focus` repaint reason:
- `glyphRepaint.onWindowFocus()` — immediate full-range repair **plus** the delayed verify the settle path already arms (#1230's lesson: a single refresh can itself race).
- Wired to DOM `window focus` **and** `visibilitychange → visible` (inert on Windows, #882, but the signal on macOS); a 250ms dedup window coalesces the pair into one repair.
- Deliberately **not** sharing the pane-focus throttle: a pane-focus repaint may have fired moments before the occlusion that caused the staleness.
- Gated on pane visibility — a hidden pane's repair is the `visible` repaint on reveal.

## Tests

5 new scheduler cases (33 total in the file): immediate+verify firing, signal-pair coalescing, non-interference with the focus throttle, verify-timer sharing with the settle path, dispose cancellation.

Reporter: it lands as draft since the corruption is driver/timing-dependent — if you can still repro on this build, the `[wmux:glyph-repaint]` console.debug line (Verbose) will say whether `window-focus` fired on refocus.