### PR TITLE
fix(remote): return to a local workspace on the first click

### DIFF
--- a/changelog.d/1282.md
+++ b/changelog.d/1282.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Returning to a local workspace after visiting a remote one takes one click
+  again.** The remote mirror and the local workspace were tracked by two
+  independent selections, and the mirror won the tie — so any action that made
+  the local viewport the thing you wanted to see, but forgot to drop the mirror
+  selection, left the mirror covering it and looked like a swallowed click.
+  Adopting an orphan session and Ctrl+clicking a workspace into the multiview
+  grid both did that. Local activation now runs through one place that always
+  drops the mirror, and a detached mirror can no longer leave the centre blank
+  (#1086).

--- a/changelog.d/1282.md
+++ b/changelog.d/1282.md
@@ -1,11 +1,9 @@
 ### Fixed
 
-- **Returning to a local workspace after visiting a remote one takes one click
-  again.** The remote mirror and the local workspace were tracked by two
-  independent selections, and the mirror won the tie — so any action that made
-  the local viewport the thing you wanted to see, but forgot to drop the mirror
-  selection, left the mirror covering it and looked like a swallowed click.
-  Adopting an orphan session and Ctrl+clicking a workspace into the multiview
-  grid both did that. Local activation now runs through one place that always
-  drops the mirror, and a detached mirror can no longer leave the centre blank
-  (#1086).
+- **Adopting an orphan session, or Ctrl+clicking the multiview grid, no longer
+  leaves a remote mirror covering the local view.** A remote mirror and the
+  local workspace are two independent selections and the mirror wins the tie, so
+  these two actions changed the local view underneath a mirror that kept
+  covering it — the click looked swallowed and only a second, different
+  selection got you back. Local activation now runs through one place that
+  always drops the mirror selection (#1086).

--- a/src/renderer/components/AgentToolbar/ToolbarHost.tsx
+++ b/src/renderer/components/AgentToolbar/ToolbarHost.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../../stores';
 import AgentToolbar, { AGENT_TOOLBAR_HEIGHT } from './AgentToolbar';
 import { useComposeShortcut } from './useComposeShortcut';
 import { useHoverReveal, HOVER_TRIGGER_ZONE_PX } from './useHoverReveal';
+import { isRemoteMirrorVisible } from '../../stores/slices/remoteWorkspacesSlice';
 
 /**
  * Owns the reveal state for AgentToolbar and the element the trigger band is
@@ -25,7 +26,9 @@ export default function ToolbarHost() {
   // them), but every toolbar verb targets the LOCAL active workspace's pty. A
   // bar floating over a remote screen would inject into a terminal that is not
   // on screen and spawn worktrees in the wrong repo.
-  const remoteActive = useStore((s) => s.activeRemoteKey != null);
+  // #1086 — the same predicate WorkspaceCenter's render gate reads, so chrome
+  // and centre can never disagree about which surface is on screen.
+  const remoteActive = useStore(isRemoteMirrorVisible);
 
   if (!enabled || remoteActive) return null;
   return <RevealHost />;

--- a/src/renderer/components/Layout/WorkspaceCenter.tsx
+++ b/src/renderer/components/Layout/WorkspaceCenter.tsx
@@ -7,10 +7,16 @@
 import { useStore } from '../../stores';
 import { WorkspaceViewport } from './WorkspaceViewport';
 import RemoteWorkspaceView from '../Remote/RemoteWorkspaceView';
+import { isRemoteMirrorVisible } from '../../stores/slices/remoteWorkspacesSlice';
 
 export function WorkspaceCenter() {
   const remoteWorkspaces = useStore((s) => s.remoteWorkspaces);
   const activeRemoteKey = useStore((s) => s.activeRemoteKey);
+  // #1086 — one predicate decides the local-vs-remote gate (and a dangling key
+  // reads as "local", never as a blank centre). Selecting a local workspace
+  // drops activeRemoteKey in the store (activateLocalWorkspace), so the local
+  // tree comes back on the FIRST click.
+  const remoteVisible = useStore(isRemoteMirrorVisible);
 
   return (
     <div className="flex-1 min-h-0 relative">
@@ -20,7 +26,7 @@ export function WorkspaceCenter() {
       <div
         className="absolute inset-0 flex flex-col"
         data-pane-grid-wrapper
-        style={{ display: activeRemoteKey ? 'none' : 'flex' }}
+        style={{ display: remoteVisible ? 'none' : 'flex' }}
       >
         <WorkspaceViewport />
       </div>
@@ -32,7 +38,7 @@ export function WorkspaceCenter() {
         <div
           key={rw.key}
           className="absolute inset-0 flex flex-col"
-          style={{ display: rw.key === activeRemoteKey ? 'flex' : 'none' }}
+          style={{ display: remoteVisible && rw.key === activeRemoteKey ? 'flex' : 'none' }}
         >
           <RemoteWorkspaceView workspace={rw} />
         </div>

--- a/src/renderer/components/Palette/CommandPalette.tsx
+++ b/src/renderer/components/Palette/CommandPalette.tsx
@@ -14,6 +14,7 @@ import { postPluginCommand } from '../../plugins/pluginFrameRegistry';
 import { runProjectCommand } from '../../utils/projectCommands';
 import { applyProjectLayoutFresh } from '../../utils/projectConfigProbe';
 import { COMPANY_MODE_ENABLED } from '../../../shared/featureFlags';
+import { isRemoteMirrorVisible } from '../../stores/slices/remoteWorkspacesSlice';
 
 // ---------------------------------------------------------------------------
 // SVG Icons (inline, no external dependency)
@@ -296,7 +297,7 @@ export default function CommandPalette() {
           // worktrees in a repo the user is not looking at. Suppressing the
           // toolbar for remote views and then adding an unguarded keyboard
           // route would have reopened the hole from the other side.
-          if (state.activeRemoteKey != null) { setVisible(false); return; }
+          if (isRemoteMirrorVisible(state)) { setVisible(false); return; }
           if (state.activeWorkspaceId) state.openFanOut(state.activeWorkspaceId, null);
           setVisible(false);
         },

--- a/src/renderer/components/Pane/Pane.tsx
+++ b/src/renderer/components/Pane/Pane.tsx
@@ -23,6 +23,7 @@ import { applyRoleBinding, bindingEnforcesModel, type RoleBinding } from '../../
 import { ResumeInfoChipGate } from './ResumeInfoChip';
 import { tokenAttrs } from '../../themes';
 import PaneDecorations from '../../plugins/PaneDecorations';
+import { isRemoteMirrorVisible } from '../../stores/slices/remoteWorkspacesSlice';
 
 interface PaneProps {
   pane: PaneLeaf;
@@ -382,7 +383,7 @@ export default function PaneComponent({ pane, workspace, isActive, isWorkspaceVi
   // hides the local area (WorkspaceCenter, display:none) without touching
   // activeWorkspaceId, so this pane still reports isActive while nobody can
   // see it — a question arriving then must stay unseen.
-  const remoteSelected = useStore((s) => s.activeRemoteKey !== null);
+  const remoteSelected = useStore(isRemoteMirrorVisible);
   useEffect(() => {
     if (isActive && !remoteSelected && activeSurfacePtyId && activePendingQuestion) {
       markSurfaceQuestionSeen(activeSurfacePtyId);

--- a/src/renderer/hooks/useNotificationListener.ts
+++ b/src/renderer/hooks/useNotificationListener.ts
@@ -114,6 +114,11 @@ export interface FocusTargetState {
    * tree). Optional for the same reason as `unstashPane`: minimal test
    * fixtures without the remoteWorkspacesSlice mounted stay terse, and a
    * missing field reads as "no remote mirror is showing", the correct default.
+   * Deliberately the raw flag rather than `isRemoteMirrorVisible` (#1282): this
+   * interface is a minimal surface that callers satisfy with hand-built
+   * fixtures, and the predicate needs `remoteWorkspaces` too. The gap only
+   * matters for a key with no entry behind it, which nothing can produce today
+   * — and here it errs the safe way: the jump fires an extra activation.
    */
   activeRemoteKey?: string | null;
 }

--- a/src/renderer/stores/slices/__tests__/activeWorkspaceIdAssignment.guard.test.ts
+++ b/src/renderer/stores/slices/__tests__/activeWorkspaceIdAssignment.guard.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+// #1086 — the "call clearRemoteSelection at every activeWorkspaceId assignment"
+// convention was documented but unenforceable, and that is exactly how the
+// orphan-adopt path shipped without it: the remote mirror stayed on screen and
+// the click looked swallowed. `activateLocalWorkspace` is now the single place
+// that makes a local workspace visible; this guard keeps it that way by failing
+// the build if a raw assignment reappears anywhere in the renderer.
+
+const RENDERER_ROOT = join(__dirname, '..', '..', '..');
+// The helper itself is the one legal assignment site.
+const ALLOWED = new Set([join('stores', 'slices', 'workspaceSlice.ts')]);
+const ASSIGNMENT = /(?:state|draft|s)\.activeWorkspaceId\s*=(?!=)/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      walk(full, out);
+    } else if (/\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('#1086 — activeWorkspaceId assignment guard', () => {
+  it('only activateLocalWorkspace assigns activeWorkspaceId', () => {
+    const offenders: string[] = [];
+    for (const file of walk(RENDERER_ROOT)) {
+      const rel = file.slice(RENDERER_ROOT.length + 1);
+      if (ALLOWED.has(rel)) continue;
+      readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+        if (line.trim().startsWith('*') || line.trim().startsWith('//')) return;
+        if (ASSIGNMENT.test(line)) offenders.push(`${rel}:${i + 1}`);
+      });
+    }
+    expect(offenders, 'use activateLocalWorkspace(state, id) instead — it drops the remote mirror selection (#1086)').toEqual([]);
+  });
+});

--- a/src/renderer/stores/slices/__tests__/activeWorkspaceIdAssignment.guard.test.ts
+++ b/src/renderer/stores/slices/__tests__/activeWorkspaceIdAssignment.guard.test.ts
@@ -7,24 +7,53 @@ import { join } from 'path';
 // orphan-adopt path shipped without it: the remote mirror stayed on screen and
 // the click looked swallowed. `activateLocalWorkspace` is now the single place
 // that makes a local workspace visible; this guard keeps it that way by failing
-// the build if a raw assignment reappears anywhere in the renderer.
+// the build if a raw assignment reappears anywhere in the renderer — including
+// in workspaceSlice.ts itself, which held six of the eight pre-#1282 raw
+// assignments and so is exactly the file a whitelist must not exempt.
+//
+// The one legal assignment carries an inline `// guard-allow` marker, so the
+// exemption lives at the line it applies to rather than at a file granularity
+// that would re-open the whole slice.
 
 const RENDERER_ROOT = join(__dirname, '..', '..', '..');
-// The helper itself is the one legal assignment site.
-const ALLOWED = new Set([join('stores', 'slices', 'workspaceSlice.ts')]);
-const ASSIGNMENT = /(?:state|draft|s)\.activeWorkspaceId\s*=(?!=)/;
+const ALLOW_MARKER = 'guard-allow';
+
+// Any receiver name, not just the three this codebase happens to use today:
+// `st.`, `d.`, `next.` are the same bug with a different local variable.
+const MEMBER_ASSIGNMENT = /[A-Za-z_$][\w$]*\.activeWorkspaceId\s*=(?!=)/;
+// zustand's other idiom: a plain patch object handed to set() / Object.assign().
+const PATCH_KEY = /\bactiveWorkspaceId\s*:/;
+const PATCH_CALL = /\b(?:set|setState|Object\.assign)\s*\(/;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) {
-      if (entry === '__tests__' || entry === 'node_modules') continue;
+      if (entry === 'node_modules') continue;
       walk(full, out);
-    } else if (/\.tsx?$/.test(entry)) {
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
       out.push(full);
     }
   }
   return out;
+}
+
+/** A patch-object assignment can span lines — `set({\n  activeWorkspaceId: id`
+ *  — so a key line counts only when a set()/assign() call is still open above
+ *  it. Brace depth since the call is enough to tell that from a type literal. */
+function patchAssignmentLines(lines: string[]): Set<number> {
+  const hits = new Set<number>();
+  let openAt = -1;
+  let depth = 0;
+  lines.forEach((line, i) => {
+    if (openAt < 0 && PATCH_CALL.test(line)) { openAt = i; depth = 0; }
+    if (openAt >= 0) {
+      if (PATCH_KEY.test(line) && i - openAt <= 6) hits.add(i);
+      depth += (line.match(/[({]/g)?.length ?? 0) - (line.match(/[)}]/g)?.length ?? 0);
+      if (depth <= 0 && i > openAt) openAt = -1;
+    }
+  });
+  return hits;
 }
 
 describe('#1086 — activeWorkspaceId assignment guard', () => {
@@ -32,12 +61,29 @@ describe('#1086 — activeWorkspaceId assignment guard', () => {
     const offenders: string[] = [];
     for (const file of walk(RENDERER_ROOT)) {
       const rel = file.slice(RENDERER_ROOT.length + 1);
-      if (ALLOWED.has(rel)) continue;
-      readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
-        if (line.trim().startsWith('*') || line.trim().startsWith('//')) return;
-        if (ASSIGNMENT.test(line)) offenders.push(`${rel}:${i + 1}`);
+      const lines = readFileSync(file, 'utf8').split('\n');
+      const patchLines = patchAssignmentLines(lines);
+      lines.forEach((line, i) => {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('*') || trimmed.startsWith('//') || trimmed.startsWith('/*')) return;
+        if (line.includes(ALLOW_MARKER)) return;
+        if (MEMBER_ASSIGNMENT.test(line) || patchLines.has(i)) offenders.push(`${rel}:${i + 1}`);
       });
     }
     expect(offenders, 'use activateLocalWorkspace(state, id) instead — it drops the remote mirror selection (#1086)').toEqual([]);
+  });
+
+  // The marker is the whole exemption, so it must stay a single line in the one
+  // function that owns the invariant — not a token anyone can sprinkle.
+  it('the only exempt line is the assignment inside activateLocalWorkspace', () => {
+    const marked: string[] = [];
+    for (const file of walk(RENDERER_ROOT)) {
+      const rel = file.slice(RENDERER_ROOT.length + 1);
+      readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+        if (line.includes(ALLOW_MARKER) && MEMBER_ASSIGNMENT.test(line)) marked.push(`${rel}:${i + 1}`);
+      });
+    }
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toMatch(/^stores[/\\]slices[/\\]workspaceSlice\.ts:/);
   });
 });

--- a/src/renderer/stores/slices/__tests__/remoteSelectionInvariant.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteSelectionInvariant.test.ts
@@ -12,6 +12,11 @@ import {
   type AttachedRemoteWorkspace,
 } from '../remoteWorkspacesSlice';
 import { createWorkspace, type Workspace } from '../../../../shared/types';
+import {
+  activatePaneTarget,
+  focusNotificationTarget,
+  type FocusTargetState,
+} from '../../../hooks/useNotificationListener';
 
 // #1086 Bug 1 — "returning to a local workspace after visiting a remote one
 // takes two clicks". `activeWorkspaceId` (workspaceSlice) and `activeRemoteKey`
@@ -144,6 +149,46 @@ describe('#1086 — a local selection always drops the remote mirror', () => {
   it('Ctrl+click into the multiview grid clears it', () => {
     store.getState().toggleMultiviewWorkspace(wsB.id);
     expect(store.getState().multiviewIds).toContain(wsB.id);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+
+  // The clear covers the WHOLE action, not just the join branch: un-picking a
+  // member also lands the user on the local grid/workspace, and a rule that
+  // fired on some Ctrl+clicks but not others is the drift this suite pins.
+  it('Ctrl+click OUT of the multiview grid clears it too', () => {
+    store.setState((s) => { s.multiviewIds = [wsA.id, wsB.id]; });
+    store.getState().toggleMultiviewWorkspace(wsB.id);
+    expect(store.getState().multiviewIds).toEqual([]);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+
+  // #1089 / #1138 landed the same invariant in the focus path; pin it here so
+  // the two guards are covered by this suite instead of assumed. Both cases are
+  // "the target workspace is ALREADY active and a mirror is on screen" — the
+  // shape a bare `!==` guard skips.
+  // The real store actions do the mutating; the handful of members this focus
+  // surface needs but the minimal store does not mount are stubbed, exactly as
+  // useNotificationListener's own fixtures do.
+  const focusState = () => ({
+    ...store.getState(),
+    setActiveSurface: vi.fn(),
+    setPaneNotificationRing: vi.fn(),
+    markRead: vi.fn(),
+    notifications: [],
+    zoomedPaneId: null,
+  }) as unknown as FocusTargetState;
+
+  it('a pane-row jump inside the already-active workspace clears it', () => {
+    const paneId = wsA.rootPane.id;
+    const surfaceId = (wsA.rootPane as { surfaces?: Array<{ id: string }> }).surfaces?.[0]?.id ?? 'sf-1';
+    activatePaneTarget(focusState, { workspaceId: wsA.id, paneId, surfaceId });
+    expect(store.getState().activeWorkspaceId).toBe(wsA.id);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+
+  it('an app-level jump to the already-active workspace clears it', () => {
+    const handled = focusNotificationTarget(focusState, { workspaceId: wsA.id });
+    expect(handled).toBe(true);
     expect(store.getState().activeRemoteKey).toBeNull();
   });
 });

--- a/src/renderer/stores/slices/__tests__/remoteSelectionInvariant.test.ts
+++ b/src/renderer/stores/slices/__tests__/remoteSelectionInvariant.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createWorkspaceSlice, type WorkspaceSlice } from '../workspaceSlice';
+import { createPaneSlice, type PaneSlice } from '../paneSlice';
+import { createUISlice, type UISlice } from '../uiSlice';
+import { createOrphanSessionsSlice, type OrphanSessionsSlice } from '../orphanSessionsSlice';
+import {
+  createRemoteWorkspacesSlice,
+  isRemoteMirrorVisible,
+  type RemoteWorkspacesSlice,
+  type AttachedRemoteWorkspace,
+} from '../remoteWorkspacesSlice';
+import { createWorkspace, type Workspace } from '../../../../shared/types';
+
+// #1086 Bug 1 — "returning to a local workspace after visiting a remote one
+// takes two clicks". `activeWorkspaceId` (workspaceSlice) and `activeRemoteKey`
+// (remoteWorkspacesSlice) are independent fields and WorkspaceCenter checks the
+// remote one FIRST, so ANY action that makes the local viewport the thing the
+// user wants to see must drop the remote selection in the same mutation.
+// These tests pin the paths where that was left to a hand-written convention.
+
+vi.mock('../../../i18n', () => ({
+  setLocale: vi.fn(),
+  t: (k: string) => k,
+}));
+vi.mock('../../../themes', () => ({
+  applyCustomCssVars: vi.fn(),
+  clearCustomCssVars: vi.fn(),
+  DEFAULT_CUSTOM_THEME: {},
+}));
+vi.mock('../../../utils/sessionSaveBridge', () => ({ saveSessionNow: vi.fn() }));
+vi.mock('../../../events/publisher', () => ({
+  publishPaneCreated: vi.fn(),
+  publishPaneFocused: vi.fn(),
+  publishPaneStashed: vi.fn(),
+}));
+
+Object.defineProperty(globalThis, 'document', {
+  value: { documentElement: { setAttribute: vi.fn() } },
+  writable: true,
+});
+Object.defineProperty(globalThis, 'window', {
+  value: {
+    electronAPI: {
+      pty: { list: vi.fn(async () => []), dispose: vi.fn(async () => undefined) },
+      settings: {
+        setToastEnabled: vi.fn(),
+        setAutoUpdateEnabled: vi.fn(),
+        setMutedNotificationCategories: vi.fn(),
+      },
+    },
+  },
+  writable: true,
+});
+
+type TestState = WorkspaceSlice & PaneSlice & UISlice & OrphanSessionsSlice & RemoteWorkspacesSlice & {
+  pushToast: ReturnType<typeof vi.fn>;
+  paneGate: 'pending' | 'ready';
+};
+
+function createTestStore() {
+  return create<TestState>()(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    immer((...args: any) => ({
+      pushToast: vi.fn(),
+      // @ts-expect-error — minimal test store doesn't match full StoreState
+      ...createWorkspaceSlice(...args),
+      // @ts-expect-error — same
+      ...createPaneSlice(...args),
+      // @ts-expect-error — same
+      ...createUISlice(...args),
+      // @ts-expect-error — same
+      ...createOrphanSessionsSlice(...args),
+      // @ts-expect-error — same
+      ...createRemoteWorkspacesSlice(...args),
+      // Last: startup restore settled (uiSlice seeds 'pending'), which is the
+      // gate computeOrphans checks.
+      paneGate: 'ready' as const,
+    })),
+  );
+}
+
+function makeRemote(overrides: Partial<AttachedRemoteWorkspace> = {}): AttachedRemoteWorkspace {
+  return {
+    key: 'host-1:ws-1',
+    hostId: 'host-1',
+    hostLabel: 'office-mac',
+    workspaceId: 'ws-1',
+    name: 'Remote WS',
+    panes: [],
+    ...overrides,
+  };
+}
+
+describe('#1086 — a local selection always drops the remote mirror', () => {
+  let store: ReturnType<typeof createTestStore>;
+  let wsA: Workspace;
+  let wsB: Workspace;
+
+  beforeEach(() => {
+    store = createTestStore();
+    wsA = createWorkspace('CTO', 1);
+    wsB = createWorkspace('Other', 2);
+    store.setState((s) => {
+      s.workspaces = [wsA, wsB];
+      s.activeWorkspaceId = wsA.id;
+      s.remoteWorkspaces = [makeRemote()];
+      s.activeRemoteKey = 'host-1:ws-1';
+    });
+  });
+
+  // The reporter's exact click: the local workspace they want back is STILL
+  // activeWorkspaceId (only activeRemoteKey moved when they opened the mirror),
+  // so re-selecting it must not be treated as a no-op anywhere on the path.
+  it('re-selecting the ALREADY-ACTIVE workspace clears the remote selection', () => {
+    store.getState().setActiveWorkspace(wsA.id);
+    expect(store.getState().activeWorkspaceId).toBe(wsA.id);
+    expect(store.getState().activeRemoteKey).toBeNull();
+    expect(isRemoteMirrorVisible(store.getState())).toBe(false);
+  });
+
+  it('selecting a DIFFERENT local workspace clears it too', () => {
+    store.getState().setActiveWorkspace(wsB.id);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+
+  // Adopting an orphan session assigns activeWorkspaceId directly (it does not
+  // route through setActiveWorkspace), so before the single activation helper
+  // it left the mirror on screen and the adopt click read as a no-op.
+  it('adopting an orphan session into the active workspace clears it', () => {
+    store.getState().setDaemonSessionInventory([
+      { id: 'pty-orphan-1', shell: '/bin/zsh', state: 'detached', workspaceId: wsA.id, cwd: '/repo' },
+    ]);
+    const paneId = store.getState().adoptOrphanSession('pty-orphan-1');
+    expect(paneId).not.toBeNull();
+    expect(store.getState().activeWorkspaceId).toBe(wsA.id);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+
+  // Ctrl+click multiview never assigns activeWorkspaceId — the grid IS the
+  // local viewport, so it needs the same clear or the mirror keeps covering it
+  // and the Ctrl+click looks like it did nothing.
+  it('Ctrl+click into the multiview grid clears it', () => {
+    store.getState().toggleMultiviewWorkspace(wsB.id);
+    expect(store.getState().multiviewIds).toContain(wsB.id);
+    expect(store.getState().activeRemoteKey).toBeNull();
+  });
+});
+
+// The render gate WorkspaceCenter reads. Kept as one predicate so local-vs-
+// remote has a single reading, including the dangling-key case the raw flag
+// cannot express.
+describe('#1086 — isRemoteMirrorVisible (WorkspaceCenter gate)', () => {
+  it('is true only while a selected key has a live entry behind it', () => {
+    const attached = [makeRemote()];
+    expect(isRemoteMirrorVisible({ remoteWorkspaces: attached, activeRemoteKey: 'host-1:ws-1' })).toBe(true);
+    expect(isRemoteMirrorVisible({ remoteWorkspaces: attached, activeRemoteKey: null })).toBe(false);
+    // Dangling key (entry gone): show the local tree, never a blank centre.
+    expect(isRemoteMirrorVisible({ remoteWorkspaces: [], activeRemoteKey: 'host-1:ws-1' })).toBe(false);
+  });
+
+  it('flips to local on the first selection of an already-active workspace', () => {
+    const store = createTestStore();
+    const ws = createWorkspace('CTO', 1);
+    store.setState((s) => {
+      s.workspaces = [ws];
+      s.activeWorkspaceId = ws.id;
+      s.remoteWorkspaces = [makeRemote()];
+      s.activeRemoteKey = 'host-1:ws-1';
+    });
+    expect(isRemoteMirrorVisible(store.getState())).toBe(true);
+    store.getState().setActiveWorkspace(ws.id);
+    expect(isRemoteMirrorVisible(store.getState())).toBe(false);
+  });
+});

--- a/src/renderer/stores/slices/companySlice.ts
+++ b/src/renderer/stores/slices/companySlice.ts
@@ -12,7 +12,7 @@ import {
   MAX_INBOX_SIZE,
 } from '../../../shared/types';
 import type { QueuedMessage } from '../../company/MessageQueue';
-import { clearColdParkEntry, clearRemoteSelection, pruneMultiviewMembership } from './workspaceSlice';
+import { activateLocalWorkspace, pruneMultiviewMembership } from './workspaceSlice';
 
 /** Maximum number of pending messages in the queue to prevent memory exhaustion. */
 const MAX_MESSAGE_QUEUE_SIZE = 500;
@@ -125,12 +125,10 @@ export const createCompanySlice: StateCreator<StoreState, [['zustand/immer', nev
     pruneMultiviewMembership(state);
     // If active workspace was a company one, switch to first remaining
     if (!state.workspaces.some((ws) => ws.id === state.activeWorkspaceId)) {
-      state.activeWorkspaceId = state.workspaces[0]?.id || '';
-      clearColdParkEntry(state, state.activeWorkspaceId); // keep promoted ws visible
-      // #1086: every site that assigns activeWorkspaceId must drop the remote
-      // mirror selection too, or WorkspaceCenter keeps showing the mirror while
-      // the sidebar highlights the newly-promoted local workspace.
-      clearRemoteSelection(state);
+      // Promotion goes through the single activation helper: it keeps the
+      // promoted workspace un-parked AND drops any remote mirror selection,
+      // which would otherwise keep covering the newly-promoted workspace.
+      activateLocalWorkspace(state, state.workspaces[0]?.id || '');
     }
     state.company = null;
     state.memberCosts = {};
@@ -173,12 +171,10 @@ export const createCompanySlice: StateCreator<StoreState, [['zustand/immer', nev
     state.workspaces = state.workspaces.filter((ws) => !memberWsIds.has(ws.id));
     pruneMultiviewMembership(state);
     if (!state.workspaces.some((ws) => ws.id === state.activeWorkspaceId)) {
-      state.activeWorkspaceId = state.workspaces[0]?.id || '';
-      clearColdParkEntry(state, state.activeWorkspaceId); // keep promoted ws visible
-      // #1086: every site that assigns activeWorkspaceId must drop the remote
-      // mirror selection too, or WorkspaceCenter keeps showing the mirror while
-      // the sidebar highlights the newly-promoted local workspace.
-      clearRemoteSelection(state);
+      // Promotion goes through the single activation helper: it keeps the
+      // promoted workspace un-parked AND drops any remote mirror selection,
+      // which would otherwise keep covering the newly-promoted workspace.
+      activateLocalWorkspace(state, state.workspaces[0]?.id || '');
     }
     // Remove department
     const idx = state.company.departments.findIndex((d) => d.id === deptId);

--- a/src/renderer/stores/slices/orphanSessionsSlice.ts
+++ b/src/renderer/stores/slices/orphanSessionsSlice.ts
@@ -20,6 +20,7 @@ import type { Pane, PaneLeaf, Workspace } from '../../../shared/types';
 import { generateId } from '../../../shared/types';
 import { getWorkspacePtyIds, getWorkspaceLeafPanes, findPane, getLeafPanes } from '../../../shared/paneUtils';
 import { MAX_PANES_PER_WORKSPACE } from './paneSlice';
+import { activateLocalWorkspace } from './workspaceSlice';
 import { publishPaneCreated, publishPaneFocused } from '../../events/publisher';
 import { saveSessionNow } from '../../utils/sessionSaveBridge';
 import { t } from '../../i18n';
@@ -242,7 +243,11 @@ export const createOrphanSessionsSlice: StateCreator<
       }
       adopted = { wsId: ws.id, paneId: leaf.id, previousActiveId: ws.activePaneId };
       ws.activePaneId = leaf.id;
-      state.activeWorkspaceId = ws.id;
+      // #1086 — adopting is a local-view action: the adopted pane must be what
+      // the user ends up looking at. Going through the activation helper drops
+      // any remote mirror selection, which otherwise keeps covering the local
+      // tree and makes the adopt click look like it did nothing.
+      activateLocalWorkspace(state, ws.id);
       // A zoom pinned elsewhere must not swallow the adopted pane — the same
       // born-hidden un-zoom splitPane applies (#182).
       if (state.zoomedPaneId && findPane(ws.rootPane, state.zoomedPaneId)) {

--- a/src/renderer/stores/slices/remoteWorkspacesSlice.ts
+++ b/src/renderer/stores/slices/remoteWorkspacesSlice.ts
@@ -141,6 +141,25 @@ export interface RemoteWorkspacesSlice {
   setActiveRemoteKey: (key: string | null) => void;
 }
 
+/**
+ * #1086 — the ONE definition of "a remote mirror is what's on screen".
+ *
+ * WorkspaceCenter renders the local pane tree and every attached mirror at
+ * once and picks with display:none, so this predicate decides which surface
+ * the user is looking at. Keeping it here (rather than re-deriving
+ * `activeRemoteKey ? …` at each call site) means the local-vs-remote gate has
+ * a single reading, and it adds the check the raw flag cannot make on its
+ * own: a key with no live entry behind it selects nothing, so it must fall
+ * back to the local tree instead of hiding everything.
+ */
+export function isRemoteMirrorVisible(state: {
+  remoteWorkspaces: AttachedRemoteWorkspace[];
+  activeRemoteKey: string | null;
+}): boolean {
+  if (!state.activeRemoteKey) return false;
+  return state.remoteWorkspaces.some((r) => r.key === state.activeRemoteKey);
+}
+
 export const createRemoteWorkspacesSlice: StateCreator<StoreState, [['zustand/immer', never]], [], RemoteWorkspacesSlice> = (set) => ({
   remoteWorkspaces: [],
   activeRemoteKey: null,

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -6,6 +6,7 @@ import { canStashPaneSurfaces } from '../../../shared/paneStash';
 import { isDaemonModeActive } from '../../daemon/daemonMode';
 import { computePaneAutoName, paneDisplayName } from '../../utils/paneNaming';
 import { MAX_PANES_PER_WORKSPACE } from './paneSlice';
+import { clearRemoteSelection } from './workspaceSlice';
 import { publishPaneStashed, publishPaneFocused } from '../../events/publisher';
 import { saveSessionNow } from '../../utils/sessionSaveBridge';
 import { markRetentionMigrationDone } from '../retentionMigration';
@@ -1414,6 +1415,12 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
       if (!state.multiviewIds.includes(wsId)) {
         state.multiviewIds.push(wsId);
       }
+      // #1086 — the grid IS the local viewport, so joining it is a local-view
+      // action even though it never assigns activeWorkspaceId (which is why
+      // activateLocalWorkspace cannot cover this site). Without the clear,
+      // WorkspaceCenter keeps the mirror on top and Ctrl+click reads as "does
+      // nothing". Guarded for stores mounted without the remote slice.
+      clearRemoteSelection(state);
       // Cold-park (TASK-9): a workspace joining the multiview grid becomes
       // visible — un-park it synchronously so the tile renders live this frame.
       // Guarded for tests that mount uiSlice without the workspaceSlice maps.

--- a/src/renderer/stores/slices/uiSlice.ts
+++ b/src/renderer/stores/slices/uiSlice.ts
@@ -1415,12 +1415,6 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
       if (!state.multiviewIds.includes(wsId)) {
         state.multiviewIds.push(wsId);
       }
-      // #1086 — the grid IS the local viewport, so joining it is a local-view
-      // action even though it never assigns activeWorkspaceId (which is why
-      // activateLocalWorkspace cannot cover this site). Without the clear,
-      // WorkspaceCenter keeps the mirror on top and Ctrl+click reads as "does
-      // nothing". Guarded for stores mounted without the remote slice.
-      clearRemoteSelection(state);
       // Cold-park (TASK-9): a workspace joining the multiview grid becomes
       // visible — un-park it synchronously so the tile renders live this frame.
       // Guarded for tests that mount uiSlice without the workspaceSlice maps.
@@ -1435,6 +1429,15 @@ export const createUISlice: StateCreator<StoreState, [['zustand/immer', never]],
     if (state.multiviewIds.length <= 1) {
       state.multiviewIds = [];
     }
+    // #1086 — the grid IS the local viewport, so ANY Ctrl+click on it is a
+    // local-view action even though this one never assigns activeWorkspaceId
+    // (which is why activateLocalWorkspace cannot cover this site). Applied to
+    // the whole action rather than the join branch alone: leaving the grid, and
+    // collapsing it by un-picking the last partner, land the user on the local
+    // active workspace just as much as joining does, and a rule that fires on
+    // some Ctrl+clicks but not others is the drift this PR is removing.
+    // Guarded for stores mounted without the remote slice.
+    clearRemoteSelection(state);
     });
   },
 

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -64,6 +64,38 @@ export function clearRemoteSelection(state: { activeRemoteKey?: string | null })
 }
 
 /**
+ * #1086 — THE one place that makes a local workspace the visible surface.
+ *
+ * `activeWorkspaceId` and `activeRemoteKey` are independent fields and
+ * WorkspaceCenter checks the remote one FIRST, so an assignment that forgets
+ * `clearRemoteSelection` leaves the mirror on screen while the sidebar
+ * highlights the local row — the user's click looks swallowed and only a
+ * SECOND selection (which does run the clear) gets them back. The convention
+ * of "remember to call the two helpers at every assignment site" is what kept
+ * failing: it was documented but unenforceable, and new sites (orphan-session
+ * adopt) shipped without it.
+ *
+ * So: never write `state.activeWorkspaceId = …` directly — call this. Both
+ * companion clears are idempotent and guarded for stores/tests mounted
+ * without the cold-park maps or the remoteWorkspacesSlice, so this is safe
+ * everywhere. A guard test (activeWorkspaceIdAssignment.guard.test.ts) fails
+ * the build if a raw assignment reappears anywhere in src/renderer.
+ */
+export function activateLocalWorkspace(
+  state: {
+    activeWorkspaceId: string;
+    parkedWorkspaceIds?: Record<string, true>;
+    lastVisibleAt?: Record<string, number>;
+    activeRemoteKey?: string | null;
+  },
+  id: string,
+): void {
+  state.activeWorkspaceId = id;
+  clearColdParkEntry(state, id);
+  clearRemoteSelection(state);
+}
+
+/**
  * Drop multiview members whose workspace is gone, and disband a group left with
  * fewer than two. Call from every path where workspaces disappear — the same set
  * clearColdParkEntry covers (removeWorkspace, company destroy/removeDept,
@@ -344,8 +376,7 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       }
       state.nextWorkspaceOrdinal = wsOrdinal + 1;
       state.workspaces.push(ws);
-      state.activeWorkspaceId = ws.id;
-      clearRemoteSelection(state);
+      activateLocalWorkspace(state, ws.id);
     }),
 
     addWorkspaceWithPreset: (presetId, name) => set((state: StoreState) => {
@@ -381,8 +412,7 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       };
       state.nextWorkspaceOrdinal = wsOrdinal + 1;
       state.workspaces.push(ws);
-      state.activeWorkspaceId = ws.id;
-      clearRemoteSelection(state);
+      activateLocalWorkspace(state, ws.id);
     }),
 
     // #1011 — Active → Archived → Deleted. Archiving snapshots the
@@ -445,11 +475,10 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         }
         state.nextWorkspaceOrdinal = highWater + 1;
         state.workspaces.push(ws);
-        state.activeWorkspaceId = ws.id;
-        // Same convention as every other activeWorkspaceId assignment
-        // (clearRemoteSelection's contract): a restore while a remote mirror
-        // is showing must actually land on the restored workspace.
-        clearRemoteSelection(state);
+        // A restore while a remote mirror is showing must actually land on the
+        // restored workspace — activateLocalWorkspace is the single site that
+        // guarantees it (see its doc comment).
+        activateLocalWorkspace(state, ws.id);
         state.archivedWorkspaces = state.archivedWorkspaces.filter((a) => a.id !== archivedId);
       });
     },
@@ -502,8 +531,7 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
       state.nextWorkspaceOrdinal = wsOrdinal + 1;
       // Insert right after the source for intuitive placement, then activate.
       state.workspaces.splice(idx + 1, 0, ws);
-      state.activeWorkspaceId = ws.id;
-      clearRemoteSelection(state);
+      activateLocalWorkspace(state, ws.id);
     }),
 
     // NOTE: PTY cleanup is the caller's responsibility (see Sidebar.handleClose, useKeyboard Ctrl+Shift+W)
@@ -680,8 +708,7 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         if (state.parkedWorkspaceIds[id]) delete state.parkedWorkspaceIds[id];
         if (state.lastVisibleAt[id] !== undefined) delete state.lastVisibleAt[id];
       }
-      state.activeWorkspaceId = id;
-      clearRemoteSelection(state);
+      activateLocalWorkspace(state, id);
       // D-teardown: a workspace switch invalidates any marked-region queries
       // the inspect overlay is holding, so exit inspect explicitly rather than
       // letting it dangle against a now-unmounted DOM (inspect is preserved as
@@ -994,8 +1021,7 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
         : [];
       // The previous session's group cannot describe this one's workspaces.
       pruneMultiviewMembership(state);
-      state.activeWorkspaceId = data.activeWorkspaceId;
-      clearRemoteSelection(state);
+      activateLocalWorkspace(state, data.activeWorkspaceId);
       state.sidebarVisible = data.sidebarVisible;
 
       // ── P2 hydration backfill (checklist F) ──────────────────────────────

--- a/src/renderer/stores/slices/workspaceSlice.ts
+++ b/src/renderer/stores/slices/workspaceSlice.ts
@@ -90,7 +90,7 @@ export function activateLocalWorkspace(
   },
   id: string,
 ): void {
-  state.activeWorkspaceId = id;
+  state.activeWorkspaceId = id; // guard-allow — the one legal assignment (see the guard test)
   clearColdParkEntry(state, id);
   clearRemoteSelection(state);
 }
@@ -644,11 +644,13 @@ export const createWorkspaceSlice: StateCreator<StoreState, [['zustand/immer', n
           const neighbor = i >= 0 ? (mvBefore[i + 1] ?? mvBefore[i - 1]) : undefined;
           next = neighbor && mvNow.includes(neighbor) ? neighbor : mvNow[0];
         }
-        state.activeWorkspaceId =
-          next ?? state.workspaces[Math.min(idx, state.workspaces.length - 1)].id;
-        // Cold-park: the newly-promoted workspace must not stay parked.
-        clearColdParkEntry(state, state.activeWorkspaceId);
-        clearRemoteSelection(state);
+        // Promotion is an activation like any other: the helper un-parks the
+        // promoted workspace and drops any remote mirror selection, so the user
+        // actually lands on it instead of on a mirror that stayed on top.
+        activateLocalWorkspace(
+          state,
+          next ?? state.workspaces[Math.min(idx, state.workspaces.length - 1)].id,
+        );
       }
       // D-teardown: removing a workspace (sidebar X, Ctrl+Shift+W, kill-pane)
       // unmounts the marked-region DOM the inspect overlay queries. setActiveWorkspace


### PR DESCRIPTION
## Summary

Removes a class of "the first click did nothing" bugs around attached remote
workspaces, found while chasing the remaining Bug 1 of #1086.

**Scope honesty, up front:** the reporter's original repro — click the
already-active local workspace row (or a nested pane row under it) after
visiting a mirror — could NOT be reproduced on current `main`. Three independent
reads agree: `setActiveWorkspace` has no same-id early return and always calls
`clearRemoteSelection`, the sidebar row's `onSelect` dispatches unconditionally,
and `useNotificationListener.ts:142` / `:235` already carry `|| state.activeRemoteKey`
from #1089 / #1138. What this PR actually fixes is adjacent drift off the same
invariant (orphan-adopt and Ctrl+click multiview), plus the reason that drift
was possible at all. **#1086 Bug 1 stays open** pending a live trace, alongside
its other open item (startup parity for remote workspace creation) — hence
`Refs`, not a closing keyword. The rename/color half shipped in #1247 and is
untouched.

## Root cause

`activeWorkspaceId` (workspaceSlice) and `activeRemoteKey` (remoteWorkspacesSlice)
are independent fields, and `WorkspaceCenter` checks the remote key FIRST — the
local pane tree stays `display: none` until something drops the remote selection.
The store's answer was a convention documented on `clearRemoteSelection`: "call
this at every site that assigns `activeWorkspaceId`". A convention is not a
mechanism, and two paths had drifted off it — both of which present as a
swallowed click:

- `orphanSessionsSlice.adoptOrphanSession` assigns `state.activeWorkspaceId`
  directly and never called `clearRemoteSelection`: adopting an orphan session
  row while a mirror is showing changed the local tree behind a mirror that kept
  covering it.
- `uiSlice.toggleMultiviewWorkspace` (Ctrl+click) never assigns
  `activeWorkspaceId` at all, so no amount of assignment-site discipline could
  cover it — yet the multiview grid IS the local viewport.

Both reproduce with the real store on `main` (see Tests).

## Fix

Make the invariant hold in one place instead of at every call site:

- `activateLocalWorkspace(state, id)` in `workspaceSlice` is now the only way to
  make a local workspace active: assign + `clearColdParkEntry` +
  `clearRemoteSelection`. Every site routes through it — the six workspaceSlice
  sites, `removeWorkspace`'s promotion, both companySlice promotions, and
  orphan-adopt.
- `toggleMultiviewWorkspace` clears the selection for the WHOLE action rather
  than only the join branch. Chosen deliberately: joining the grid, leaving it,
  and collapsing it by un-picking the last partner all land the user on the
  local view, and a rule that fires on some Ctrl+clicks but not others is the
  drift this PR exists to remove.
- `isRemoteMirrorVisible(state)` in `remoteWorkspacesSlice` is the single
  definition of "a mirror is what's on screen". `WorkspaceCenter`, `ToolbarHost`,
  `CommandPalette`'s fan-out guard and `Pane`'s question-seen guard all read it,
  so chrome and centre cannot disagree. `useNotificationListener` deliberately
  keeps the raw flag: its `FocusTargetState` is a minimal surface built by hand
  in fixtures, the predicate needs `remoteWorkspaces` too, and there it errs the
  safe way (one extra activation). Documented at the field.
  The predicate also ignores a key with no live entry behind it. That is a
  defensive invariant, **not** a bug fix: no reachable path produces a dangling
  key today (`detachRemoteWorkspace` nulls it, `attachRemoteWorkspace` sets both
  in one mutation, `restoreRemoteWorkspace` never selects, and the key is not
  persisted).
- A guard test fails the build if a raw `activeWorkspaceId` assignment reappears
  anywhere in `src/renderer` — `workspaceSlice.ts` included, with the one legal
  assignment exempted by an inline `// guard-allow` marker that a second test
  pins to exactly one line. It matches any receiver name and the
  `set({ activeWorkspaceId: … })` patch shape, verified against a throwaway
  probe file containing both.

Note: this adds a `uiSlice` → `workspaceSlice` import. Safe — `clearRemoteSelection`
is called at action time, not module-init time.

## Tests

New `remoteSelectionInvariant.test.ts` (real store: workspace + pane + ui +
orphan + remote slices) and `activeWorkspaceIdAssignment.guard.test.ts`.

Against `origin/main`:

- adopt an orphan session while a mirror shows → `activeRemoteKey` stays
  `'host-1:ws-1'` (expected `null`) — **fails**
- Ctrl+click into (and out of) the multiview grid → same — **fails**
- guard scan → offenders in `companySlice.ts`, `orphanSessionsSlice.ts` and
  (with the hardened version) `workspaceSlice.ts` — **fails**
- the already-active-click case, the `activatePaneTarget` /
  `focusNotificationTarget` cases and the render-gate cases pass on `main` once
  the new export exists; they are regression locks for #1089 / #1138 and for the
  reporter's path, not demonstrations of a bug.

Gates: `npx tsc --noEmit` clean, eslint clean on all changed files, full
`npx vitest run` = 15507 passed / 1 failed — the known `THIRD_PARTY_NOTICES`
drift guard, which fails only because this worktree symlinks `node_modules`.

## Dogfood

With a mirror attached and selected, one click each: the already-active local
workspace's sidebar row, a nested agent row under it, an orphan-session row, and
Ctrl+click a second local workspace (grid must appear at once), then Ctrl+click
it back out. The first two are the reporter's path and are expected to already
work on `main` — if they take two clicks there, the real mechanism is still
unfound and #1086 Bug 1 needs a live trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7XXScnD6iemykDXdtrKN4