### PR TITLE
fix(updater): honour autoUpdateEnabled from process start (#1250)

### DIFF
--- a/changelog.d/1257.md
+++ b/changelog.d/1257.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The auto-update toggle is honoured from process start.** Turning auto-update off used to be silently ignored on cold boots: the setting reached the updater before its listener existed, so background checks, downloads, and the "update ready" prompt kept appearing. The toggle now lands reliably, is also seeded from the saved session when the window is still loading, and a download that has not started yet is stopped if you flip the toggle mid-check. (#1257)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -445,6 +445,12 @@ const autoUpdater = new AutoUpdater(() => mainWindow, {
   // before-quit takes the daemon.shutdown branch instead of detaching.
   onInstallRequiresFullShutdown: () => { fullShutdownRequested = true; },
   getDaemonPid: () => readDaemonPid(getWmuxDir()),
+  // #1250: seed the updater's enabled flag from session.json. The renderer
+  // sends the toggle during loadSession, but that send races this module's
+  // own ready sequence; a locked session.json can stop it from ever arriving.
+  // The disk read fills the silence; the renderer's IPC still wins when it
+  // lands (AutoUpdater.start applies the read only if nothing arrived).
+  readAutoUpdateEnabled: () => sessionManager.readAutoUpdateEnabled(),
 });
 
 // #1046: a Squirrel install can half-complete (an AV lock race inside the

--- a/src/main/session/SessionManager.ts
+++ b/src/main/session/SessionManager.ts
@@ -265,6 +265,26 @@ export class SessionManager {
     }
   }
 
+  /**
+   * #1250: the persisted auto-update toggle, as a targeted read.
+   *
+   * The updater needs the value before the renderer's session load runs, and
+   * load() is the wrong tool: it pulls the whole workspace payload through
+   * the migration machinery and logs a second load line, all for one boolean.
+   * Returns null when nothing is persisted (first launch, or a locked/corrupt
+   * file — the caller keeps its default rather than failing the boot).
+   */
+  readAutoUpdateEnabled(): boolean | null {
+    try {
+      const loaded = atomicReadJSONSync<SessionData>(this.filePath, {
+        validate: SessionManager.isSessionData,
+      });
+      return loaded?.autoUpdateEnabled ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   load(): SessionData | null {
     // v2 RCA fix (adversarial review): distinguish "no session file" (true
     // first launch → null) from "file exists but unreadable" (transient AV/

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -197,6 +197,20 @@ export interface AutoUpdaterHooks {
    * install.
    */
   getDaemonPid: () => number | null;
+  /**
+   * The persisted auto-update toggle, read straight from session.json (#1250).
+   *
+   * Injected rather than imported for the same reason as getDaemonPid above:
+   * pulling the session module into the updater drags its migration machinery
+   * into the electron-mocked unit tests. main owns the SessionManager, so it
+   * hands over a reader instead.
+   *
+   * Used once, in start(), to initialize `enabled` from what the user last
+   * chose — covering the boots where the renderer never delivers the toggle
+   * (window not yet loaded, or its session load failed on a locked file).
+   * A null/undefined means "nothing persisted" and leaves the default.
+   */
+  readAutoUpdateEnabled?: () => boolean | null;
 }
 
 export class AutoUpdater {
@@ -205,6 +219,11 @@ export class AutoUpdater {
   private hooks: AutoUpdaterHooks;
   private isChecking = false;
   private enabled = true;
+  // #1250: whether the renderer's AUTO_UPDATE_ENABLED send has been received.
+  // start() initializes `enabled` from session.json ONLY while this is false —
+  // once the renderer has spoken, its value is fresher than anything on disk
+  // and must not be clobbered by the boot read.
+  private enabledFromRenderer = false;
   private pendingUpdate: UpdateInfo | null = null;
   private downloadedPath: string | null = null;
   // The digest `downloadedPath` was accepted under. Kept so the bytes can be
@@ -237,9 +256,35 @@ export class AutoUpdater {
     // module evaluation, before the window exists at all.
     ipcMain.handle(IPC.UPDATE_TAKE_REFUSED_INSTALL, () => this.takeRefusedInstall());
     ipcMain.handle(IPC.UPDATE_GET_PENDING_INSTALL, () => this.getPendingInstall());
+    // #1250 — same class of bug as #866, one channel over. The renderer sends
+    // the persisted auto-update toggle during loadSession (~1s in), and it
+    // sends with ipcRenderer.send — fire-and-forget. A listener registered in
+    // start() (registerIpcHandlers, which runs at the END of the ready
+    // sequence) is not there yet, the send is silently dropped, and `enabled`
+    // stays at its default true for the whole session: every boot, a user who
+    // turned auto-update off still gets background checks, downloads, and the
+    // "update ready" toast. Registered here so the early send lands.
+    ipcMain.on(IPC.AUTO_UPDATE_ENABLED, (_event, enabled: boolean) => {
+      this.enabledFromRenderer = true;
+      this.setEnabled(enabled);
+    });
   }
 
   start(): void {
+    // #1250: before anything is scheduled, seed `enabled` from what the user
+    // last persisted — unless the renderer already delivered the toggle, which
+    // is fresher than the disk (the user may have flipped the setting between
+    // renderer mount and this point). This covers the boots where the renderer
+    // never sends it at all: window still loading, or its session load failed
+    // on a locked session.json and fell back without dispatching loadSession.
+    if (!this.enabledFromRenderer) {
+      const persisted = this.hooks.readAutoUpdateEnabled?.() ?? null;
+      if (persisted !== null && persisted !== this.enabled) {
+        this.enabled = persisted;
+        console.log(`[AutoUpdater] initialized from session.json: ${persisted ? 'Enabled' : 'Disabled'}`);
+      }
+    }
+
     // Register IPC handlers on every platform so the renderer's "check for
     // updates" UI resolves cleanly (it gets a not-available reply off win32),
     // but only schedule background checks on a supported platform.
@@ -594,6 +639,13 @@ export class AutoUpdater {
    */
   private async downloadUpdate(): Promise<void> {
     if (!isUpdaterSupported) return;
+    // #1250: the enabled gate in check() runs when the poll STARTS. The
+    // renderer's toggle (or the boot read) can land between that start and
+    // this dispatch — fetchUpdate is awaited — and a background download must
+    // still honour it. oneShotInstall is the explicit user request ("check
+    // for updates" as "update now") and stays exempt, matching check()'s
+    // gate: the toggle must never brick the manual path.
+    if (!this.enabled && !this.oneShotInstall) return;
     const pending = this.pendingUpdate;
     if (!pending) return;
     if (this.isDownloading) return;
@@ -799,11 +851,6 @@ export class AutoUpdater {
   }
 
   private registerIpcHandlers(): void {
-    ipcMain.on(IPC.AUTO_UPDATE_ENABLED, (_event, enabled: boolean) => {
-      this.setEnabled(enabled);
-    });
-
-
     ipcMain.handle(IPC.UPDATE_CHECK, async () => {
       if (process.env.NODE_ENV === 'development' || !isUpdaterSupported) {
         return { status: 'not-available' };

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -403,6 +403,61 @@ describe('AutoUpdater two-step flow (win32)', () => {
     expect(String(unlinkMock.mock.calls[0][0])).toContain('wmux-update-');
   });
 
+  it('#1250: a toggle landing after the check started still stops the background download', async () => {
+    // check() gates on `enabled` when the poll STARTS, but fetchUpdate is
+    // awaited — the toggle (renderer IPC or the boot session.json read) can
+    // land in that window. The dispatch into downloadUpdate must re-honour
+    // it, or a user who turned auto-update off mid-poll still gets the
+    // 150 MB download and the "update ready" nag.
+    const { AutoUpdater, requestUrls, sent, win } = await loadWin32();
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+    updater.start();
+
+    const internals = updater as unknown as {
+      enabled: boolean;
+      oneShotInstall: boolean;
+      pendingUpdate: { name: string; notes: string; url: string } | null;
+      downloadUpdate: () => Promise<void>;
+    };
+    // A background poll found an update; the toggle lands before the
+    // download is dispatched. oneShotInstall is false — nobody pressed
+    // anything.
+    internals.enabled = false;
+    internals.oneShotInstall = false;
+    internals.pendingUpdate = { name: NEW_VERSION, notes: 'n', url: DL_URL };
+
+    await internals.downloadUpdate();
+    await flush();
+
+    expect(requestUrls.some((u) => u.includes('update-manifest.json'))).toBe(false);
+    expect(sent.some((s) => `${s.channel}:${s.data.status}` === `${IPC.UPDATE_AVAILABLE}:downloaded`)).toBe(false);
+  });
+
+  it('#1250: a manual press is exempt from the download gate — the toggle must not brick updating', async () => {
+    const { AutoUpdater, requestUrls, sent, win } = await loadWin32();
+    const updater = new AutoUpdater(() => win as never, quitHooks());
+    updater.start();
+
+    const internals = updater as unknown as {
+      enabled: boolean;
+      oneShotInstall: boolean;
+      pendingUpdate: { name: string; notes: string; url: string } | null;
+      downloadUpdate: () => Promise<void>;
+    };
+    // Toggle off, but the user pressed "check for updates" (one-shot intent):
+    // the download must proceed — with the toggle off this is the ONLY update
+    // path short of reinstalling (same contract as check()'s gate).
+    internals.enabled = false;
+    internals.oneShotInstall = true;
+    internals.pendingUpdate = { name: NEW_VERSION, notes: 'n', url: DL_URL };
+
+    await internals.downloadUpdate();
+    await flush();
+
+    expect(requestUrls.some((u) => u.includes('update-manifest.json'))).toBe(true);
+    expect(sent.some((s) => `${s.channel}:${s.data.status}` === `${IPC.UPDATE_AVAILABLE}:downloaded`)).toBe(true);
+  });
+
   it('a newer release supersedes a downloaded one: old artifact unlinked, new one downloaded', async () => {
     const { AutoUpdater, feed, sent, unlinkMock, win } = await loadWin32();
     const updater = new AutoUpdater(() => win as never, quitHooks());

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -939,6 +939,68 @@ describe('AutoUpdater — the auto-update toggle gates background polls only', (
 
     updater.stop();
   });
+
+  it('#1250: the toggle listener exists at CONSTRUCTION, before start() — the renderer sends during loadSession', async () => {
+    // The renderer pushes the persisted auto-update toggle ~1s into boot,
+    // while start() (end of the ready sequence, waiting on the daemon
+    // bootstrap) may not run for tens of seconds. The send is
+    // ipcRenderer.send — fire-and-forget — so a listener registered in
+    // start() misses it silently and `enabled` stays true for the whole
+    // session. This is the exact shape of the live bug: toggle off, yet
+    // background checks, downloads, and the update toast kept coming.
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls, ipcListeners } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null, quitHooks());
+    // The renderer's boot-time send happens BEFORE start(). No start() yet.
+    ipcListeners.get(IPC.AUTO_UPDATE_ENABLED)!(null, false);
+
+    updater.start();
+    await vi.advanceTimersByTimeAsync(15_000 + 30 * 60 * 1000);
+    expect(requestUrls).toHaveLength(0);
+
+    updater.stop();
+  });
+
+  it('#1250: start() seeds the toggle from session.json when the renderer never sends it', async () => {
+    // Covers the boots where the IPC never arrives at all: window still
+    // loading, or the renderer's session load failed on a locked file and
+    // fell back without dispatching loadSession. The disk read is the only
+    // voice left, and it must be honoured.
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null, {
+      ...quitHooks(),
+      readAutoUpdateEnabled: () => false,
+    });
+    // No AUTO_UPDATE_ENABLED send — the renderer never spoke.
+    updater.start();
+    await vi.advanceTimersByTimeAsync(15_000 + 30 * 60 * 1000);
+    expect(requestUrls).toHaveLength(0);
+
+    updater.stop();
+  });
+
+  it('#1250: the renderer-delivered toggle wins over a stale session.json value', async () => {
+    // The disk read in start() fills the silence, never overwrites: if the
+    // renderer already delivered the toggle, its value is fresher (the user
+    // may have flipped the setting after the last session save).
+    vi.useFakeTimers();
+    const { AutoUpdater, requestUrls, ipcListeners } = await loadForPlatform('win32');
+
+    const updater = new AutoUpdater(() => null, {
+      ...quitHooks(),
+      readAutoUpdateEnabled: () => true, // stale disk value
+    });
+    ipcListeners.get(IPC.AUTO_UPDATE_ENABLED)!(null, false); // fresh renderer value
+
+    updater.start();
+    await vi.advanceTimersByTimeAsync(15_000 + 30 * 60 * 1000);
+    expect(requestUrls).toHaveLength(0);
+
+    updater.stop();
+  });
 });
 
 describe('AutoUpdater #866 — a refused install is reported on the next boot', () => {


### PR DESCRIPTION
## Root cause (#1250, claim 1: "the setting is not honoured")

The `AUTO_UPDATE_ENABLED` listener was registered inside `start()`, which runs at the **end** of the ready sequence — the daemon bootstrap can hold it for tens of seconds on a cold boot (measured 39s in dogfood, per the #866 comment in the same file). The renderer sends the persisted toggle during `loadSession` ~1s in, via fire-and-forget `ipcRenderer.send` — so on essentially every cold boot the send arrived before any listener existed and was **silently dropped**. `enabled` stayed at its default `true` for the whole session: background checks, downloads, and the update-ready toast all ran against an explicit `autoUpdateEnabled: false`. That matches the reporter's 4/4 reproducibility.

Same bug class as #866, one channel over — and the same fix pattern (constructor registration) was already established in this file for the two #866 handlers.

## Changes

- **Constructor registration** of the `AUTO_UPDATE_ENABLED` listener (`AutoUpdater.ts`) so the renderer's boot-time send lands.
- **Boot read from session.json** (`SessionManager.readAutoUpdateEnabled`, injected as an `AutoUpdaterHooks` reader so the updater stays free of the session module — same injection rationale as `getDaemonPid`). Applied in `start()` only when the renderer has not delivered the toggle: the renderer's value is fresher than disk and always wins. Covers boots where the IPC never arrives at all (window still loading, or the renderer's session load failed on a locked file and fell back without dispatching `loadSession`).
- **Re-check `enabled` at `downloadUpdate()` entry** — `check()`'s gate runs when the poll *starts*; the toggle can land while `fetchUpdate` is awaited, and the 150 MB download must still be stopped. `oneShotInstall` stays exempt, matching `check()`'s gate: the toggle must never brick the manual update path.
- `performInstall` is deliberately **not** gated: every path into it is user-initiated (Restart button / one-shot press); background polls only ever download.

## Scope note on the issue's claims 2 & 3

The silent-failure and relaunch-loop halves of #1250 were observed on v3.46.0 and are the failure family already hardened by #1057/#1058/#1059/#1085/#1136 (all shipped by v3.48.1–v3.51.0): the waiter is now provably started before quitting, refusals are recorded and surfaced, and the marker feeds the boot notice. The one piece this PR does not explain is the *unattended* install handoff in the report — both v3.46.0 and current code require a user press (toast/Settings) to cross from download to install, so that part is worth re-verifying on 3.51.0 with the reporter. A follow-up comment on the issue asks for that.

## Tests

- `AutoUpdater.platform.test.ts`: listener registered at construction before `start()` (the exact live shape of the bug); `start()` seeds from the persisted hook when the renderer never sends; renderer-delivered value wins over a stale disk value.
- `AutoUpdater.download.test.ts`: a toggle landing after the check started still stops the background download; a manual press remains exempt.

Full suite: 988 files / 15,135 tests green. `tsc --noEmit` clean. (The 4 pre-existing `no-var-requires` eslint errors in these files are untouched.)

Fixes #1250 (claim 1; claims 2–3 already mitigated on production — see scope note).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-update preferences are now restored when the application starts, even if the renderer is unavailable.
  * Disabling automatic updates during a background check now prevents pending downloads.
  * Manual, one-time update installations continue to work when automatic updates are disabled.
  * Early toggle changes are now reliably applied before update checks begin.

* **Documentation**
  * Added a changelog entry describing the auto-update behavior improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->