### PR TITLE
fix(usage): restore rejected-token status after credential reads recover

### DIFF
--- a/changelog.d/1254.md
+++ b/changelog.d/1254.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Usage status after a credential read recovers.** The usage chip returns to the known token-rejected state when a transient file read failure clears, instead of retaining the obsolete read error until the next full poll. (#1254)

--- a/src/main/claude/UsagePoller.ts
+++ b/src/main/claude/UsagePoller.ts
@@ -403,8 +403,8 @@ export class UsagePoller {
     ) {
       // The same token Anthropic already refused, asked about less than
       // a normal poll period ago. Nothing on disk has changed, so the
-      // answer would almost certainly be the same 401 — leave the state
-      // as it is and spend no request. The next tick re-reads the
+      // answer would almost certainly be the same 401 — restore the
+      // known rejection status and spend no request. The next tick re-reads the
       // credential, which is the whole point of staying armed.
       //
       // Two bounds, because a 401 has two possible causes:
@@ -424,9 +424,11 @@ export class UsagePoller {
       // that fails once moves the status off 'unauthorized' while the
       // credential underneath is unchanged, and the skip would then
       // release early and re-send the token it exists to withhold.
-      // Nor does the pin strand any other status: every one of them
-      // recovers by way of a *different* credential, and a different
-      // token fails this comparison on the first tick that reads it.
+      this.setState({
+        status: 'unauthorized',
+        lastError: 'HTTP 401/403',
+        subscriptionType: credential.subscriptionType,
+      });
       return;
     }
     // Past the skip, so whatever the pin was pointing at is no longer

--- a/src/main/claude/__tests__/UsagePoller.test.ts
+++ b/src/main/claude/__tests__/UsagePoller.test.ts
@@ -626,8 +626,17 @@ describe('UsagePoller', () => {
     expect(poller.getState().status).toBe('read-error');
 
     // The same token is back and the poll period has not elapsed, so
-    // nothing goes out — however the chip currently reads.
-    await vi.advanceTimersByTimeAsync(10_000);
+    // nothing goes out, but the recovered read restores the known
+    // rejection instead of leaving the transient read error on screen.
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushPromises();
+    expect(callCount(fetchImpl)).toBe(1);
+    expect(call).toBe(3);
+    expect(poller.getState().status).toBe('unauthorized');
+    expect(poller.getState().lastError).toBe('HTTP 401/403');
+    expect(poller.getState().subscriptionType).toBe('pro');
+
+    await vi.advanceTimersByTimeAsync(9000);
     await flushPromises();
     expect(callCount(fetchImpl)).toBe(1);
     expect(call).toBeGreaterThan(10);


### PR DESCRIPTION
## Summary

Restore the usage chip's known unauthorized status when a credential read recovers and returns the same recently rejected token. The transient read error remains visible only while the credential is unreadable.

## Changes

- Restore status, error and subscription information inside the existing known-token skip.
- Extend the 401 / transient read failure / recovered same-token test to check the first recovered read, while retaining the assertion that no extra request is sent.

## CHANGELOG entry

### Fixed

- **Usage status after a credential read recovers.** The usage chip returns to the known token-rejected state when a transient file read failure clears, instead of retaining the obsolete read error until the next full poll.

## Stability tier impact

- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

Run from the repository root in Linux with Node 22 and npm 11:

- `node node_modules/vitest/vitest.mjs run src/main/claude/__tests__/UsagePoller.test.ts --maxWorkers=4`: 27 passed.
- The stronger test against the unchanged production file: 1 failed, 26 passed, on the recovered-read status assertion.
- `node node_modules/typescript/bin/tsc --noEmit`: passed.
- `node node_modules/vitest/vitest.mjs run --maxWorkers=4 --exclude '**/*.runtime.test.ts' --exclude '**/*.runtime.test.tsx' --exclude '**/*.runtime.test.mjs'`: candidate and unchanged base each reported 15,111 passed, 1 failed, 28 skipped (3 failed suites). The same process-tree timeout test failed in both; `perfConfirmFresh` also could not resolve HEAD in the disposable Git index.
- `node node_modules/vitest/vitest.mjs run --config vitest.runtime.config.ts`: candidate and unchanged base each reported 193 passed, 43 skipped.

The complete suite is not green in this Linux environment; there are no candidate-only failure identities in the comparison. No native Windows or packaged-app run is claimed.

## Related issues / PRs

Fixes #1253. Follow-up to the display-state note on #1024.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed (n/a).
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the usage indicator so it correctly returns to the unauthorized/token-rejected state after a temporary file read failure clears.
  - Restored accurate error and subscription details, including the HTTP 401/403 message and subscription type.
  - Continued preventing requests with a previously rejected token, avoiding unnecessary network calls while preserving the correct status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->