### PR TITLE
fix(updater): start the Windows install waiter outside wmux's job object

### DIFF
--- a/changelog.d/1283.md
+++ b/changelog.d/1283.md
@@ -4,8 +4,12 @@
   before it could report an outcome" message. The install waiter was spawned as
   a child of the app, which on Windows put it inside the app's job object — so
   it was killed the instant wmux quit, before it could start `Setup.exe`. It is
-  now started by the Task Scheduler instead, outside the app's job object and
-  outside any process tree the teardown can reach. ([#1264](https://github.com/openwong2kim/wmux/issues/1264))
+  now registered as an on-demand Task Scheduler entry and started by the
+  scheduler, outside the app's job object and outside any process tree the
+  teardown can reach. ([#1264](https://github.com/openwong2kim/wmux/issues/1264))
+- Windows: the update install waiter now runs on battery power and is not
+  stopped when a laptop is unplugged mid-install, and it keeps the elevation the
+  app itself was running with.
 - Windows: when the install waiter is killed mid-flight, the message on the next
   start now says the waiter started and was stopped, rather than reading the
   same as a refused install.

--- a/changelog.d/1283.md
+++ b/changelog.d/1283.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Windows: in-app auto-update no longer aborts with a generic "interrupted
+  before it could report an outcome" message. The install waiter was spawned as
+  a child of the app, which on Windows put it inside the app's job object — so
+  it was killed the instant wmux quit, before it could start `Setup.exe`. It is
+  now started by the Task Scheduler instead, outside the app's job object and
+  outside any process tree the teardown can reach. ([#1264](https://github.com/openwong2kim/wmux/issues/1264))
+- Windows: when the install waiter is killed mid-flight, the message on the next
+  start now says the waiter started and was stopped, rather than reading the
+  same as a refused install.

--- a/src/main/updater/AutoUpdater.ts
+++ b/src/main/updater/AutoUpdater.ts
@@ -33,6 +33,7 @@ import { LocalUpdateFeed } from './LocalUpdateFeed';
 import {
   collectInstallRootProcesses,
   clearAbortMarker,
+  sweepStaleWaiterTasks,
   freeSpaceShortfall,
   INSTALL_ABORT_MARKER,
   INSTALL_READY_MARKER,
@@ -298,6 +299,15 @@ export class AutoUpdater {
       console.log(`[AutoUpdater] In-app updates are not supported on ${process.platform}; skipping auto-check (update via your package manager).`);
       return;
     }
+
+    // #1283 review — sweep waiter task registrations a previous update failed
+    // to clean up (a `/Create` that timed out after the server committed, a
+    // `/Delete` that failed). They carry no trigger so they cannot fire on
+    // their own, but they point at a `%TEMP%` path the installer has since
+    // invalidated and they are litter in the user's task list. Startup is
+    // where this belongs: the quit path is the one place blocking costs the
+    // user something.
+    if (process.platform === 'win32') sweepStaleWaiterTasks();
 
     void this.sweepStaleArtifacts();
 

--- a/src/main/updater/__tests__/AutoUpdater.download.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.download.test.ts
@@ -176,6 +176,7 @@ async function loadWin32(
     // never leaks an UPDATE_ERROR into tests about other flows.
     readAbortMarker: vi.fn((): string | null => null),
     clearAbortMarker: vi.fn(),
+    sweepStaleWaiterTasks: vi.fn(() => 0),
     waitForWaiterHeartbeat: vi.fn(async (): Promise<boolean> => true),
     INSTALL_ABORT_MARKER: 'update-install-aborted.txt',
     INSTALL_READY_MARKER: 'update-install-ready.tmp',

--- a/src/main/updater/__tests__/AutoUpdater.platform.test.ts
+++ b/src/main/updater/__tests__/AutoUpdater.platform.test.ts
@@ -162,6 +162,7 @@ async function loadForPlatform(
     readDaemonPid: vi.fn((): number | null => null),
     readAbortMarker: vi.fn((): string | null => null),
     clearAbortMarker: vi.fn(),
+    sweepStaleWaiterTasks: vi.fn(() => 0),
     // #1056 — resolves true by default so existing tests exercise the same
     // happy path as before this check existed; the dedicated test below
     // overrides it to prove the refusal branch.
@@ -208,6 +209,24 @@ describe('AutoUpdater platform gating', () => {
 
     expect(requestUrls).toContain(EXPECTED_WIN32_FEED);
     updater.stop();
+  });
+
+  it('win32: start() sweeps leftover waiter task registrations; other platforms do not', async () => {
+    // #1283 review — the two leak paths (a /Create that timed out after the
+    // server committed, a /Delete that failed) can only be cleaned up later,
+    // and startup is the one place blocking costs the user nothing.
+    vi.useFakeTimers();
+    const win = await loadForPlatform('win32');
+    const winUpdater = new win.AutoUpdater(() => null, quitHooks());
+    winUpdater.start();
+    expect(win.teardown.sweepStaleWaiterTasks).toHaveBeenCalledTimes(1);
+    winUpdater.stop();
+
+    const mac = await loadForPlatform('darwin');
+    const macUpdater = new mac.AutoUpdater(() => null, quitHooks());
+    macUpdater.start();
+    expect(mac.teardown.sweepStaleWaiterTasks).not.toHaveBeenCalled();
+    macUpdater.stop();
   });
 
   it('win32: periodic timer keeps polling the win32 feed', async () => {

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -750,6 +750,31 @@ describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spaw
     fs.writeFileSync(vbs, '\uFEFF' + (launcher as string), 'utf16le');
   }
 
+  /**
+   * The property CRITICAL 2 actually needs: the stored task has no trigger that
+   * could ever fire it, so a registration that leaks cannot start a waiter on
+   * its own later (a late waiter would open the recorded pids BY NUMBER and
+   * taskkill whatever inherited them).
+   *
+   * Measured on both CI runners (validate and the cross-platform baseline,
+   * identical output): Task Scheduler normalises a trigger-less definition by
+   * storing an EMPTY, self-closing `<Triggers />` — it materialises no trigger
+   * of its own. So a substring match on `<Triggers` is the wrong test; what
+   * must be asserted is the absence of CHILD trigger elements.
+   */
+  function expectNoOwnTrigger(xml: string): void {
+    if (!xml.includes('<Triggers')) return;
+    if (/<Triggers\s*\/>/.test(xml)) return;
+    const block = /<Triggers[^>]*>([\s\S]*?)<\/Triggers>/.exec(xml);
+    expect(block, `could not parse the Triggers element out of:\n${xml}`).not.toBeNull();
+    const inner = (block as RegExpExecArray)[1];
+    const found = [...inner.matchAll(/<([A-Za-z][\w.]*)/g)].map((m) => m[1]);
+    // Listed, not just counted: if the scheduler ever DOES materialise a
+    // trigger, the failure has to name it — that would mean this transport
+    // needs a different guarantee (register disabled, enable only for /Run).
+    expect(found, `the scheduler stored trigger element(s) we never asked for: ${found.join(', ')}\nreadback was:\n${xml}`).toEqual([]);
+  }
+
   /** Poll for `p` for up to `ms`. */
   function waitFor(p: string, ms: number): boolean {
     const deadline = Date.now() + ms;
@@ -809,23 +834,36 @@ describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spaw
       `if ($LASTEXITCODE -ne 0) { exit 5 }`,
     ]))) return;
 
-    // #1283 review asked whether the battery settings are PROVABLY applied.
-    // The builder's own test pins what we emit; this pins what the scheduler
-    // actually stored after importing it.
-    const stored = spawnSync(SCHTASKS, ['/Query', '/TN', taskName, '/XML', 'ONE'],
-      { encoding: 'utf-8', windowsHide: true, timeout: 20_000 });
-    const storedXml = (stored.stdout ?? '').replace(/\0/g, '');
-    expect(storedXml).toContain('<DisallowStartIfOnBatteries>false<');
-    expect(storedXml).toContain('<StopIfGoingOnBatteries>false<');
-    expect(storedXml).toContain('<ExecutionTimeLimit>PT0S<');
-    expect(storedXml).toContain('<MultipleInstancesPolicy>IgnoreNew<');
-    // No trigger survived the import either — a leaked task cannot self-fire.
-    expect(storedXml).not.toContain('<Triggers');
-
     expect(fs.existsSync(stamp)).toBe(true);
     // The parent is gone and its job closed with it. The scheduler's child is
     // not a member, so it is still there when the lock clears — and it runs
     // the stub Setup.exe, which is the branch the field never reached.
     expect(waitFor(setupStamp, 40_000)).toBe(true);
+
+    // #1283 review asked whether the battery settings are PROVABLY applied.
+    // The builder's own test pins what we EMIT; this pins what the scheduler
+    // STORED after importing it. Asserted after the survival proof above so a
+    // definition problem can never mask the property this file exists for.
+    const stored = spawnSync(SCHTASKS, ['/Query', '/TN', taskName, '/XML', 'ONE'],
+      { encoding: 'utf-8', windowsHide: true, timeout: 20_000 });
+    const storedXml = (stored.stdout ?? '').replace(/\0/g, '');
+    expect(storedXml, `readback was:\n${storedXml}`).toContain('<DisallowStartIfOnBatteries>false<');
+    expect(storedXml).toContain('<StopIfGoingOnBatteries>false<');
+    expect(storedXml).toContain('<ExecutionTimeLimit>PT0S<');
+    expect(storedXml).toContain('<MultipleInstancesPolicy>IgnoreNew<');
+    expect(storedXml).toContain('<LogonType>InteractiveToken<');
+    // RunLevel: the scheduler omits an element whose value is the default, and
+    // LeastPrivilege IS the default — so "absent" and "LeastPrivilege" are the
+    // same stored state. Anything else would mean the import changed it.
+    const runLevel = /<RunLevel>([^<]*)<\/RunLevel>/.exec(storedXml)?.[1] ?? 'LeastPrivilege';
+    expect(runLevel, `readback was:\n${storedXml}`).toBe('LeastPrivilege');
+    // The guard has to be able to fail, or it proves nothing. Both shapes of
+    // "empty" pass; a materialised trigger does not.
+    expect(() => expectNoOwnTrigger('<Task><Triggers /></Task>')).not.toThrow();
+    expect(() => expectNoOwnTrigger('<Task><Triggers>\n  </Triggers></Task>')).not.toThrow();
+    expect(() => expectNoOwnTrigger(
+      '<Task><Triggers><TimeTrigger><StartBoundary>2026-01-01T23:59:00</StartBoundary></TimeTrigger></Triggers></Task>',
+    )).toThrow(/TimeTrigger/);
+    expectNoOwnTrigger(storedXml);
   }, 180_000);
 });

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -23,6 +23,7 @@ import {
   buildWaiterVbsLauncher,
   buildScheduledTaskCreateArgs,
   buildScheduledTaskRunArgs,
+  buildScheduledTaskXml,
   spawnInstallWaiter,
   collectInstallRootPids,
   probeVolume,
@@ -659,7 +660,7 @@ describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spaw
    * Returns false when the job could not be built (an agent where nesting is
    * refused), so the caller can skip rather than assert on a broken premise.
    */
-  function runInsideDyingJob(launchLines: string[]): boolean {
+  function runInsideDyingJob(launchLines: string[]): number | null {
     const proofPath = path.join(sandbox, 'job-armed.txt');
     const stub = path.join(sandbox, 'stub-parent.ps1');
     fs.writeFileSync(stub, [
@@ -692,7 +693,40 @@ describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spaw
       ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', stub],
       { encoding: 'utf-8', timeout: 90_000, windowsHide: true },
     );
-    return res.status === 0 && fs.existsSync(proofPath);
+    // #1283 review: the stub's exit code is the DIAGNOSIS — 1/2/3 mean the
+    // kill-on-close job could not be built on this agent, 4/5 mean schtasks
+    // refused. Conflating them into a boolean is how a real regression in the
+    // mechanism would have gone green, and this pair of tests is the only proof
+    // the fix has.
+    if (res.status === 0 && !fs.existsSync(proofPath)) return -1;
+    return res.status;
+  }
+
+  // The runtime proof may only be waived deliberately. On windows-latest the
+  // premises (job objects, Task Scheduler) are expected to hold, so a failure
+  // to arm them is a RED test, not a silent skip.
+  const optOut = process.env.WMUX_SKIP_JOB_RUNTIME_TESTS === '1';
+
+  /** Assert the job half armed; returns false only under an explicit opt-out. */
+  function requireJobArmed(status: number | null): boolean {
+    if (status === 0) return true;
+    if (optOut) {
+      console.warn(`[#1264] job/schtasks premise unmet (stub exit ${String(status)}) — waived by WMUX_SKIP_JOB_RUNTIME_TESTS`);
+      return false;
+    }
+    // Named so a CI failure says WHICH premise broke.
+    const why: Record<string, string> = {
+      '1': 'CreateJobObject failed',
+      '2': 'SetInformationJobObject(KILL_ON_JOB_CLOSE) failed',
+      '3': 'AssignProcessToJobObject failed',
+      '4': 'schtasks /Create failed',
+      '5': 'schtasks /Run failed',
+      '-1': 'the stub exited 0 without arming the job',
+    };
+    throw new Error(
+      `[#1264] the runtime premise did not hold: ${why[String(status)] ?? `stub exit ${String(status)}`}. ` +
+      'Set WMUX_SKIP_JOB_RUNTIME_TESTS=1 to waive deliberately.',
+    );
   }
 
   function writeWaiterFor(stamp: string, script: string, vbs: string): void {
@@ -737,13 +771,9 @@ describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spaw
     writeWaiterFor(stamp, script, vbs);
     holdRootFor(12);
 
-    const armed = runInsideDyingJob([
+    if (!requireJobArmed(runInsideDyingJob([
       `Start-Process -FilePath ${q(WSCRIPT)} -ArgumentList '//B','//Nologo',${q(vbs)} -WindowStyle Hidden`,
-    ]);
-    if (!armed) {
-      console.warn('[#1264] kill-on-close job objects unavailable on this agent — control skipped');
-      return;
-    }
+    ]))) return;
 
     // It really did start: the launch stamp is the waiter's first act.
     expect(fs.existsSync(stamp)).toBe(true);
@@ -760,21 +790,37 @@ describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spaw
     holdRootFor(12);
 
     const taskName = `wmux-update-t${Date.now().toString(36).replace(/[^A-Za-z0-9]/g, '')}`;
-    const createArgs = buildScheduledTaskCreateArgs(taskName, WSCRIPT, vbs);
+    // The REAL definition, through the real builders — so an XML the importer
+    // refuses (a settings element out of sequence, a mis-escaped path) fails
+    // this test rather than silently costing the fix in the field.
+    const xmlPath = path.join(waiterDir, 'waiter-task.xml');
+    const xml = buildScheduledTaskXml(WSCRIPT, vbs);
+    expect(xml).not.toBeNull();
+    fs.writeFileSync(xmlPath, '\uFEFF' + (xml as string), 'utf16le');
+    const createArgs = buildScheduledTaskCreateArgs(taskName, xmlPath);
     expect(createArgs).not.toBeNull();
     tasks.push(taskName);
 
     const psArr = (a: readonly string[]) => '@(' + a.map(q).join(',') + ')';
-    const armed = runInsideDyingJob([
+    if (!requireJobArmed(runInsideDyingJob([
       `& ${q(SCHTASKS)} ${psArr(createArgs as string[])} | Out-Null`,
       `if ($LASTEXITCODE -ne 0) { exit 4 }`,
       `& ${q(SCHTASKS)} ${psArr(buildScheduledTaskRunArgs(taskName))} | Out-Null`,
       `if ($LASTEXITCODE -ne 0) { exit 5 }`,
-    ]);
-    if (!armed) {
-      console.warn('[#1264] job object or schtasks registration unavailable on this agent — survival test skipped');
-      return;
-    }
+    ]))) return;
+
+    // #1283 review asked whether the battery settings are PROVABLY applied.
+    // The builder's own test pins what we emit; this pins what the scheduler
+    // actually stored after importing it.
+    const stored = spawnSync(SCHTASKS, ['/Query', '/TN', taskName, '/XML', 'ONE'],
+      { encoding: 'utf-8', windowsHide: true, timeout: 20_000 });
+    const storedXml = (stored.stdout ?? '').replace(/\0/g, '');
+    expect(storedXml).toContain('<DisallowStartIfOnBatteries>false<');
+    expect(storedXml).toContain('<StopIfGoingOnBatteries>false<');
+    expect(storedXml).toContain('<ExecutionTimeLimit>PT0S<');
+    expect(storedXml).toContain('<MultipleInstancesPolicy>IgnoreNew<');
+    // No trigger survived the import either — a leaked task cannot self-fire.
+    expect(storedXml).not.toContain('<Triggers');
 
     expect(fs.existsSync(stamp)).toBe(true);
     // The parent is gone and its job closed with it. The scheduler's child is

--- a/src/main/updater/__tests__/installTeardown.runtime.test.ts
+++ b/src/main/updater/__tests__/installTeardown.runtime.test.ts
@@ -20,6 +20,9 @@ import { spawn, spawnSync, execFileSync, type ChildProcess } from 'node:child_pr
 import { createHash } from 'node:crypto';
 import {
   buildWaiterScript,
+  buildWaiterVbsLauncher,
+  buildScheduledTaskCreateArgs,
+  buildScheduledTaskRunArgs,
   spawnInstallWaiter,
   collectInstallRootPids,
   probeVolume,
@@ -558,7 +561,13 @@ describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWa
     const written = spawnInstallWaiter(mkPlan());
     expect(written).not.toBeNull();
     launchedDir = path.dirname(written as string);
-    expect(path.basename(written as string)).toBe('wait-and-install-w.ps1');
+    // #1264 put the scheduled-task transport AHEAD of this one, because it is
+    // the only one that survives the app's exit. Which of the two wins is a
+    // property of the machine (Task Scheduler access), so both are legal here
+    // — what stays pinned is that a HIDDEN transport wins, never the visible
+    // cmd.exe fallback behind them.
+    expect(['wait-and-install-s.ps1', 'wait-and-install-w.ps1'])
+      .toContain(path.basename(written as string));
 
     // ...and it is a REAL waiter, not just a process that stamped and died:
     // the same end-to-end proof the transport suite's first test makes.
@@ -566,4 +575,211 @@ describe.skipIf(!onWindows)('waiter transport (#1056 — the REAL spawnInstallWa
     while (Date.now() < deadline && !fs.existsSync(envStamp)) sleep200();
     expect(fs.existsSync(envStamp)).toBe(true);
   }, 120_000);
+});
+
+// #1264 — the reported defect, against a real Windows kernel.
+//
+// Every transport before this one was started with `child_process.spawn` from
+// the app, so the waiter was a member of whatever job object the app is in.
+// A job created with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE terminates every member
+// when its last handle closes — i.e. the instant wmux's last process exits —
+// and a process killed by the kernel cannot reach any of the waiter's own exit
+// branches. That is exactly the reported artifact set: `alive` heartbeat and a
+// launch stamp on disk, then silence and no Setup.exe.
+//
+// The test builds that job for real: a stub "parent" PowerShell that joins a
+// kill-on-close job, launches the waiter, and exits. A lock holder OUTSIDE the
+// job keeps the install root busy past the parent's death, so the waiter can
+// only reach Setup.exe if it OUTLIVED the parent.
+describe.skipIf(!onWindows)('#1264 — the waiter must outlive the app that spawned it', () => {
+  let sandbox: string;
+  let root: string;
+  let heldExe: string;
+  let setupStamp: string;
+  let fakeSetup: string;
+  let waiterDir: string;
+  const children: ChildProcess[] = [];
+  const tasks: string[] = [];
+
+  const SYS = path.join(process.env.SystemRoot || 'C:\\Windows', 'System32');
+  const SCHTASKS = path.join(SYS, 'schtasks.exe');
+  const WSCRIPT = path.join(SYS, 'wscript.exe');
+
+  beforeEach(() => {
+    sandbox = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-job-')));
+    root = path.join(sandbox, 'wmux');
+    fs.mkdirSync(path.join(root, 'app-1.0.0'), { recursive: true });
+    // Shape of a successful install, so the waiter's post-exit verification
+    // exits 0 instead of popping the exit-6 MessageBox at a headless runner.
+    fs.writeFileSync(path.join(root, 'Update.exe'), 'x');
+    fs.writeFileSync(path.join(root, 'app-1.0.0', 'icudtl.dat'), 'x');
+    heldExe = path.join(root, 'app-1.0.0', 'held.exe');
+    fs.writeFileSync(heldExe, 'x');
+    setupStamp = path.join(sandbox, 'setup-ran.txt');
+    fakeSetup = path.join(sandbox, 'fake-setup.cmd');
+    fs.writeFileSync(fakeSetup, `@echo off\r\necho ran > "${setupStamp}"\r\n`);
+    waiterDir = fs.mkdtempSync(path.join(sandbox, 'waiter-'));
+  });
+
+  afterEach(() => {
+    for (const c of children.splice(0)) { try { c.kill(); } catch { /* gone */ } }
+    for (const t of tasks.splice(0)) {
+      try { execFileSync(SCHTASKS, ['/Delete', '/TN', t, '/F'], { windowsHide: true, stdio: 'ignore', timeout: 20_000 }); } catch { /* gone */ }
+    }
+    // The waiter is not our child by design — reap by command line.
+    const dirLike = sandbox.replace(/'/g, "''");
+    try {
+      execFileSync(PS, ['-NoProfile', '-NonInteractive', '-Command',
+        `Get-CimInstance Win32_Process -Filter "Name='powershell.exe' OR Name='wscript.exe'" | Where-Object { $_.CommandLine -like '*${dirLike}*' } | ForEach-Object { taskkill /PID $_.ProcessId /T /F } | Out-Null`,
+      ], { windowsHide: true, timeout: 20_000 });
+    } catch { /* nothing to reap */ }
+    try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch { /* lock lingers */ }
+  });
+
+  /** Holds a binary under the install root open for `seconds`, outside the job. */
+  function holdRootFor(seconds: number): void {
+    const child = spawn(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-Command',
+        `$s=[System.IO.File]::Open(${q(heldExe)},'Open','Read','None'); Start-Sleep -Seconds ${seconds}; $s.Close()`],
+      { windowsHide: true, stdio: 'ignore' },
+    );
+    children.push(child);
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      try { const fd = fs.openSync(heldExe, 'r+'); fs.closeSync(fd); } catch { return; }
+      execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 100'], { windowsHide: true });
+    }
+    throw new Error('holder never took the lock');
+  }
+
+  /**
+   * Run `launchLines` from a process that is inside a kill-on-close job, then
+   * let that process exit — closing the job and killing everything still in it.
+   * Returns false when the job could not be built (an agent where nesting is
+   * refused), so the caller can skip rather than assert on a broken premise.
+   */
+  function runInsideDyingJob(launchLines: string[]): boolean {
+    const proofPath = path.join(sandbox, 'job-armed.txt');
+    const stub = path.join(sandbox, 'stub-parent.ps1');
+    fs.writeFileSync(stub, [
+      `$ErrorActionPreference = 'Stop'`,
+      `Add-Type -Namespace WmuxT -Name Job -MemberDefinition @"`,
+      `[DllImport("kernel32.dll", CharSet=CharSet.Unicode)] public static extern IntPtr CreateJobObject(IntPtr a, string name);`,
+      `[DllImport("kernel32.dll")] public static extern bool SetInformationJobObject(IntPtr job, int infoClass, IntPtr info, uint len);`,
+      `[DllImport("kernel32.dll")] public static extern bool AssignProcessToJobObject(IntPtr job, IntPtr proc);`,
+      `"@`,
+      `$job = [WmuxT.Job]::CreateJobObject([IntPtr]::Zero, $null)`,
+      `if ($job -eq [IntPtr]::Zero) { exit 1 }`,
+      // JOBOBJECT_EXTENDED_LIMIT_INFORMATION is 144 bytes on x64; LimitFlags
+      // sits at offset 16, and 0x2000 is JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.
+      `$len = 144`,
+      `$buf = [System.Runtime.InteropServices.Marshal]::AllocHGlobal($len)`,
+      `for ($i = 0; $i -lt $len; $i++) { [System.Runtime.InteropServices.Marshal]::WriteByte($buf, $i, 0) }`,
+      `[System.Runtime.InteropServices.Marshal]::WriteInt32($buf, 16, 0x2000)`,
+      `if (-not [WmuxT.Job]::SetInformationJobObject($job, 9, $buf, $len)) { exit 2 }`,
+      `if (-not [WmuxT.Job]::AssignProcessToJobObject($job, (Get-Process -Id $PID).Handle)) { exit 3 }`,
+      `Set-Content -LiteralPath ${q(proofPath)} -Value 'armed'`,
+      ...launchLines,
+      // Long enough for the launched waiter to be well past its first lines,
+      // and still far short of the lock holder's window.
+      `Start-Sleep -Seconds 4`,
+      `exit 0`,
+    ].join('\n'), 'utf-8');
+
+    const res = spawnSync(
+      PS,
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', stub],
+      { encoding: 'utf-8', timeout: 90_000, windowsHide: true },
+    );
+    return res.status === 0 && fs.existsSync(proofPath);
+  }
+
+  function writeWaiterFor(stamp: string, script: string, vbs: string): void {
+    const plan: WaiterPlan = {
+      pids: [],
+      setupExePath: fakeSetup,
+      installRoot: root,
+      abortMarkerPath: path.join(sandbox, 'abort.txt'),
+      readyMarkerPath: path.join(sandbox, 'ready.tmp'),
+      lockBudgetMs: 60_000,
+      forceKillEligiblePids: [],
+      forceKillGraceMs: 5_000,
+    };
+    const body = buildWaiterScript(plan, stamp);
+    expect(body).not.toBeNull();
+    fs.writeFileSync(script, '\uFEFF' + (body as string), 'utf-8');
+    const launcher = buildWaiterVbsLauncher(
+      PS, ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File'], script,
+    );
+    expect(launcher).not.toBeNull();
+    fs.writeFileSync(vbs, '\uFEFF' + (launcher as string), 'utf16le');
+  }
+
+  /** Poll for `p` for up to `ms`. */
+  function waitFor(p: string, ms: number): boolean {
+    const deadline = Date.now() + ms;
+    while (Date.now() < deadline) {
+      if (fs.existsSync(p)) return true;
+      try {
+        execFileSync(PS, ['-NoProfile', '-Command', 'Start-Sleep -Milliseconds 250'], { windowsHide: true });
+      } catch { /* keep polling */ }
+    }
+    return fs.existsSync(p);
+  }
+
+  it('the in-tree wscript transport is killed with the job (the reported defect)', () => {
+    // This is the CONTROL, and it is the mechanism proof: same script, same
+    // hidden launcher, started the way the app used to start it — as a child.
+    const stamp = path.join(waiterDir, 'launched-w.txt');
+    const script = path.join(waiterDir, 'wait-and-install-w.ps1');
+    const vbs = path.join(waiterDir, 'launch-waiter-w.vbs');
+    writeWaiterFor(stamp, script, vbs);
+    holdRootFor(12);
+
+    const armed = runInsideDyingJob([
+      `Start-Process -FilePath ${q(WSCRIPT)} -ArgumentList '//B','//Nologo',${q(vbs)} -WindowStyle Hidden`,
+    ]);
+    if (!armed) {
+      console.warn('[#1264] kill-on-close job objects unavailable on this agent — control skipped');
+      return;
+    }
+
+    // It really did start: the launch stamp is the waiter's first act.
+    expect(fs.existsSync(stamp)).toBe(true);
+    // ...and then the job closed. The lock clears ~8s after the parent died,
+    // so a SURVIVING waiter would have launched the stub installer by now.
+    expect(waitFor(setupStamp, 25_000)).toBe(false);
+  }, 180_000);
+
+  it('the scheduled-task transport survives the job and runs the installer', () => {
+    const stamp = path.join(waiterDir, 'launched-s.txt');
+    const script = path.join(waiterDir, 'wait-and-install-s.ps1');
+    const vbs = path.join(waiterDir, 'launch-waiter-s.vbs');
+    writeWaiterFor(stamp, script, vbs);
+    holdRootFor(12);
+
+    const taskName = `wmux-update-t${Date.now().toString(36).replace(/[^A-Za-z0-9]/g, '')}`;
+    const createArgs = buildScheduledTaskCreateArgs(taskName, WSCRIPT, vbs);
+    expect(createArgs).not.toBeNull();
+    tasks.push(taskName);
+
+    const psArr = (a: readonly string[]) => '@(' + a.map(q).join(',') + ')';
+    const armed = runInsideDyingJob([
+      `& ${q(SCHTASKS)} ${psArr(createArgs as string[])} | Out-Null`,
+      `if ($LASTEXITCODE -ne 0) { exit 4 }`,
+      `& ${q(SCHTASKS)} ${psArr(buildScheduledTaskRunArgs(taskName))} | Out-Null`,
+      `if ($LASTEXITCODE -ne 0) { exit 5 }`,
+    ]);
+    if (!armed) {
+      console.warn('[#1264] job object or schtasks registration unavailable on this agent — survival test skipped');
+      return;
+    }
+
+    expect(fs.existsSync(stamp)).toBe(true);
+    // The parent is gone and its job closed with it. The scheduler's child is
+    // not a member, so it is still there when the lock clears — and it runs
+    // the stub Setup.exe, which is the branch the field never reached.
+    expect(waitFor(setupStamp, 40_000)).toBe(true);
+  }, 180_000);
 });

--- a/src/main/updater/__tests__/installTeardown.spawn.test.ts
+++ b/src/main/updater/__tests__/installTeardown.spawn.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { spawnInstallWaiter } from '../installTeardown';
+import { spawnInstallWaiter, sweepStaleWaiterTasks } from '../installTeardown';
 
 const spawnMock = vi.fn();
 const execFileSyncMock = vi.fn();
@@ -62,21 +62,24 @@ describe('spawnInstallWaiter launch path (#1264)', () => {
     forceKillGraceMs: 5_000,
   });
 
-  /** The directory the module mkdtemp'd, read off the /TR it registered. */
-  function waiterDirFrom(tr: string): string {
-    const vbs = tr.slice(tr.lastIndexOf('"', tr.length - 2) + 1, tr.length - 1);
-    const dir = path.dirname(vbs);
+  /** The directory the module mkdtemp'd, read off the definition it registered. */
+  function waiterDirFrom(xmlPath: string): string {
+    const dir = path.dirname(xmlPath);
     dirs.push(dir);
     return dir;
   }
+
+  /** schtasks calls only — the elevation probe shares the mock. */
+  const schtasksCalls = () =>
+    execFileSyncMock.mock.calls.filter((c) => /schtasks\.exe$/.test(c[0] as string));
 
   it('registers and runs a scheduled task BEFORE spawning anything of its own', () => {
     execFileSyncMock.mockImplementation((exe: string, args: string[]) => {
       if (args[0] === '/Run') {
         // The scheduler started it: stamp, exactly as the real waiter's first
         // lines do.
-        const tr = execFileSyncMock.mock.calls.find((c) => c[1][0] === '/Create')![1][4] as string;
-        fs.writeFileSync(path.join(waiterDirFrom(tr), 'launched-s.txt'), 'launched');
+        const xmlPath = execFileSyncMock.mock.calls.find((c) => c[1][0] === '/Create')![1][4] as string;
+        fs.writeFileSync(path.join(waiterDirFrom(xmlPath), 'launched-s.txt'), 'launched');
       }
       return '';
     });
@@ -89,8 +92,7 @@ describe('spawnInstallWaiter launch path (#1264)', () => {
     // Nothing of ours was spawned — no wscript, no cmd, no powershell child.
     expect(spawnMock).not.toHaveBeenCalled();
 
-    const calls = execFileSyncMock.mock.calls;
-    expect(calls[0][0]).toMatch(/schtasks\.exe$/);
+    const calls = schtasksCalls();
     expect(calls[0][1][0]).toBe('/Create');
     expect(calls[1][1][0]).toBe('/Run');
     // The registration is removed once the scheduler has started the process:
@@ -98,12 +100,21 @@ describe('spawnInstallWaiter launch path (#1264)', () => {
     expect(calls[2][1][0]).toBe('/Delete');
     expect(calls[0][1][2]).toBe(calls[1][1][2]);
     expect(calls[0][1][2]).toBe(calls[2][1][2]);
-    // The registered action is the hidden wscript launcher, quoted.
-    expect(calls[0][1][4]).toMatch(/^"[^"]*wscript\.exe" \/\/B \/\/Nologo "[^"]*launch-waiter-s\.vbs"$/);
-    // Every call is silent and bounded — this runs on the quit path.
-    for (const c of calls) {
+    expect(calls[0][1][2]).toMatch(/^wmux-update-[A-Za-z0-9]+$/);
+    // Registered from XML, not /TR — the short form cannot carry the battery
+    // settings, and the definition on disk is the hidden wscript launcher.
+    expect(calls[0][1][3]).toBe('/XML');
+    const xml = fs.readFileSync(calls[0][1][4] as string, 'utf16le').replace(/^\uFEFF/, '');
+    expect(xml).toContain('<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>');
+    expect(xml).toContain('<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>');
+    expect(xml).toMatch(/<Arguments>\/\/B \/\/Nologo "[^"]*launch-waiter-s\.vbs"<\/Arguments>/);
+    expect(xml).toMatch(/<Command>[^<]*wscript\.exe<\/Command>/);
+    // #1283 review — every call is silent and SHORT: this blocks the main
+    // process right after the user clicked Install.
+    for (const c of execFileSyncMock.mock.calls) {
       expect((c[2] as { windowsHide?: boolean }).windowsHide).toBe(true);
       expect((c[2] as { timeout?: number }).timeout).toBeGreaterThan(0);
+      expect((c[2] as { timeout?: number }).timeout).toBeLessThanOrEqual(3_000);
     }
   });
 
@@ -127,7 +138,7 @@ describe('spawnInstallWaiter launch path (#1264)', () => {
     expect(path.basename(written as string)).toBe('wait-and-install-w.ps1');
     expect(spawnMock.mock.calls[0][0]).toMatch(/wscript\.exe$/);
     // ...and the task registration is not left behind on the way past.
-    expect(execFileSyncMock.mock.calls.some((c) => c[1][0] === '/Delete')).toBe(true);
+    expect(schtasksCalls().some((c) => c[1][0] === '/Delete')).toBe(true);
   }, 30_000);
 
   it('a schtasks that throws does not abort the handoff', () => {
@@ -141,4 +152,88 @@ describe('spawnInstallWaiter launch path (#1264)', () => {
 
     expect(path.basename(spawnInstallWaiter(plan()) as string)).toBe('wait-and-install-w.ps1');
   }, 30_000);
+});
+
+describe('leaked waiter task registrations (#1283 review)', () => {
+  const realPlatform2 = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    spawnMock.mockReset();
+    execFileSyncMock.mockReset();
+    spawnMock.mockImplementation(() => fakeChild());
+  });
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform2, configurable: true });
+  });
+
+  it('a /Create that fails still tries to remove a name the server may have committed', () => {
+    // The dangerous shape: /Create TIMES OUT after the scheduler committed, so
+    // the registration exists even though we saw a failure. Without this the
+    // only cleanup is the next startup sweep.
+    execFileSyncMock.mockImplementation((exe: string, args: string[]) => {
+      if (/schtasks\.exe$/.test(exe) && args[0] === '/Create') {
+        const e = new Error('ETIMEDOUT') as Error & { code: string };
+        e.code = 'ETIMEDOUT';
+        throw e;
+      }
+      return '';
+    });
+    spawnMock.mockImplementation((exe: string, args: string[]) => {
+      if (/wscript\.exe$/.test(exe)) {
+        fs.writeFileSync(path.join(path.dirname(args[2]), 'launched-w.txt'), 'launched');
+      }
+      return fakeChild();
+    });
+
+    expect(path.basename(spawnInstallWaiter({
+      pids: [], setupExePath: 'C:\\Temp\\Setup.exe', installRoot: 'C:\\wmux',
+      abortMarkerPath: 'C:\\Temp\\a.txt', readyMarkerPath: 'C:\\Temp\\r.tmp',
+      lockBudgetMs: 60_000, forceKillEligiblePids: [], forceKillGraceMs: 5_000,
+    }) as string)).toBe('wait-and-install-w.ps1');
+
+    const deletes = execFileSyncMock.mock.calls.filter((c) => c[1][0] === '/Delete');
+    expect(deletes.length).toBeGreaterThan(0);
+    expect(deletes[0][1][2]).toMatch(/^wmux-update-[A-Za-z0-9]+$/);
+  }, 30_000);
+
+  it('the startup sweep removes only our own leftovers', () => {
+    execFileSyncMock.mockImplementation((_exe: string, args: string[]) => {
+      if (args[0] === '/Query') {
+        return [
+          'Folder: \\',
+          'HostName:                             DESKTOP',
+          'TaskName:                             \\wmux-update-wmuxinstallwaiterA1b2',
+          'Next Run Time:                        N/A',
+          '',
+          'TaskName:                             \\wmux-update-wmuxinstallwaiterZ9y8',
+          '',
+          // Not ours, and a name that only LOOKS close — neither may be touched.
+          'TaskName:                             \\GoogleUpdateTaskMachineUA',
+          'TaskName:                             \\wmux-update-nested\\evil',
+          'TaskName:                             \\OneDrive Reporting Task-S-1-5-21',
+        ].join('\r\n');
+      }
+      return '';
+    });
+
+    expect(sweepStaleWaiterTasks()).toBe(2);
+    const deleted = execFileSyncMock.mock.calls
+      .filter((c) => c[1][0] === '/Delete')
+      .map((c) => c[1][2]);
+    expect(deleted.sort()).toEqual([
+      'wmux-update-wmuxinstallwaiterA1b2',
+      'wmux-update-wmuxinstallwaiterZ9y8',
+    ]);
+  });
+
+  it('the sweep is inert off Windows and when the scheduler refuses', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    expect(sweepStaleWaiterTasks()).toBe(0);
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    execFileSyncMock.mockImplementation(() => { throw new Error('access denied'); });
+    expect(sweepStaleWaiterTasks()).toBe(0);
+  });
 });

--- a/src/main/updater/__tests__/installTeardown.spawn.test.ts
+++ b/src/main/updater/__tests__/installTeardown.spawn.test.ts
@@ -1,0 +1,144 @@
+// #1264 — what spawnInstallWaiter actually LAUNCHES, and in what order.
+//
+// The field failure this pins: every transport the module had was started with
+// `child_process.spawn` from the Electron main process, which on Windows makes
+// the waiter a member of the app's job object — so it was killed by the kernel
+// the moment wmux exited, before reaching any of its own exit branches. The fix
+// is a transport whose process is started by the Task Scheduler service instead
+// of by us. Nothing about that is observable from a spawn's return value, so
+// what is asserted here is the launch PATH: schtasks is tried first, with the
+// arguments that make the scheduler (not us) the parent, and the in-tree
+// transports are only reached when it does not prove execution.
+//
+// win32 is forced and child_process is mocked, so this runs on any host — the
+// real-kernel half lives in installTeardown.runtime.test.ts (windows-latest).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { spawnInstallWaiter } from '../installTeardown';
+
+const spawnMock = vi.fn();
+const execFileSyncMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  spawn: (...a: unknown[]) => spawnMock(...a),
+  execFileSync: (...a: unknown[]) => execFileSyncMock(...a),
+}));
+
+
+const realPlatform = process.platform;
+
+/** A ChildProcess stub good enough for `swallowSpawnError` + `unref`. */
+function fakeChild(pid = 4242) {
+  return { pid, on: vi.fn(), unref: vi.fn() };
+}
+
+describe('spawnInstallWaiter launch path (#1264)', () => {
+  const dirs: string[] = [];
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    spawnMock.mockReset();
+    execFileSyncMock.mockReset();
+    spawnMock.mockImplementation(() => fakeChild());
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: realPlatform, configurable: true });
+    for (const d of dirs.splice(0)) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
+  });
+
+  const plan = () => ({
+    pids: [],
+    setupExePath: 'C:\\Temp\\Setup.exe',
+    installRoot: 'C:\\Users\\Daniel\\AppData\\Local\\wmux',
+    abortMarkerPath: 'C:\\Temp\\abort.txt',
+    readyMarkerPath: 'C:\\Temp\\ready.tmp',
+    lockBudgetMs: 60_000,
+    forceKillEligiblePids: [],
+    forceKillGraceMs: 5_000,
+  });
+
+  /** The directory the module mkdtemp'd, read off the /TR it registered. */
+  function waiterDirFrom(tr: string): string {
+    const vbs = tr.slice(tr.lastIndexOf('"', tr.length - 2) + 1, tr.length - 1);
+    const dir = path.dirname(vbs);
+    dirs.push(dir);
+    return dir;
+  }
+
+  it('registers and runs a scheduled task BEFORE spawning anything of its own', () => {
+    execFileSyncMock.mockImplementation((exe: string, args: string[]) => {
+      if (args[0] === '/Run') {
+        // The scheduler started it: stamp, exactly as the real waiter's first
+        // lines do.
+        const tr = execFileSyncMock.mock.calls.find((c) => c[1][0] === '/Create')![1][4] as string;
+        fs.writeFileSync(path.join(waiterDirFrom(tr), 'launched-s.txt'), 'launched');
+      }
+      return '';
+    });
+
+    const written = spawnInstallWaiter(plan());
+
+    expect(written).not.toBeNull();
+    // The transport that carried it is identifiable from the script name.
+    expect(path.basename(written as string)).toBe('wait-and-install-s.ps1');
+    // Nothing of ours was spawned — no wscript, no cmd, no powershell child.
+    expect(spawnMock).not.toHaveBeenCalled();
+
+    const calls = execFileSyncMock.mock.calls;
+    expect(calls[0][0]).toMatch(/schtasks\.exe$/);
+    expect(calls[0][1][0]).toBe('/Create');
+    expect(calls[1][1][0]).toBe('/Run');
+    // The registration is removed once the scheduler has started the process:
+    // the running instance is not ours to keep registered.
+    expect(calls[2][1][0]).toBe('/Delete');
+    expect(calls[0][1][2]).toBe(calls[1][1][2]);
+    expect(calls[0][1][2]).toBe(calls[2][1][2]);
+    // The registered action is the hidden wscript launcher, quoted.
+    expect(calls[0][1][4]).toMatch(/^"[^"]*wscript\.exe" \/\/B \/\/Nologo "[^"]*launch-waiter-s\.vbs"$/);
+    // Every call is silent and bounded — this runs on the quit path.
+    for (const c of calls) {
+      expect((c[2] as { windowsHide?: boolean }).windowsHide).toBe(true);
+      expect((c[2] as { timeout?: number }).timeout).toBeGreaterThan(0);
+    }
+  });
+
+  it('falls through to the in-tree transports when the scheduler proves nothing', () => {
+    // No stamp is ever written, so the S gate times out. The fallbacks must
+    // still be reachable — a machine with Task Scheduler locked down keeps
+    // today's behaviour rather than losing the update entirely.
+    execFileSyncMock.mockImplementation((_exe: string, args: string[]) => {
+      if (args[0] === '/Create') waiterDirFrom(args[4]);
+      return '';
+    });
+    spawnMock.mockImplementation((exe: string, args: string[]) => {
+      if (/wscript\.exe$/.test(exe)) {
+        fs.writeFileSync(path.join(path.dirname(args[2]), 'launched-w.txt'), 'launched');
+      }
+      return fakeChild();
+    });
+
+    const written = spawnInstallWaiter(plan());
+
+    expect(path.basename(written as string)).toBe('wait-and-install-w.ps1');
+    expect(spawnMock.mock.calls[0][0]).toMatch(/wscript\.exe$/);
+    // ...and the task registration is not left behind on the way past.
+    expect(execFileSyncMock.mock.calls.some((c) => c[1][0] === '/Delete')).toBe(true);
+  }, 30_000);
+
+  it('a schtasks that throws does not abort the handoff', () => {
+    execFileSyncMock.mockImplementation(() => { throw new Error('access denied'); });
+    spawnMock.mockImplementation((exe: string, args: string[]) => {
+      if (/wscript\.exe$/.test(exe)) {
+        fs.writeFileSync(path.join(path.dirname(args[2]), 'launched-w.txt'), 'launched');
+      }
+      return fakeChild();
+    });
+
+    expect(path.basename(spawnInstallWaiter(plan()) as string)).toBe('wait-and-install-w.ps1');
+  }, 30_000);
+});

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -18,6 +18,10 @@ import {
   parseProcessRows,
   buildWaiterScript,
   buildWaiterVbsLauncher,
+  buildScheduledTaskCreateArgs,
+  buildScheduledTaskRunArgs,
+  buildScheduledTaskDeleteArgs,
+  SCHEDULED_TASK_TR_LIMIT,
   readDaemonPid,
   terminatePids,
   readAbortMarker,
@@ -758,5 +762,57 @@ describe('buildWaiterVbsLauncher (#1136 — the hidden transport)', () => {
     expect(buildWaiterVbsLauncher(PS, ['-NoProfile', ''], 'C:\\Temp\\w.ps1')).toBeNull();
     // A space in either PATH stays legal — that is the whole point of quoting.
     expect(buildWaiterVbsLauncher(PS, ARGS, 'C:\\Program Files\\w.ps1')).not.toBeNull();
+  });
+});
+
+describe('buildScheduledTaskCreateArgs (#1264 — the job-escaping transport)', () => {
+  const WSCRIPT = 'C:\\Windows\\System32\\wscript.exe';
+  const VBS = 'C:\\Users\\Daniel\\AppData\\Local\\Temp\\wmux-install-waiter-eOsG6n\\launch-waiter-s.vbs';
+
+  it('registers a one-shot task whose action is the hidden wscript launcher', () => {
+    const args = buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, VBS) as string[];
+    expect(args).not.toBeNull();
+    // The task name must be addressable by the /Run and /Delete calls.
+    expect(args[args.indexOf('/TN') + 1]).toBe('wmux-update-abc123');
+    const tr = args[args.indexOf('/TR') + 1];
+    // Both paths quoted (TEMP holds spaces), and the wscript switches bare.
+    expect(tr).toBe(`"${WSCRIPT}" //B //Nologo "${VBS}"`);
+    // One-shot, overwrite a leftover rather than prompt.
+    expect(args).toContain('/SC');
+    expect(args[args.indexOf('/SC') + 1]).toBe('ONCE');
+    expect(args).toContain('/F');
+    // No /RU: the task runs as the logged-on interactive user, so no password
+    // is needed and no elevation is requested.
+    expect(args).not.toContain('/RU');
+    expect(args).not.toContain('/RP');
+  });
+
+  it('the run and delete calls address the same task', () => {
+    expect(buildScheduledTaskRunArgs('wmux-update-abc123')).toEqual(['/Run', '/TN', 'wmux-update-abc123']);
+    expect(buildScheduledTaskDeleteArgs('wmux-update-abc123')).toEqual(['/Delete', '/TN', 'wmux-update-abc123', '/F']);
+  });
+
+  it('fails closed rather than registering a truncated or broken action', () => {
+    // Task Scheduler silently caps /TR; a truncated command line would
+    // register a task that runs the WRONG thing, which is worse than falling
+    // through to transport W.
+    const longVbs = 'C:\\Users\\' + 'x'.repeat(SCHEDULED_TASK_TR_LIMIT) + '\\launch-waiter-s.vbs';
+    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, longVbs)).toBeNull();
+    // A quote would break out of the /TR literal; a newline would break the
+    // argument entirely. Same fail-closed rule as buildWaiterVbsLauncher.
+    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, 'C:\\a"b.vbs')).toBeNull();
+    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, 'C:\\a\nb.vbs')).toBeNull();
+    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', '', VBS)).toBeNull();
+    // The name is a Task Scheduler PATH: a backslash would nest it into a
+    // folder, and anything unexpected is refused outright.
+    expect(buildScheduledTaskCreateArgs('wmux-update-a\\b', WSCRIPT, VBS)).toBeNull();
+    expect(buildScheduledTaskCreateArgs('Some Other Task', WSCRIPT, VBS)).toBeNull();
+    expect(buildScheduledTaskCreateArgs('wmux-update-', WSCRIPT, VBS)).toBeNull();
+  });
+
+  it('accepts the name shape spawnInstallWaiter actually generates', () => {
+    // mkdtemp basename with every non-alphanumeric stripped.
+    const generated = `wmux-update-${'wmux-install-waiter-eOsG6n'.replace(/[^A-Za-z0-9]/g, '')}`;
+    expect(buildScheduledTaskCreateArgs(generated, WSCRIPT, VBS)).not.toBeNull();
   });
 });

--- a/src/main/updater/__tests__/installTeardown.test.ts
+++ b/src/main/updater/__tests__/installTeardown.test.ts
@@ -21,7 +21,7 @@ import {
   buildScheduledTaskCreateArgs,
   buildScheduledTaskRunArgs,
   buildScheduledTaskDeleteArgs,
-  SCHEDULED_TASK_TR_LIMIT,
+  buildScheduledTaskXml,
   readDaemonPid,
   terminatePids,
   readAbortMarker,
@@ -765,24 +765,108 @@ describe('buildWaiterVbsLauncher (#1136 — the hidden transport)', () => {
   });
 });
 
-describe('buildScheduledTaskCreateArgs (#1264 — the job-escaping transport)', () => {
+describe('buildScheduledTaskXml (#1264 — the definition that survives a laptop)', () => {
   const WSCRIPT = 'C:\\Windows\\System32\\wscript.exe';
   const VBS = 'C:\\Users\\Daniel\\AppData\\Local\\Temp\\wmux-install-waiter-eOsG6n\\launch-waiter-s.vbs';
 
-  it('registers a one-shot task whose action is the hidden wscript launcher', () => {
-    const args = buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, VBS) as string[];
+  it('carries the power settings the /TR short form cannot express', () => {
+    // These four are the correctness of the transport, not polish. With the
+    // scheduler's defaults (DisallowStartIfOnBatteries / StopIfGoingOnBatteries
+    // both true) a laptop on battery starts NOTHING on /Run — we fall through
+    // to the transport that cannot survive the job — and unplugging mid-wait
+    // makes the scheduler terminate the waiter, which is #1264 all over again.
+    const xml = buildScheduledTaskXml(WSCRIPT, VBS) as string;
+    expect(xml).not.toBeNull();
+    expect(xml).toContain('<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>');
+    expect(xml).toContain('<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>');
+    // The waiter's own budgets are the only deadline it may have.
+    expect(xml).toContain('<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>');
+    expect(xml).toContain('<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>');
+    // The scheduler must not hard-kill it either.
+    expect(xml).toContain('<AllowHardTerminate>false</AllowHardTerminate>');
+    // /IT equivalent: a logon type with a desktop and no stored password.
+    expect(xml).toContain('<LogonType>InteractiveToken</LogonType>');
+  });
+
+  it('has NO trigger, so a leaked registration can never fire by itself', () => {
+    // The /TR form needed /SC ONCE /ST <time>. A registration that leaked (a
+    // /Create that timed out after the server committed, a /Delete that failed)
+    // would then fire later the same day — and a late waiter opens the recorded
+    // pids BY NUMBER, so after pid recycling it would taskkill strangers and
+    // write a false "install root still locked" marker against an already
+    // updated install.
+    const xml = buildScheduledTaskXml(WSCRIPT, VBS) as string;
+    expect(xml).not.toContain('<Triggers');
+    expect(xml).not.toContain('<StartBoundary>');
+    // On-demand is therefore the ONLY way it can start.
+    expect(xml).toContain('<AllowStartOnDemand>true</AllowStartOnDemand>');
+  });
+
+  it('mirrors the current process elevation onto the run level', () => {
+    // An elevated wmux handing the install to a medium-IL waiter means its
+    // taskkill against the app's own pids fails, $stuck fires, and the install
+    // is refused with exit 3 — a failure mode the in-tree transports never had,
+    // because they inherited the app's token.
+    expect(buildScheduledTaskXml(WSCRIPT, VBS) as string)
+      .toContain('<RunLevel>LeastPrivilege</RunLevel>');
+    expect(buildScheduledTaskXml(WSCRIPT, VBS, 'HighestAvailable') as string)
+      .toContain('<RunLevel>HighestAvailable</RunLevel>');
+  });
+
+  it('escapes the command path instead of letting it break the document', () => {
+    // `&` is legal in a Windows path and is the one character that silently
+    // turns a valid path into an invalid document. Quotes and angle brackets
+    // cannot occur in a path, but the escape is unconditional rather than
+    // resting on that.
+    const amp = 'C:\\Temp\\R&D\\launch-waiter-s.vbs';
+    const xml = buildScheduledTaskXml(WSCRIPT, amp) as string;
+    expect(xml).toContain('R&amp;D');
+    expect(xml).not.toMatch(/R&D/);
+    // Non-ASCII rides through untouched — the file is written as UTF-16 and
+    // the declaration says so, which is what makes a non-Latin %TEMP% safe.
+    const korean = 'C:\\Users\\홍길동\\AppData\\Local\\Temp\\w\\launch-waiter-s.vbs';
+    expect(buildScheduledTaskXml(WSCRIPT, korean) as string).toContain('홍길동');
+    expect(buildScheduledTaskXml(WSCRIPT, VBS) as string)
+      .toContain('<?xml version="1.0" encoding="UTF-16"?>');
+    // A line break would split the text node and silently change the command.
+    expect(buildScheduledTaskXml(WSCRIPT, 'C:\\a\nb.vbs')).toBeNull();
+    expect(buildScheduledTaskXml(WSCRIPT, 'C:\\a\rb.vbs')).toBeNull();
+    expect(buildScheduledTaskXml('', VBS)).toBeNull();
+  });
+
+  it('emits Settings in the order the importer round-trips', () => {
+    // The task XSD validates a SEQUENCE; a definition in the wrong order is
+    // refused, which fails closed to transport W and silently costs the fix.
+    // This is the order `schtasks /Query /XML` itself emits.
+    const xml = buildScheduledTaskXml(WSCRIPT, VBS) as string;
+    const order = [
+      'MultipleInstancesPolicy', 'DisallowStartIfOnBatteries', 'StopIfGoingOnBatteries',
+      'AllowHardTerminate', 'StartWhenAvailable', 'RunOnlyIfNetworkAvailable',
+      'IdleSettings', 'AllowStartOnDemand', 'Enabled', 'Hidden', 'RunOnlyIfIdle',
+      'WakeToRun', 'ExecutionTimeLimit', 'Priority',
+    ].map((tag) => xml.indexOf(`<${tag}`));
+    expect(order.every((i) => i >= 0)).toBe(true);
+    expect([...order].sort((a, b) => a - b)).toEqual(order);
+    // RegistrationInfo → Principals → Settings → Actions, likewise a sequence.
+    const top = ['<RegistrationInfo>', '<Principals>', '<Settings>', '<Actions']
+      .map((tag) => xml.indexOf(tag));
+    expect([...top].sort((a, b) => a - b)).toEqual(top);
+  });
+});
+
+describe('buildScheduledTaskCreateArgs (#1264 — the job-escaping transport)', () => {
+  const XML = 'C:\\Users\\Daniel\\AppData\\Local\\Temp\\wmux-install-waiter-eOsG6n\\waiter-task.xml';
+
+  it('registers the definition from XML, overwriting a leftover name', () => {
+    const args = buildScheduledTaskCreateArgs('wmux-update-abc123', XML) as string[];
     expect(args).not.toBeNull();
-    // The task name must be addressable by the /Run and /Delete calls.
     expect(args[args.indexOf('/TN') + 1]).toBe('wmux-update-abc123');
-    const tr = args[args.indexOf('/TR') + 1];
-    // Both paths quoted (TEMP holds spaces), and the wscript switches bare.
-    expect(tr).toBe(`"${WSCRIPT}" //B //Nologo "${VBS}"`);
-    // One-shot, overwrite a leftover rather than prompt.
-    expect(args).toContain('/SC');
-    expect(args[args.indexOf('/SC') + 1]).toBe('ONCE');
+    // /XML, not /TR: the short form cannot express the battery settings.
+    expect(args[args.indexOf('/XML') + 1]).toBe(XML);
+    expect(args).not.toContain('/TR');
+    expect(args).not.toContain('/SC');
     expect(args).toContain('/F');
-    // No /RU: the task runs as the logged-on interactive user, so no password
-    // is needed and no elevation is requested.
+    // No /RU or /RP: the principal is in the XML, and no password is stored.
     expect(args).not.toContain('/RU');
     expect(args).not.toContain('/RP');
   });
@@ -792,27 +876,19 @@ describe('buildScheduledTaskCreateArgs (#1264 — the job-escaping transport)', 
     expect(buildScheduledTaskDeleteArgs('wmux-update-abc123')).toEqual(['/Delete', '/TN', 'wmux-update-abc123', '/F']);
   });
 
-  it('fails closed rather than registering a truncated or broken action', () => {
-    // Task Scheduler silently caps /TR; a truncated command line would
-    // register a task that runs the WRONG thing, which is worse than falling
-    // through to transport W.
-    const longVbs = 'C:\\Users\\' + 'x'.repeat(SCHEDULED_TASK_TR_LIMIT) + '\\launch-waiter-s.vbs';
-    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, longVbs)).toBeNull();
-    // A quote would break out of the /TR literal; a newline would break the
-    // argument entirely. Same fail-closed rule as buildWaiterVbsLauncher.
-    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, 'C:\\a"b.vbs')).toBeNull();
-    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', WSCRIPT, 'C:\\a\nb.vbs')).toBeNull();
-    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', '', VBS)).toBeNull();
-    // The name is a Task Scheduler PATH: a backslash would nest it into a
-    // folder, and anything unexpected is refused outright.
-    expect(buildScheduledTaskCreateArgs('wmux-update-a\\b', WSCRIPT, VBS)).toBeNull();
-    expect(buildScheduledTaskCreateArgs('Some Other Task', WSCRIPT, VBS)).toBeNull();
-    expect(buildScheduledTaskCreateArgs('wmux-update-', WSCRIPT, VBS)).toBeNull();
+  it('refuses a name it could not address again later', () => {
+    // The name is a Task Scheduler PATH and the handle /Run, /Delete and the
+    // startup sweep all use. A backslash would nest it into a folder the sweep
+    // does not look in.
+    expect(buildScheduledTaskCreateArgs('wmux-update-a\\b', XML)).toBeNull();
+    expect(buildScheduledTaskCreateArgs('Some Other Task', XML)).toBeNull();
+    expect(buildScheduledTaskCreateArgs('wmux-update-', XML)).toBeNull();
+    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', 'C:\\a"b.xml')).toBeNull();
+    expect(buildScheduledTaskCreateArgs('wmux-update-abc123', '')).toBeNull();
   });
 
   it('accepts the name shape spawnInstallWaiter actually generates', () => {
-    // mkdtemp basename with every non-alphanumeric stripped.
     const generated = `wmux-update-${'wmux-install-waiter-eOsG6n'.replace(/[^A-Za-z0-9]/g, '')}`;
-    expect(buildScheduledTaskCreateArgs(generated, WSCRIPT, VBS)).not.toBeNull();
+    expect(buildScheduledTaskCreateArgs(generated, XML)).not.toBeNull();
   });
 });

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -356,6 +356,72 @@ export function selectOwnTreePids(
 }
 
 /**
+ * #1264 — the Task Scheduler transport's command line.
+ *
+ * ROOT CAUSE this exists for. Every transport below (W/A/B) reaches the waiter
+ * by `child_process.spawn` from the Electron main process, and on Windows that
+ * makes the waiter a MEMBER OF WHATEVER JOB OBJECT THE APP IS IN. libuv never
+ * passes `CREATE_BREAKAWAY_FROM_JOB` (its own win/process.c comment says so),
+ * and `detached: true` only buys DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP —
+ * neither of which leaves a job. A job created with
+ * `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` terminates every member the moment its
+ * last handle closes, i.e. exactly when wmux's last process exits. The
+ * `wscript` hop does not help: it is spawned the same way, so the whole
+ * trampoline is inside the job with the PowerShell it hosts.
+ *
+ * That is precisely the reported signature: `update-install-ready.tmp` =
+ * `alive` and `launched-w.txt` = `launched` (the waiter's first two lines ran),
+ * then nothing — no marker overwrite from ANY of the script's own exit
+ * branches, and no Setup.exe. A process that is killed by the kernel cannot
+ * reach a branch.
+ *
+ * The fix is to stop being the parent. `schtasks /Create` + `schtasks /Run`
+ * makes the Task Scheduler service start the process: it is not our child, not
+ * in our job, and not in any tree a `taskkill /T` of ours can walk. No admin
+ * rights are needed for a per-user task, and no password is needed because the
+ * task is left to run as the logged-on interactive user.
+ *
+ * The command still goes through `wscript.exe` rather than straight to
+ * PowerShell: Task Scheduler starts an interactive-user task with a normal
+ * console, so a console-subsystem child would flash the very window #1136
+ * removed. wscript is GUI-subsystem and starts PowerShell hidden.
+ *
+ * `/TR` is capped by Task Scheduler at 261 characters, so a long enough TEMP
+ * path has to fail CLOSED here and fall through to transport W rather than
+ * register a truncated command.
+ */
+export const SCHEDULED_TASK_TR_LIMIT = 261;
+
+export function buildScheduledTaskCreateArgs(
+  taskName: string,
+  wscriptPath: string,
+  vbsPath: string,
+): string[] | null {
+  // The name rides an argv slot, but it is also a Task Scheduler path: `\`
+  // would nest it into a folder and a quote would break the /TR parse.
+  if (!/^wmux-update-[A-Za-z0-9]{1,32}$/.test(taskName)) return null;
+  // Both paths are QUOTED inside /TR, so whitespace is fine and only a quote
+  // or a line break could break out — same fail-closed rule as the VBS builder.
+  if (![wscriptPath, vbsPath].every((p) => p.length > 0 && !/["\r\n]/.test(p))) return null;
+  const tr = `"${wscriptPath}" //B //Nologo "${vbsPath}"`;
+  if (tr.length > SCHEDULED_TASK_TR_LIMIT) return null;
+  // /SC ONCE needs a /ST even though the task is started by /Run immediately;
+  // 23:59 is simply the furthest-out slot in the day, so a task that somehow
+  // outlives its deletion below is least likely to fire on its own. /F
+  // overwrites a same-named leftover instead of prompting.
+  return ['/Create', '/TN', taskName, '/TR', tr, '/SC', 'ONCE', '/ST', '23:59', '/F'];
+}
+
+/** `schtasks` arguments that start, and that remove, a created waiter task. */
+export function buildScheduledTaskRunArgs(taskName: string): string[] {
+  return ['/Run', '/TN', taskName];
+}
+
+export function buildScheduledTaskDeleteArgs(taskName: string): string[] {
+  return ['/Delete', '/TN', taskName, '/F'];
+}
+
+/**
  * The waiter script. Pure so its ordering guarantees are unit-testable — the
  * one property that matters is that Setup.exe is never started before both the
  * handle waits and the lock probe have passed.
@@ -466,7 +532,7 @@ export function buildWaiterScript(plan: WaiterPlan, launchStampPath?: string): s
     // #1043 newcomer-marker note above). Written BEFORE the WinForms block so
     // an Add-Type failure cannot eat it, and only AFTER the mutex so a
     // yielding newcomer (exit 5) cannot clobber the incumbent's outcome.
-    `try { Set-Content -LiteralPath $marker -Value 'install-aborted: wmux quit to install the update, but the installer step was interrupted before it could report an outcome. Try again, or run the installer from the releases page.' -Encoding utf8 } catch { }`,
+    `try { Set-Content -LiteralPath $marker -Value 'install-aborted: wmux quit to install the update and the install waiter did start, but it was stopped before it could run the installer — interrupted before it could report an outcome. Try again, or run the installer from the releases page.' -Encoding utf8 } catch { }`,
     // #1043 — best-effort "please wait" indicator for the whole silent
     // window below. Deliberately outside every correctness path: every use
     // of $form is null-checked and wrapped in its own try/catch, so a
@@ -806,6 +872,20 @@ function swallowSpawnError(child: ChildProcess): void {
   child.on('error', () => { /* the launch-stamp gate is the real verdict */ });
 }
 
+/**
+ * Remove a waiter task registration. Best-effort by construction: a task that
+ * cannot be deleted is cosmetic litter, while a throw here would land in
+ * spawnInstallWaiter's outer catch and refuse an install that is already
+ * running.
+ */
+function deleteScheduledTask(schtasksPath: string, taskName: string): void {
+  try {
+    execFileSync(schtasksPath, buildScheduledTaskDeleteArgs(taskName), {
+      timeout: 10_000, windowsHide: true, stdio: 'ignore',
+    });
+  } catch { /* litter, not a failure */ }
+}
+
 /** True once `stampPath` exists, polling every 50ms up to `budgetMs`. */
 function waitForLaunchStamp(stampPath: string, budgetMs: number): boolean {
   const deadline = Date.now() + budgetMs;
@@ -835,6 +915,13 @@ function waitForLaunchStamp(stampPath: string, budgetMs: number): boolean {
 // windows (~14s) before the refusal instead of two (~8s) — paid only on the
 // path that was already going to end in a refusal dialog, and nothing is
 // armed yet (the 20s before-quit deadline starts at app.quit()).
+// #1264 — S is the most generous: its critical path is a schtasks registration
+// round-trip plus a scheduler-service process start, on top of the same wscript
+// host + PS 5.1 cold start + AMSI scan the W budget already pays for. It is
+// also the only transport that can actually deliver the install on a machine
+// inside a kill-on-close job, so misreading a slow-but-working scheduler as
+// dead costs the whole update.
+const LAUNCH_STAMP_BUDGET_S_MS = 10_000;
 const LAUNCH_STAMP_BUDGET_W_MS = 6_000;
 const LAUNCH_STAMP_BUDGET_A_MS = 6_000;
 const LAUNCH_STAMP_BUDGET_B_MS = 2_000;
@@ -855,7 +942,13 @@ const LAUNCH_STAMP_BUDGET_B_MS = 2_000;
  * nothing on stderr, no AV detection — while the same PowerShell created by
  * a detached cmd.exe survives and runs to completion. So:
  *
- *   transport W — #1136, PREFERRED. wscript.exe (GUI subsystem, so it never
+ *   transport S — #1264, PREFERRED. A one-shot Task Scheduler entry, started
+ *       with `schtasks /Run`. The only transport whose process is NOT our
+ *       child: the scheduler service starts it, so it is outside our job
+ *       object and outside every tree our own `taskkill /T` can walk. It is
+ *       the fix for "the waiter stamped `alive` and then died the instant the
+ *       app exited" — see buildScheduledTaskCreateArgs.
+ *   transport W — #1136. wscript.exe (GUI subsystem, so it never
  *       touches the Win11 default-terminal delegation that made the cmd.exe
  *       trampoline flash a visible Windows Terminal window) running a VBS
  *       one-liner that starts the same PowerShell hidden and waits on it.
@@ -884,13 +977,16 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
   if (process.platform !== 'win32') return null;
   try {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-install-waiter-'));
+    const stampS = path.join(dir, 'launched-s.txt');
     const stampW = path.join(dir, 'launched-w.txt');
     const stampA = path.join(dir, 'launched-a.txt');
     const stampB = path.join(dir, 'launched-b.txt');
+    const scriptS = buildWaiterScript(plan, stampS);
     const scriptW = buildWaiterScript(plan, stampW);
     const scriptA = buildWaiterScript(plan, stampA);
     const scriptB = buildWaiterScript(plan, stampB);
-    if (!scriptW || !scriptA || !scriptB) return null;
+    if (!scriptS || !scriptW || !scriptA || !scriptB) return null;
+    const scriptPathS = path.join(dir, 'wait-and-install-s.ps1');
     const scriptPathW = path.join(dir, 'wait-and-install-w.ps1');
     const scriptPathA = path.join(dir, 'wait-and-install.ps1');
     const scriptPathB = path.join(dir, 'wait-and-install-b.ps1');
@@ -900,6 +996,7 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
     // Measured: with `C:\Users\홍길동\...` the BOM-less script still exits 0
     // while writing to the wrong path, which is the worst shape a failure can
     // take here (silent success). With the BOM it behaves.
+    fs.writeFileSync(scriptPathS, '\uFEFF' + scriptS, 'utf-8');
     fs.writeFileSync(scriptPathW, '\uFEFF' + scriptW, 'utf-8');
     fs.writeFileSync(scriptPathA, '\uFEFF' + scriptA, 'utf-8');
     fs.writeFileSync(scriptPathB, '\uFEFF' + scriptB, 'utf-8');
@@ -919,6 +1016,37 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
     let spawnedA = false;
     let spawnedB = false;
 
+    // #1264 — transport S, tried FIRST: the only one that structurally
+    // survives wmux's exit. Everything below is a child of this process and
+    // therefore a member of the app's job object; see
+    // buildScheduledTaskCreateArgs for the full mechanism.
+    const wscriptPath = path.join(systemRoot, 'System32', 'wscript.exe');
+    const schtasksPath = path.join(systemRoot, 'System32', 'schtasks.exe');
+    const taskName = `wmux-update-${path.basename(dir).replace(/[^A-Za-z0-9]/g, '')}`;
+    const vbsS = buildWaiterVbsLauncher(powershell, psArgs, scriptPathS);
+    const taskArgs = vbsS === null ? null : buildScheduledTaskCreateArgs(taskName, wscriptPath, path.join(dir, 'launch-waiter-s.vbs'));
+    if (vbsS !== null && taskArgs !== null) {
+      let created = false;
+      try {
+        fs.writeFileSync(path.join(dir, 'launch-waiter-s.vbs'), '\uFEFF' + vbsS, 'utf16le');
+        execFileSync(schtasksPath, taskArgs, { timeout: 10_000, windowsHide: true, stdio: 'ignore' });
+        created = true;
+        execFileSync(schtasksPath, buildScheduledTaskRunArgs(taskName), { timeout: 10_000, windowsHide: true, stdio: 'ignore' });
+      } catch { /* no Task Scheduler access — W/A/B still get their windows */ }
+      if (created && waitForLaunchStamp(stampS, LAUNCH_STAMP_BUDGET_S_MS)) {
+        // The registration has done its job the moment the scheduler has
+        // started the process: the waiter is already running as a child of
+        // the scheduler service, and deleting the task definition does not
+        // stop a started instance. Delete now rather than at the next boot so
+        // nothing of ours is left registered on a machine that is about to be
+        // replaced by the new install.
+        deleteScheduledTask(schtasksPath, taskName);
+        console.log(`[installTeardown] waiter verified via scheduled task (${taskName}): ${scriptPathS}`);
+        return scriptPathS;
+      }
+      if (created) deleteScheduledTask(schtasksPath, taskName);
+    }
+
     // #1136 — transport W, tried first because it is the only one that stays
     // invisible under the Win11 default-terminal delegation.
     const vbs = buildWaiterVbsLauncher(powershell, psArgs, scriptPathW);
@@ -933,7 +1061,7 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
       try {
         fs.writeFileSync(vbsPath, '\uFEFF' + vbs, 'utf16le');
         const w = spawn(
-          path.join(systemRoot, 'System32', 'wscript.exe'),
+          wscriptPath,
           // //B: batch mode. Without it a machine with Windows Script Host
           // disabled by policy shows an error DIALOG — the exact class of
           // visible window this transport exists to remove. With it, wscript

--- a/src/main/updater/installTeardown.ts
+++ b/src/main/updater/installTeardown.ts
@@ -386,30 +386,138 @@ export function selectOwnTreePids(
  * console, so a console-subsystem child would flash the very window #1136
  * removed. wscript is GUI-subsystem and starts PowerShell hidden.
  *
- * `/TR` is capped by Task Scheduler at 261 characters, so a long enough TEMP
- * path has to fail CLOSED here and fall through to transport W rather than
- * register a truncated command.
+ * The definition is registered from XML rather than the `/TR` short form, and
+ * that is load-bearing rather than tidy — see buildScheduledTaskXml for the
+ * power settings `/TR` cannot express and for why the task carries no trigger.
  */
-export const SCHEDULED_TASK_TR_LIMIT = 261;
+export const WAITER_TASK_NAME_RE = /^wmux-update-[A-Za-z0-9]{1,32}$/;
 
-export function buildScheduledTaskCreateArgs(
-  taskName: string,
+/** XML text escape. Everything that can occur in a Windows path plus the
+ *  attribute-safe quotes, so the same helper is safe in both positions. */
+function xmlEscape(v: string): string {
+  return v
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * The task definition, as XML.
+ *
+ * #1283 review, CRITICAL — the `/TR` short form was WRONG here, and wrong in a
+ * way that reproduces the very bug this transport fixes. A task registered
+ * through `/TR` inherits the scheduler's power defaults:
+ * `DisallowStartIfOnBatteries=true` and `StopIfGoingOnBatteries=true`. On a
+ * laptop running on battery `/Run` then starts NOTHING (we fall through to
+ * transport W, the one that cannot survive the job), and unplugging mid-wait
+ * makes the scheduler TERMINATE the waiter — a silent kill wearing the
+ * pessimistic marker, i.e. #1264 again. `/TR` cannot express those settings;
+ * only `/XML` (or COM) can. So the settings below are not decoration, they are
+ * the correctness of the transport:
+ *
+ *   DisallowStartIfOnBatteries=false  — start on battery,
+ *   StopIfGoingOnBatteries=false      — do not kill it when the plug is pulled,
+ *   AllowHardTerminate=false          — the scheduler may not hard-kill it,
+ *   ExecutionTimeLimit=PT0S           — no time limit (the waiter's own budgets
+ *                                       are the bound; PT72H would be a second,
+ *                                       invisible deadline),
+ *   MultipleInstancesPolicy=IgnoreNew — belt to the waiter's own root mutex,
+ *   AllowStartOnDemand=true           — /Run is the ONLY way this task starts.
+ *
+ * There is deliberately NO `<Triggers>` element. The `/TR` form needed
+ * `/SC ONCE /ST <time>`, which meant a registration that leaked (a `/Create`
+ * that timed out after the server committed, a `/Delete` that failed) would
+ * FIRE ON ITS OWN later the same day — and a late waiter opens the recorded
+ * pids by NUMBER, so after pid recycling it would `taskkill /T /F` strangers,
+ * possibly relaunch Setup.exe out of %TEMP%, and write a false "install root
+ * still locked" marker against an already-updated install. An on-demand-only
+ * task cannot fire by itself at all, which removes that failure mode rather
+ * than making it rare. The startup sweep below is the second half.
+ *
+ * The element ORDER matches what `schtasks /Query /XML` itself emits: the
+ * importer validates against a sequence, and a definition that does not
+ * round-trip is refused. A refusal here is not dangerous — it fails closed to
+ * transport W exactly like every other S bail-out — but it would silently cost
+ * the fix, so the order is pinned by a test.
+ *
+ * `runLevel` mirrors the CURRENT process. #1283 review: with a hardcoded
+ * LeastPrivilege, a wmux that was started elevated would hand the install to a
+ * medium-IL waiter whose `taskkill` against the elevated app pids fails — the
+ * waiter then reports `$stuck` and refuses with exit 3, a NEW failure mode for
+ * elevated users. `HighestAvailable` when we are elevated reproduces the token
+ * the old in-tree transports inherited.
+ */
+export function buildScheduledTaskXml(
   wscriptPath: string,
   vbsPath: string,
+  runLevel: 'LeastPrivilege' | 'HighestAvailable' = 'LeastPrivilege',
+): string | null {
+  // A line break would split the XML text node and silently change the command.
+  // Everything else — `&`, `<`, quotes, non-ASCII — is handled by escaping plus
+  // the UTF-16 encoding the file is written in, so a path is only refused when
+  // escaping genuinely cannot save it.
+  if (![wscriptPath, vbsPath].every((p) => p.length > 0 && !/[\r\n]/.test(p))) return null;
+  return [
+    '<?xml version="1.0" encoding="UTF-16"?>',
+    '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">',
+    '  <RegistrationInfo>',
+    '    <Description>wmux update install handoff (on demand only; removed once it has started)</Description>',
+    '  </RegistrationInfo>',
+    '  <Principals>',
+    '    <Principal id="Author">',
+    // InteractiveToken: run as the logged-on user with no stored password, the
+    // `/IT` equivalent. Without it schtasks picks a logon type, and a
+    // non-interactive one has no desktop for the waiter's "please wait" window.
+    '      <LogonType>InteractiveToken</LogonType>',
+    `      <RunLevel>${runLevel}</RunLevel>`,
+    '    </Principal>',
+    '  </Principals>',
+    '  <Settings>',
+    '    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>',
+    '    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>',
+    '    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>',
+    '    <AllowHardTerminate>false</AllowHardTerminate>',
+    '    <StartWhenAvailable>false</StartWhenAvailable>',
+    '    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>',
+    '    <IdleSettings>',
+    '      <StopOnIdleEnd>false</StopOnIdleEnd>',
+    '      <RestartOnIdle>false</RestartOnIdle>',
+    '    </IdleSettings>',
+    '    <AllowStartOnDemand>true</AllowStartOnDemand>',
+    '    <Enabled>true</Enabled>',
+    '    <Hidden>false</Hidden>',
+    '    <RunOnlyIfIdle>false</RunOnlyIfIdle>',
+    '    <WakeToRun>false</WakeToRun>',
+    '    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>',
+    '    <Priority>5</Priority>',
+    '  </Settings>',
+    '  <Actions Context="Author">',
+    '    <Exec>',
+    `      <Command>${xmlEscape(wscriptPath)}</Command>`,
+    // //B keeps a policy-disabled WSH silent instead of popping a dialog, same
+    // as the in-tree wscript transport.
+    `      <Arguments>//B //Nologo "${xmlEscape(vbsPath)}"</Arguments>`,
+    '    </Exec>',
+    '  </Actions>',
+    '</Task>',
+  ].join('\r\n');
+}
+
+/**
+ * `schtasks /Create` against a definition file. The name is validated here
+ * because it is also the handle `/Run`, `/Delete` and the startup sweep use.
+ */
+export function buildScheduledTaskCreateArgs(
+  taskName: string,
+  xmlPath: string,
 ): string[] | null {
-  // The name rides an argv slot, but it is also a Task Scheduler path: `\`
-  // would nest it into a folder and a quote would break the /TR parse.
-  if (!/^wmux-update-[A-Za-z0-9]{1,32}$/.test(taskName)) return null;
-  // Both paths are QUOTED inside /TR, so whitespace is fine and only a quote
-  // or a line break could break out — same fail-closed rule as the VBS builder.
-  if (![wscriptPath, vbsPath].every((p) => p.length > 0 && !/["\r\n]/.test(p))) return null;
-  const tr = `"${wscriptPath}" //B //Nologo "${vbsPath}"`;
-  if (tr.length > SCHEDULED_TASK_TR_LIMIT) return null;
-  // /SC ONCE needs a /ST even though the task is started by /Run immediately;
-  // 23:59 is simply the furthest-out slot in the day, so a task that somehow
-  // outlives its deletion below is least likely to fire on its own. /F
-  // overwrites a same-named leftover instead of prompting.
-  return ['/Create', '/TN', taskName, '/TR', tr, '/SC', 'ONCE', '/ST', '23:59', '/F'];
+  // A `\` would nest the task into a folder the sweep does not look in, and a
+  // quote would break the argv round-trip.
+  if (!WAITER_TASK_NAME_RE.test(taskName)) return null;
+  if (xmlPath.length === 0 || /["\r\n]/.test(xmlPath)) return null;
+  return ['/Create', '/TN', taskName, '/XML', xmlPath, '/F'];
 }
 
 /** `schtasks` arguments that start, and that remove, a created waiter task. */
@@ -878,12 +986,88 @@ function swallowSpawnError(child: ChildProcess): void {
  * spawnInstallWaiter's outer catch and refuse an install that is already
  * running.
  */
-function deleteScheduledTask(schtasksPath: string, taskName: string): void {
+function deleteScheduledTask(schtasksPath: string, taskName: string): boolean {
   try {
     execFileSync(schtasksPath, buildScheduledTaskDeleteArgs(taskName), {
-      timeout: 10_000, windowsHide: true, stdio: 'ignore',
+      timeout: SCHTASKS_DELETE_TIMEOUT_MS, windowsHide: true, stdio: 'ignore',
     });
-  } catch { /* litter, not a failure */ }
+    return true;
+  } catch (err) {
+    // #1283 review: a swallowed delete is how a registration leaks. It cannot
+    // be made fatal — the install is already under way by then — but it must
+    // not be invisible, because the startup sweep is what has to clean it up.
+    console.warn(`[installTeardown] could not remove waiter task ${taskName}: ${describeError(err)}`);
+    return false;
+  }
+}
+
+/**
+ * #1283 review — remove waiter tasks a previous run failed to clean up.
+ *
+ * Two leak paths exist and neither can be closed at the point it happens: a
+ * `/Create` that TIMES OUT after the server already committed (we never learn
+ * the name was registered), and a `/Delete` that fails. The definitions carry
+ * no trigger, so a leaked one can never fire on its own — but it is still
+ * litter in the user's task list with a `%TEMP%` path in it, and a leaked name
+ * would collide with `/F` on the next update. Swept at startup, where blocking
+ * costs nothing on the quit path.
+ *
+ * Best-effort throughout: this is hygiene, never a gate on the update.
+ */
+export function sweepStaleWaiterTasks(): number {
+  if (process.platform !== 'win32') return 0;
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows';
+  const schtasksPath = path.join(systemRoot, 'System32', 'schtasks.exe');
+  let removed = 0;
+  try {
+    const out = execFileSync(schtasksPath, ['/Query', '/FO', 'LIST'], {
+      encoding: 'utf-8', timeout: SCHTASKS_CALL_TIMEOUT_MS, windowsHide: true,
+    });
+    // `TaskName: \\wmux-update-xxxx` — root folder only, which is the only
+    // place this module ever registers one. Names are re-validated against the
+    // same pattern the builder enforces, so nothing else can be deleted here
+    // however the query output is shaped or localized.
+    const names = new Set<string>();
+    for (const line of out.split(/\r?\n/)) {
+      const m = /^\s*[^:]+:\s*\\(\S+)\s*$/.exec(line);
+      if (m && WAITER_TASK_NAME_RE.test(m[1])) names.add(m[1]);
+    }
+    for (const name of names) {
+      if (deleteScheduledTask(schtasksPath, name)) removed += 1;
+    }
+    if (removed > 0) console.log(`[installTeardown] swept ${removed} leftover waiter task(s)`);
+  } catch { /* no scheduler access — nothing to sweep, nothing to report */ }
+  return removed;
+}
+
+/** Message + errno for a caught exec failure, for the field log. */
+function describeError(err: unknown): string {
+  const e = err as { code?: unknown; status?: unknown; message?: unknown };
+  const bits = [
+    e?.code === undefined ? null : `code=${String(e.code)}`,
+    e?.status === undefined ? null : `status=${String(e.status)}`,
+    e?.message === undefined ? null : String(e.message),
+  ].filter((b): b is string => b !== null);
+  return bits.length > 0 ? bits.join(' ') : 'unknown error';
+}
+
+/**
+ * #1283 review — are we elevated? Mirrored onto the task's RunLevel so an
+ * elevated wmux does not hand the install to a medium-IL waiter whose
+ * `taskkill` against the app's own (elevated) pids would fail and turn into a
+ * spurious exit-3 refusal. `fltMC.exe` with no arguments is the cheap standard
+ * probe: it needs administrator rights and exits non-zero without them.
+ * Anything unexpected answers "not elevated", which is the pre-#1264 behaviour.
+ */
+function isProcessElevated(systemRoot: string): boolean {
+  try {
+    execFileSync(path.join(systemRoot, 'System32', 'fltMC.exe'), [], {
+      timeout: SCHTASKS_CALL_TIMEOUT_MS, windowsHide: true, stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** True once `stampPath` exists, polling every 50ms up to `budgetMs`. */
@@ -915,13 +1099,23 @@ function waitForLaunchStamp(stampPath: string, budgetMs: number): boolean {
 // windows (~14s) before the refusal instead of two (~8s) — paid only on the
 // path that was already going to end in a refusal dialog, and nothing is
 // armed yet (the 20s before-quit deadline starts at app.quit()).
-// #1264 — S is the most generous: its critical path is a schtasks registration
-// round-trip plus a scheduler-service process start, on top of the same wscript
-// host + PS 5.1 cold start + AMSI scan the W budget already pays for. It is
-// also the only transport that can actually deliver the install on a machine
-// inside a kill-on-close job, so misreading a slow-but-working scheduler as
-// dead costs the whole update.
-const LAUNCH_STAMP_BUDGET_S_MS = 10_000;
+// #1264 — S gets the same window as W: its extra hop is a scheduler-service
+// process start, and the expensive part (wscript host + PS 5.1 cold start +
+// AMSI scan) is identical. #1283 review: the FIRST draft spent 10s each on the
+// create, the run, the stamp and the delete, which put up to ~40s of
+// synchronous main-process blocking in front of a user who had just clicked
+// Install, on top of W/A/B's existing ~14s. schtasks is a LOCAL RPC — it
+// answers in milliseconds or it is broken — so the calls get short timeouts and
+// only the stamp poll keeps a generous one. Worst case S now adds ~14s, the
+// same order as the fallbacks behind it, and only on a machine where the
+// scheduler accepts the task and then runs nothing.
+const SCHTASKS_CALL_TIMEOUT_MS = 3_000;
+const SCHTASKS_DELETE_TIMEOUT_MS = 2_000;
+const LAUNCH_STAMP_BUDGET_S_MS = 6_000;
+// Grace re-poll after the S gate expires. A scheduler instance that starts
+// just past the deadline would otherwise be abandoned in favour of a transport
+// that cannot survive, and the two would then race the root mutex.
+const LAUNCH_STAMP_GRACE_S_MS = 1_000;
 const LAUNCH_STAMP_BUDGET_W_MS = 6_000;
 const LAUNCH_STAMP_BUDGET_A_MS = 6_000;
 const LAUNCH_STAMP_BUDGET_B_MS = 2_000;
@@ -1018,33 +1212,87 @@ export function spawnInstallWaiter(plan: WaiterPlan): string | null {
 
     // #1264 — transport S, tried FIRST: the only one that structurally
     // survives wmux's exit. Everything below is a child of this process and
-    // therefore a member of the app's job object; see
-    // buildScheduledTaskCreateArgs for the full mechanism.
+    // therefore a member of the app's job object; see buildScheduledTaskXml
+    // for the full mechanism and for the settings that keep it alive on a
+    // laptop running on battery.
     const wscriptPath = path.join(systemRoot, 'System32', 'wscript.exe');
     const schtasksPath = path.join(systemRoot, 'System32', 'schtasks.exe');
     const taskName = `wmux-update-${path.basename(dir).replace(/[^A-Za-z0-9]/g, '')}`;
+    const vbsPathS = path.join(dir, 'launch-waiter-s.vbs');
+    const xmlPathS = path.join(dir, 'waiter-task.xml');
     const vbsS = buildWaiterVbsLauncher(powershell, psArgs, scriptPathS);
-    const taskArgs = vbsS === null ? null : buildScheduledTaskCreateArgs(taskName, wscriptPath, path.join(dir, 'launch-waiter-s.vbs'));
-    if (vbsS !== null && taskArgs !== null) {
+    // #1283 review: log EVERY bail-out with its cause. The field follow-up for
+    // #1264 is "does the log say `verified via scheduled task`?", and until now
+    // its absence could mean any of four different things.
+    const skipS = (why: string): void => {
+      console.warn(`[installTeardown] scheduled-task transport unavailable (${why}) — falling through to the in-tree transports (#1264)`);
+    };
+    const runLevel = isProcessElevated(systemRoot) ? 'HighestAvailable' : 'LeastPrivilege';
+    const xmlS = vbsS === null ? null : buildScheduledTaskXml(wscriptPath, vbsPathS, runLevel);
+    const taskArgs = xmlS === null ? null : buildScheduledTaskCreateArgs(taskName, xmlPathS);
+    if (vbsS === null || xmlS === null || taskArgs === null) {
+      skipS('the task definition could not be built for these paths');
+    } else {
       let created = false;
+      let ran = false;
       try {
-        fs.writeFileSync(path.join(dir, 'launch-waiter-s.vbs'), '\uFEFF' + vbsS, 'utf16le');
-        execFileSync(schtasksPath, taskArgs, { timeout: 10_000, windowsHide: true, stdio: 'ignore' });
-        created = true;
-        execFileSync(schtasksPath, buildScheduledTaskRunArgs(taskName), { timeout: 10_000, windowsHide: true, stdio: 'ignore' });
-      } catch { /* no Task Scheduler access — W/A/B still get their windows */ }
-      if (created && waitForLaunchStamp(stampS, LAUNCH_STAMP_BUDGET_S_MS)) {
-        // The registration has done its job the moment the scheduler has
-        // started the process: the waiter is already running as a child of
-        // the scheduler service, and deleting the task definition does not
-        // stop a started instance. Delete now rather than at the next boot so
-        // nothing of ours is left registered on a machine that is about to be
-        // replaced by the new install.
-        deleteScheduledTask(schtasksPath, taskName);
-        console.log(`[installTeardown] waiter verified via scheduled task (${taskName}): ${scriptPathS}`);
-        return scriptPathS;
+        fs.writeFileSync(vbsPathS, '\uFEFF' + vbsS, 'utf16le');
+        // schtasks /XML wants a Unicode file, and the declared encoding has to
+        // match what is on disk or a non-ASCII path (the %TEMP% under a
+        // non-Latin username that #1056 already paid for once) is misdecoded.
+        fs.writeFileSync(xmlPathS, '\uFEFF' + xmlS, 'utf16le');
+        try {
+          execFileSync(schtasksPath, taskArgs, {
+            timeout: SCHTASKS_CALL_TIMEOUT_MS, windowsHide: true, stdio: 'ignore',
+          });
+          created = true;
+        } catch (err) {
+          // A TIMEOUT is the dangerous shape: the server may have committed
+          // before we gave up, so the name can exist even though we "failed".
+          // Try to remove it here as well as at the next startup sweep.
+          skipS(`schtasks /Create failed: ${describeError(err)}`);
+          deleteScheduledTask(schtasksPath, taskName);
+        }
+        if (created) {
+          execFileSync(schtasksPath, buildScheduledTaskRunArgs(taskName), {
+            timeout: SCHTASKS_CALL_TIMEOUT_MS, windowsHide: true, stdio: 'ignore',
+          });
+          ran = true;
+        }
+      } catch (err) {
+        skipS(`schtasks /Run failed: ${describeError(err)}`);
       }
-      if (created) deleteScheduledTask(schtasksPath, taskName);
+      if (ran) {
+        let stamped = waitForLaunchStamp(stampS, LAUNCH_STAMP_BUDGET_S_MS);
+        if (!stamped) {
+          // The registration has to go either way — it is the leak the startup
+          // sweep exists for — but a scheduler instance that starts just past
+          // the deadline still deserves to be adopted rather than raced.
+          deleteScheduledTask(schtasksPath, taskName);
+          stamped = waitForLaunchStamp(stampS, LAUNCH_STAMP_GRACE_S_MS);
+          if (!stamped) {
+            // #1283 review (GLM): deleting the DEFINITION cannot stop an
+            // instance the scheduler has already started, so there is a narrow
+            // window where a waiter appears after we have given up on S. The
+            // waiter's root mutex makes that safe (the newcomer yields with
+            // exit 5 and writes nothing), but it is worth saying out loud in
+            // the log, because it is also the one case where a user who was
+            // told the install did not start may still get it.
+            skipS('the scheduler accepted the task but nothing had started within the budget — if an instance starts late, the root mutex keeps it from racing the fallback');
+          }
+        }
+        if (stamped) {
+          // Delete once (or confirm the delete above already happened): the
+          // running instance is not ours to keep registered, and a definition
+          // left behind points at a %TEMP% path the installer is about to
+          // invalidate.
+          deleteScheduledTask(schtasksPath, taskName);
+          console.log(`[installTeardown] waiter verified via scheduled task (${taskName}, runLevel=${runLevel}): ${scriptPathS}`);
+          return scriptPathS;
+        }
+      } else if (created) {
+        deleteScheduledTask(schtasksPath, taskName);
+      }
     }
 
     // #1136 — transport W, tried first because it is the only one that stays


### PR DESCRIPTION
## Summary

Windows in-app auto-update never completed: the install waiter started, wrote its
`alive` heartbeat and its launch stamp, and then died before reaching any of its
own exit branches, so `Setup.exe` was never launched. This adds a waiter
transport that the app's exit cannot reach.

## Root cause, with evidence

The reporter's artifact set is decisive: `update-install-ready.tmp` = `alive` and
`launched-w.txt` = `launched` (the waiter's first two statements ran), and then
the abort marker still holds the *pessimistic* text that every one of the
script's exit branches overwrites. A process killed by the kernel cannot reach a
branch.

In `src/main/updater/installTeardown.ts`, all three transports (W = `wscript`
trampoline, A = `cmd.exe` trampoline, B = direct) reach the waiter through
`child_process.spawn` from the Electron main process. On Windows that makes the
waiter a **member of whatever job object the app is in**: libuv never passes
`CREATE_BREAKAWAY_FROM_JOB` (its own `win/process.c` comment says so), and
`detached: true` only buys `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` —
neither leaves a job. A job created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
terminates every member when its last handle closes, i.e. exactly when wmux's
last process exits. The `wscript` hop does not help; it is spawned the same way,
so the whole trampoline is inside the job along with the PowerShell it hosts.

The second hypothesis in the issue — the waiter's own `taskkill /T` reaching back
up its parent chain — is **not** what fired here. That call only runs after
`forceKillGraceMs` expires for a force-kill-eligible pid, and the reported run
logged `5 of our own left to app.quit()` with no stuck pid and no exit-3 marker.
It remains a real hazard on the refusal path, and the new transport happens to
remove it too (the scheduler's child is in no tree of ours).

## Fix

Add **transport S**, tried before W/A/B: an **on-demand Task Scheduler entry**,
registered with `schtasks /Create /XML` and started with `schtasks /Run`. The
Task Scheduler service starts the process, so it is not our child, not in our
job, and not in any tree our own `taskkill /T` can walk. No admin rights and no
stored password: `LogonType InteractiveToken`, run as the logged-on user.

Registration is from **XML, not `/TR`** — and that is load-bearing, not tidiness.
A `/TR`-registered task inherits `DisallowStartIfOnBatteries=true` and
`StopIfGoingOnBatteries=true`, which on a laptop means `/Run` starts nothing (we
fall through to the transport that cannot survive the job) and unplugging
mid-wait lets the scheduler terminate the waiter — #1264 again, wearing the same
pessimistic marker. The definition sets `DisallowStartIfOnBatteries=false`,
`StopIfGoingOnBatteries=false`, `AllowHardTerminate=false`,
`ExecutionTimeLimit=PT0S` (the waiter's own budgets are the only deadline) and
`MultipleInstancesPolicy=IgnoreNew`.

It carries **no `<Triggers>` element at all**. A leaked registration therefore
cannot fire by itself — which matters because a late waiter would open the
recorded pids *by number*, `taskkill /T /F` whatever inherited them, possibly
relaunch `Setup.exe` out of `%TEMP%`, and write a false "install root still
locked" marker against an already-updated install. The second half is
`sweepStaleWaiterTasks()` at startup (`schtasks /Query` + `/Delete` for names
matching `^wmux-update-`, re-validated against the same pattern the builder
enforces), plus a best-effort delete in the `/Create` failure path (a timeout can
mean the server committed anyway) and a logged, no-longer-swallowed delete
result.

`RunLevel` mirrors the current process's elevation (`fltMC` probe →
`HighestAvailable` when elevated, `LeastPrivilege` otherwise). Without it an
elevated wmux would hand the install to a medium-IL waiter whose `taskkill`
against the app's own pids fails, `$stuck` fires, and the install is refused with
exit 3 — a failure mode the in-tree transports never had, because they inherited
the app's token.

Other details kept from review:

- The action is still the hidden `wscript` launcher, so the console window #1136
  removed does not come back.
- Every S bail-out (definition unbuildable, `/Create` or `/Run` failure, stamp
  timeout) logs its cause and errno before falling through. The reporter is told
  to look for `waiter verified via scheduled task`; its absence now says *which*
  of the four fired.
- **Quit-path blocking is capped.** schtasks is a local RPC, so the calls get 3s
  (create/run) and 2s (delete); only the stamp poll keeps a generous window, and
  it was cut from 10s to 6s to match W. Worst case S adds ~14s rather than ~40s.
- If the stamp gate expires, the task is deleted and the stamp re-polled for a 1s
  grace, so a scheduler instance that starts just past the deadline is adopted
  rather than raced.
- W/A/B are untouched and still carry the install where Task Scheduler is
  unavailable. Every S failure is fail-closed to them.

The honest-reporting design is kept: every branch still writes its specific
reason. The pessimistic sentinel now states that the waiter **did start** and was
stopped before running the installer, so "killed waiter" reads differently from
"refused install".

## Test plan

**Are the battery settings provably applied?** Yes, at two levels. A unit test
asserts the generated XML carries `DisallowStartIfOnBatteries=false`,
`StopIfGoingOnBatteries=false`, `ExecutionTimeLimit=PT0S`,
`MultipleInstancesPolicy=IgnoreNew`, `AllowHardTerminate=false` and
`InteractiveToken`, and that there is no trigger; and the `windows-latest`
runtime test re-reads the task back with `schtasks /Query /XML ONE` after the
real import and asserts the scheduler **stored** those values. What is *not*
proven by either is behaviour on an actual battery transition — no CI runner has
a battery.

New/changed tests:

- `installTeardown.test.ts` — `buildScheduledTaskXml`: the power settings, the
  absence of a trigger, elevation mirrored onto `RunLevel`, XML escaping of `&`
  and pass-through of non-ASCII with a matching UTF-16 declaration, fail-closed
  on `\r`/`\n`, and the Settings/top-level element **order** (the importer
  validates a sequence; a definition that does not round-trip would fail closed
  and silently cost the fix). `buildScheduledTaskCreateArgs`: `/XML` not `/TR`,
  no `/RU`/`/RP`, and a name it could not address again later is refused.
- `installTeardown.spawn.test.ts` (new file) — launch **path**, win32 forced and
  `child_process` mocked, runs on any host: `/Create` → `/Run` → `/Delete`
  happens before any `spawn` of ours, all three address the same validated name,
  the registered definition on disk is the hidden wscript launcher with the
  battery settings, every exec is `windowsHide` and **≤3s**; fall-through to W on
  a scheduler that proves nothing or throws; a `/Create` failure still attempts a
  delete; and the startup sweep deletes only names matching our pattern (a
  `\wmux-update-nested\evil` and a `GoogleUpdateTask...` are left alone).
- `AutoUpdater.platform.test.ts` — `start()` sweeps on win32 and not elsewhere.
- `installTeardown.runtime.test.ts` — real kernel, `windows-latest` only. A stub
  parent PowerShell joins a real `KILL_ON_JOB_CLOSE` job, launches the waiter and
  exits; a lock holder **outside** the job keeps the install root busy past the
  parent's death, so the waiter can only run the stub `Setup.exe` if it outlived
  the parent.
  - **control**: launched the old way (`Start-Process wscript` from inside the
    job) — the launch stamp appears and the stub installer never runs. This is
    the mechanism proof, and it is red on the pre-fix launch path by
    construction.
  - **fix**: registered and started through the real builders — the waiter
    survives the job closing, the stored XML carries the battery settings, and
    the stub installer's file is written.
  - Per review, the stub's **exit code is returned and diagnosed** (1/2/3 =
    job-object premise, 4/5 = schtasks premise, −1 = exited 0 without arming).
    On `windows-latest` an unmet premise now **FAILS** with a message naming
    which one, unless `WMUX_SKIP_JOB_RUNTIME_TESTS=1` is set. It can no longer
    go green by not running.
- The existing #1136 transport-identity test accepts either hidden transport (S
  or W) and still refuses the visible `cmd.exe` fallback.

Gates: `tsc --noEmit` clean; eslint 0 errors on the changed files (warnings are
the suite's pre-existing non-null-assertion style); `vitest run src/main
src/daemon/__tests__` → 5443 passed / 53 skipped (the Windows-only suites skip on
macOS).

## Residual risk — what still needs the reporter

- **CI proves the mechanism, not the field.** The runtime tests now fail loudly
  if the job-object or schtasks premise is unmet on the runner, so "green" means
  they ran — but a GitHub Windows runner is still not a desktop: no battery, no
  UAC-elevated session, and its Task Scheduler behaviour for an interactive-user
  task may differ from a real user's box.
- **Not proven at all here**: that a winget/Squirrel install under
  `%LOCALAPPDATA%\wmux` on Windows 10 22H2 actually reaches transport S, and that
  a real `Setup.exe` then completes. @DanielIshi — the line to look for in
  `main-*.log` is `waiter verified via scheduled task (wmux-update-…, runLevel=…)`.
  If it instead says `scheduled-task transport unavailable (…)`, that message now
  carries the exact cause and errno, and that is the datum to paste back.
  Battery-specific confirmation (start an update while unplugged, and pull the
  plug mid-install) would be the most valuable single data point.
- Narrow window, logged not fixed: deleting the task **definition** cannot stop
  an instance the scheduler has already started, so a waiter can still appear
  just after we give up on S. The waiter's root mutex makes that safe (the
  newcomer yields with exit 5 and writes nothing), but it is the one case where a
  user told the install did not start may still get it.
- The daemon's 60 s graceful-shutdown budget producing a spurious exit 3 with
  busy panes — the reporter's separate observation — is untouched here.

Fixes #1264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7XXScnD6iemykDXdtrKN4
