### PR TITLE
fix: open formatted terminal links in the selected browser

### DIFF
--- a/changelog.d/1265.md
+++ b/changelog.d/1265.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Formatted terminal links open in the selected browser.** Clicking a Claude/Codex report link now opens its destination after confirmation instead of failing on a blocked blank popup. External mode uses the OS default browser; embedded routing and modifier-key behavior use the existing terminal URL policy. (#1265)

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1,3 +1,4 @@
+import { createOsc8LinkHandler } from '../terminal/osc8LinkHandler';
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
@@ -1112,12 +1113,15 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Smart link routing (X3): localhost URLs open in the embedded browser
     // pane, external ones in the system browser; Ctrl/Cmd+click inverts. The
     // ptyId identifies the owning workspace (multiview-safe reverse lookup).
-    const webLinksAddon = new WebLinksAddon((event, uri) => {
+    const activateTerminalUrl = (event: MouseEvent, uri: string) => {
       openTerminalUrl(uri, {
         modifierHeld: event.ctrlKey || event.metaKey,
         ptyId: ptyIdRef.current || undefined,
       });
-    });
+    };
+    // Rebind adopted terminals too, so the callback uses the current pane ref.
+    terminal.options.linkHandler = createOsc8LinkHandler(activateTerminalUrl);
+    const webLinksAddon = new WebLinksAddon(activateTerminalUrl);
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(searchAddon);
     terminal.loadAddon(webLinksAddon);

--- a/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
+++ b/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Terminal, type ILink, type ILinkProvider } from '@xterm/xterm';
+import { createOsc8LinkHandler } from '../osc8LinkHandler';
+import { openTerminalUrl } from '../../utils/browserPaneActions';
+import { useStore } from '../../stores';
+
+const terminals: Terminal[] = [];
+const openExternal = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(window, 'confirm').mockReturnValue(true);
+  // Match Electron's window-open policy: a blank popup is denied.
+  vi.spyOn(window, 'open').mockReturnValue(null);
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true, value: { shell: { openExternal } },
+  });
+  useStore.setState({ browserBackend: 'external' });
+});
+afterEach(() => { terminals.splice(0).forEach((t) => t.dispose()); vi.restoreAllMocks(); });
+
+async function hyperlink(uri: string): Promise<ILink | undefined> {
+  const terminal = new Terminal({ cols: 80, rows: 24 });
+  terminals.push(terminal);
+  terminal.options.linkHandler = createOsc8LinkHandler((event, url) =>
+    openTerminalUrl(url, { modifierHeld: event.ctrlKey || event.metaKey }));
+  await new Promise<void>((resolve) => terminal.write(`\x1b]8;;${uri}\x07Report\x1b]8;;\x07`, resolve));
+  // Use xterm's actual OSC 8 parser/provider, not an invented link callback.
+  const core = (terminal as unknown as {
+    _core: { _linkProviderService: { linkProviders: ILinkProvider[] } };
+  })._core;
+  return new Promise((resolve) => core._linkProviderService.linkProviders[0].provideLinks(1, (links) => resolve(links?.[0])));
+}
+
+describe('formatted terminal hyperlinks', () => {
+  it.each([
+    ['https://example.com/reports/run?team=one&view=full', false],
+    ['https://example.com/reports/run', true],
+    ['http://localhost:3000/report', false],
+  ])('opens %s in the OS browser with external backend (modifier=%s)', async (url, ctrlKey) => {
+    const link = await hyperlink(url as string);
+    expect(link).toBeDefined();
+    link!.activate(new MouseEvent('click', { ctrlKey: ctrlKey as boolean }), link!.text);
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining(url as string));
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith(url);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('does not open anything when the destination confirmation is cancelled', async () => {
+    vi.mocked(window.confirm).mockReturnValue(false);
+    const link = await hyperlink('https://example.com/report');
+    link!.activate(new MouseEvent('click'), link!.text);
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it.each(['file:///C:/Windows/notepad.exe', 'javascript:alert(1)', 'custom:launch'])('does not activate non-web OSC 8 destinations: %s', async (url) => {
+    expect(await hyperlink(url)).toBeUndefined();
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(window.confirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
+++ b/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
@@ -4,6 +4,7 @@ import { Terminal, type ILink, type ILinkProvider } from '@xterm/xterm';
 import { createOsc8LinkHandler } from '../osc8LinkHandler';
 import { openTerminalUrl } from '../../utils/browserPaneActions';
 import { useStore } from '../../stores';
+import { getLeafPanes } from '../../../shared/paneUtils';
 
 const terminals: Terminal[] = [];
 const openExternal = vi.fn();
@@ -44,6 +45,18 @@ describe('formatted terminal hyperlinks', () => {
     link!.activate(new MouseEvent('click', { ctrlKey: ctrlKey as boolean }), link!.text);
     expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining(url as string));
     expect(openExternal).toHaveBeenCalledExactlyOnceWith(url);
+    expect(window.open).not.toHaveBeenCalled();
+  });
+
+  it('retains embedded routing for localhost in builtin mode', async () => {
+    useStore.setState({ browserBackend: 'builtin' });
+    const url = 'http://localhost:4991/osc8-report';
+    const link = await hyperlink(url);
+    link!.activate(new MouseEvent('click'), link!.text);
+    const browsers = useStore.getState().workspaces.flatMap((ws) =>
+      getLeafPanes(ws.rootPane).flatMap((pane) => pane.surfaces).filter((surface) => surface.type === 'browser'));
+    expect(browsers.some((surface) => surface.url === url)).toBe(true);
+    expect(openExternal).not.toHaveBeenCalled();
     expect(window.open).not.toHaveBeenCalled();
   });
 

--- a/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
+++ b/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
@@ -54,8 +54,8 @@ describe('formatted terminal hyperlinks', () => {
     const link = await hyperlink(url);
     link!.activate(new MouseEvent('click'), link!.text);
     const browsers = useStore.getState().workspaces.flatMap((ws) =>
-      getLeafPanes(ws.rootPane).flatMap((pane) => pane.surfaces).filter((surface) => surface.type === 'browser'));
-    expect(browsers.some((surface) => surface.url === url)).toBe(true);
+      getLeafPanes(ws.rootPane).flatMap((pane) => pane.surfaces).filter((surface) => surface.surfaceType === 'browser'));
+    expect(browsers.some((surface) => surface.browserUrl === url)).toBe(true);
     expect(openExternal).not.toHaveBeenCalled();
     expect(window.open).not.toHaveBeenCalled();
   });

--- a/src/renderer/terminal/osc8LinkHandler.ts
+++ b/src/renderer/terminal/osc8LinkHandler.ts
@@ -1,0 +1,20 @@
+import type { ILinkHandler } from '@xterm/xterm';
+
+/**
+ * OSC 8 links can hide their destination behind a label, so retain xterm's
+ * confirmation. Its default window.open() starts with about:blank, which
+ * Electron correctly denies before the destination can be assigned. Dispatch
+ * the confirmed URL through the same route as plain-text terminal links.
+ */
+export function createOsc8LinkHandler(
+  activate: (event: MouseEvent, uri: string) => void,
+): ILinkHandler {
+  return {
+    allowNonHttpProtocols: false,
+    activate(event, uri) {
+      if (window.confirm(`Do you want to navigate to ${uri}?\n\nWARNING: This link could potentially be dangerous`)) {
+        activate(event, uri);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Formatted terminal hyperlinks (OSC 8, including Claude/Codex report links) show xterm's confirmation dialog but do nothing after OK. Its default handler calls `window.open()` without a URL; wmux denies that blank popup before xterm can assign the destination.

Route confirmed OSC 8 links through the same browser-preference and workspace-aware handler as plain-text URLs. This is not WSL-specific.

## Changes

- Add an OSC 8 link handler that retains destination confirmation and delegates directly to wmux's existing URL route.
- Rebind the handler for adopted terminal instances and share the callback with the plain-text web-links addon.
- Retain HTTP(S)-only activation and existing Electron popup restrictions.

## CHANGELOG entry

### Fixed

- **Formatted terminal links open in the selected browser.** Clicking a Claude/Codex report link now opens its destination after confirmation instead of failing on a blocked blank popup. External mode uses the OS default browser; embedded routing and modifier-key behavior use the existing terminal URL policy.

## Stability tier impact

- [x] Change to an `internal` surface (no contract impact).

## Substrate contract impact (Substrate 3.0)

n/a — no IPC/RPC shape, permission boundary or named-pipe changes.

## Test plan

- `npx tsc --noEmit`: pass.
- Full regular suite: 990 suites / 15,154 tests passed; 2 suites / 28 tests skipped.
- Final focused hyperlink/browser-routing tests: 39 passed on both Linux and Windows (including an added embedded-routing regression after the full regular run). The regression test writes actual OSC 8 sequences into xterm and activates its real link provider, covering reports, localhost, modifier keys, cancellation and blocked non-web schemes.
- Windows Electron 41.10.3 smoke: actual xterm hyperlink → new handler → existing `registerShellHandlers` IPC → Windows `shell.openExternal` resolved successfully for the GitHub PR page. Zero blank popup attempts. The fixture accepts the confirmation automatically; the handler retains the normal user confirmation.
- Windows `npm run make`: pass. The local test package also includes the independent WSL fix from #1263; this PR contains only the hyperlink fix.
- Changelog fragment: `changelog.d/1265.md`.

## Related issues / PRs

Reported while testing WSL support in #1263. This fix is independent and based directly on main.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs do not require changes.
- [x] Tests cover the new behavior and the regression case.
- [x] No secrets, tokens, `.env`, or unrelated large binaries committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal hyperlinks now support formatted and OSC 8 links, including Claude and Codex report destinations.
  * Confirmed web links open using the configured terminal behavior, such as the embedded view or the operating system’s default browser.
  * Links can be opened through modifier-key interactions where supported.

* **Bug Fixes**
  * Restricted terminal links now reject unsupported destinations, including local file and script-based URLs.
  * Added confirmation before navigating to terminal links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->