### PR TITLE
fix(terminal): bind overlays to the live instance, preserve scroll across resync (#1256)

### DIFF
--- a/changelog.d/1258.md
+++ b/changelog.d/1258.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **The scroll-to-bottom button and a resynced pane's scroll position.** The floating scroll button could silently do nothing, and revealing a hidden pane could throw you to the bottom of its output. Both came from one pattern: overlay components captured the terminal at render time, before the terminal actually existed — and the pane-recovery repaint reset the viewport. The button (and the bookmark markers) now bind the live terminal instance, and a recovered pane puts you back where you were scrolled to. (#1258)

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -239,9 +239,12 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
   // `isActive` for the stacked/tab case (one tab visible at a time).
   const shown = visible ?? isActive;
   const isVisible = isWorkspaceVisible && shown;
-  const { terminal: terminalRef, findNext, findPrevious, clearSearch } = useTerminal(containerRef, { ptyId, isVisible, scrollbackFile, onFirstData: scrollbackFile ? handleFirstData : undefined, onContextMenu: handleContextMenu });
+  const { terminal: terminalRef, terminalInstance, findNext, findPrevious, clearSearch } = useTerminal(containerRef, { ptyId, isVisible, scrollbackFile, onFirstData: scrollbackFile ? handleFirstData : undefined, onContextMenu: handleContextMenu });
 
-  const showViCopyMode = viCopyModeActive && isActive && terminalRef.current !== null;
+  // terminalInstance (state, #1256) — not terminalRef.current (a render-time
+  // snapshot): the ref is populated after this render ran, so a snapshot read
+  // here sees null until an unrelated re-render happens.
+  const showViCopyMode = viCopyModeActive && isActive && terminalInstance !== null;
   const showSearchBar = searchBarVisible && isActive;
 
   const handleCloseSearch = () => {
@@ -396,15 +399,21 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
         style={{ width: '100%', height: '100%', padding: '4px' }}
       />
 
-      {/* Scrollback bookmark markers on the left edge */}
+      {/* Scrollback bookmark markers on the left edge. #1256: bound to the
+          state-published instance — a render-time terminalRef.current snapshot
+          goes null/stale when the mount effect swaps the terminal without a
+          re-render (fresh creation, adoption). */}
       <BookmarkIndicator
-        terminal={terminalRef.current}
+        terminal={terminalInstance}
         bookmarks={bookmarks}
         containerRef={containerRef}
       />
 
-      {/* Floating scroll-to-bottom button — appears only when scrolled up */}
-      <ScrollToBottomButton terminal={terminalRef.current} />
+      {/* Floating scroll-to-bottom button — appears only when scrolled up.
+          #1256: same live-instance binding as BookmarkIndicator above; the
+          button's subscriptions and click handler must track the real
+          terminal or scrolling/clicking silently no-ops. */}
+      <ScrollToBottomButton terminal={terminalInstance} />
 
       {/* Search bar overlay */}
       {showSearchBar && (

--- a/src/renderer/components/Terminal/__tests__/Terminal.liveBinding.test.ts
+++ b/src/renderer/components/Terminal/__tests__/Terminal.liveBinding.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * #1256 — live terminal binding for the floating overlay consumers.
+ *
+ * ScrollToBottomButton and BookmarkIndicator receive the xterm instance as a
+ * prop and subscribe (onScroll/onWriteParsed/onResize) against whatever they
+ * were handed at render time. useTerminal populates its ref by mutation
+ * inside the mount effect — fresh creation and adoption both — with no
+ * re-render to follow, so a render-time `terminalRef.current` snapshot stays
+ * null (button never mounts its subscriptions, clicks no-op) or goes stale
+ * (subscriptions target a detached instance). The fix publishes the instance
+ * as state (`terminalInstance`); this pins that Terminal.tsx binds the state,
+ * not the ref snapshot.
+ */
+describe('Terminal.tsx — overlay consumers bind the state-published instance (#1256)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'Terminal.tsx'), 'utf-8');
+
+  it('ScrollToBottomButton receives terminalInstance, never a ref snapshot', () => {
+    expect(src).toMatch(/<ScrollToBottomButton terminal=\{terminalInstance\} \/>/);
+    expect(src).not.toMatch(/<ScrollToBottomButton terminal=\{terminalRef\.current\}/);
+  });
+
+  it('BookmarkIndicator receives terminalInstance, never a ref snapshot', () => {
+    expect(src).toMatch(/<BookmarkIndicator\s+terminal=\{terminalInstance\}/);
+    expect(src).not.toMatch(/<BookmarkIndicator\s+terminal=\{terminalRef\.current\}/);
+  });
+
+  it('the instance comes from useTerminal state and the vi-copy gate uses it too', () => {
+    expect(src).toMatch(/const \{ terminal: terminalRef, terminalInstance,/);
+    expect(src).toMatch(/showViCopyMode = viCopyModeActive && isActive && terminalInstance !== null/);
+    expect(src).not.toMatch(/terminalRef\.current !== null/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.hiddenRetention.test.ts
@@ -164,7 +164,9 @@ describe('Phase 3 PR-B — useTerminal snapshot-resync ladder (source-level)', (
   it('dead-snapshot paint mirrors the flush-complete contract', () => {
     const idx = src.indexOf('const paintDeadSnapshot');
     expect(idx).toBeGreaterThan(0);
-    const paint = src.slice(idx, idx + 2200);
+    // Window widened for #1256's scroll-preservation block; the ordering
+    // contract below is unchanged.
+    const paint = src.slice(idx, idx + 3000);
     // discard stale backlog → reset → write payload → write held bytes → clean.
     // The payload write is writeReplayed() since #998 (clipboard bridge muted
     // while stored bytes are parsed); the order is what this locks.
@@ -181,5 +183,49 @@ describe('Phase 3 PR-B — useTerminal snapshot-resync ladder (source-level)', (
     expect(paint).toMatch(/STALE_REPLAY_INPUT_MODE_RESETS/);
     // No flush marker is coming: it settles the resync state itself.
     expect(paint).toMatch(/st\.resolvers\.splice\(0\)\.forEach/);
+  });
+
+  it('#1256: a resync repaint preserves the scroll position across reset()', () => {
+    // reset() snaps the viewport to the bottom; without preservation, showing
+    // a hidden pane yanked a scrolled-up user to the bottom. Both repaint
+    // paths (dead snapshot + live flush-complete) capture the distance from
+    // the bottom BEFORE the reset and restore it after the recovered screen
+    // is parsed — a trailing empty write is the parse barrier, the same
+    // shape as hydrateForRead.
+    for (const [name, fn] of [['dead-snapshot', 'const paintDeadSnapshot'], ['flush-complete', 'const completeResyncFromFlush']] as const) {
+      const idx = src.indexOf(fn);
+      expect(idx).toBeGreaterThan(0);
+      const body = src.slice(idx, idx + 2600);
+      const capture = body.indexOf('fromBottom = Math.max(0,');
+      const reset = body.indexOf('.reset()');
+      // `term.write` (dead-snapshot) / `terminal.write` (flush-complete) —
+      // match on the trailing parse-barrier write itself.
+      const barrier = body.indexOf(".write('', () =>");
+      const restore = body.indexOf('scrollToLine(Math.max(0,');
+      expect(capture).toBeGreaterThan(0);
+      expect(reset).toBeGreaterThan(capture);
+      expect(barrier).toBeGreaterThan(reset);
+      expect(restore).toBeGreaterThan(barrier);
+      expect(body).toMatch(/baseY - fromBottom/);
+      // Restoration is cosmetic and must never take the mount down on a
+      // terminal disposed mid-restore.
+      expect(body.slice(barrier, restore + 400)).toMatch(/catch/);
+      void name;
+    }
+  });
+
+  it('#1256: the live terminal instance is published as state for snapshot consumers', () => {
+    // terminalRef is populated by mutation inside the mount effect — no
+    // re-render follows, so a consumer reading terminalRef.current at render
+    // time keeps null (fresh mount) or a detached instance (adoption swap).
+    // Both assignment sites publish identity through state so Terminal.tsx
+    // can bind the scroll button / bookmark indicator to the real instance.
+    expect(src).toMatch(/const \[terminalInstance, setTerminalInstance\] = useState<Terminal \| null>\(null\)/);
+    const publish = src.match(/terminalRef\.current = terminal;\s*\n\s*\/\/ #1256[\s\S]{0,200}setTerminalInstance\(terminal\)/);
+    expect(publish).not.toBeNull();
+    const clearIdx = src.indexOf('terminalRef.current = null;');
+    const clearBody = src.slice(clearIdx, clearIdx + 400);
+    expect(clearBody).toMatch(/setTerminalInstance\(null\)/);
+    expect(src).toMatch(/return \{ terminal: terminalRef, terminalInstance,/);
   });
 });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -631,6 +631,16 @@ interface UseTerminalOptions {
 
 export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>, options: UseTerminalOptions) {
   const terminalRef = useRef<Terminal | null>(null);
+  // #1256: the live instance, published as STATE. The ref is populated by
+  // mutation inside the mount effect (fresh Terminal or an adopted parked
+  // one) — no re-render follows, so a consumer that captured
+  // `terminalRef.current` at render time keeps a null (before the instance
+  // exists) or a detached instance (after adoption swapped it) for as long as
+  // nothing else happens to re-render. Terminal.tsx passes this state to the
+  // scroll-to-bottom button and the bookmark indicator; their subscriptions
+  // and click handlers now track the real instance because identity changes
+  // re-render.
+  const [terminalInstance, setTerminalInstance] = useState<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   /**
    * A fit() that the selection guard skipped, and nobody re-ran (#747).
@@ -824,6 +834,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       try {
         const bytes = Uint8Array.from(atob(payloadBase64), (c) => c.charCodeAt(0));
         console.log(`[wmux:reveal] ptyId=${ptyIdRef.current} mechanism=dead-snapshot payload=${bytes.length}`);
+        // #1256: reset() snaps the viewport to the bottom, and this repaint
+        // used to ship that snap — a user scrolled up in a hidden pane was
+        // yanked down on reveal. Capture the distance from the bottom BEFORE
+        // the reset (rows, the same convention terminalPark uses, so the
+        // restore stays proportional if the repaint reflows line counts).
+        const fromBottom = Math.max(0, term.buffer.active.baseY - term.buffer.active.viewportY);
         discardTerminalOutput(term);
         term.reset();
         // Historical bytes — clipboard bridge muted (#998).
@@ -836,6 +852,18 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           writePtyDataImmediately(term, chunk, replayMuteRef.current);
         }
         markTerminalClean(term);
+        if (fromBottom > 0) {
+          // Everything above went through term.write, and xterm invokes write
+          // callbacks in write order — so an empty trailing write's callback
+          // fires only after the repaint has fully parsed and the buffer's
+          // baseY is final. That is the one moment a scrollToLine lands
+          // where the user was. (Same parse-barrier shape as hydrateForRead.)
+          term.write('', () => {
+            try {
+              term.scrollToLine(Math.max(0, term.buffer.active.baseY - fromBottom));
+            } catch { /* disposed mid-restore — teardown owns cleanup */ }
+          });
+        }
       } catch { /* disposed mid-paint — teardown owns cleanup */ }
     }
     st.buffer.length = 0;
@@ -2165,12 +2193,26 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       const mechanism = st.viaRawFallback ? 'dirty-raw-fallback' : 'dirty-snapshot';
       st.viaRawFallback = false;
       console.log(`[wmux:reveal] ptyId=${ptyId} mechanism=${mechanism} recoveredBytes=${recoveredBytes} buffered=${st.bufferedChars} chunks=${st.buffer.length}`);
+      // #1256: same viewport-preservation contract as paintDeadSnapshot —
+      // the reset below snaps to bottom, and a user scrolled up in the pane
+      // must stay where they were after the recovered screen lands.
+      const fromBottom = Math.max(0, terminal.buffer.active.baseY - terminal.buffer.active.viewportY);
       discardTerminalOutput(terminal); // stale retained backlog + dirty flag
       terminal.reset();
       // The scanner labels every held chunk at its source. Historical bytes
       // are muted for their exact parse lifetime; live output is not muted.
       for (const chunk of st.buffer) {
         writePtyDataImmediately(terminal, chunk, replayMuteRef.current);
+      }
+      if (fromBottom > 0) {
+        // Trailing empty write = parse barrier (callbacks fire in write
+        // order); scrollToLine only after the recovered screen is parsed and
+        // baseY is final. See the identical block in paintDeadSnapshot.
+        terminal.write('', () => {
+          try {
+            terminal.scrollToLine(Math.max(0, terminal.buffer.active.baseY - fromBottom));
+          } catch { /* disposed mid-restore — teardown owns cleanup */ }
+        });
       }
       st.buffer.length = 0;
       st.bufferedChars = 0;
@@ -2488,6 +2530,9 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     //   - fresh/adopted branch: immediately after connectPty()
 
     terminalRef.current = terminal;
+    // #1256: publish identity as state so snapshot consumers re-render onto
+    // the real instance (fresh or adopted — both swap identity here).
+    setTerminalInstance(terminal);
     fitAddonRef.current = fitAddon;
     searchAddonRef.current = searchAddon;
 
@@ -2680,6 +2725,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       }
       unsubscribeKeyboardLiveness();
       terminalRef.current = null;
+      // #1256: clear the published instance too. On a ptyId re-run the next
+      // effect publishes the new instance; on a true unmount React ignores
+      // the set. Either way consumers never keep a disposed terminal.
+      setTerminalInstance(null);
       fitAddonRef.current = null;
       searchAddonRef.current = null;
     };
@@ -3004,5 +3053,5 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     terminalRef.current?.scrollToLine(line);
   }, []);
 
-  return { terminal: terminalRef, fit, searchAddonRef, findNext, findPrevious, clearSearch, getScrollPosition, scrollToLine };
+  return { terminal: terminalRef, terminalInstance, fit, searchAddonRef, findNext, findPrevious, clearSearch, getScrollPosition, scrollToLine };
 }


### PR DESCRIPTION
## Root cause

Two defects, one root pattern — render-time snapshots of a ref that is populated by mutation:

**1. The scroll-to-bottom button intermittently no-ops.** `ScrollToBottomButton` (and `BookmarkIndicator` — same pattern, found during verification) received `terminalRef.current` at render time. `useTerminal` populates that ref inside its mount effect — both fresh creation and parked-terminal adoption — with no re-render to follow. So the snapshot the overlays hold is `null` after mount until some unrelated state change re-renders, and stale after an adoption swaps the instance. Null/stale means: the button's `onScroll`/`onWriteParsed`/`onResize` subscriptions target a detached terminal (visibility never updates), and clicks call `scrollToBottom()` on a dead buffer — the silent no-op from the report.

**2. Resync yanks the viewport to the bottom.** Both resync repaint paths (`paintDeadSnapshot` for dead sessions, `completeResyncFromFlush` for the live snapshot/reflow ladder) do `reset()` + full buffer rewrite, and `reset()` snaps the viewport to the bottom. Showing a hidden pane while scrolled up ripped the position down.

## Changes

- `useTerminal` publishes the live instance as **state** (`terminalInstance`), set at both assignment sites (creation/adoption, dispose-on-cleanup). Identity changes now re-render; `Terminal.tsx` binds `terminalInstance` for `ScrollToBottomButton`, `BookmarkIndicator`, and the vi-copy gate. Prop contracts of the two components are unchanged.
- Both repaint paths capture **distance-from-bottom** before the reset and restore it after the recovered screen parses — via a trailing empty `term.write('', cb)` as a parse barrier (xterm invokes write callbacks in order; same shape as the existing `hydrateForRead` barrier). Rows-based, the same convention `terminalPark.restoreParkedViewport` uses.

## Tests

- `useTerminal.hiddenRetention.test.ts`: new source-contract tests pinning (a) capture-before-reset → parse-barrier → scrollToLine ordering in both repaint paths, (b) the instance state publication at both assignment sites and the hook return.
- New `Terminal.liveBinding.test.ts`: Terminal.tsx binds `terminalInstance` (never a `terminalRef.current` snapshot) for both overlays and the vi-copy gate.
- Existing repaint-ordering contracts kept (window widened — ordering unchanged).

Full suite green: 990 files / 15,135 tests. `tsc --noEmit` clean; no new lint findings (the 3 `no-empty-function` errors in useTerminal.ts are pre-existing on main).

Fixes #1256.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the scroll-to-bottom button so it consistently responds when the terminal is ready.
  - Fixed bookmark indicators and copy-mode availability when terminals are refreshed or replaced.
  - Preserved the current scroll position when a hidden or disconnected pane is recovered, preventing unexpected jumps to the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->