### PR TITLE
fix: hand the real $? to the wrapped pwsh prompt

### DIFF
--- a/changelog.d/1268.md
+++ b/changelog.d/1268.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Exit-code segments in a custom pwsh prompt work again.** wmux wraps your
+  `prompt` function to emit its command-boundary markers, and it snapshotted
+  `$?` correctly — but never handed that snapshot to the prompt it wrapped.
+  Roughly ten statements ran in between, and in PowerShell every statement
+  resets `$?` to true, so oh-my-posh's `status` segment (and Starship, and
+  anything else that reads `$?`) reported success after every failed command
+  inside a wmux pane, while the same config coloured correctly in Windows
+  Terminal. The wrapper now re-asserts the real status immediately before
+  delegating, and the local-mode prompt hook — the one used when the daemon is
+  gone — is fixed the same way. (#1268, #1267)

--- a/src/daemon/__tests__/shellIntegration.runtime.test.ts
+++ b/src/daemon/__tests__/shellIntegration.runtime.test.ts
@@ -79,6 +79,44 @@ function waitForEventAfter(
   });
 }
 
+/**
+ * Poll the session's raw output until `pattern` matches something written
+ * after `baselineBytes`.
+ *
+ * The prompt body is rendered by the shell itself — it is not reported as a
+ * PromptEvent — so verifying what the WRAPPED prompt observed means reading
+ * the PTY stream rather than promptLog.
+ */
+function waitForOutputAfter(
+  managed: ManagedSession,
+  baselineBytes: number,
+  pattern: RegExp,
+  label: string,
+  timeoutMs = EVENT_TIMEOUT_MS,
+): Promise<RegExpMatchArray> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = () => {
+      const fresh = managed.ringBuffer.readAll().subarray(baselineBytes).toString('utf8');
+      const match = fresh.match(pattern);
+      if (match) {
+        resolve(match);
+        return;
+      }
+      if (Date.now() > deadline) {
+        reject(
+          new Error(
+            `timed out waiting for ${label} — tail after baseline: ${JSON.stringify(fresh.slice(-400))}`,
+          ),
+        );
+        return;
+      }
+      setTimeout(tick, 50);
+    };
+    tick();
+  });
+}
+
 describe.runIf(hasPowerShell)('OSC 133 runtime — powershell.exe', () => {
   let manager: DaemonSessionManager;
 
@@ -162,6 +200,53 @@ describe.runIf(hasPowerShell)('OSC 133 runtime — powershell.exe', () => {
       'command_end with non-zero exitCode',
     );
     expect(cmdEnd.exitCode).toBe(7);
+  }, EVENT_TIMEOUT_MS + 2000);
+
+  // Issue #1267. The wrapper delegates to $global:__wmux_prev_prompt, so
+  // whatever $? that scriptblock observes is exactly what oh-my-posh or
+  // Starship would observe. Installing a probe there exercises the real
+  // contract through a real ConPTY — a substring assertion on PWSH_INIT can
+  // prove the restore is present but not that it actually survives to the
+  // delegation, which is the half that was broken.
+  it('hands the real $? to the wrapped prompt', async () => {
+    manager = new DaemonSessionManager();
+    const id = `rt-pwsh-status-${Date.now()}`;
+    manager.createSession({
+      id,
+      cmd: POWERSHELL,
+      cwd: path.resolve(process.cwd()),
+    });
+
+    const managed = manager.getSession(id)!;
+
+    // Stand in for the user's prompt engine. $q must be assigned as the
+    // scriptblock's first statement — reading $? later would measure this
+    // probe's own bookkeeping instead of the command that just ran.
+    managed.ptyProcess.write('$global:__wmux_prev_prompt = { $q = $?; "WMUXPROBE[$q]" }\r');
+    await waitForOutputAfter(managed, 0, /WMUXPROBE\[(?:True|False)\]/, 'the probe prompt to render');
+
+    // A failing native command: the wrapped prompt must see $? = False.
+    const beforeFailure = managed.ringBuffer.readAll().length;
+    managed.ptyProcess.write(`& "${CMD_EXE}" /c exit 7\r`);
+    const afterFailure = await waitForOutputAfter(
+      managed,
+      beforeFailure,
+      /WMUXPROBE\[(True|False)\]/,
+      'a prompt render after a failing command',
+    );
+    expect(afterFailure[1]).toBe('False');
+
+    // ...and True again after one that succeeds, so a fix that simply pins
+    // the status to False cannot pass.
+    const beforeSuccess = managed.ringBuffer.readAll().length;
+    managed.ptyProcess.write(`& "${CMD_EXE}" /c exit 0\r`);
+    const afterSuccess = await waitForOutputAfter(
+      managed,
+      beforeSuccess,
+      /WMUXPROBE\[(True|False)\]/,
+      'a prompt render after a successful command',
+    );
+    expect(afterSuccess[1]).toBe('True');
   }, EVENT_TIMEOUT_MS + 2000);
 });
 

--- a/src/daemon/__tests__/shellIntegration.test.ts
+++ b/src/daemon/__tests__/shellIntegration.test.ts
@@ -181,3 +181,39 @@ describe('BASH_INIT — OSC 7 cwd report (#540)', () => {
     expect(BASH_INIT).not.toContain('"${HOSTNAME-localhost}" "$p"');
   });
 });
+
+// Issue #1267: the wrapper snapshots $? as its very first statement but used
+// to delegate to the wrapped prompt ~10 statements later — and in PowerShell
+// EVERY statement resets $? to true. So any prompt engine that reads $? to
+// detect the last command's status (oh-my-posh `status`, Starship) saw
+// "success" forever inside a wmux pane, while the same config in Windows
+// Terminal coloured correctly. $? is not assignable and the snapshot cannot be
+// deferred, so the wrapper re-creates the value immediately before delegating.
+describe('PWSH_INIT — the wrapped prompt sees the real $? (#1267)', () => {
+  const promptBody = PWSH_INIT.slice(PWSH_INIT.indexOf('function global:prompt'));
+
+  it('re-asserts the status with nothing between it and the delegation', () => {
+    // Placement IS the fix. A single cmdlet call in between — a Test-Path,
+    // say — resets $? straight back to true and the restore silently becomes
+    // a no-op, which looks identical in review and fails only at runtime.
+    expect(promptBody).toMatch(
+      /if \(-not \$__wmux_ok\) \{ Write-Error [^\n]*-ErrorAction Ignore \}\s*\r?\n\s*\$body = if \(\$global:__wmux_prev_prompt\)/,
+    );
+  });
+
+  it('re-asserts AFTER the snapshot is taken, never before', () => {
+    const snapshot = promptBody.indexOf('$__wmux_ok = $?');
+    const restore = promptBody.indexOf('if (-not $__wmux_ok)');
+    expect(snapshot).toBeGreaterThanOrEqual(0);
+    expect(restore).toBeGreaterThan(snapshot);
+  });
+
+  it('uses -ErrorAction Ignore, never SilentlyContinue', () => {
+    // Ignore sets $? false and records NOTHING in $Error. SilentlyContinue
+    // also sets $? false, but pushes a synthetic ErrorRecord — and oh-my-posh
+    // reads the newest record as exit code 1, so the swap would report 1 over
+    // the real exit code instead of fixing anything.
+    expect(promptBody).toMatch(/Write-Error [^\n]*-ErrorAction Ignore/);
+    expect(promptBody).not.toMatch(/Write-Error [^\n]*-ErrorAction SilentlyContinue/);
+  });
+});

--- a/src/daemon/shell-integration.ts
+++ b/src/daemon/shell-integration.ts
@@ -39,7 +39,13 @@ import { isMac } from '../shared/platform';
 // a directory whose real name contains a literal percent sequence
 // ("build%20cache") was silently corrupted, and a raw ESC/BEL byte in a
 // directory name could terminate the OSC 7 early and inject terminal escapes.
-const INTEGRATION_VERSION = 9;
+// v10: hand the $? snapshot to the wrapped prompt (issue #1267). The wrapper
+// snapshots $? and $LASTEXITCODE as its first two statements, but never gave
+// that snapshot to the prompt it wraps — and every statement in between resets
+// $? to true. So oh-my-posh, Starship, and anything else that reads $? to
+// colour an exit-code segment saw "success" after every failed command, while
+// the same config in Windows Terminal was correct.
+const INTEGRATION_VERSION = 10;
 const VERSION_FILE = '.version';
 
 // -----------------------------------------------------------------------
@@ -107,6 +113,23 @@ function global:prompt {
         $osc7Path = ($loc.ProviderPath -split '\\\\' | ForEach-Object { [Uri]::EscapeDataString($_) }) -join '/'
         $pre += "$esc]7;file://$env:COMPUTERNAME/$osc7Path$bel"
     }
+
+    # Re-assert the snapshot before delegating (#1267). Every statement above
+    # reset $? to true, so the prompt we wrap would otherwise always see
+    # "success" and an exit-code segment (oh-my-posh status, Starship) would
+    # stay green after a failed command. $? is not assignable and the snapshot
+    # cannot be deferred — any statement is enough to reset it — so the value
+    # is re-created here instead.
+    #
+    # -ErrorAction Ignore is the variant with no side effects: unlike
+    # SilentlyContinue it records nothing in $Error, which matters because
+    # oh-my-posh reads the newest error record as exit code 1 and would mask
+    # the real code. Ignore also never throws under $ErrorActionPreference =
+    # 'Stop', on 5.1 and 7+ alike.
+    #
+    # This must stay the LAST statement before the delegation: any cmdlet call
+    # in between (a Test-Path, say) resets $? straight back to true.
+    if (-not $__wmux_ok) { Write-Error -Message 'wmux: last command failed' -ErrorAction Ignore }
 
     $body = if ($global:__wmux_prev_prompt) {
         try { & $global:__wmux_prev_prompt } catch { "PS $($executionContext.SessionState.Path.CurrentLocation)> " }

--- a/src/main/pty/__tests__/pwshHook.test.ts
+++ b/src/main/pty/__tests__/pwshHook.test.ts
@@ -10,4 +10,30 @@ describe('PowerShell terminal hook', () => {
     expect(hook).not.toMatch(/^\s*\[Console\]::Write\(/m);
     expect(hook).toContain('return $oscPrefix + [string]$body');
   });
+
+  // Issue #1267. This hook wraps the user's prompt too, and the Test-Path
+  // guard sitting in front of the delegation reset $? to true — so an
+  // exit-code segment (oh-my-posh `status`, Starship) stayed green after a
+  // failed command. Same defect as the daemon-mode wrapper in
+  // src/daemon/shell-integration.ts; this is the local-mode fallback path
+  // wmux uses when the daemon is gone.
+  it('hands the real $? to the wrapped prompt', () => {
+    const hookPath = path.resolve(process.cwd(), 'src/main/pty/shell-hooks/pwsh.ps1');
+    const hook = fs.readFileSync(hookPath, 'utf8');
+
+    // The snapshot must be the first statement of the prompt function —
+    // comments are fine, any statement before it is not.
+    expect(hook).toMatch(/function prompt \{(?:\s*#[^\n]*\n)*\s*\$__wmux_ok = \$\?/);
+
+    // ...and the restore must be the last thing before the delegation, with
+    // the Test-Path guard (which resets $?) already behind it.
+    expect(hook).toMatch(
+      /if \(-not \$__wmux_ok\) \{ Write-Error [^\n]*-ErrorAction Ignore \}\s*\r?\n\s*__wmux_original_prompt/,
+    );
+
+    // Ignore records nothing in $Error. SilentlyContinue would push a
+    // synthetic record that oh-my-posh reads as exit code 1, masking the real
+    // one — the swap looks harmless and is not.
+    expect(hook).not.toMatch(/Write-Error [^\n]*-ErrorAction SilentlyContinue/);
+  });
 });

--- a/src/main/pty/shell-hooks/pwsh.ps1
+++ b/src/main/pty/shell-hooks/pwsh.ps1
@@ -18,7 +18,16 @@ if (Test-Path Function:\prompt) {
 }
 
 function prompt {
+    # Snapshot $? first and re-assert it immediately before delegating (#1267):
+    # the Test-Path below resets $? to true, so the prompt we wrap would always
+    # see "success" and an exit-code segment (oh-my-posh status, Starship)
+    # would stay green after a failed command. -ErrorAction Ignore sets $?
+    # false while recording nothing in $Error, so oh-my-posh's error-record
+    # branch cannot mistake it for a real failure and report 1 over the true
+    # exit code.
+    $__wmux_ok = $?
     $body = if (Test-Path Function:\__wmux_original_prompt) {
+        if (-not $__wmux_ok) { Write-Error -Message 'wmux: last command failed' -ErrorAction Ignore }
         __wmux_original_prompt
     } else {
         "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "


### PR DESCRIPTION
## Summary

The pwsh shell integration wraps the user's `prompt` function and snapshots `$?` as its very first statement, but never handed that snapshot to the prompt it wraps — and every statement in between resets `$?` to true. Any prompt engine that reads `$?` to detect the last command's result therefore saw "success" forever inside a wmux pane. This passes the real status through to the wrapped prompt, in both the daemon-mode wrapper and the local-mode hook.

## Changes

- `src/daemon/shell-integration.ts` — re-assert the `$?` snapshot immediately before delegating to `$global:__wmux_prev_prompt`. Bump `INTEGRATION_VERSION` 9 → 10 so `installShellIntegration()` actually rewrites the on-disk script.
- `src/main/pty/shell-hooks/pwsh.ps1` — same defect on the local-mode fallback path: the `Test-Path` guard sits between the function entry and the delegation. Snapshot on entry, re-assert inside the `if`, immediately before the call.
- Unit tests pinning the placement and the `-ErrorAction Ignore` choice, plus a runtime test that drives a real ConPTY pane.

## Why `Write-Error -ErrorAction Ignore`

`$?` is not assignable, and the snapshot cannot be deferred — any statement before the delegation is enough to reset it — so the value has to be re-created. `-ErrorAction Ignore` is the variant with no side effects. Measured, not assumed:

- sets `$?` to `$false`, and reaches `$global:?` too (so Starship is covered, not just oh-my-posh);
- records **nothing** in `$Error`. `SilentlyContinue` does push a synthetic record, and oh-my-posh reads the newest error record as exit code 1 — so that variant would mask the real exit code rather than fix anything;
- does not throw under `$ErrorActionPreference = 'Stop'`;
- behaves identically on Windows PowerShell 5.1 and pwsh 7+.

The issue suggested `$global:NVS_ORIGINAL_LASTEXECUTIONSTATUS` instead. I went the generic route because that global only helps oh-my-posh, and once written it is a `[bool]` forever — so oh-my-posh never consults `$?` again, and if the wrapper is later displaced (re-running `oh-my-posh init` inside a pane, which the issue notes people do) the stale value freezes the status permanently. Happy to switch if you'd rather keep the change narrower.

**Placement is the whole fix.** A single cmdlet call between the restore and the delegation resets `$?` straight back to true and the restore becomes a silent no-op — it looks identical in review and fails only at runtime. That is exactly how the local-mode hook's `Test-Path` broke it, and my first attempt there reproduced the mistake. The tests assert adjacency for that reason.

## CHANGELOG entry

### Fixed

- **Exit-code segments in a custom pwsh prompt work again.** wmux wraps your `prompt` function to emit its command-boundary markers, and it snapshotted `$?` correctly — but never handed that snapshot to the prompt it wrapped. Roughly ten statements ran in between, and in PowerShell every statement resets `$?` to true, so oh-my-posh's `status` segment (and Starship, and anything else reading `$?`) reported success after every failed command inside a wmux pane, while the same config coloured correctly in Windows Terminal. The wrapper now re-asserts the real status immediately before delegating, and the local-mode prompt hook — the one used when the daemon is gone — is fixed the same way. (#1267)

## Stability tier impact

- [x] Change to an `internal` surface (no contract impact).

The OSC 133 wire format is unchanged; this only affects what the wrapped prompt observes.

## Substrate contract impact (Substrate 3.0)

n/a — no PaneMetadata, EventBus, permission, pipe, or RPC surface touched.

## Test plan

**Unit** — `src/daemon/__tests__/shellIntegration.test.ts`, `src/main/pty/__tests__/pwshHook.test.ts`: the restore is adjacent to the delegation with nothing in between, sits after the snapshot, and uses `-ErrorAction Ignore` rather than `SilentlyContinue`.

**Runtime** — `src/daemon/__tests__/shellIntegration.runtime.test.ts`: spawns a real `powershell.exe` pane through `DaemonSessionManager.createSession()`, installs a probe as `$global:__wmux_prev_prompt`, and asserts the probe observes `False` after a failing command and `True` after a successful one. Whatever that scriptblock sees is exactly what oh-my-posh or Starship would see, so this tests the real contract rather than the text of the script.

All four new assertions fail without the fix (verified by reverting it).

**Manual** — against the emitted script, on pwsh 7.6.6 and Windows PowerShell 5.1:

| last command | before | after |
|---|---|---|
| `cmd /c exit 7` | `$? = True` | `$? = False` |
| `cmd /c exit 0` | `$? = True` | `$? = True` |
| `Get-Item Q:\nope-xyz` | `$? = True` | `$? = False` |

`$Error` stays empty and `$LASTEXITCODE` still reads 7 afterwards. Confirmed `.version` flips 9 → 10 on disk and the installed script carries the fix.

**Suite** — `npx tsc --noEmit` clean; `npm test` green (15,151 parallel + 225 runtime).

## Related issues / PRs

Closes #1267

## Two adjacent bugs found while measuring — want follow-up issues?

Neither is touched by this PR. Both are in wmux's *own* exit-status reporting rather than the wrapped prompt, and both change what daemon consumers observe, so they seemed to deserve their own review rather than riding along here. Both reproduced on the real script. Say the word and I'll open issues (or fold them in, if you'd prefer).

**1. `shell-integration.ts` emits `133;D;0` after a failing cmdlet.**

```powershell
$ec = if ($null -ne $__wmux_le) { $__wmux_le } elseif ($__wmux_ok) { 0 } else { 1 }
```

`$LASTEXITCODE` is preferred over the `$?` snapshot, and it is non-null from the first native command onward — so the `$__wmux_ok` branch is effectively dead for the rest of the session. `Get-Item Q:\nope-xyz` emits `133;D;0`. This feeds `agent.lifecycle.exitCode`. VS Code's integration checks `$?` first. Note this contradicts the original issue's assumption that OSC 133 reporting was unaffected — it is, for native exit codes, but not for cmdlet failures.

**2. `pwsh.ps1` never restores `$LASTEXITCODE`.**

Its own `git rev-parse` (line ~52) zeroes `$LASTEXITCODE` on every prompt render and nothing puts it back, so after `cmd /c exit 7` the user sees `$LASTEXITCODE = 0`. The daemon wrapper handles this deliberately; the local-mode hook does not.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed — n/a, no surface change.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.

https://claude.ai/code/session_01GBZkAo17s8gJxM8AwK4WUy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PowerShell prompt status reporting so oh-my-posh, Starship, and similar tools correctly reflect whether the previous command succeeded or failed.
  * Preserved accurate command status in both connected and local terminal sessions.
  * Updated shell integration to ensure the corrected behavior is applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->