### PR TITLE
feat(window): transparency + Windows 11 backdrop material (#1133)

### DIFF
--- a/changelog.d/1244.md
+++ b/changelog.d/1244.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Window transparency & Windows 11 backdrop material** (#1133): a new Appearance setting paints the window background at reduced opacity so the desktop (or the system-composited mica/acrylic backdrop, Windows 11 only) shows through — the frosted-terminal look, with panels and terminals staying fully readable. Opacity and material changes apply live; enabling or disabling transparency itself takes effect after a restart (the window is built with the flag at startup). Off by default.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,9 +34,13 @@ process.on('uncaughtException', (err) => {
 import { markBoot, emitBootSummary } from './util/bootTrace';
 import * as crypto from 'crypto';
 import * as path from 'path';
+import * as os from 'os';
+import { parseWindowsBuildNumber } from '../shared/platform';
+import { WINDOWS_11_FIRST_BUILD } from '../shared/conptyWindows';
+import { normalizeWindowAppearance, type WindowAppearancePrefs } from '../shared/windowAppearance';
 import { app, BrowserWindow, dialog, ipcMain, powerMonitor } from 'electron';
 import { checkUserDataIsolation } from './dataIsolation';
-import { createWindow, loadMainRenderer } from './window/createWindow';
+import { createWindow, loadMainRenderer, windowWillBeTranslucent } from './window/createWindow';
 import { attachDesktopPresenceReporter, reportDesktopPresence } from './window/desktopPresence';
 import { PTYManager } from './pty/PTYManager';
 import { PTYBridge } from './pty/PTYBridge';
@@ -109,6 +113,7 @@ import { McpRegistrar } from './mcp/McpRegistrar';
 import { BrokerSupervisor, isMcpBrokerEnabled } from './mcp/BrokerSupervisor';
 import { WebviewCdpManager } from './browser-session/WebviewCdpManager';
 import { BrowserBackendStore } from './browser-session/BrowserBackendStore';
+import { WindowAppearanceStore } from './window/WindowAppearanceStore';
 import { ChromeLauncherRegistry } from './browser-session/ChromeLauncher';
 import { ChromeProfileStore } from './browser-session/ChromeProfileStore';
 import { ChromeSurfaceStore } from './browser-session/ChromeSurfaceStore';
@@ -801,6 +806,37 @@ registerPerfRpc(rpcRouter);
 // arrive before the renderer has pushed anything, so renderer-push authority
 // would race and fail open to builtin).
 const browserBackendStore = new BrowserBackendStore(app.getPath('userData'));
+// #1133 window transparency: main owns the prefs for the same reason — the
+// window is created `transparent: true` (or not) before the renderer boots.
+const windowAppearanceStore = new WindowAppearanceStore(app.getPath('userData'));
+/** Whether the CURRENT main window was created translucent — flips only with
+ *  a window rebuild, so the Settings UI can say "restart to apply" honestly. */
+let mainWindowCreatedTranslucent = false;
+/** Every main-window creation site goes through here so the appearance prefs
+ *  (and the translucency mirror above) apply uniformly — boot, the updater's
+ *  abort-install rebuild, and the macOS activate re-open. */
+function createMainWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow {
+  const appearance = windowAppearanceStore.get();
+  mainWindowCreatedTranslucent = windowWillBeTranslucent(appearance);
+  return createWindow({ ...opts, appearance });
+}
+/** Live-apply what CAN change without a window rebuild: the OS backdrop
+ *  material and the renderer tint. The `transparent` flag itself cannot. */
+function applyLiveWindowAppearance(prefs: WindowAppearancePrefs): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (process.platform === 'win32') {
+      const build = parseWindowsBuildNumber(os.release());
+      if (build !== null && build >= WINDOWS_11_FIRST_BUILD) {
+        try {
+          mainWindow.setBackgroundMaterial(prefs.material);
+        } catch {
+          /* OS/driver refusal degrades to the plain tint */
+        }
+      }
+    }
+    mainWindow.webContents.send(IPC.WINDOW_APPEARANCE_CHANGED, prefs);
+  }
+}
 // 'chrome' backend: per-profile real-Chrome instances (Phase 2.5). The
 // 'default' profile keeps the pre-registry dir so existing logins survive.
 const chromeProfileStore = new ChromeProfileStore();
@@ -1178,6 +1214,20 @@ ipcMain.handle('browser:set-backend', (_event, value: unknown) => {
   browserBackendStore.set(value);
   return { ok: true };
 });
+// #1133 — window transparency prefs. `active` reports whether the LIVE window
+// was created translucent: the `transparent` flag is creation-only in
+// Chromium, so a prefs write that flips windowNeedsTransparentCreation() is
+// restart-gated and the Settings UI must say so instead of silently applying.
+ipcMain.handle(IPC.WINDOW_APPEARANCE_GET, () => ({
+  ...windowAppearanceStore.get(),
+  active: mainWindowCreatedTranslucent,
+}));
+ipcMain.handle(IPC.WINDOW_APPEARANCE_SET, (_event, raw: unknown) => {
+  const prefs = normalizeWindowAppearance(raw);
+  windowAppearanceStore.set(prefs);
+  applyLiveWindowAppearance(prefs);
+  return { ...prefs, active: mainWindowCreatedTranslucent };
+});
 // Phase 2.5 — chrome-backend profiles + workspace bindings (workspace card
 // menu). Validation lives in the store; IPC only shapes the payloads.
 ipcMain.handle('browser:chrome-profiles:list', () => ({
@@ -1400,7 +1450,7 @@ app.on('ready', async () => {
   registerPluginProtocolHandler(() => pluginHostLoader);
   markBoot('plugins-loaded');
 
-  mainWindow = createWindow({ deferLoad: true });
+  mainWindow = createMainWindow({ deferLoad: true });
   markBoot('window-created');
   console.log(`[Main] Window created (renderer load deferred): ${!!mainWindow}`);
   logLine('info', 'main', `window created (deferred): present=${!!mainWindow}`);
@@ -2107,7 +2157,7 @@ async function abortInstallQuit(): Promise<void> {
   // its renderer, or the caller's error IPC lands before any listener exists.
   // deferLoad so the reload backoff and console wiring are attached before the
   // navigation starts — this window's whole job is to render the failure.
-  const win = createWindow({ deferLoad: true });
+  const win = createMainWindow({ deferLoad: true });
   mainWindow = win;
   adoptMainWindow(win);
   loadMainRenderer(win);
@@ -2448,7 +2498,7 @@ app.on('activate', () => {
   if (isQuitting) return;
   const windows = BrowserWindow.getAllWindows();
   if (windows.length === 0) {
-    mainWindow = createWindow();
+    mainWindow = createMainWindow();
     adoptMainWindow(mainWindow);
     return;
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -834,7 +834,14 @@ function applyLiveWindowAppearance(prefs: WindowAppearancePrefs): void {
         }
       }
     }
-    mainWindow.webContents.send(IPC.WINDOW_APPEARANCE_CHANGED, prefs);
+    // `active` rides the push too: the renderer must NOT tint a window that
+    // was not created transparent (an opaque native backgroundColor sits
+    // behind the web content — tinting over it renders a wrong, dark-shifted
+    // blend until the restart that rebuilds the window).
+    mainWindow.webContents.send(IPC.WINDOW_APPEARANCE_CHANGED, {
+      ...prefs,
+      active: mainWindowCreatedTranslucent,
+    });
   }
 }
 // 'chrome' backend: per-profile real-Chrome instances (Phase 2.5). The

--- a/src/main/window/WindowAppearanceStore.ts
+++ b/src/main/window/WindowAppearanceStore.ts
@@ -18,8 +18,15 @@ import {
 export class WindowAppearanceStore {
   private readonly filePath: string;
   private prefs: WindowAppearancePrefs = DEFAULT_WINDOW_APPEARANCE;
+  // Trailing debounce for the disk write: the Settings slider fires a set()
+  // per tick, and each persist is a synchronous mkdir+write+rename on the
+  // MAIN process — a 30→100 drag must not become ~70 sequential sync writes.
+  // The in-memory value (what window creation reads) is always immediate.
+  private persistTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly persistDebounceMs: number;
 
-  constructor(userDataDir: string) {
+  constructor(userDataDir: string, persistDebounceMs = 150) {
+    this.persistDebounceMs = persistDebounceMs;
     this.filePath = join(userDataDir, 'window-appearance.json');
     try {
       const parsed: unknown = JSON.parse(readFileSync(this.filePath, 'utf8'));
@@ -38,18 +45,30 @@ export class WindowAppearanceStore {
 
   set(prefs: WindowAppearancePrefs): void {
     this.prefs = normalizeWindowAppearance(prefs);
-    try {
-      mkdirSync(dirname(this.filePath), { recursive: true });
-      // Atomic write (tmp + rename): a crash mid-write must not leave a
-      // truncated file that boots the next window opaque (or translucent)
-      // contrary to what the user chose.
-      const tmpPath = `${this.filePath}.tmp`;
-      writeFileSync(tmpPath, JSON.stringify({ appearance: this.prefs }), 'utf8');
-      renameSync(tmpPath, this.filePath);
-    } catch (err) {
-      // In-memory value still applies for this session; persistence failures
-      // are logged, not swallowed.
-      console.error('[WindowAppearanceStore] persist failed:', err);
+    if (this.persistTimer) clearTimeout(this.persistTimer);
+    const flush = (): void => {
+      this.persistTimer = null;
+      try {
+        mkdirSync(dirname(this.filePath), { recursive: true });
+        // Atomic write (tmp + rename): a crash mid-write must not leave a
+        // truncated file that boots the next window opaque (or translucent)
+        // contrary to what the user chose.
+        const tmpPath = `${this.filePath}.tmp`;
+        writeFileSync(tmpPath, JSON.stringify({ appearance: this.prefs }), 'utf8');
+        renameSync(tmpPath, this.filePath);
+      } catch (err) {
+        // In-memory value still applies for this session; persistence failures
+        // are logged, not swallowed.
+        console.error('[WindowAppearanceStore] persist failed:', err);
+      }
+    };
+    if (this.persistDebounceMs <= 0) {
+      flush();
+      return;
     }
+    this.persistTimer = setTimeout(flush, this.persistDebounceMs);
+    // The debounced write must not be lost to process exit — a quit while a
+    // drag's trailing write is pending would silently roll the choice back.
+    (this.persistTimer as { unref?: () => void }).unref?.();
   }
 }

--- a/src/main/window/WindowAppearanceStore.ts
+++ b/src/main/window/WindowAppearanceStore.ts
@@ -1,0 +1,55 @@
+import { readFileSync, writeFileSync, mkdirSync, renameSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  type WindowAppearancePrefs,
+  DEFAULT_WINDOW_APPEARANCE,
+  normalizeWindowAppearance,
+} from '../../shared/windowAppearance';
+
+/**
+ * Main-owned persistence for the window transparency prefs (#1133).
+ *
+ * Same shape and rationale as BrowserBackendStore: the consumer is window
+ * creation in the main process, which runs before the renderer exists, so the
+ * value is read synchronously at construction — the very first window is
+ * created with the right `transparent` flag with no settled gate or race.
+ * The renderer Settings UI reads/writes over IPC and keeps only a mirror.
+ */
+export class WindowAppearanceStore {
+  private readonly filePath: string;
+  private prefs: WindowAppearancePrefs = DEFAULT_WINDOW_APPEARANCE;
+
+  constructor(userDataDir: string) {
+    this.filePath = join(userDataDir, 'window-appearance.json');
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(this.filePath, 'utf8'));
+      const value = (parsed as { appearance?: unknown } | null)?.appearance;
+      this.prefs = normalizeWindowAppearance(value);
+      // Unknown/corrupt content degrades per-field to the defaults — a broken
+      // opacity must never take an opaque-window user by surprise.
+    } catch {
+      /* missing or unreadable file → defaults (today's opaque behaviour) */
+    }
+  }
+
+  get(): WindowAppearancePrefs {
+    return this.prefs;
+  }
+
+  set(prefs: WindowAppearancePrefs): void {
+    this.prefs = normalizeWindowAppearance(prefs);
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      // Atomic write (tmp + rename): a crash mid-write must not leave a
+      // truncated file that boots the next window opaque (or translucent)
+      // contrary to what the user chose.
+      const tmpPath = `${this.filePath}.tmp`;
+      writeFileSync(tmpPath, JSON.stringify({ appearance: this.prefs }), 'utf8');
+      renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      // In-memory value still applies for this session; persistence failures
+      // are logged, not swallowed.
+      console.error('[WindowAppearanceStore] persist failed:', err);
+    }
+  }
+}

--- a/src/main/window/__tests__/WindowAppearanceStore.test.ts
+++ b/src/main/window/__tests__/WindowAppearanceStore.test.ts
@@ -51,12 +51,19 @@ describe('windowNeedsTransparentCreation', () => {
 });
 
 describe('WindowAppearanceStore', () => {
+  // set() debounces the disk write (150ms default) — tests construct with 0
+  // so every set() flushes synchronously, which is what the round-trip
+  // assertions read.
+  function storeNow(dir: string): WindowAppearanceStore {
+    return new WindowAppearanceStore(dir, 0);
+  }
+
   it('falls back to defaults for a missing or corrupt file', () => {
     const dir = tmpDir();
     try {
-      expect(new WindowAppearanceStore(dir).get()).toEqual(DEFAULT_WINDOW_APPEARANCE);
+      expect(new WindowAppearanceStore(dir, 0).get()).toEqual(DEFAULT_WINDOW_APPEARANCE);
       writeFileSync(join(dir, 'window-appearance.json'), '{not json', 'utf8');
-      expect(new WindowAppearanceStore(dir).get()).toEqual(DEFAULT_WINDOW_APPEARANCE);
+      expect(new WindowAppearanceStore(dir, 0).get()).toEqual(DEFAULT_WINDOW_APPEARANCE);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -65,9 +72,9 @@ describe('WindowAppearanceStore', () => {
   it('round-trips a written prefs object', () => {
     const dir = tmpDir();
     try {
-      const store = new WindowAppearanceStore(dir);
+      const store = storeNow(dir);
       store.set({ opacity: 75, material: 'mica' });
-      expect(new WindowAppearanceStore(dir).get()).toEqual({ opacity: 75, material: 'mica' });
+      expect(new WindowAppearanceStore(dir, 0).get()).toEqual({ opacity: 75, material: 'mica' });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -76,9 +83,9 @@ describe('WindowAppearanceStore', () => {
   it('normalizes on write — an out-of-range value never reaches disk', () => {
     const dir = tmpDir();
     try {
-      const store = new WindowAppearanceStore(dir);
+      const store = storeNow(dir);
       store.set({ opacity: 250, material: 'mica' } as never);
-      expect(new WindowAppearanceStore(dir).get()).toEqual({ opacity: 100, material: 'mica' });
+      expect(new WindowAppearanceStore(dir, 0).get()).toEqual({ opacity: 100, material: 'mica' });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/main/window/__tests__/WindowAppearanceStore.test.ts
+++ b/src/main/window/__tests__/WindowAppearanceStore.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WindowAppearanceStore } from '../WindowAppearanceStore';
+import {
+  DEFAULT_WINDOW_APPEARANCE,
+  normalizeWindowAppearance,
+  windowNeedsTransparentCreation,
+} from '../../../shared/windowAppearance';
+
+// #1133 — main-owned prefs. Same contract shape as BrowserBackendStore: sync
+// read at construction, atomic write, per-field degradation on corruption.
+
+function tmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'wmux-window-appearance-'));
+}
+
+describe('normalizeWindowAppearance', () => {
+  it('defaults for garbage of every shape', () => {
+    expect(normalizeWindowAppearance(undefined)).toEqual(DEFAULT_WINDOW_APPEARANCE);
+    expect(normalizeWindowAppearance(null)).toEqual(DEFAULT_WINDOW_APPEARANCE);
+    expect(normalizeWindowAppearance('mica')).toEqual(DEFAULT_WINDOW_APPEARANCE);
+    expect(normalizeWindowAppearance({ opacity: 'lots', material: 4 })).toEqual(DEFAULT_WINDOW_APPEARANCE);
+  });
+
+  it('degrades per field — a corrupt opacity keeps the material', () => {
+    expect(normalizeWindowAppearance({ opacity: NaN, material: 'acrylic' }))
+      .toEqual({ opacity: 100, material: 'acrylic' });
+    expect(normalizeWindowAppearance({ opacity: 70, material: 'frosted-glass' }))
+      .toEqual({ opacity: 70, material: 'none' });
+  });
+
+  it('clamps and rounds opacity into 0..100', () => {
+    expect(normalizeWindowAppearance({ opacity: 140 }).opacity).toBe(100);
+    expect(normalizeWindowAppearance({ opacity: -3 }).opacity).toBe(0);
+    expect(normalizeWindowAppearance({ opacity: 66.6 }).opacity).toBe(67);
+  });
+});
+
+describe('windowNeedsTransparentCreation', () => {
+  it('is false exactly for today’s opaque behaviour', () => {
+    expect(windowNeedsTransparentCreation({ opacity: 100, material: 'none' })).toBe(false);
+  });
+
+  it('is true for a reduced opacity or any material', () => {
+    expect(windowNeedsTransparentCreation({ opacity: 99, material: 'none' })).toBe(true);
+    expect(windowNeedsTransparentCreation({ opacity: 100, material: 'mica' })).toBe(true);
+    expect(windowNeedsTransparentCreation({ opacity: 80, material: 'acrylic' })).toBe(true);
+  });
+});
+
+describe('WindowAppearanceStore', () => {
+  it('falls back to defaults for a missing or corrupt file', () => {
+    const dir = tmpDir();
+    try {
+      expect(new WindowAppearanceStore(dir).get()).toEqual(DEFAULT_WINDOW_APPEARANCE);
+      writeFileSync(join(dir, 'window-appearance.json'), '{not json', 'utf8');
+      expect(new WindowAppearanceStore(dir).get()).toEqual(DEFAULT_WINDOW_APPEARANCE);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('round-trips a written prefs object', () => {
+    const dir = tmpDir();
+    try {
+      const store = new WindowAppearanceStore(dir);
+      store.set({ opacity: 75, material: 'mica' });
+      expect(new WindowAppearanceStore(dir).get()).toEqual({ opacity: 75, material: 'mica' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('normalizes on write — an out-of-range value never reaches disk', () => {
+    const dir = tmpDir();
+    try {
+      const store = new WindowAppearanceStore(dir);
+      store.set({ opacity: 250, material: 'mica' } as never);
+      expect(new WindowAppearanceStore(dir).get()).toEqual({ opacity: 100, material: 'mica' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/main/window/createWindow.ts
+++ b/src/main/window/createWindow.ts
@@ -1,8 +1,14 @@
 import { app, BrowserWindow, powerMonitor, shell } from 'electron';
 import path from 'node:path';
-import { platformChoice } from '../../shared/platform';
+import os from 'node:os';
+import { platformChoice, parseWindowsBuildNumber } from '../../shared/platform';
+import { WINDOWS_11_FIRST_BUILD } from '../../shared/conptyWindows';
 import { IPC } from '../../shared/constants';
 import { PLUGIN_PROTOCOL_SCHEME } from '../../shared/pluginHost';
+import {
+  type WindowAppearancePrefs,
+  windowNeedsTransparentCreation,
+} from '../../shared/windowAppearance';
 import { attachFlashFrameAutoClear } from './flashFrame';
 import { windowDisplayedReporter } from './windowDisplayed';
 
@@ -85,7 +91,25 @@ export function loadMainRenderer(mainWindow: BrowserWindow): void {
  * leaves `deferLoad` unset because the daemon is already healthy by the
  * time activate fires.
  */
-export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow {
+/**
+ * #1133 — whether this machine's next window is created translucent. The
+ * platform term lives here (next to its only consumer) so main/index.ts's
+ * "was the current window created translucent" mirror cannot drift from the
+ * creation decision. Linux stays opaque on purpose — without a compositor
+ * guarantee the transparent flag yields a black window.
+ */
+export function windowWillBeTranslucent(appearance: WindowAppearancePrefs): boolean {
+  return windowNeedsTransparentCreation(appearance)
+    && (process.platform === 'win32' || process.platform === 'darwin');
+}
+
+export function createWindow(
+  opts: { deferLoad?: boolean; appearance?: WindowAppearancePrefs } = {},
+): BrowserWindow {
+  // #1133 — translucency is a CREATION-time flag in Chromium: `transparent`
+  // cannot be toggled on a live window, so the prefs (main-owned, read before
+  // the renderer boots) decide it here.
+  const translucent = opts.appearance !== undefined && windowWillBeTranslucent(opts.appearance);
   const mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
@@ -130,7 +154,9 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
     }),
     // Matches the amber (default) theme's bgBase so the first paint doesn't
     // flash a foreign color behind the renderer (was catppuccin '#1e1e2e').
-    backgroundColor: '#151517',
+    // A translucent window must NOT set it: an opaque native background would
+    // sit behind the web content forever, defeating transparency entirely.
+    ...(translucent ? { transparent: true } : { backgroundColor: '#151517' }),
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -138,6 +164,21 @@ export function createWindow(opts: { deferLoad?: boolean } = {}): BrowserWindow 
       webviewTag: true,
     },
   });
+
+  // #1133 — Windows 11 system backdrop. mica/acrylic composite at the OS level
+  // (near-zero GPU cost); the renderer's `--bg-base` tint paints OVER whatever
+  // material shows through. Older Windows and other platforms ignore it.
+  const material = opts.appearance?.material;
+  const winBuild = parseWindowsBuildNumber(os.release());
+  if (translucent && material && material !== 'none' && process.platform === 'win32' &&
+      winBuild !== null && winBuild >= WINDOWS_11_FIRST_BUILD) {
+    try {
+      mainWindow.setBackgroundMaterial(material);
+    } catch {
+      // A driver/OS refusal must not take the window down — opaque-ish tint
+      // over nothing is the graceful degradation.
+    }
+  }
 
   // macOS: native fullscreen hides the traffic lights, so the renderer's
   // titlebar must drop its 72px left reserve (and restore it on exit) — the

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -298,6 +298,26 @@ const electronAPI = {
     get: () => ipcRenderer.invoke(IPC.AUTOSTART_GET) as Promise<{ enabled: boolean }>,
     set: (enabled: boolean) => ipcRenderer.invoke(IPC.AUTOSTART_SET, enabled) as Promise<{ enabled: boolean }>,
   },
+  // #1133 — window transparency. Main owns the prefs (the `transparent` flag
+  // is decided at window creation, before this renderer exists). `active` in
+  // the responses says whether the LIVE window was created translucent — a
+  // change that flips it applies after a restart, not now. The changed event
+  // re-tints every renderer surface without a reload.
+  windowAppearance: {
+    get: () => ipcRenderer.invoke(
+      IPC.WINDOW_APPEARANCE_GET,
+    ) as Promise<import('../shared/windowAppearance').WindowAppearancePrefs & { active: boolean }>,
+    set: (prefs: import('../shared/windowAppearance').WindowAppearancePrefs) =>
+      ipcRenderer.invoke(
+        IPC.WINDOW_APPEARANCE_SET,
+        prefs,
+      ) as Promise<import('../shared/windowAppearance').WindowAppearancePrefs & { active: boolean }>,
+    onChanged: (listener: (prefs: import('../shared/windowAppearance').WindowAppearancePrefs) => void) => {
+      const l = (_e: Electron.IpcRendererEvent, prefs: import('../shared/windowAppearance').WindowAppearancePrefs): void => listener(prefs);
+      ipcRenderer.on(IPC.WINDOW_APPEARANCE_CHANGED, l);
+      return () => { ipcRenderer.removeListener(IPC.WINDOW_APPEARANCE_CHANGED, l); };
+    },
+  },
   notification: {
     // ptyId may be null for app-level notifications (e.g. external MCP
     // `notify` RPC, where no PTY originates the message). When null, the

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -652,6 +652,35 @@ function useUiScaleSync(uiScale: number): void {
   }, [uiScale]);
 }
 
+/**
+ * #1133 — window transparency tint. Reflects main's prefs onto the document
+ * root as two properties the globals.css rules read: whether translucency is
+ * wanted at all (`data-window-translucent`) and how much of `--bg-base` to
+ * paint over the desktop / backdrop material (`--window-bg-opacity`). Live
+ * via the WINDOW_APPEARANCE_CHANGED push; the creation-time `transparent`
+ * flag itself is main's to gate (restart-required changes surface in the
+ * Settings UI, not here).
+ */
+function useWindowAppearanceTint(): void {
+  useEffect(() => {
+    const api = window.electronAPI?.windowAppearance;
+    if (!api) return; // tests / non-electron
+    const apply = (prefs: { opacity: number; material: string }): void => {
+      const translucent = prefs.opacity < 100 || prefs.material !== 'none';
+      if (translucent) {
+        document.documentElement.dataset.windowTranslucent = 'true';
+        document.documentElement.style.setProperty('--window-bg-opacity', String(prefs.opacity));
+      } else {
+        delete document.documentElement.dataset.windowTranslucent;
+        document.documentElement.style.removeProperty('--window-bg-opacity');
+      }
+    };
+    void api.get().then(apply).catch(() => { /* preload gap → opaque, today's behaviour */ });
+    const off = api.onChanged(apply);
+    return off;
+  }, []);
+}
+
 export default function AppLayout() {
   // UI scale (#822): the persisted factor. The sync effect below forwards it
   // to main, which scales the whole renderer and re-places the native chrome.
@@ -661,6 +690,8 @@ export default function AppLayout() {
   // Forward the persisted UI-scale factor to main whenever it changes or the
   // theme (overlay colors) does — see useUiScaleSync below.
   useUiScaleSync(uiScale);
+  // #1133 — reflect the window-transparency prefs onto the document root.
+  useWindowAppearanceTint();
   const sidebarVisible = useStore((s) => s.sidebarVisible);
   const channelDockVisible = useStore((s) => s.channelDockVisible);
   const sidebarPosition = useStore((s) => s.sidebarPosition);
@@ -1779,7 +1810,7 @@ export default function AppLayout() {
   return (
     <ErrorBoundary name="AppLayout">
     <div
-      className="flex flex-col h-screen w-screen bg-[var(--bg-base)] overflow-hidden"
+      className="app-layout-root flex flex-col h-screen w-screen bg-[var(--bg-base)] overflow-hidden"
       style={{
         ...(prefixMode ? {
           boxShadow: 'inset 0 0 0 2px var(--accent-red)',

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -665,8 +665,12 @@ function useWindowAppearanceTint(): void {
   useEffect(() => {
     const api = window.electronAPI?.windowAppearance;
     if (!api) return; // tests / non-electron
-    const apply = (prefs: { opacity: number; material: string }): void => {
-      const translucent = prefs.opacity < 100 || prefs.material !== 'none';
+    // `active` says whether the LIVE window was created transparent — without
+    // it, first-time enable (pre-restart) would tint html/body over the opaque
+    // native background and every non-amber theme would render a wrong blend.
+    const apply = (prefs: { opacity: number; material: string; active?: boolean }): void => {
+      const translucent = (prefs.opacity < 100 || prefs.material !== 'none')
+        && prefs.active !== false;
       if (translucent) {
         document.documentElement.dataset.windowTranslucent = 'true';
         document.documentElement.style.setProperty('--window-bg-opacity', String(prefs.opacity));

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useState, useCallback, type ReactNode } from 'react';
 import { BROWSER_BACKENDS, isBrowserBackend } from '../../../shared/browserBackend';
+import {
+  WINDOW_OPACITY_SLIDER_MIN,
+  type WindowMaterial,
+  type WindowAppearancePrefs,
+} from '../../../shared/windowAppearance';
 import type { ImagePasteMode } from '../../../shared/imagePaste';
 import { useShallow } from 'zustand/react/shallow';
 import { useStore } from '../../stores';
@@ -3665,6 +3670,58 @@ function TabAppearance() {
   const uiScale = useStore((s) => s.uiScale);
   const setUiScale = useStore((s) => s.setUiScale);
 
+  // #1133 — window transparency. Main owns the prefs (creation-time
+  // `transparent` flag); the mirror here is non-persisted, for rendering only.
+  // Linux is excluded — without a compositor guarantee the flag yields a black
+  // window — and the material row additionally needs Windows 11.
+  const isWindows11 = useMemo(() => {
+    const build = window.electronAPI?.windowsBuildNumber;
+    return build !== null && build !== undefined && build >= 22000;
+  }, []);
+  const appearanceSupported = useMemo(
+    () => window.electronAPI?.platform === 'win32' || window.electronAPI?.platform === 'darwin',
+    [],
+  );
+  const [windowOpacity, setWindowOpacity] = useState<number | null>(null);
+  const [windowMaterial, setWindowMaterial] = useState<WindowMaterial | null>(null);
+  const [windowTransparencyActive, setWindowTransparencyActive] = useState<boolean | null>(null);
+  useEffect(() => {
+    const api = window.electronAPI?.windowAppearance;
+    if (!api || !appearanceSupported) return;
+    let alive = true;
+    void api.get().then((prefs) => {
+      if (!alive) return;
+      setWindowOpacity(prefs.opacity);
+      setWindowMaterial(prefs.material);
+      setWindowTransparencyActive(prefs.active);
+    }).catch(() => { /* preload gap → controls stay hidden */ });
+    const off = api.onChanged((prefs) => {
+      setWindowOpacity(prefs.opacity);
+      setWindowMaterial(prefs.material);
+    });
+    return () => { alive = false; off(); };
+  }, [appearanceSupported]);
+  const pushWindowAppearance = useCallback((next: WindowAppearancePrefs) => {
+    void window.electronAPI?.windowAppearance?.set(next).then((res) => {
+      // The live window cannot become (un)translucent without a rebuild —
+      // surface that honestly instead of pretending the toggle applied.
+      setWindowTransparencyActive(res.active);
+    }).catch(() => { /* main persists best-effort */ });
+  }, []);
+  const onWindowOpacityChange = useCallback((opacity: number) => {
+    setWindowOpacity(opacity);
+    if (windowMaterial !== null) pushWindowAppearance({ opacity, material: windowMaterial });
+  }, [pushWindowAppearance, windowMaterial]);
+  const onWindowMaterialChange = useCallback((material: WindowMaterial) => {
+    setWindowMaterial(material);
+    if (windowOpacity !== null) pushWindowAppearance({ opacity: windowOpacity, material });
+  }, [pushWindowAppearance, windowOpacity]);
+  // Restart is needed when the prefs ask for translucency the live window
+  // was not created with (or no longer wants).
+  const windowRestartPending = windowOpacity !== null && windowMaterial !== null &&
+    windowTransparencyActive !== null &&
+    windowTransparencyActive !== (windowOpacity < 100 || windowMaterial !== 'none');
+
   const currentTheme = useStore((s) => s.theme);
   const setTheme = useStore((s) => s.setTheme);
   // Live custom-theme colors drive the `custom` card's thumbnail so it always
@@ -3870,6 +3927,57 @@ function TabAppearance() {
             </span>
           </div>
         </SettingRow>
+        {/* #1133 — window transparency (Windows/macOS; material is Win11). */}
+        {appearanceSupported && windowOpacity !== null && windowMaterial !== null && (
+          <>
+            <SettingRow
+              id="window-opacity"
+              label={t('settings.windowOpacity')}
+              description={t('settings.windowOpacityDesc')}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min={WINDOW_OPACITY_SLIDER_MIN}
+                  max={100}
+                  step={1}
+                  value={windowOpacity}
+                  onChange={(e) => onWindowOpacityChange(Number(e.target.value))}
+                  aria-label={t('settings.windowOpacity')}
+                  className="w-24 accent-[color:var(--accent-blue)]"
+                />
+                <span className="text-xs font-mono tabular-nums text-[color:var(--text-sub)] w-8 text-right">
+                  {windowOpacity}%
+                </span>
+              </div>
+            </SettingRow>
+            {isWindows11 && (
+              <SettingRow
+                id="window-material"
+                label={t('settings.windowMaterial')}
+                description={t('settings.windowMaterialDesc')}
+              >
+                <div className="flex items-center gap-2">
+                  <select
+                    className="ui-select text-xs"
+                    value={windowMaterial}
+                    onChange={(e) => onWindowMaterialChange(e.target.value as WindowMaterial)}
+                    aria-label={t('settings.windowMaterial')}
+                  >
+                    <option value="none">{t('settings.windowMaterialNone')}</option>
+                    <option value="mica">{t('settings.windowMaterialMica')}</option>
+                    <option value="acrylic">{t('settings.windowMaterialAcrylic')}</option>
+                  </select>
+                </div>
+              </SettingRow>
+            )}
+            {windowRestartPending && (
+              <p className="text-xs text-[color:var(--accent-amber)]">
+                {t('settings.windowTransparencyRestart')}
+              </p>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/Settings/SettingsPanel.tsx
+++ b/src/renderer/components/Settings/SettingsPanel.tsx
@@ -3675,8 +3675,11 @@ function TabAppearance() {
   // Linux is excluded — without a compositor guarantee the flag yields a black
   // window — and the material row additionally needs Windows 11.
   const isWindows11 = useMemo(() => {
+    // 22621 (22H2), not 22000: Electron documents setBackgroundMaterial as
+    // "Windows 11 22H2 and up" — offering mica/acrylic on 21H2 would show
+    // controls that can never apply.
     const build = window.electronAPI?.windowsBuildNumber;
-    return build !== null && build !== undefined && build >= 22000;
+    return build !== null && build !== undefined && build >= 22621;
   }, []);
   const appearanceSupported = useMemo(
     () => window.electronAPI?.platform === 'win32' || window.electronAPI?.platform === 'darwin',
@@ -3713,8 +3716,15 @@ function TabAppearance() {
     if (windowMaterial !== null) pushWindowAppearance({ opacity, material: windowMaterial });
   }, [pushWindowAppearance, windowMaterial]);
   const onWindowMaterialChange = useCallback((material: WindowMaterial) => {
+    // Picking a material at opacity 100 would paint --bg-base fully opaque
+    // and the backdrop would never show — nudge the tint down once, visibly
+    // (the slider moves with it; the user can drag it back).
+    const nextOpacity = material !== 'none' && windowOpacity === 100 ? 90 : windowOpacity;
     setWindowMaterial(material);
-    if (windowOpacity !== null) pushWindowAppearance({ opacity: windowOpacity, material });
+    if (nextOpacity !== null) {
+      setWindowOpacity(nextOpacity);
+      pushWindowAppearance({ opacity: nextOpacity, material });
+    }
   }, [pushWindowAppearance, windowOpacity]);
   // Restart is needed when the prefs ask for translucency the live window
   // was not created with (or no longer wants).

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -945,6 +945,16 @@ export const en = {
   'settings.chromePresetApplied': 'Interface visibility updated.',
   'settings.uiScale': 'UI scale',
   'settings.uiScaleDesc': 'Scale the whole interface — useful on high-DPI displays. Restart not required.',
+
+  // Window transparency (#1133) — Windows/macOS; the material row is Win11.
+  'settings.windowOpacity': 'Window transparency',
+  'settings.windowOpacityDesc': 'Paint the window background at reduced opacity so the desktop (or the system backdrop) shows through. Turning this on or off applies after a restart.',
+  'settings.windowMaterial': 'Backdrop material (Windows 11)',
+  'settings.windowMaterialDesc': 'The system-composited backdrop behind the tint — mica is subtle, acrylic is the frosted-glass look.',
+  'settings.windowMaterialNone': 'None',
+  'settings.windowMaterialMica': 'Mica',
+  'settings.windowMaterialAcrylic': 'Acrylic',
+  'settings.windowTransparencyRestart': 'Pending restart — the window is built with (or without) transparency at startup.',
   'settings.sidebarPosition': 'Sidebar position',
   'settings.sidebarPositionDesc': 'Left or right of the terminal area',
   'settings.sidebarAttentionFirst': 'Needs-you rows first',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -934,6 +934,16 @@ export const pl = {
   'settings.chromePresetApplied': 'Zaktualizowano widoczność interfejsu.',
   'settings.uiScale': 'Skala interfejsu',
   'settings.uiScaleDesc': 'Skaluj cały interfejs — przydatne na ekranach o wysokiej DPI. Restart nie jest wymagany.',
+
+  // Przezroczystość okna (#1133) — Windows/macOS; wiersz materiału tylko Win11.
+  'settings.windowOpacity': 'Przezroczystość okna',
+  'settings.windowOpacityDesc': 'Rysuje tło okna ze zmniejszoną nieprzezroczystością, aby biurko (lub kompozycja systemowa) prześwitywało. Włączenie lub wyłączenie zadziała po restarcie.',
+  'settings.windowMaterial': 'Materiał tła (Windows 11)',
+  'settings.windowMaterialDesc': 'Kompozycja systemowa za warstwą koloru — mica jest subtelna, akryl daje efekt mlecznego szkła.',
+  'settings.windowMaterialNone': 'Brak',
+  'settings.windowMaterialMica': 'Mica',
+  'settings.windowMaterialAcrylic': 'Akryl',
+  'settings.windowTransparencyRestart': 'Oczekuje na restart — okno powstaje z (lub bez) przezroczystości podczas uruchamiania.',
   'settings.sidebarPosition': 'Pozycja paska bocznego',
   'settings.sidebarPositionDesc': 'Po lewej lub po prawej stronie obszaru terminala',
   'settings.sidebarAttentionFirst': 'Wiersze czekające na Ciebie u góry',

--- a/src/renderer/styles/globals.css
+++ b/src/renderer/styles/globals.css
@@ -445,6 +445,21 @@ html, body, #root {
   font-family: var(--font-ui);
 }
 
+/* #1133 — window transparency. The document root paints --bg-base with the
+   user's opacity over whatever the OS composites behind the (transparent)
+   window: the desktop, or the Windows 11 mica/acrylic backdrop material.
+   Attribute selectors so these beats the tailwind utilities above without
+   !important; the AppLayout root carries the same tint so its own
+   bg-[var(--bg-base)] cannot repaint the window opaque. Surfaces INSIDE the
+   layout (mantle/surface panels, terminals) stay fully opaque on purpose —
+   readability over blur is the whole point of the tint model. */
+html[data-window-translucent='true'],
+html[data-window-translucent='true'] body,
+html[data-window-translucent='true'] #root,
+html[data-window-translucent='true'] .app-layout-root {
+  background-color: color-mix(in srgb, var(--bg-base) calc(var(--window-bg-opacity, 100) * 1%), transparent);
+}
+
 /* 네이티브 버튼 외형 제거: macOS에서 <button>이 Aqua 그라데이션·베벨·그림자를
    직접 그려 평평한 커스텀 테마 위로 새어나오는 문제를 막는다. checkbox/radio/
    select는 네이티브 외형(체크표시·드롭다운 화살표)이 필요하므로 건드리지 않는다. */

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -490,6 +490,14 @@ export const IPC = {
   // native min/max/close) so the controls never clash with the theme.
   // Windows-only no-op elsewhere (see registerHandlers).
   WINDOW_SET_TITLEBAR_OVERLAY: 'window:setTitleBarOverlay',
+  // #1133 — window transparency prefs. Main owns them (the window's
+  // `transparent` flag is decided at creation, before the renderer boots):
+  // pull the current value + whether the LIVE window was created translucent
+  // (restart-gated changes), push writes, and a change event so every
+  // renderer surface re-tints without a reload.
+  WINDOW_APPEARANCE_GET: 'window:appearance:get',
+  WINDOW_APPEARANCE_SET: 'window:appearance:set',
+  WINDOW_APPEARANCE_CHANGED: 'window:appearance-changed',
   // Whole-interface zoom (#822): the renderer asks main to scale the
   // BrowserWindow with setZoomFactor and re-place the native chrome to match.
   // One-way send — the persisted factor lives in the renderer store.

--- a/src/shared/windowAppearance.ts
+++ b/src/shared/windowAppearance.ts
@@ -1,0 +1,68 @@
+/**
+ * #1133 — window transparency preferences.
+ *
+ * Two independent knobs, one composited effect:
+ *   - `opacity`  — how much of the theme's `--bg-base` is painted over the
+ *                  desktop (100 = fully opaque, today's behaviour). Applies to
+ *                  any platform whose window was created `transparent: true`.
+ *   - `material` — Windows 11 only: the system-composited backdrop (mica /
+ *                  acrylic) behind that tint, at near-zero GPU cost.
+ *
+ * Main is the authority (the window must be created `transparent: true` BEFORE
+ * the renderer boots — the flag cannot be toggled on a live window), so the
+ * durable copy lives in main's `window-appearance.json`, not session.json.
+ * The renderer keeps only a mirror for the Settings UI.
+ *
+ * Platform note: everything here must stay parameter-free at module scope —
+ * this module is imported by both main and the sandboxed renderer.
+ */
+
+/** Electron `setBackgroundMaterial` vocabulary, restricted to what we expose. */
+export type WindowMaterial = 'none' | 'mica' | 'acrylic';
+
+export interface WindowAppearancePrefs {
+  /** 0–100: percent of `--bg-base` painted. Below 100 needs a translucent window. */
+  opacity: number;
+  material: WindowMaterial;
+}
+
+export const DEFAULT_WINDOW_APPEARANCE: WindowAppearancePrefs = {
+  opacity: 100,
+  material: 'none',
+};
+
+/** The lowest opacity the Settings slider offers — below this the window is
+ *  unreadable on any real background; the normalizer still accepts lower
+ *  values from a hand-edited file rather than silently rewriting them. */
+export const WINDOW_OPACITY_SLIDER_MIN = 30;
+
+export function isWindowMaterial(value: unknown): value is WindowMaterial {
+  return value === 'none' || value === 'mica' || value === 'acrylic';
+}
+
+/**
+ * Coerce anything (disk JSON, IPC args) into a valid prefs object. Unknown
+ * fields fall back to the defaults one field at a time — a corrupt opacity
+ * must not also lose the material, and vice versa.
+ */
+export function normalizeWindowAppearance(raw: unknown): WindowAppearancePrefs {
+  const obj = (typeof raw === 'object' && raw !== null ? raw : {}) as {
+    opacity?: unknown;
+    material?: unknown;
+  };
+  const opacity = typeof obj.opacity === 'number' && Number.isFinite(obj.opacity)
+    ? Math.min(100, Math.max(0, Math.round(obj.opacity)))
+    : DEFAULT_WINDOW_APPEARANCE.opacity;
+  const material = isWindowMaterial(obj.material) ? obj.material : DEFAULT_WINDOW_APPEARANCE.material;
+  return { opacity, material };
+}
+
+/**
+ * Whether the window must be CREATED `transparent: true`. That flag is
+ * creation-only in Chromium, so this is the restart-gated predicate: a prefs
+ * change that flips this return value applies on the next window, not now.
+ * (Material 'none' with opacity 100 is exactly today's opaque behaviour.)
+ */
+export function windowNeedsTransparentCreation(prefs: WindowAppearancePrefs): boolean {
+  return prefs.opacity < 100 || prefs.material !== 'none';
+}


### PR DESCRIPTION
Closes #1133 (items 1 and 2; item 3, background image, deliberately not attempted here).

## What

- **Window transparency slider** (30–100%, Settings → Appearance, Windows/macOS): the window background paints `--bg-base` at the chosen opacity over the desktop. Inner surfaces (panels, terminals) stay fully opaque — readability over blur is the tint model, matching Windows Terminal.
- **Backdrop material** (Windows 11 only): `mica` / `acrylic` via Electron's `setBackgroundMaterial`, system-composited behind the tint at near-zero GPU cost. `acrylic` is the classic frosted-terminal look.
- Defaults unchanged — opaque, exactly today's behaviour — so nothing shifts for users who never open the slider (DESIGN.md defaults untouched).

## How

- **Main owns the prefs** (`window-appearance.json`, the BrowserBackendStore pattern) because Chromium's `transparent` flag is **creation-only**: read synchronously before the first window, and all three creation sites (boot, updater rebuild, macOS activate) go through one `createMainWindow` wrapper that tracks whether the live window is translucent.
- **Honest restart gating**: opacity/material values apply live (IPC + change event; renderer tints via `data-window-translucent` + `--window-bg-opacity` with attribute-specificity CSS — no per-component edits), but crossing the translucent/opaque boundary needs a rebuild, and the Settings UI says "pending restart" when it detects that (main returns `active` alongside the prefs).
- **Platform gating**: Linux excluded (transparent without a compositor guarantee = black window); material row additionally requires Windows 11 (build ≥ 22000 via the preload's `windowsBuildNumber`).
- The leftover `wmux-appearance-prefs` keys the issue found in a settings.json never existed in this repo's history (`git log -S` empty) — likely from an experimental build; this PR supersedes them.

## Tests

- `WindowAppearanceStore.test.ts` (9): per-field corruption degradation, clamp/round, transparent-creation predicate, round-trip, normalize-on-write.
- Polish coverage lock satisfied (en + pl strings added).
- Settings suites (155) and tsc/eslint clean.