### PR TITLE
fix(search): clear highlight decorations when the search bar goes away

### DIFF
--- a/changelog.d/1281.md
+++ b/changelog.d/1281.md
@@ -8,3 +8,11 @@
   re-highlighting an abandoned term — landing on whatever text occupied those
   cells by then, with no search box left to dismiss it. The highlights are now
   cleared whenever the search bar goes away, not only via its close button.
+
+### Changed
+
+- **Leaving a pane now ends its search.** Focusing another pane drops the
+  highlights and the addon's cached term, and reopening the search bar starts
+  from an empty query. The query box was already per-mount local state, so it
+  never survived a pane switch; the highlights now match it instead of
+  outliving it.

--- a/changelog.d/1281.md
+++ b/changelog.d/1281.md
@@ -1,18 +1,21 @@
 ### Fixed
 
-- **Search highlights no longer linger in a pane after you leave it (#1266).**
-  The search bar is only rendered for the active pane, so focusing another
-  pane made it disappear without ever ending the search. `@xterm/addon-search`
-  treats a search as live until it is explicitly cleared and re-applies its
-  highlights after every subsequent chunk of output, so the pane kept
-  re-highlighting an abandoned term — landing on whatever text occupied those
-  cells by then, with no search box left to dismiss it. The highlights are now
-  cleared whenever the search bar goes away, not only via its close button.
+- **Search highlights can no longer be stranded in a pane (#1266).** Closing
+  the search bar left every highlight behind with no way to dismiss them —
+  the "artifacts frozen into the pane" in the report. Worse, the bar was
+  shown per *tab* rather than per focused *pane*, so every pane rendered its
+  own bar and moving to another pane never ended the abandoned pane's
+  search: `@xterm/addon-search` treats a search as live until it is
+  explicitly cleared and re-applies its highlights after every subsequent
+  chunk of output, so that pane kept re-highlighting a term nobody was
+  searching for, at coordinates that no longer matched anything — orange
+  marks drifting over neighbouring panes. The search bar now belongs to the
+  focused pane, and its highlights are cleared whenever it goes away.
 
 ### Changed
 
-- **Leaving a pane now ends its search.** Focusing another pane drops the
-  highlights and the addon's cached term, and reopening the search bar starts
-  from an empty query. The query box was already per-mount local state, so it
-  never survived a pane switch; the highlights now match it instead of
-  outliving it.
+- **Only the focused pane shows the search bar, and leaving a pane ends its
+  search.** Previously every pane showed one simultaneously. Moving focus
+  elsewhere now drops that pane's highlights and the addon's cached term;
+  reopening the bar starts from an empty query (the query box was already
+  per-mount state and never survived a pane switch).

--- a/changelog.d/1281.md
+++ b/changelog.d/1281.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **Search highlights no longer linger in a pane after you leave it (#1266).**
+  The search bar is only rendered for the active pane, so focusing another
+  pane made it disappear without ever ending the search. `@xterm/addon-search`
+  treats a search as live until it is explicitly cleared and re-applies its
+  highlights after every subsequent chunk of output, so the pane kept
+  re-highlighting an abandoned term — landing on whatever text occupied those
+  cells by then, with no search box left to dismiss it. The highlights are now
+  cleared whenever the search bar goes away, not only via its close button.

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -252,6 +252,19 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
     setSearchBarVisible(false);
   };
 
+  // #1266 — the search bar is gated on `isActive`, so focusing another pane
+  // unmounts it without ever running handleCloseSearch. The addon keeps its
+  // cached term, and its own onWriteParsed hook keeps re-running the search
+  // and re-creating highlight decorations on every subsequent chunk of
+  // output: highlights the user can no longer see a search bar for, landing
+  // on whatever text happens to occupy those cells now, with no UI left to
+  // dismiss them. Tear the decorations down whenever the bar goes away for
+  // any reason, not just via the close button.
+  useEffect(() => {
+    if (showSearchBar) return;
+    clearSearch();
+  }, [showSearchBar, clearSearch]);
+
   const handleCopy = useCallback(() => {
     if (ctxMenu?.selectedText) {
       // main may throw on failure (size / lock / invalid type); the helper

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -9,6 +9,7 @@ import { pasteClipboardImage } from '../../utils/imagePaste';
 import { openTerminalUrl } from '../../utils/browserPaneActions';
 import { terminalFontFamilyCss } from '../../utils/terminalFont';
 import { isFileDrag } from '../../../shared/dragDrop';
+import { findLeafBySurfaceId } from '../../../shared/paneUtils';
 import ViCopyMode from './ViCopyMode';
 import SearchBar from './SearchBar';
 import BookmarkIndicator from './BookmarkIndicator';
@@ -245,21 +246,37 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
   // snapshot): the ref is populated after this render ran, so a snapshot read
   // here sees null until an unrelated re-render happens.
   const showViCopyMode = viCopyModeActive && isActive && terminalInstance !== null;
-  const showSearchBar = searchBarVisible && isActive;
+  // #1266 — `isActive` means "selected tab INSIDE this pane", not "this pane
+  // has focus". `searchBarVisible` is a single global flag, so gating on
+  // `isActive` alone put a search bar in every pane at once and meant the bar
+  // never unmounted when the user moved to another pane: the abandoned pane
+  // kept its cached term and went on re-creating highlight decorations on
+  // every later chunk of output, at coordinates that no longer matched
+  // anything. Gate on real pane focus so exactly one bar is up and leaving a
+  // pane genuinely ends its search.
+  const isPaneFocused = useStore((s) => {
+    if (!ownerSurfaceId) return true;
+    const ws = s.workspaces.find((w) => w.id === (ownerWorkspaceId ?? s.activeWorkspaceId));
+    if (!ws) return true;
+    const leaf = findLeafBySurfaceId(ws.rootPane, ownerSurfaceId);
+    // Surfaces we cannot place (stashed panes, transitional trees) keep the
+    // previous behaviour rather than losing their search bar.
+    return leaf ? leaf.id === ws.activePaneId : true;
+  });
+  const showSearchBar = searchBarVisible && isActive && isPaneFocused;
 
   const handleCloseSearch = () => {
     clearSearch();
     setSearchBarVisible(false);
   };
 
-  // #1266 — the search bar is gated on `isActive`, so focusing another pane
-  // unmounts it without ever running handleCloseSearch. The addon keeps its
-  // cached term, and its own onWriteParsed hook keeps re-running the search
-  // and re-creating highlight decorations on every subsequent chunk of
-  // output: highlights the user can no longer see a search bar for, landing
-  // on whatever text happens to occupy those cells now, with no UI left to
-  // dismiss them. Tear the decorations down whenever the bar goes away for
-  // any reason, not just via the close button.
+  // #1266 — the bar can go away without handleCloseSearch ever running:
+  // toggling it off globally, switching to another surface in this pane, or
+  // (with the focus gate above) moving to another pane. In every one of
+  // those the addon would otherwise keep its cached term and its
+  // onWriteParsed hook, re-creating highlight decorations on every later
+  // chunk of output with no UI left to dismiss them. Tear them down whenever
+  // the bar goes away, for any reason.
   useEffect(() => {
     if (showSearchBar) return;
     clearSearch();

--- a/src/renderer/components/Terminal/__tests__/searchBarUnmountClears.test.tsx
+++ b/src/renderer/components/Terminal/__tests__/searchBarUnmountClears.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+//
+// #1266 — render-level guard for the search-highlight teardown.
+//
+// The bug was a lifecycle gap, not a search bug: Terminal.tsx renders the
+// search bar under `searchBarVisible && isActive`, so focusing another pane
+// unmounts it WITHOUT running the close handler. The addon then keeps its
+// cached term and goes on re-creating highlight decorations on every later
+// chunk of output. This mounts the real Terminal component, flips `isActive`
+// so the bar goes away, and asserts the search addon's clearDecorations()
+// actually ran — the behaviour, not the shape of the source.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/** Stands in for the SearchAddon instance useTerminal owns. */
+const searchAddon = { clearDecorations: vi.fn(), findNext: vi.fn(), findPrevious: vi.fn() };
+
+vi.mock('../../../hooks/useTerminal', () => ({
+  // Mirrors the real hook's three-line wrappers, so the assertion lands on
+  // the addon call the production code makes.
+  useTerminal: () => ({
+    terminal: { current: null },
+    terminalInstance: null,
+    fit: vi.fn(),
+    searchAddonRef: { current: searchAddon },
+    findNext: (text: string) => searchAddon.findNext(text),
+    findPrevious: (text: string) => searchAddon.findPrevious(text),
+    clearSearch: () => searchAddon.clearDecorations(),
+    getScrollPosition: () => 0,
+    scrollToLine: vi.fn(),
+  }),
+  copySelectionWithFeedback: vi.fn(),
+  getPaneSyncUi: () => null,
+  subscribePaneSyncUi: () => (): void => undefined,
+}));
+
+vi.mock('../../../hooks/useIpc', () => ({ useIpc: () => ({ invoke: vi.fn() }) }));
+vi.mock('../../../hooks/useT', () => ({ useT: () => (k: string) => k }));
+vi.mock('../../../i18n', () => ({ t: (k: string) => k }));
+
+// The overlays are exercised by their own tests; stub them so this file only
+// depends on Terminal.tsx's own wiring.
+vi.mock('../SearchBar', () => ({ default: () => <div data-testid="search-bar" /> }));
+vi.mock('../ViCopyMode', () => ({ default: () => null }));
+vi.mock('../BookmarkIndicator', () => ({ default: () => null }));
+vi.mock('../ContextMenu', () => ({ default: () => null }));
+vi.mock('../ScrollToBottomButton', () => ({ default: () => null }));
+
+const state: Record<string, unknown> = {
+  viCopyModeActive: false,
+  setViCopyModeActive: vi.fn(),
+  searchBarVisible: true,
+  setSearchBarVisible: vi.fn(),
+  pendingDeadPaneRecoveryBySurfaceId: {},
+  terminalBookmarks: {},
+  supervisionByPtyId: {},
+  terminalTextDropDragActive: false,
+  terminalFontSize: 13,
+  terminalFontFamily: 'Cascadia Code',
+  activeWorkspaceId: 'ws-1',
+  defaultShell: 'pwsh',
+  workspaces: [],
+  startupDirectory: '',
+  updateSurfaceCwd: vi.fn(),
+  pushToast: vi.fn(),
+};
+
+vi.mock('../../../stores', () => {
+  const useStore = <T,>(selector: (s: Record<string, unknown>) => T): T => selector(state);
+  useStore.getState = () => state;
+  useStore.setState = (patch: unknown) => {
+    Object.assign(state, typeof patch === 'function' ? {} : patch);
+  };
+  return { useStore };
+});
+
+import TerminalComponent from '../Terminal';
+
+describe('Terminal.tsx tears down search highlights when the bar goes away (#1266)', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    searchAddon.clearDecorations.mockClear();
+    state.searchBarVisible = true;
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    host.remove();
+  });
+
+  const render = (isActive: boolean) => {
+    act(() => {
+      root.render(<TerminalComponent ptyId="pty-1" isActive={isActive} />);
+    });
+  };
+
+  it('does not clear while the bar is up', () => {
+    render(true);
+    expect(host.querySelector('[data-testid="search-bar"]')).not.toBeNull();
+    expect(searchAddon.clearDecorations).not.toHaveBeenCalled();
+  });
+
+  it('clears when the pane loses focus and the bar unmounts', () => {
+    render(true);
+    expect(searchAddon.clearDecorations).not.toHaveBeenCalled();
+
+    // Focus moves to another pane. `searchBarVisible` is a single global
+    // flag, so nothing else here changes — this is exactly the path that
+    // used to leave the highlights behind.
+    render(false);
+
+    expect(host.querySelector('[data-testid="search-bar"]')).toBeNull();
+    expect(searchAddon.clearDecorations).toHaveBeenCalled();
+  });
+
+  it('clears when the search bar is closed while the pane stays focused', () => {
+    render(true);
+    state.searchBarVisible = false;
+    render(true);
+
+    expect(host.querySelector('[data-testid="search-bar"]')).toBeNull();
+    expect(searchAddon.clearDecorations).toHaveBeenCalled();
+  });
+});

--- a/src/renderer/components/Terminal/__tests__/searchBarUnmountClears.test.tsx
+++ b/src/renderer/components/Terminal/__tests__/searchBarUnmountClears.test.tsx
@@ -2,31 +2,47 @@
 //
 // #1266 — render-level guard for the search-highlight teardown.
 //
-// The bug was a lifecycle gap, not a search bug: Terminal.tsx renders the
-// search bar under `searchBarVisible && isActive`, so focusing another pane
-// unmounts it WITHOUT running the close handler. The addon then keeps its
-// cached term and goes on re-creating highlight decorations on every later
-// chunk of output. This mounts the real Terminal component, flips `isActive`
-// so the bar goes away, and asserts the search addon's clearDecorations()
-// actually ran — the behaviour, not the shape of the source.
+// The bug is a lifecycle/ownership gap, not a search bug. `searchBarVisible`
+// is one global flag and Terminal.tsx gated the bar on `isActive`, which
+// Pane.tsx passes as `surface.id === pane.activeSurfaceId` — the selected TAB
+// inside a pane, not "this pane has focus". So every pane rendered its own
+// search bar, and moving to another pane never unmounted the abandoned one's:
+// its addon kept the cached term and went on re-creating highlight
+// decorations on every later chunk of output, at coordinates that no longer
+// matched anything (live dogfood measured them drawn outside the pane).
+//
+// These tests mount the real Terminal component and assert the addon's
+// clearDecorations() actually ran — the behaviour, not the shape of the
+// source.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-/** Stands in for the SearchAddon instance useTerminal owns. */
-const searchAddon = { clearDecorations: vi.fn(), findNext: vi.fn(), findPrevious: vi.fn() };
+/** One stand-in SearchAddon per pty, as useTerminal owns one per terminal. */
+type FakeAddon = { clearDecorations: ReturnType<typeof vi.fn<() => void>> };
+const addons = new Map<string, FakeAddon>();
+function addonFor(ptyId: string): FakeAddon {
+  let a = addons.get(ptyId);
+  if (!a) {
+    a = { clearDecorations: vi.fn<() => void>() };
+    addons.set(ptyId, a);
+  }
+  return a;
+}
+/** The single-pane cases use this one. */
+const searchAddon = addonFor('pty-1');
 
 vi.mock('../../../hooks/useTerminal', () => ({
   // Mirrors the real hook's three-line wrappers, so the assertion lands on
   // the addon call the production code makes.
-  useTerminal: () => ({
+  useTerminal: (_ref: unknown, options: { ptyId?: string }) => ({
     terminal: { current: null },
     terminalInstance: null,
     fit: vi.fn(),
-    searchAddonRef: { current: searchAddon },
-    findNext: (text: string) => searchAddon.findNext(text),
-    findPrevious: (text: string) => searchAddon.findPrevious(text),
-    clearSearch: () => searchAddon.clearDecorations(),
+    searchAddonRef: { current: addonFor(options.ptyId ?? 'pty-1') },
+    findNext: vi.fn(),
+    findPrevious: vi.fn(),
+    clearSearch: () => addonFor(options.ptyId ?? 'pty-1').clearDecorations(),
     getScrollPosition: () => 0,
     scrollToLine: vi.fn(),
   }),
@@ -60,7 +76,22 @@ const state: Record<string, unknown> = {
   terminalFontFamily: 'Cascadia Code',
   activeWorkspaceId: 'ws-1',
   defaultShell: 'pwsh',
-  workspaces: [],
+  // Two panes side by side, each with one terminal surface. Pane A is
+  // focused by default.
+  workspaces: [
+    {
+      id: 'ws-1',
+      activePaneId: 'pane-a',
+      rootPane: {
+        type: 'branch',
+        id: 'root',
+        children: [
+          { type: 'leaf', id: 'pane-a', surfaces: [{ id: 'surf-a' }] },
+          { type: 'leaf', id: 'pane-b', surfaces: [{ id: 'surf-b' }] },
+        ],
+      },
+    },
+  ],
   startupDirectory: '',
   updateSurfaceCwd: vi.fn(),
   pushToast: vi.fn(),
@@ -82,7 +113,7 @@ describe('Terminal.tsx tears down search highlights when the bar goes away (#126
   let root: Root;
 
   beforeEach(() => {
-    searchAddon.clearDecorations.mockClear();
+    for (const a of addons.values()) a.clearDecorations.mockClear();
     state.searchBarVisible = true;
     host = document.createElement('div');
     document.body.appendChild(host);
@@ -126,5 +157,68 @@ describe('Terminal.tsx tears down search highlights when the bar goes away (#126
 
     expect(host.querySelector('[data-testid="search-bar"]')).toBeNull();
     expect(searchAddon.clearDecorations).toHaveBeenCalled();
+  });
+
+  it("clears when this pane's surface is swapped out for another tab", () => {
+    render(true);
+    render(false);
+    expect(searchAddon.clearDecorations).toHaveBeenCalled();
+  });
+});
+
+/**
+ * The reporter's exact scenario (#1266): search in pane A, click into pane B,
+ * output keeps arriving in A. Before the focus gate, A's bar stayed mounted
+ * (it is gated on A's own active TAB, which never changed), the effect never
+ * ran, and A went on re-highlighting forever — searchDecorationLeak.test.ts
+ * pins that the addon does exactly that once output arrives.
+ */
+describe("#1266 reporter scenario — focus moves to the other pane", () => {
+  let host: HTMLDivElement;
+  let rootA: Root;
+  let rootB: Root;
+
+  const renderBoth = () => {
+    act(() => {
+      rootA.render(<TerminalComponent ptyId="pty-a" surfaceId="surf-a" workspaceId="ws-1" isActive />);
+      rootB.render(<TerminalComponent ptyId="pty-b" surfaceId="surf-b" workspaceId="ws-1" isActive />);
+    });
+  };
+
+  beforeEach(() => {
+    for (const a of addons.values()) a.clearDecorations.mockClear();
+    state.searchBarVisible = true;
+    (state.workspaces as Array<{ activePaneId: string }>)[0].activePaneId = 'pane-a';
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    const a = document.createElement('div');
+    const b = document.createElement('div');
+    host.append(a, b);
+    rootA = createRoot(a);
+    rootB = createRoot(b);
+  });
+
+  afterEach(() => {
+    act(() => { rootA.unmount(); rootB.unmount(); });
+    host.remove();
+  });
+
+  const bars = () => host.querySelectorAll('[data-testid="search-bar"]').length;
+
+  it('shows exactly one search bar — the focused pane\'s', () => {
+    renderBoth();
+    expect(bars()).toBe(1);
+  });
+
+  it('clears the abandoned pane\'s highlights when focus moves', () => {
+    renderBoth();
+    expect(addonFor('pty-a').clearDecorations).not.toHaveBeenCalled();
+
+    // User clicks into pane B. Nothing about pane A's own surfaces changes.
+    (state.workspaces as Array<{ activePaneId: string }>)[0].activePaneId = 'pane-b';
+    renderBoth();
+
+    expect(addonFor('pty-a').clearDecorations).toHaveBeenCalled();
+    expect(bars()).toBe(1);
   });
 });

--- a/src/renderer/components/Terminal/__tests__/searchDecorationLeak.test.ts
+++ b/src/renderer/components/Terminal/__tests__/searchDecorationLeak.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Terminal } from '@xterm/headless';
+import { SearchAddon } from '@xterm/addon-search';
+
+/**
+ * #1266 — "search isn't functional": highlights land on unrelated characters
+ * and stay frozen in the pane.
+ *
+ * The mechanism is a lifecycle leak, not a search-range bug. Once findNext()
+ * runs with `decorations`, @xterm/addon-search caches the term and installs
+ * an onWriteParsed hook that re-runs the search and re-creates the highlight
+ * decorations 200ms after every subsequent chunk of output — indefinitely,
+ * until clearDecorations() is called. Terminal.tsx only called clearSearch()
+ * from the search bar's close button, but the bar is rendered under
+ * `searchBarVisible && isActive`, so focusing another pane unmounts it
+ * without closing it. The pane is then left re-highlighting a term the user
+ * can no longer see a search box for.
+ *
+ * The first test pins the addon behaviour (real addon, real terminal, no
+ * mock); the second pins that Terminal.tsx clears on the bar going away for
+ * any reason rather than only on the close button.
+ */
+
+/** Drives the real addon far enough to own a cached term + write hook. */
+function makeTerminal(): { term: Terminal; search: SearchAddon; results: number[] } {
+  const term = new Terminal({ rows: 10, cols: 40, scrollback: 1000, allowProposedApi: true });
+  // Headless has no renderer, so decoration creation is a no-op. The addon's
+  // cached-term / write-hook lifecycle — the part under test — does not care.
+  let selection: { start: { x: number; y: number }; end: { x: number; y: number } } | undefined;
+  Object.assign(term, {
+    registerDecoration: () => undefined,
+    getSelectionPosition: () => selection,
+    clearSelection: () => { selection = undefined; },
+    select: (col: number, row: number, size: number) => {
+      selection = { start: { x: col, y: row }, end: { x: col + size, y: row } };
+    },
+  });
+  const search = new SearchAddon();
+  term.loadAddon(search);
+  const results: number[] = [];
+  search.onDidChangeResults((e) => results.push(e.resultCount));
+  return { term, search, results };
+}
+
+const DECORATIONS = {
+  matchBackground: '#E8A33D40',
+  matchBorder: '#E8A33D',
+  matchOverviewRuler: '#E8A33D',
+  activeMatchBackground: '#E8A33D80',
+  activeMatchBorder: '#E8A33D',
+  activeMatchColorOverviewRuler: '#E8A33D',
+};
+
+const write = (term: Terminal, data: string) =>
+  new Promise<void>((resolve) => term.write(data, () => resolve()));
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 350));
+
+describe('addon-search keeps re-highlighting until decorations are cleared (#1266)', () => {
+  it('re-runs the cached search on every later write', async () => {
+    const { term, search, results } = makeTerminal();
+    for (let i = 0; i < 40; i++) await write(term, `line ${i} ${i % 7 === 0 ? 'NEEDLE' : 'plain'}\r\n`);
+
+    search.findNext('NEEDLE', { decorations: DECORATIONS });
+    const afterSearch = results.length;
+    expect(afterSearch).toBeGreaterThan(0);
+
+    // Output arriving after the user has moved on still drives the search.
+    await write(term, 'unrelated output\r\n');
+    await settle();
+    expect(results.length).toBeGreaterThan(afterSearch);
+
+    search.dispose();
+    term.dispose();
+  });
+
+  it('stops once clearDecorations() runs — the fix Terminal.tsx must invoke', async () => {
+    const { term, search, results } = makeTerminal();
+    for (let i = 0; i < 40; i++) await write(term, `line ${i} ${i % 7 === 0 ? 'NEEDLE' : 'plain'}\r\n`);
+
+    search.findNext('NEEDLE', { decorations: DECORATIONS });
+    await settle();
+    search.clearDecorations();
+
+    const quiesced = results.length;
+    await write(term, 'unrelated output\r\n');
+    await settle();
+    expect(results.length).toBe(quiesced);
+
+    search.dispose();
+    term.dispose();
+  });
+
+  it('finds matches across the whole scrollback, not just the viewport', async () => {
+    const { term, search } = makeTerminal();
+    for (let i = 0; i < 40; i++) await write(term, `line ${i} ${i % 7 === 0 ? 'NEEDLE' : 'plain'}\r\n`);
+    // Scroll up so the viewport no longer covers the last match.
+    term.scrollLines(-30);
+    expect(term.buffer.active.viewportY).toBeLessThan(term.buffer.active.baseY);
+
+    let count = 0;
+    search.onDidChangeResults((e) => { count = e.resultCount; });
+    search.findNext('NEEDLE', { decorations: DECORATIONS });
+    // 0, 7, 14, 21, 28, 35 — including rows below the scrolled-up viewport.
+    expect(count).toBe(6);
+
+    search.dispose();
+    term.dispose();
+  });
+});
+
+describe('Terminal.tsx clears search decorations when the bar goes away (#1266)', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'Terminal.tsx'), 'utf-8');
+
+  it('has an effect keyed on showSearchBar that calls clearSearch', () => {
+    expect(src).toMatch(/if \(showSearchBar\) return;\s*\n\s*clearSearch\(\);\s*\n\s*\}, \[showSearchBar, clearSearch\]\);/);
+  });
+
+  it('still clears on the explicit close button', () => {
+    expect(src).toMatch(/const handleCloseSearch = \(\) => \{\s*\n\s*clearSearch\(\);/);
+  });
+});

--- a/src/renderer/components/Terminal/__tests__/searchDecorationLeak.test.ts
+++ b/src/renderer/components/Terminal/__tests__/searchDecorationLeak.test.ts
@@ -1,6 +1,4 @@
 import { describe, it, expect } from 'vitest';
-import fs from 'node:fs';
-import path from 'node:path';
 import { Terminal } from '@xterm/headless';
 import { SearchAddon } from '@xterm/addon-search';
 
@@ -23,14 +21,54 @@ import { SearchAddon } from '@xterm/addon-search';
  * any reason rather than only on the close button.
  */
 
-/** Drives the real addon far enough to own a cached term + write hook. */
-function makeTerminal(): { term: Terminal; search: SearchAddon; results: number[] } {
+/** The addon only ever stores these; nothing under test disposes them. */
+const noopDisposable = { dispose: (): void => undefined };
+
+interface FakeDecoration {
+  marker: unknown;
+  disposed: boolean;
+  onRender: (cb: (el: unknown) => void) => { dispose: () => void };
+  onDispose: (cb: () => void) => { dispose: () => void };
+  dispose: () => void;
+}
+
+/**
+ * Drives the real addon far enough to own a cached term + write hook.
+ *
+ * Headless has no renderer, so `registerDecoration` has to be supplied — but
+ * it returns a real object with the lifecycle surface the addon's
+ * DecorationManager uses (marker, onRender, onDispose, dispose), so creation
+ * AND teardown are genuinely exercised rather than short-circuited.
+ */
+function makeTerminal(): {
+  term: Terminal;
+  search: SearchAddon;
+  results: number[];
+  decorations: FakeDecoration[];
+} {
   const term = new Terminal({ rows: 10, cols: 40, scrollback: 1000, allowProposedApi: true });
-  // Headless has no renderer, so decoration creation is a no-op. The addon's
-  // cached-term / write-hook lifecycle — the part under test — does not care.
+  const decorations: FakeDecoration[] = [];
   let selection: { start: { x: number; y: number }; end: { x: number; y: number } } | undefined;
   Object.assign(term, {
-    registerDecoration: () => undefined,
+    registerDecoration: (options: { marker: unknown }): FakeDecoration => {
+      const onDisposeCbs: Array<() => void> = [];
+      const decoration: FakeDecoration = {
+        marker: options.marker,
+        disposed: false,
+        onRender: () => noopDisposable,
+        onDispose: (cb: () => void) => {
+          onDisposeCbs.push(cb);
+          return noopDisposable;
+        },
+        dispose: () => {
+          if (decoration.disposed) return;
+          decoration.disposed = true;
+          for (const cb of onDisposeCbs) cb();
+        },
+      };
+      decorations.push(decoration);
+      return decoration;
+    },
     getSelectionPosition: () => selection,
     clearSelection: () => { selection = undefined; },
     select: (col: number, row: number, size: number) => {
@@ -41,7 +79,7 @@ function makeTerminal(): { term: Terminal; search: SearchAddon; results: number[
   term.loadAddon(search);
   const results: number[] = [];
   search.onDidChangeResults((e) => results.push(e.resultCount));
-  return { term, search, results };
+  return { term, search, results, decorations };
 }
 
 const DECORATIONS = {
@@ -77,12 +115,22 @@ describe('addon-search keeps re-highlighting until decorations are cleared (#126
   });
 
   it('stops once clearDecorations() runs — the fix Terminal.tsx must invoke', async () => {
-    const { term, search, results } = makeTerminal();
+    const { term, search, results, decorations } = makeTerminal();
     for (let i = 0; i < 40; i++) await write(term, `line ${i} ${i % 7 === 0 ? 'NEEDLE' : 'plain'}\r\n`);
 
     search.findNext('NEEDLE', { decorations: DECORATIONS });
     await settle();
+
+    // One highlight decoration per match (plus the active-match decoration),
+    // all live until the search is cleared.
+    expect(decorations.length).toBeGreaterThanOrEqual(6);
+    expect(decorations.some((d) => d.disposed)).toBe(false);
+
     search.clearDecorations();
+
+    // Every decoration the addon created is torn down — this is what stops
+    // the stale highlights sitting in the pane.
+    expect(decorations.every((d) => d.disposed)).toBe(true);
 
     const quiesced = results.length;
     await write(term, 'unrelated output\r\n');
@@ -108,17 +156,5 @@ describe('addon-search keeps re-highlighting until decorations are cleared (#126
 
     search.dispose();
     term.dispose();
-  });
-});
-
-describe('Terminal.tsx clears search decorations when the bar goes away (#1266)', () => {
-  const src = fs.readFileSync(path.join(__dirname, '..', 'Terminal.tsx'), 'utf-8');
-
-  it('has an effect keyed on showSearchBar that calls clearSearch', () => {
-    expect(src).toMatch(/if \(showSearchBar\) return;\s*\n\s*clearSearch\(\);\s*\n\s*\}, \[showSearchBar, clearSearch\]\);/);
-  });
-
-  it('still clears on the explicit close button', () => {
-    expect(src).toMatch(/const handleCloseSearch = \(\) => \{\s*\n\s*clearSearch\(\);/);
   });
 });

--- a/src/shared/paneUtils.ts
+++ b/src/shared/paneUtils.ts
@@ -24,6 +24,24 @@ export function findPane(root: Pane, id: string): Pane | null {
   return null;
 }
 
+/**
+ * Find the leaf pane that owns a surface.
+ *
+ * Surfaces know their own id but not which pane holds them, so anything that
+ * needs to ask "is my pane the focused one?" (#1266: the search bar) has to
+ * walk back up from the surface.
+ */
+export function findLeafBySurfaceId(root: Pane, surfaceId: string): PaneLeaf | null {
+  if (root.type === 'leaf') {
+    return root.surfaces?.some((s) => s.id === surfaceId) ? root : null;
+  }
+  for (const child of root.children) {
+    const found = findLeafBySurfaceId(child, surfaceId);
+    if (found) return found;
+  }
+  return null;
+}
+
 /** Find the parent branch of a pane by ID */
 export function findParent(root: Pane, id: string): PaneBranch | null {
   if (root.type === 'branch') {


### PR DESCRIPTION
## Summary

Ctrl+F/Cmd+F search highlights get stranded in a pane: they survive the
search bar being closed with no way to dismiss them, and an abandoned pane
keeps re-applying them as new output arrives, at coordinates that no longer
match anything. Fixes #1266.

## Root cause

Two layers, both ownership problems rather than search problems.

**1. The bar belongs to the wrong thing.** `Terminal.tsx` gated the search
bar on `searchBarVisible && isActive`, but `Pane.tsx` passes
`isActive={surface.id === activeSurfaceId}` — the selected **tab inside a
pane**, not "this pane has focus". `searchBarVisible` is a single global
flag, so *every* pane rendered its own search bar at once (live dogfood
measured two bars up simultaneously), and moving focus to another pane never
unmounted the abandoned pane's bar.

**2. A search stays live until it is explicitly cleared.**
`@xterm/addon-search` caches the term on `findNext(term, { decorations })`
and installs an `onWriteParsed` hook that re-runs the search and re-creates
every highlight decoration 200ms after each later chunk of output.
`clearSearch()` was only wired to the bar's close button. So closing the bar
stranded the highlights, and an abandoned pane went on re-highlighting for
its whole life — dogfood measured those decorations sitting at stale
coordinates (-245,-76), drawn as orange marks bleeding over the neighbouring
pane. That is the visual half of "highlights unrelated characters".

### Two hypotheses checked and rejected

- **Scan bound.** An earlier draft patched `@xterm/addon-search` to scan to
  `buffer.active.length` instead of `buffer.active.baseY + rows`. Rejected:
  `baseY` is `ybase` (`lines.length - rows`) and scrolling moves
  `ydisp`/`viewportY`, not `baseY`, so the bounds are identically equal and
  the patch is a semantic no-op. Measured with the real addon against a real
  terminal (patched vs unpatched bundles, scrolled up): identical results.
  Confirmed independently by two reviewers and by dogfood — search from a
  scrolled-up position finds and cycles matches across the whole scrollback.
- **Renderer.** `BufferDecorationRenderer` failing to reposition on
  redraw-only frames. Dogfood shows scrolling with an active search tracks
  correctly. Dead end, no follow-up needed.

## Fix

- Gate the bar on real pane focus: the workspace's `activePaneId`, resolved
  from the surface via a new `findLeafBySurfaceId` helper in
  `shared/paneUtils.ts`. Exactly one bar is up.
- Clear the addon's decorations whenever the bar goes away for any reason —
  close button, global toggle, tab switch within a pane, or focus leaving
  the pane.

### Intended UX consequence

Only the focused pane shows the search bar (previously all of them did), and
leaving a pane **ends** its search: highlights and the addon's cached term
are both dropped, and reopening the bar starts from an empty query. The
query box is per-mount `useState` and already did not survive a pane switch;
the highlights now match it instead of outliving it.

## Tests

`src/renderer/components/Terminal/__tests__/searchBarUnmountClears.test.tsx`
— mounts the real Terminal component (jsdom, `createRoot` + `act`, in the
style of `ContextMenu.portal.test.tsx`) and asserts the addon's
`clearDecorations()` actually ran:

- bar up → not cleared; global toggle off → cleared; tab swap → cleared;
- **the reporter's scenario**: two panes side by side, focus on A, then
  focus moves to B — exactly one bar is up throughout, and A's highlights
  are cleared when focus leaves. Both of those cases fail without the focus
  gate (verified by reverting it).

`src/renderer/components/Terminal/__tests__/searchDecorationLeak.test.ts` —
real `@xterm/addon-search` against a real `@xterm/headless` terminal, no
addon mock; `registerDecoration` returns a decoration with the lifecycle
surface the addon uses, so creation and teardown are genuinely exercised:

- an abandoned search keeps re-running on every later write (the "output
  arrives in A" half of the reporter's scenario);
- `clearDecorations()` disposes every decoration it created and quiesces the
  write hook;
- matches are found across the whole scrollback while scrolled up (guards
  the rejected scan-bound direction).

Gates: `npx tsc --noEmit` clean; eslint clean on changed files (the two
warnings on `Terminal.tsx` — unused `useMemo` import, non-null assertion —
are pre-existing on `main`); `vitest run src/renderer/terminal
src/renderer/components/Terminal` → 28 files / 421 tests, and `vitest run
src/shared src/renderer/stores` → 130 files / 2367 tests, all passing.

## Reviewer checklist

- [ ] One search bar in the focused pane is the wanted model (see "Intended
      UX consequence").
- [ ] `findLeafBySurfaceId` falling back to "focused" for surfaces it cannot
      place (stashed panes, transitional trees) is the right default — it
      preserves today's behaviour rather than hiding a bar.

## Follow-ups, deliberately out of scope

- Scoping search state per pane properly (a `searchBarVisible` + query keyed
  by pane, so a pane can keep its query across a focus round-trip). This PR
  makes the existing global flag mean what it claims; owning per-pane state
  is a store-slice change with its own keybinding and results-panel
  implications.
- #1266 reply: on macOS Ctrl+F is consumed by xterm and Cmd+F opens the bar.
  If the reporter pressed Ctrl+F on Windows and got terminal behaviour, that
  is a separate discoverability question to answer in the issue.

Fixes #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7XXScnD6iemykDXdtrKN4