### PR TITLE
fix(terminal): floor tiny fits, re-assert real geometry on recovery (#1255)

### DIFF
--- a/changelog.d/1259.md
+++ b/changelog.d/1259.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Panes no longer collapse to a single column after resizing, splitting, or restoring a session.** A transient mid-layout measurement used to be applied to the terminal for real, re-wrapping all its scrollback at a broken width — damage a later resize could not undo — while the background session was independently clamped to a minimum width, leaving the two permanently out of step. Sub-floor measurements are now skipped until the layout settles, and every pane recovery re-asserts the real size. (#1259)

--- a/src/daemon/DaemonSessionManager.ts
+++ b/src/daemon/DaemonSessionManager.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { DaemonSession, DaemonSessionState, DaemonSessionSupervision, DaemonConfig } from './types';
+import { MIN_SAFE_COLS, MIN_SAFE_ROWS } from '../shared/terminalGeometry';
 import { RingBuffer } from './RingBuffer';
 import { DaemonPTYBridge } from './DaemonPTYBridge';
 import { PromptEventLog } from './PromptEventLog';
@@ -119,10 +120,9 @@ const DEFERRED_UNMUTE_DELAY_MS = 100;
  * observed 6/7 boundary, which may shift with prompt width or locale. The
  * renderer's xterm view can briefly be narrower than the PTY during a layout
  * transition — harmless compared to a dead shell, and the next settled resize
- * reconciles them.
+ * reconciles them. (#1255: the renderer now skips sub-floor fits entirely —
+ * shared constant, see shared/terminalGeometry.ts.)
  */
-const MIN_SAFE_COLS = 10;
-const MIN_SAFE_ROWS = 2;
 const clampCols = (cols: number): number => Math.max(MIN_SAFE_COLS, cols);
 const clampRows = (rows: number): number => Math.max(MIN_SAFE_ROWS, rows);
 

--- a/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
@@ -91,3 +91,71 @@ describe('#747 — a deferred fit must be recorded and settled', () => {
     expect(block).not.toMatch(/fitAddon\.fit\(\)/);
   });
 });
+
+// #1255 — sub-floor fits are skipped, and recovered sessions re-assert their
+// real geometry. A transient small-but-nonzero container (mid-split, session
+// restore before the panels settle) used to be FITTED: the tiny columns were
+// applied to the xterm buffer and the reflow re-wrapped the whole scrollback
+// at that width — damage a later correct fit does not undo, which is how a
+// pane rendered ~1 column wide forever. The daemon clamps its side to
+// MIN_SAFE_COLS(10) regardless, so the two sides of the pipe also split.
+describe('#1255 — every fit() apply site is floor-gated, every recovery re-asserts', () => {
+  const hookPath = path.join(__dirname, '..', 'useTerminal.ts');
+  const src = readSource(hookPath);
+
+  it('imports the shared floor (single-sourced with the daemon clamp)', () => {
+    expect(src).toMatch(/import \{ isSafeGeometry \} from '\.\.\/\.\.\/shared\/terminalGeometry'/);
+  });
+
+  it('the exported fit() gates below the floor, after the zero-dimension guard', () => {
+    const start = src.indexOf('const fit = useCallback');
+    const block = src.slice(start, src.indexOf('}, [ptyId, containerRef]', start));
+    const zero = block.indexOf('offsetWidth === 0');
+    const gate = block.indexOf('proposedSafeDimensions(fitAddonRef.current)');
+    const fitCall = block.indexOf('fitAddonRef.current.fit()');
+    expect(zero).toBeGreaterThan(-1);
+    expect(gate).toBeGreaterThan(zero);
+    expect(fitCall).toBeGreaterThan(gate);
+  });
+
+  it('the initial mount fit treats a sub-floor container like a hidden one', () => {
+    const anchor = 'container.offsetWidth > 0 && container.offsetHeight > 0 && proposedSafeDimensions(fitAddon)';
+    expect(src).toContain(anchor);
+  });
+
+  it('fonts.ready and runFit gate their fits too', () => {
+    const fonts = src.slice(src.indexOf('document.fonts.ready'), src.indexOf('document.fonts.ready') + 1400);
+    expect(fonts).toMatch(/if \(proposedSafeDimensions\(fitAddon\)\) fitAddon\.fit\(\)/);
+    const runFitStart = src.indexOf('const runFit = () => {');
+    const runFit = src.slice(runFitStart, src.indexOf('const autoCopy = createAutoSelectionCopy', runFitStart));
+    // BEFORE claimFit: a floor skip records no selection debt — the settled
+    // layout re-fires the ResizeObserver, which is the retry.
+    const gate = runFit.indexOf('proposedSafeDimensions(fitAddon)) return');
+    const claim = runFit.indexOf('claimFit(');
+    expect(gate).toBeGreaterThan(-1);
+    expect(claim).toBeGreaterThan(gate);
+  });
+
+  it('the font/theme effect gates its fit as well', () => {
+    // The zero-dimension skip logs a near-identical line; anchor on the
+    // sub-floor one specifically.
+    const start = src.indexOf('[Terminal] font/theme fit skipped — sub-floor dimensions');
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start - 500, start);
+    expect(block).toMatch(/proposedSafeDimensions\(fitAddonRef\.current\)/);
+  });
+
+  it('a resync settle and a daemon reattach both re-assert DOM geometry (no dedup)', () => {
+    // sendResize carries no lastSentCols dedup — these two points must push
+    // the real size even when the renderer cache already "matches", or the
+    // daemon stays pinned at its clamp after a transient tiny fit.
+    const resync = src.slice(src.indexOf('const completeResyncFromFlush'), src.indexOf('const completeResyncFromFlush') + 2000);
+    expect(resync).toMatch(/proposedSafeDimensions\(fitAddon\)/);
+    expect(resync).toMatch(/sendResize\(ptyId, dims\.cols, dims\.rows\)/);
+    // Anchor on the reattach log line itself — plain "daemon reattach" also
+    // appears in unrelated comments above this effect.
+    const reattach = src.slice(src.indexOf('[useTerminal] daemon reattach ptyId='), src.indexOf('[useTerminal] daemon reattach ptyId=') + 2200);
+    expect(reattach).toMatch(/proposedSafeDimensions\(fitAddonRef\.current\)/);
+    expect(reattach).toMatch(/sendResize\(id, dims\.cols, dims\.rows\)/);
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.deferredFit.test.ts
@@ -149,7 +149,9 @@ describe('#1255 — every fit() apply site is floor-gated, every recovery re-ass
     // sendResize carries no lastSentCols dedup — these two points must push
     // the real size even when the renderer cache already "matches", or the
     // daemon stays pinned at its clamp after a transient tiny fit.
-    const resync = src.slice(src.indexOf('const completeResyncFromFlush'), src.indexOf('const completeResyncFromFlush') + 2000);
+    // Window covers the whole settle fn — #1258's scroll-preservation block
+    // also lives inside it, ahead of the re-assert.
+    const resync = src.slice(src.indexOf('const completeResyncFromFlush'), src.indexOf('const completeResyncFromFlush') + 2700);
     expect(resync).toMatch(/proposedSafeDimensions\(fitAddon\)/);
     expect(resync).toMatch(/sendResize\(ptyId, dims\.cols, dims\.rows\)/);
     // Anchor on the reattach log line itself — plain "daemon reattach" also

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { SearchAddon } from '@xterm/addon-search';
 import { applyUnicodeWidthModel } from '../../shared/terminalUnicode';
+import { isSafeGeometry } from '../../shared/terminalGeometry';
 import { matchesDisabledShortcut } from '../../shared/keymap';
 import { xtermWindowsBuildNumber } from '../../shared/conptyWindows';
 import { WebLinksAddon } from '@xterm/addon-web-links';
@@ -393,6 +394,29 @@ function writePtyDataImmediately(
 ): void {
   if (payload.replay) writeReplayed(term, payload.data, mute);
   else term.write(payload.data);
+}
+
+/**
+ * #1255: the dimensions a fit() would apply right now, or null when the fit
+ * must be skipped — container not measurable, or the proposal is below the
+ * shared geometry floor. Applying a sub-floor fit reflows the entire
+ * scrollback at that width and permanently garbles the pane; the daemon
+ * would clamp the PTY side to MIN_SAFE_COLS anyway, splitting the two sides
+ * of the pipe. Callers skip; a later resize tick (layout settled, pane
+ * revealed, font swapped) re-proposes.
+ */
+function proposedSafeDimensions(
+  addon: FitAddon | null | undefined,
+): { cols: number; rows: number } | null {
+  if (!addon) return null;
+  try {
+    const dims = addon.proposeDimensions();
+    if (!dims) return null;
+    if (!isSafeGeometry(dims.cols, dims.rows)) return null;
+    return dims;
+  } catch {
+    return null; // disposed addon — caller's other guards own teardown
+  }
 }
 
 function hiddenRetentionActive(): boolean {
@@ -950,6 +974,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Calling fit() on a display:none element produces 0 cols/rows which
     // corrupts the xterm buffer and causes the "infinite copy downward" bug.
     if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
+    // #1255: skip sub-floor fits. A mid-split/restoring container can measure
+    // small-but-nonzero; fit() would APPLY those columns to the buffer and
+    // the reflow re-wraps the whole scrollback at that width — damage a later
+    // correct fit does not undo. The ResizeObserver re-fires when the layout
+    // settles, so skipping is self-healing.
+    if (!proposedSafeDimensions(fitAddonRef.current)) return;
     try {
       fitAddonRef.current.fit();
       // This path fits and resizes too, so it settles any deferred debt (#747) —
@@ -1448,7 +1478,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // hidden workspace — an agent splitting a background pane, say) has no
     // valid fit to restore against. Hold the parked viewport until one runs.
     let pendingAdoptViewport: ParkedTerminal | null = null;
-    if (container.offsetWidth > 0 && container.offsetHeight > 0) {
+    // #1255: sub-floor proposals (mid-split/restoring container) are treated
+    // exactly like a hidden container — no fit, and an adoption holds its
+    // parked viewport until a real fit runs.
+    if (container.offsetWidth > 0 && container.offsetHeight > 0 && proposedSafeDimensions(fitAddon)) {
       fitAddon.fit();
       // #1002: the fit runs AFTER the adopted element is back in the DOM and
       // can change how many rows the viewport holds, which moves what "the
@@ -1486,7 +1519,10 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         console.debug('[Terminal] fonts.ready fit deferred — active selection');
         return;
       }
-      fitAddon.fit();
+      pendingFitRef.current = false;
+      // #1255: floor gate — fonts re-measure a container that may still be
+      // mid-layout; a sub-floor proposal is skipped, not applied.
+      if (proposedSafeDimensions(fitAddon)) fitAddon.fit();
       terminal.refresh(0, terminal.rows - 1);
     });
 
@@ -1524,6 +1560,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         if (term !== terminal) return;
 
         if (container.offsetWidth === 0 || container.offsetHeight === 0) return;
+
+        // #1255: floor gate BEFORE the selection guard — a sub-floor proposal
+        // records no fit debt: layout settling re-fires the ResizeObserver,
+        // which is the retry. (Checked before claimFit so the debt mechanism
+        // stays reserved for selection-deferred fits.)
+        if (!proposedSafeDimensions(fitAddon)) return;
 
         // Selection-preservation guard: xterm's SelectionService clears the
         // active selection on any rowsChanged event from fit(). While the user
@@ -2175,6 +2217,13 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       st.buffer.length = 0;
       st.bufferedChars = 0;
       resetStaleReplayModes(recoveredBytes);
+      // #1255: re-assert DOM-derived geometry past the runFit dedup. The
+      // recovered session must get the real size even if the renderer's
+      // lastSentCols cache already "matches" — a transient sub-floor fit
+      // could have left the daemon pinned at its MIN_SAFE_COLS clamp while
+      // the cache believed otherwise. sendResize carries no dedup.
+      const dims = proposedSafeDimensions(fitAddon);
+      if (dims) sendResize(ptyId, dims.cols, dims.rows);
       st.resolvers.splice(0).forEach((r) => r());
       return true;
     };
@@ -2726,6 +2775,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
           // last reported value so a reattach cannot silently revert it.
           if (ptyIdRef.current !== id) return;
           reportViewerVisibility(id, viewerVisibleRef.current);
+          // #1255: re-assert DOM-derived geometry after a reconnect — the
+          // daemon session was recreated at its default/clamped size; the
+          // renderer's dedup cache may already "match" that stale value, so
+          // the resize goes out unconditionally via sendResize (no dedup).
+          const dims = proposedSafeDimensions(fitAddonRef.current);
+          if (dims) sendResize(id, dims.cols, dims.rows);
         })
         .finally(() => { inFlight = false; reconnectInFlightRef.current = false; });
     };
@@ -2801,6 +2856,12 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     const container = containerRef.current;
     if (!container || container.offsetWidth === 0 || container.offsetHeight === 0) {
       console.debug('[Terminal] font/theme fit skipped — container has zero dimensions');
+      return;
+    }
+    // #1255: floor gate — a font change re-measures the container; skip
+    // sub-floor proposals instead of reflowing the buffer at a broken width.
+    if (!proposedSafeDimensions(fitAddonRef.current)) {
+      console.debug('[Terminal] font/theme fit skipped — sub-floor dimensions');
       return;
     }
     fitAddonRef.current?.fit();

--- a/src/shared/__tests__/terminalGeometry.test.ts
+++ b/src/shared/__tests__/terminalGeometry.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { MIN_SAFE_COLS, MIN_SAFE_ROWS, isSafeGeometry } from '../terminalGeometry';
+
+// #1255 — the geometry floor is single-sourced between the daemon's resize
+// clamp (the zle.so SIGBUS guard) and the renderer's fit gate. These are the
+// semantics both sides rely on; a change here is a protocol change.
+describe('shared/terminalGeometry', () => {
+  it('exports the daemon-clamped floors', () => {
+    expect(MIN_SAFE_COLS).toBe(10);
+    expect(MIN_SAFE_ROWS).toBe(2);
+  });
+
+  it('rejects unmeasurable dimensions', () => {
+    expect(isSafeGeometry(undefined, undefined)).toBe(false);
+    expect(isSafeGeometry(80, undefined)).toBe(false);
+    expect(isSafeGeometry(undefined, 24)).toBe(false);
+  });
+
+  it('rejects sub-floor proposals (the transient mid-split widths)', () => {
+    expect(isSafeGeometry(2, 24)).toBe(false);
+    expect(isSafeGeometry(9, 24)).toBe(false);
+    expect(isSafeGeometry(80, 1)).toBe(false);
+  });
+
+  it('accepts floor and above', () => {
+    expect(isSafeGeometry(MIN_SAFE_COLS, MIN_SAFE_ROWS)).toBe(true);
+    expect(isSafeGeometry(80, 24)).toBe(true);
+  });
+});

--- a/src/shared/terminalGeometry.ts
+++ b/src/shared/terminalGeometry.ts
@@ -1,0 +1,25 @@
+/**
+ * Terminal geometry floors shared by both sides of the pipe (#1255).
+ *
+ * The daemon floors every resize it accepts (the zle.so SIGBUS guard — see
+ * DaemonSessionManager), but the floor matters on the renderer side too, and
+ * for a different reason: fitting an xterm instance to a transient
+ * small-but-nonzero container (mid-split, session restore before
+ * react-resizable-panels settles) APPLIES those columns to the buffer, and
+ * the reflow re-wraps the entire scrollback at that width. That damage is
+ * not undone by a later correct fit — which is how a pane could render
+ * ~1 column wide forever. Both sides importing one constant keeps the
+ * contract single-sourced: the renderer never proposes what the daemon
+ * would have to clamp.
+ */
+export const MIN_SAFE_COLS = 10;
+export const MIN_SAFE_ROWS = 2;
+
+/**
+ * Whether a proposed fit is safe to APPLY to an xterm buffer (and to send).
+ * A `undefined` dimension (container not measurable yet) is not safe — the
+ * caller skips and lets the next resize tick try again after layout settles.
+ */
+export function isSafeGeometry(cols: number | undefined, rows: number | undefined): boolean {
+  return cols !== undefined && rows !== undefined && cols >= MIN_SAFE_COLS && rows >= MIN_SAFE_ROWS;
+}


### PR DESCRIPTION
## Root cause

The report's static analysis checked out at every step. A pane collapsing to ~1 column after resize/split/restore and never recovering needs two failures, both present:

**1. Sub-floor fits were applied.** The renderer's fit sites gated only on *zero* dimensions (`offsetWidth === 0`). A transient small-but-nonzero container (mid-split, session restore before `react-resizable-panels` settles) was fitted for real: the tiny columns were applied to the xterm buffer, and the reflow re-wrapped the entire scrollback at that width — damage a later correct fit does not undo. This is why a broken pane stayed broken even after fullscreening.

**2. Nothing reconciled the two sides of the pipe.** The daemon clamps its PTY to `MIN_SAFE_COLS(10)` (`DaemonSessionManager.ts`) while the renderer's `lastSentCols` dedup believed the tiny value it sent was the live geometry. Correct fits equal to the cached value were dropped, and reconnect/resync never recomputed size from the DOM — so the daemon could sit at the clamp indefinitely.

## Changes

- **`shared/terminalGeometry.ts`** (new): the floor constants move to a shared module — the daemon imports them (single source; value and semantics unchanged, the zle.so SIGBUS guard intact), and the renderer never proposes what the daemon would have to clamp.
- **Every `fit()` apply site is floor-gated** (exported `fit`, initial mount, `fonts.ready`, `runFit`, font/theme effect) via `proposedDimensions()` + `isSafeGeometry()`: sub-floor proposals are *skipped, not applied*. Skipping is self-healing — the ResizeObserver re-fires when the layout settles. Floor skips record no selection-debt (`claimFit` mechanism stays reserved for deferrals); an adoption on a sub-floor container holds its parked viewport exactly like a hidden one.
- **Recovery re-asserts geometry**: both the resync settle (`completeResyncFromFlush`) and the daemon reattach now push DOM-derived dimensions through `sendResize` — which carries no dedup — so a session recovered at the clamp, or left there by a transient tiny fit, is handed the real size.

## Deliberately out of scope

A daemon-side readback/echo of actual geometry (belt-and-braces reconciliation in the other direction) — noted in the issue as a possible follow-up; the two fixes above cover both known divergence paths.

## Tests

- `shared/__tests__/terminalGeometry.test.ts`: the floor semantics as a shared contract.
- `useTerminal.deferredFit.test.ts` (#1255 block): source-contract pins — every fit apply site gated (ordering vs the zero guard / `claimFit`), both re-assert points present.
- Daemon geometry tests unchanged and green (behavioral, not source-matched).

Full suite green: 15,140 tests. `tsc --noEmit` clean for both the app and daemon projects; no new lint findings (the 3 `no-empty-function` errors in useTerminal.ts predate this branch).

Fixes #1255.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed terminal panes collapsing into a single column after resizing, splitting, or restoring sessions.
  - Prevented unsafe intermediate dimensions from reflowing terminal content.
  - Improved pane recovery so terminal and session sizes remain synchronized after layout changes.

- **Tests**
  - Added regression coverage for terminal resizing, font and theme updates, session recovery, and minimum safe dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->