### PR TITLE
fix(terminal): arm the atlas wake recovery with resume, not every alt-tab

### DIFF
--- a/changelog.d/1285.md
+++ b/changelog.d/1285.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Terminal rendering no longer risks corruption on every alt-tab on Windows. The shared WebGL glyph atlas rebuild meant for sleep→wake was firing on each window refocus (Chromium's occlusion tracker flips page visibility there), wiping and repacking the atlas mid-stream. It now runs only when the system actually resumed.

--- a/changelog.d/1285.md
+++ b/changelog.d/1285.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Terminal rendering no longer risks corruption on every alt-tab on Windows. The shared WebGL glyph atlas rebuild meant for sleep→wake was firing on each window refocus (Chromium's occlusion tracker flips page visibility there), wiping and repacking the atlas mid-stream. It now runs only when the system actually resumed.
+- Terminal rendering no longer risks corruption on every alt-tab on Windows. The shared WebGL glyph atlas rebuild meant for sleep→wake was firing on each window refocus (Chromium's occlusion tracker flips page visibility there), wiping and repacking the atlas mid-stream. It now runs only when the system actually resumed, latched one-shot so a slow unlock still recovers and an alt-tab never does.

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -816,6 +816,9 @@ export default function AppLayout() {
     return initAtlasWakeRecovery({
       onSystemResumed:
         typeof onResumed === 'function' ? onResumed : () => () => {},
+      // #1234: without a resume push, visibility is the only wake signal this
+      // build has, so it must keep recovering unconditionally.
+      hasSystemResumeSignal: typeof onResumed === 'function',
     });
   }, []);
 

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -811,22 +811,24 @@ export default function AppLayout() {
   // Rationale and trigger choice live in terminal/atlasWakeRecovery.ts.
   useEffect(() => {
     // optional-chain electronAPI — jsdom (tests) has no preload bridge; an
-    // older main without the push degrades to visibility-only recovery.
+    // older main without the push degrades to visibility-only recovery (the
+    // module tracks whether a resume is ever actually DELIVERED, so a platform
+    // where powerMonitor never fires keeps that fallback — see #1234).
     const onResumed = (window as any).electronAPI?.system?.onResumed;
     return initAtlasWakeRecovery({
       onSystemResumed:
         typeof onResumed === 'function' ? onResumed : () => () => {},
-      // #1234: without a resume push, visibility is the only wake signal this
-      // build has, so it must keep recovering unconditionally.
-      hasSystemResumeSignal: typeof onResumed === 'function',
     });
   }, []);
 
   // #882 — one renderer-wide subscription to "is anyone looking at this
   // window" (minimized / hidden to tray / screen locked), which panes fold
   // into their #766 viewer-visibility report. All platforms: the bit is right
-  // everywhere, it is only Windows where `document.visibilityState` could not
-  // supply it. See hooks/useWindowDisplayed.ts.
+  // everywhere, whereas `document.visibilityState` cannot supply it — on
+  // Windows it is occlusion-driven, so it flips on an ordinary alt-tab and says
+  // nothing about whether the window is minimized or the screen is locked
+  // (#1234 corrected the earlier claim that it never flips there at all).
+  // See hooks/useWindowDisplayed.ts.
   useEffect(() => windowDisplayedStore.init(), []);
 
 

--- a/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
+++ b/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { initAtlasWakeRecovery, RESUME_ARM_MS, WAKE_RECOVER_THROTTLE_MS } from '../atlasWakeRecovery';
+import { initAtlasWakeRecovery, WAKE_RECOVER_THROTTLE_MS } from '../atlasWakeRecovery';
 
 type Listener = () => void;
 
@@ -9,26 +9,32 @@ function makeFakeDocument(initial: DocumentVisibilityState = 'hidden') {
     visibilityState: initial,
     addEventListener: (_type: string, cb: EventListener) => { listeners.add(cb as Listener); },
     removeEventListener: (_type: string, cb: EventListener) => { listeners.delete(cb as Listener); },
+    fire(): void {
+      for (const cb of [...listeners]) cb();
+    },
     show(): void {
       this.visibilityState = 'visible';
-      for (const cb of [...listeners]) cb();
+      this.fire();
+    },
+    hide(): void {
+      this.visibilityState = 'hidden';
+      this.fire();
     },
     listenerCount: () => listeners.size,
   };
 }
 
-function setup(nowStart = 0, hasSystemResumeSignal = true) {
+function setup(nowStart = 0, initial: DocumentVisibilityState = 'hidden') {
   let now = nowStart;
   let resumeCb: Listener | null = null;
   let unsubscribed = 0;
   const recovered: string[] = [];
-  const doc = makeFakeDocument();
+  const doc = makeFakeDocument(initial);
   const teardown = initAtlasWakeRecovery({
     onSystemResumed: (cb) => {
       resumeCb = cb;
       return () => { unsubscribed++; };
     },
-    hasSystemResumeSignal,
     recoverNow: (reason) => recovered.push(reason),
     documentRef: doc,
     now: () => now,
@@ -44,57 +50,90 @@ function setup(nowStart = 0, hasSystemResumeSignal = true) {
 }
 
 describe('atlasWakeRecovery', () => {
-  it('rebuilds once when resume and visibility fire together (real wake), again after the throttle', () => {
+  it('recovers on resume, and again on the unlock that follows it (the latched backstop)', () => {
     const s = setup();
-    // A real wake: powerMonitor resume and visibilitychange land within ms.
+    // A real wake behind the lock screen: resume lands while hidden.
     s.fireResume();
+    expect(s.recovered).toEqual(['system-resumed']);
+    // Unlock. The latched rebuild is the effective one — Chromium can undo the
+    // one above before first present — so it fires even inside the throttle.
     s.doc.show();
-    expect(s.recovered).toEqual(['system-resumed']); // second trigger throttled
+    expect(s.recovered).toEqual(['system-resumed', 'visibility']);
     // Next wake, past the throttle window → recovers again.
     s.advance(WAKE_RECOVER_THROTTLE_MS);
     s.fireResume();
-    expect(s.recovered).toEqual(['system-resumed', 'system-resumed']);
+    expect(s.recovered).toEqual(['system-resumed', 'visibility', 'system-resumed']);
   });
 
-  it('visibility trigger fires when a resume armed it; teardown detaches both triggers', () => {
+  it('holds the latch however long the unlock takes, then consumes it exactly once', () => {
     const s = setup();
     s.fireResume();
-    s.advance(WAKE_RECOVER_THROTTLE_MS); // past the collapse window
-    s.doc.visibilityState = 'hidden';
+    s.advance(120_000); // a slow password entry: no time window could cover this
     s.doc.show();
     expect(s.recovered).toEqual(['system-resumed', 'visibility']);
-    s.teardown();
-    expect(s.unsubscribes()).toBe(1);
-    s.advance(WAKE_RECOVER_THROTTLE_MS);
-    s.doc.show();
-    expect(s.recovered).toEqual(['system-resumed', 'visibility']); // detached
+    // One rebuild per resume: an alt-tab storm right after the wake adds none.
+    for (let i = 0; i < 5; i++) {
+      s.advance(WAKE_RECOVER_THROTTLE_MS * 5);
+      s.doc.hide();
+      s.doc.show();
+    }
+    expect(s.recovered).toEqual(['system-resumed', 'visibility']);
   });
 
   // #1234: on Windows, native occlusion flips visibilityState on every
   // alt-tab. An unarmed visibility change must not wipe the shared atlas.
-  it('ignores visibility with no recent resume (the Windows alt-tab case)', () => {
-    const s = setup();
-    for (let i = 0; i < 5; i++) {
-      s.doc.visibilityState = 'hidden';
-      s.advance(WAKE_RECOVER_THROTTLE_MS * 5);
-      s.doc.show();
-    }
-    expect(s.recovered).toEqual([]);
-  });
-
-  it('disarms the visibility trigger once the resume window has passed', () => {
+  it('ignores unarmed visibility once a resume has been delivered (Windows alt-tab)', () => {
     const s = setup();
     s.fireResume();
-    s.advance(RESUME_ARM_MS); // resume no longer recent
-    s.doc.visibilityState = 'hidden';
+    s.doc.show(); // consumes the latch
+    const baseline = [...s.recovered];
+    for (let i = 0; i < 10; i++) {
+      s.advance(WAKE_RECOVER_THROTTLE_MS * 5);
+      s.doc.hide();
+      s.doc.show();
+    }
+    expect(s.recovered).toEqual(baseline);
+  });
+
+  it('does not arm the latch for a resume delivered while already visible', () => {
+    const s = setup(0, 'visible');
+    s.fireResume();
+    expect(s.recovered).toEqual(['system-resumed']);
+    // The visibilitychange that may follow ms later must not add a second wipe.
     s.doc.show();
     expect(s.recovered).toEqual(['system-resumed']);
   });
 
-  it('keeps unconditional visibility recovery when main has no resume push', () => {
-    const s = setup(0, false);
-    s.doc.visibilityState = 'hidden';
+  // Electron's powerMonitor 'resume' exists everywhere but is not reliably
+  // emitted on some Linux setups; gating on API presence would remove wake
+  // recovery there forever, so the gate closes on first DELIVERY.
+  it('keeps unconditional visibility recovery until a resume is ever delivered', () => {
+    const s = setup();
     s.doc.show();
     expect(s.recovered).toEqual(['visibility']);
+    s.advance(WAKE_RECOVER_THROTTLE_MS);
+    s.doc.hide();
+    s.doc.show();
+    expect(s.recovered).toEqual(['visibility', 'visibility']);
+    // First delivery proves the signal works — from here the latch is required.
+    s.advance(WAKE_RECOVER_THROTTLE_MS);
+    s.doc.hide(); // a real sleep: the resume lands on a hidden window
+    s.fireResume();
+    s.doc.show(); // consumes the latch armed by that resume
+    s.advance(WAKE_RECOVER_THROTTLE_MS);
+    s.doc.hide();
+    s.doc.show();
+    expect(s.recovered).toEqual([
+      'visibility', 'visibility', 'system-resumed', 'visibility',
+    ]);
+  });
+
+  it('teardown detaches both triggers', () => {
+    const s = setup();
+    s.teardown();
+    expect(s.unsubscribes()).toBe(1);
+    expect(s.doc.listenerCount()).toBe(0);
+    s.doc.show();
+    expect(s.recovered).toEqual([]);
   });
 });

--- a/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
+++ b/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { initAtlasWakeRecovery, WAKE_RECOVER_THROTTLE_MS } from '../atlasWakeRecovery';
+import { initAtlasWakeRecovery, RESUME_ARM_MS, WAKE_RECOVER_THROTTLE_MS } from '../atlasWakeRecovery';
 
 type Listener = () => void;
 
@@ -17,7 +17,7 @@ function makeFakeDocument(initial: DocumentVisibilityState = 'hidden') {
   };
 }
 
-function setup(nowStart = 0) {
+function setup(nowStart = 0, hasSystemResumeSignal = true) {
   let now = nowStart;
   let resumeCb: Listener | null = null;
   let unsubscribed = 0;
@@ -28,6 +28,7 @@ function setup(nowStart = 0) {
       resumeCb = cb;
       return () => { unsubscribed++; };
     },
+    hasSystemResumeSignal,
     recoverNow: (reason) => recovered.push(reason),
     documentRef: doc,
     now: () => now,
@@ -55,15 +56,45 @@ describe('atlasWakeRecovery', () => {
     expect(s.recovered).toEqual(['system-resumed', 'system-resumed']);
   });
 
-  it('visibility trigger only fires on becoming visible; teardown detaches both triggers', () => {
+  it('visibility trigger fires when a resume armed it; teardown detaches both triggers', () => {
     const s = setup();
+    s.fireResume();
+    s.advance(WAKE_RECOVER_THROTTLE_MS); // past the collapse window
     s.doc.visibilityState = 'hidden';
     s.doc.show();
-    expect(s.recovered).toEqual(['visibility']);
+    expect(s.recovered).toEqual(['system-resumed', 'visibility']);
     s.teardown();
     expect(s.unsubscribes()).toBe(1);
     s.advance(WAKE_RECOVER_THROTTLE_MS);
     s.doc.show();
-    expect(s.recovered).toEqual(['visibility']); // detached — no further recovery
+    expect(s.recovered).toEqual(['system-resumed', 'visibility']); // detached
+  });
+
+  // #1234: on Windows, native occlusion flips visibilityState on every
+  // alt-tab. An unarmed visibility change must not wipe the shared atlas.
+  it('ignores visibility with no recent resume (the Windows alt-tab case)', () => {
+    const s = setup();
+    for (let i = 0; i < 5; i++) {
+      s.doc.visibilityState = 'hidden';
+      s.advance(WAKE_RECOVER_THROTTLE_MS * 5);
+      s.doc.show();
+    }
+    expect(s.recovered).toEqual([]);
+  });
+
+  it('disarms the visibility trigger once the resume window has passed', () => {
+    const s = setup();
+    s.fireResume();
+    s.advance(RESUME_ARM_MS); // resume no longer recent
+    s.doc.visibilityState = 'hidden';
+    s.doc.show();
+    expect(s.recovered).toEqual(['system-resumed']);
+  });
+
+  it('keeps unconditional visibility recovery when main has no resume push', () => {
+    const s = setup(0, false);
+    s.doc.visibilityState = 'hidden';
+    s.doc.show();
+    expect(s.recovered).toEqual(['visibility']);
   });
 });

--- a/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
+++ b/src/renderer/terminal/__tests__/atlasWakeRecovery.test.ts
@@ -24,7 +24,11 @@ function makeFakeDocument(initial: DocumentVisibilityState = 'hidden') {
   };
 }
 
-function setup(nowStart = 0, initial: DocumentVisibilityState = 'hidden') {
+function setup(
+  nowStart = 0,
+  initial: DocumentVisibilityState = 'hidden',
+  platform = 'win32',
+) {
   let now = nowStart;
   let resumeCb: Listener | null = null;
   let unsubscribed = 0;
@@ -36,6 +40,7 @@ function setup(nowStart = 0, initial: DocumentVisibilityState = 'hidden') {
       return () => { unsubscribed++; };
     },
     recoverNow: (reason) => recovered.push(reason),
+    platform,
     documentRef: doc,
     now: () => now,
   });
@@ -104,11 +109,37 @@ describe('atlasWakeRecovery', () => {
     expect(s.recovered).toEqual(['system-resumed']);
   });
 
+  // #1234's reporter logged 15 minutes of ordinary alt-tabbing with no reason
+  // to think the machine had ever slept in that session. On the platform where
+  // the fix is required, that must be zero atlas wipes -- a fix that waits for
+  // a suspend to take effect is not a fix.
+  it('recovers nothing across repeated visibility transitions with no resume ever delivered (win32)', () => {
+    const s = setup(0, 'hidden', 'win32');
+    for (let i = 0; i < 20; i++) {
+      s.advance(30_000);
+      s.doc.hide();
+      s.advance(5_000);
+      s.doc.show();
+    }
+    expect(s.recovered).toEqual([]);
+  });
+
+  it('requires the latch immediately on darwin too', () => {
+    const s = setup(0, 'hidden', 'darwin');
+    s.doc.show();
+    expect(s.recovered).toEqual([]);
+    // A real wake still recovers, latched.
+    s.doc.hide();
+    s.fireResume();
+    s.doc.show();
+    expect(s.recovered).toEqual(['system-resumed', 'visibility']);
+  });
+
   // Electron's powerMonitor 'resume' exists everywhere but is not reliably
   // emitted on some Linux setups; gating on API presence would remove wake
-  // recovery there forever, so the gate closes on first DELIVERY.
-  it('keeps unconditional visibility recovery until a resume is ever delivered', () => {
-    const s = setup();
+  // recovery there forever, so on linux the gate closes on first DELIVERY.
+  it('keeps unconditional visibility recovery on linux until a resume is ever delivered', () => {
+    const s = setup(0, 'hidden', 'linux');
     s.doc.show();
     expect(s.recovered).toEqual(['visibility']);
     s.advance(WAKE_RECOVER_THROTTLE_MS);
@@ -126,6 +157,26 @@ describe('atlasWakeRecovery', () => {
     expect(s.recovered).toEqual([
       'visibility', 'visibility', 'system-resumed', 'visibility',
     ]);
+  });
+
+  it('treats an unknown platform like linux — recovery kept, not dropped', () => {
+    const s = setup(0, 'hidden', 'freebsd');
+    s.doc.show();
+    expect(s.recovered).toEqual(['visibility']);
+  });
+
+  it('treats an absent platform (no preload bridge) the same way', () => {
+    const recovered: string[] = [];
+    const doc = makeFakeDocument();
+    initAtlasWakeRecovery({
+      onSystemResumed: () => () => { /* never delivers */ },
+      platform: undefined,
+      recoverNow: (reason) => recovered.push(reason),
+      documentRef: doc,
+      now: () => 0,
+    });
+    doc.show();
+    expect(recovered).toEqual(['visibility']);
   });
 
   it('teardown detaches both triggers', () => {

--- a/src/renderer/terminal/atlasGuard.ts
+++ b/src/renderer/terminal/atlasGuard.ts
@@ -600,9 +600,24 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
     recoverNow(reason: string): void {
       const groups = groupByAtlas();
       if (groups.size === 0) return;
-      console.warn(`[wmux:atlas-guard] recover (${reason}) — atlases=${groups.size}`);
       for (const [atlas, group] of groups) {
-        rebuildGroup(atlas, group);
+        // #1234: `atlases=N` alone could not tell a wipe that did nothing from
+        // a wipe that repacked a full pool. Sample the pool BEFORE the rebuild
+        // (afterwards every page reads idle by construction) so the next field
+        // log is decisive about whether the guard is the repair or the trigger.
+        const pages = atlas.pages;
+        const len = pages && typeof pages.length === 'number' ? pages.length : 0;
+        let used = 0;
+        if (pages) for (let i = 0; i < len; i++) if (pageInUse(pages[i])) used++;
+        const outcome = rebuildGroup(atlas, group);
+        const gen =
+          typeof atlas.clearModelGeneration === 'number'
+            ? `, gen=${atlas.clearModelGeneration}`
+            : '';
+        console.warn(
+          `[wmux:atlas-guard] recover (${reason}) — atlases=${groups.size},` +
+            ` panes=${group.length}, pages=${used}/${len} used, clear=${outcome}${gen}`,
+        );
         // Re-baseline from the post-rebuild pool for the same reason the poll
         // does: a stale snapshot would read the rebuild as a "merge" and fire a
         // redundant one next tick, while dropping it would blind the next poll.

--- a/src/renderer/terminal/atlasGuard.ts
+++ b/src/renderer/terminal/atlasGuard.ts
@@ -600,6 +600,9 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
     recoverNow(reason: string): void {
       const groups = groupByAtlas();
       if (groups.size === 0) return;
+      // Entry line BEFORE the loop: a rebuild that throws still leaves an
+      // attributable record of what was attempted and why.
+      console.warn(`[wmux:atlas-guard] recover (${reason}) — atlases=${groups.size}`);
       for (const [atlas, group] of groups) {
         // #1234: `atlases=N` alone could not tell a wipe that did nothing from
         // a wipe that repacked a full pool. Sample the pool BEFORE the rebuild
@@ -609,14 +612,22 @@ export function createAtlasGuard(options: AtlasGuardOptions = {}): AtlasGuard {
         const len = pages && typeof pages.length === 'number' ? pages.length : 0;
         let used = 0;
         if (pages) for (let i = 0; i < len; i++) if (pageInUse(pages[i])) used++;
+        const genBefore =
+          typeof atlas.clearModelGeneration === 'number' ? atlas.clearModelGeneration : null;
         const outcome = rebuildGroup(atlas, group);
+        // gen is sampled on both sides of the rebuild so the line never mixes a
+        // pre-wipe reading (pages) with a post-wipe one.
         const gen =
-          typeof atlas.clearModelGeneration === 'number'
-            ? `, gen=${atlas.clearModelGeneration}`
-            : '';
+          genBefore === null
+            ? ''
+            : `, gen=${genBefore}->${
+                typeof atlas.clearModelGeneration === 'number'
+                  ? atlas.clearModelGeneration
+                  : '?'
+              }`;
         console.warn(
-          `[wmux:atlas-guard] recover (${reason}) — atlases=${groups.size},` +
-            ` panes=${group.length}, pages=${used}/${len} used, clear=${outcome}${gen}`,
+          `[wmux:atlas-guard] recover (${reason}) rebuilt —` +
+            ` panes=${group.length}, pages(pre)=${used}/${len} used, clear=${outcome}${gen}`,
         );
         // Re-baseline from the post-rebuild pool for the same reason the poll
         // does: a stale snapshot would read the rebuild as a "merge" and fire a

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -33,14 +33,32 @@
 // The two triggers routinely fire together on a real wake; the throttle
 // collapses them into one rebuild.
 //
-// ON WINDOWS THE VISIBILITY TRIGGER NEVER FIRES. Measured on Electron 41:
-// `document.visibilityState` stays 'visible' while the window is fully covered
-// by another application, and also while the window is MINIMIZED, with and
-// without Chromium's `CalculateNativeWinOcclusion` feature —
-// `visibilitychange` fires exactly once per window, at teardown. So on Windows
-// `system-resumed` is the only live trigger here. Do not assume the visibility
-// backstop above covers that platform; anything that needs to know whether the
-// window can be seen has to ask main instead (see main/window/windowDisplayed.ts,
+// THE VISIBILITY TRIGGER IS ARMED BY RESUME, NOT FIRED ON ITS OWN (#1234).
+//
+// A previous measurement on Electron 41 concluded that Windows never fires
+// `visibilitychange` while the window is covered or minimized, and the trigger
+// above was written on that assumption — a harmless macOS-only backstop. The
+// #1234 field log falsifies it: on Windows 10.0.19045 the renderer logged
+// `recover (visibility)` 18 times in 15 minutes of ordinary alt-tabbing, 12 of
+// them 13-26 ms after a `[wmux:glyph-repaint] focus`. Chromium's native window
+// occlusion does flip `visibilityState` on that build, so on Windows the
+// visibility trigger IS the window-focus trigger — the one trigger this module
+// deliberately refuses to have, because wiping the shared atlas while output is
+// flowing re-arms xterm's page-merge race (11 of those 18 wipes landed within
+// 1 s of a live output burst).
+//
+// So visibility alone no longer recovers. Its stated job is narrow: cover the
+// unlock-screen gap where main's `resume` lands while the window is still
+// hidden. That job needs a resume to exist. The trigger now fires only when a
+// `system-resumed` push arrived within `RESUME_ARM_MS` — i.e. the machine
+// really did sleep and texture memory really is suspect. Without a resume
+// nothing invalidated the GPU's texture memory, so there is nothing to rebuild
+// and a wipe is pure risk. A build whose main has no resume push at all
+// (`hasSystemResumeSignal: false`) keeps the old unconditional behaviour,
+// because for it visibility is the only wake signal there is.
+//
+// Anything that needs to know whether the window can be seen must still ask
+// main instead of reading `visibilityState` (see main/window/windowDisplayed.ts,
 // which is how the #766 viewer-visibility report gets its answer since #882).
 
 import { atlasGuard } from './atlasGuard';
@@ -49,9 +67,20 @@ import { atlasGuard } from './atlasGuard';
  *  milliseconds of each other on a real wake; one rebuild covers both. */
 export const WAKE_RECOVER_THROTTLE_MS = 1_000;
 
+/** How long a `system-resumed` push keeps the visibility trigger armed. A real
+ *  wake delivers resume and the first `visibilitychange` within milliseconds of
+ *  each other; the unlock-screen gap this backstop exists for can stretch that
+ *  to however long the user takes to type a password. Ten seconds covers the
+ *  gap without leaving the trigger armed for the next alt-tab. */
+export const RESUME_ARM_MS = 10_000;
+
 export interface AtlasWakeRecoveryDeps {
   /** Subscribe to main's system-resumed push; returns the unsubscribe. */
   onSystemResumed(callback: () => void): () => void;
+  /** False when main exposes no resume push (an older build). Visibility is
+   *  then the only wake signal available and recovers unconditionally, as it
+   *  did before #1234. Defaults to true. */
+  hasSystemResumeSignal?: boolean;
   recoverNow?: (reason: string) => void;
   documentRef?: Pick<Document, 'addEventListener' | 'removeEventListener'> & {
     visibilityState: DocumentVisibilityState;
@@ -63,12 +92,14 @@ export interface AtlasWakeRecoveryDeps {
 export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
   const {
     onSystemResumed,
+    hasSystemResumeSignal = true,
     recoverNow = (reason) => atlasGuard.recoverNow(reason),
     documentRef = document,
     now = Date.now,
   } = deps;
 
   let lastRecoverAt = -Infinity;
+  let lastResumeAt = -Infinity;
   const recover = (reason: string): void => {
     const t = now();
     if (t - lastRecoverAt < WAKE_RECOVER_THROTTLE_MS) return;
@@ -76,9 +107,21 @@ export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
     recoverNow(reason);
   };
 
-  const unsubscribeResumed = onSystemResumed(() => recover('system-resumed'));
+  const unsubscribeResumed = onSystemResumed(() => {
+    lastResumeAt = now();
+    recover('system-resumed');
+  });
   const onVisibilityChange = (): void => {
-    if (documentRef.visibilityState === 'visible') recover('visibility');
+    if (documentRef.visibilityState !== 'visible') return;
+    // #1234: on Windows this fires on every alt-tab. Only a recent resume makes
+    // the GPU's texture memory suspect; without one, skip the wipe. Logged at
+    // Verbose so the next field report can tell "the guard never ran" from "the
+    // guard ran and did not repair it".
+    if (hasSystemResumeSignal && now() - lastResumeAt >= RESUME_ARM_MS) {
+      console.debug('[wmux:atlas-wake] visibility ignored — no recent system-resumed');
+      return;
+    }
+    recover('visibility');
   };
   documentRef.addEventListener('visibilitychange', onVisibilityChange);
 

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -88,7 +88,6 @@ import { atlasGuard } from './atlasGuard';
  *  milliseconds of each other on a real wake; one rebuild covers both. */
 export const WAKE_RECOVER_THROTTLE_MS = 1_000;
 
-
 export interface AtlasWakeRecoveryDeps {
   /** Subscribe to main's system-resumed push; returns the unsubscribe. */
   onSystemResumed(callback: () => void): () => void;

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -66,15 +66,43 @@
 // on the `visibilitychange` that may follow milliseconds later — exactly what
 // the throttle was introduced to collapse.
 //
-// Until a resume has EVER been delivered, visibility keeps its old
-// unconditional behaviour. Electron's `powerMonitor` 'resume' exists as an API
-// on every platform but is not reliably emitted on some Linux session setups;
-// gating on the API's PRESENCE (rather than on a delivery we have observed)
-// would silently remove wake recovery there forever. So delivery is what flips
-// the gate: the first real resume proves the signal works on this machine, and
-// only from then on is the latch required. The cost is that such a machine
-// keeps one unjustified wipe per visibility change until its first sleep —
-// accepted, because the alternative is a platform with no wake recovery at all.
+// WHERE THE LATCH IS REQUIRED, AND WHY IT IS PLATFORM-SCOPED.
+//
+// Electron's `powerMonitor` 'resume' exists as an API everywhere but is not
+// reliably emitted on some Linux session setups, and on such a machine
+// visibility is the only wake backstop there is. So the latch is required only
+// where the resume signal is trustworthy:
+//
+//   win32 / darwin — required IMMEDIATELY. `powerMonitor` resume is dependable
+//                    on both, and on Windows we have field evidence
+//                    (#1234) that visibility fires on an ordinary alt-tab, so
+//                    an unarmed visibility change is known to be noise.
+//   linux          — keeps the pre-#1234 unconditional behaviour until a resume
+//                    has actually been DELIVERED once. That first delivery
+//                    proves the signal works on this machine and the latch is
+//                    required from then on. The cost is one unjustified wipe
+//                    per visibility change until its first sleep, accepted in
+//                    exchange for never leaving a platform with no wake
+//                    recovery at all.
+//
+// A first draft gated purely on first delivery, on every platform. Live dogfood
+// killed it: it left #1234 UNFIXED on the reporter's machine until that machine
+// happened to sleep once, and their report is 15 minutes of alt-tabbing with no
+// reason to think it ever slept. A bug fix that waits for a suspend to take
+// effect is not a fix.
+//
+// The rejected alternative was to stop trusting the event and detect the wake
+// directly — compare wall-clock elapsed against expected elapsed and treat a
+// large unexplained jump as a sleep. It is the more honest signal in principle
+// and would cover Linux too, but its discriminator is unsound in exactly the
+// state it has to work in: a hidden renderer has its timers throttled (and can
+// have them frozen outright), so an ordinary alt-tab away produces the same
+// unexplained wall-clock jump as a real suspend and would re-arm the wipe on
+// every app switch — the bug this module is fixing. The monotonic-clock variant
+// trades that for a different unknown, since whether the monotonic clock
+// advances across suspend differs by platform; if it pauses, the jump never
+// appears and wake recovery dies silently everywhere. A platform gate rests on
+// something we have actually measured.
 //
 // Anything that needs to know whether the window can be seen must still ask
 // main instead of reading `visibilityState` (see main/window/windowDisplayed.ts,
@@ -91,6 +119,11 @@ export const WAKE_RECOVER_THROTTLE_MS = 1_000;
 export interface AtlasWakeRecoveryDeps {
   /** Subscribe to main's system-resumed push; returns the unsubscribe. */
   onSystemResumed(callback: () => void): () => void;
+  /** The renderer's platform (`window.electronAPI.platform`). Decides whether
+   *  the resume latch is required immediately or only after a first delivered
+   *  resume — see the header. Unknown platforms are treated like linux, the
+   *  conservative side (recovery is kept, not dropped). */
+  platform?: string;
   recoverNow?: (reason: string) => void;
   documentRef?: Pick<Document, 'addEventListener' | 'removeEventListener'> & {
     visibilityState: DocumentVisibilityState;
@@ -102,6 +135,7 @@ export interface AtlasWakeRecoveryDeps {
 export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
   const {
     onSystemResumed,
+    platform = typeof window !== 'undefined' ? window.electronAPI?.platform : undefined,
     recoverNow = (reason) => atlasGuard.recoverNow(reason),
     documentRef = document,
     now = Date.now,
@@ -111,9 +145,12 @@ export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
   // One-shot latch: a resume delivered while the window was hidden owes us one
   // visibility recovery. Cleared the moment it is used.
   let visibilityArmed = false;
-  // Has main's resume push ever actually fired on this machine? Until it has,
-  // visibility stays unconditional (see the header — presence of the API is not
-  // evidence of delivery).
+  // Platforms whose powerMonitor resume we trust without having seen one. The
+  // latch is required from the first visibility change there; everywhere else
+  // it takes a delivered resume to prove the signal works (see the header).
+  const resumeSignalTrusted = platform === 'win32' || platform === 'darwin';
+  // Has main's resume push ever actually fired on this machine? Only consulted
+  // on the untrusted platforms.
   let resumeEverDelivered = false;
 
   const recover = (reason: string, ignoreThrottle = false): void => {
@@ -140,7 +177,7 @@ export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
       recover('visibility', true);
       return;
     }
-    if (resumeEverDelivered) {
+    if (resumeSignalTrusted || resumeEverDelivered) {
       // #1234: on Windows this fires on every alt-tab. Nothing invalidated GPU
       // texture memory, so there is nothing to rebuild and a wipe is pure risk.
       // Logged at Verbose so the next field report can tell "the guard never
@@ -148,8 +185,8 @@ export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
       console.debug('[wmux:atlas-wake] visibility ignored — unarmed (no pending system-resumed)');
       return;
     }
-    // No resume has ever been delivered on this machine; visibility is the only
-    // wake signal we can trust here. Pre-#1234 behaviour.
+    // A platform whose resume push has never been seen to fire; visibility is
+    // the only wake signal we can trust here. Pre-#1234 behaviour.
     recover('visibility');
   };
   documentRef.addEventListener('visibilitychange', onVisibilityChange);

--- a/src/renderer/terminal/atlasWakeRecovery.ts
+++ b/src/renderer/terminal/atlasWakeRecovery.ts
@@ -33,33 +33,54 @@
 // The two triggers routinely fire together on a real wake; the throttle
 // collapses them into one rebuild.
 //
-// THE VISIBILITY TRIGGER IS ARMED BY RESUME, NOT FIRED ON ITS OWN (#1234).
+// THE VISIBILITY TRIGGER IS LATCHED BY RESUME, NOT FIRED ON ITS OWN (#1234).
 //
 // A previous measurement on Electron 41 concluded that Windows never fires
 // `visibilitychange` while the window is covered or minimized, and the trigger
 // above was written on that assumption — a harmless macOS-only backstop. The
 // #1234 field log falsifies it: on Windows 10.0.19045 the renderer logged
 // `recover (visibility)` 18 times in 15 minutes of ordinary alt-tabbing, 12 of
-// them 13-26 ms after a `[wmux:glyph-repaint] focus`. Chromium's native window
-// occlusion does flip `visibilityState` on that build, so on Windows the
-// visibility trigger IS the window-focus trigger — the one trigger this module
-// deliberately refuses to have, because wiping the shared atlas while output is
-// flowing re-arms xterm's page-merge race (11 of those 18 wipes landed within
-// 1 s of a live output burst).
+// them 13-26 ms after a `[wmux:glyph-repaint] focus`. (The reason string
+// `visibility` can only be produced here, so the trigger firing is proven, not
+// inferred.) Chromium's native window occlusion does flip `visibilityState` on
+// that build, so on Windows the visibility trigger IS the window-focus trigger
+// — the one trigger this module deliberately refuses to have, because wiping
+// the shared atlas while output is flowing re-arms xterm's page-merge race (11
+// of those 18 wipes landed within 1 s of a live output burst).
 //
 // So visibility alone no longer recovers. Its stated job is narrow: cover the
 // unlock-screen gap where main's `resume` lands while the window is still
-// hidden. That job needs a resume to exist. The trigger now fires only when a
-// `system-resumed` push arrived within `RESUME_ARM_MS` — i.e. the machine
-// really did sleep and texture memory really is suspect. Without a resume
-// nothing invalidated the GPU's texture memory, so there is nothing to rebuild
-// and a wipe is pure risk. A build whose main has no resume push at all
-// (`hasSystemResumeSignal: false`) keeps the old unconditional behaviour,
-// because for it visibility is the only wake signal there is.
+// hidden, i.e. where the rebuild it triggers can be undone by Chromium before
+// first present. That is a ONE-SHOT LATCH, not a time window: a resume that
+// arrives while the window is hidden arms exactly one visibility recovery,
+// which fires on the next transition to visible and clears the latch. A time
+// window would be wrong in both directions — unlock takes as long as the user
+// takes to type a password (a 10 s window expires and the invalidated atlas
+// stays broken until the next sleep, since the poll cannot see wake
+// corruption), while any window at all leaves every alt-tab inside it firing a
+// wipe. The latch is also exempt from the throttle below, so a fast unlock is
+// not swallowed by the rebuild the resume itself just performed.
+//
+// A resume that arrives while the window is already VISIBLE does not arm the
+// latch: its own rebuild is effective, and arming would only add a second wipe
+// on the `visibilitychange` that may follow milliseconds later — exactly what
+// the throttle was introduced to collapse.
+//
+// Until a resume has EVER been delivered, visibility keeps its old
+// unconditional behaviour. Electron's `powerMonitor` 'resume' exists as an API
+// on every platform but is not reliably emitted on some Linux session setups;
+// gating on the API's PRESENCE (rather than on a delivery we have observed)
+// would silently remove wake recovery there forever. So delivery is what flips
+// the gate: the first real resume proves the signal works on this machine, and
+// only from then on is the latch required. The cost is that such a machine
+// keeps one unjustified wipe per visibility change until its first sleep —
+// accepted, because the alternative is a platform with no wake recovery at all.
 //
 // Anything that needs to know whether the window can be seen must still ask
 // main instead of reading `visibilityState` (see main/window/windowDisplayed.ts,
-// which is how the #766 viewer-visibility report gets its answer since #882).
+// which is how the #766 viewer-visibility report gets its answer since #882) —
+// that path is right on every platform, whereas `visibilityState` is only
+// occlusion-driven, as this issue's log shows.
 
 import { atlasGuard } from './atlasGuard';
 
@@ -67,20 +88,10 @@ import { atlasGuard } from './atlasGuard';
  *  milliseconds of each other on a real wake; one rebuild covers both. */
 export const WAKE_RECOVER_THROTTLE_MS = 1_000;
 
-/** How long a `system-resumed` push keeps the visibility trigger armed. A real
- *  wake delivers resume and the first `visibilitychange` within milliseconds of
- *  each other; the unlock-screen gap this backstop exists for can stretch that
- *  to however long the user takes to type a password. Ten seconds covers the
- *  gap without leaving the trigger armed for the next alt-tab. */
-export const RESUME_ARM_MS = 10_000;
 
 export interface AtlasWakeRecoveryDeps {
   /** Subscribe to main's system-resumed push; returns the unsubscribe. */
   onSystemResumed(callback: () => void): () => void;
-  /** False when main exposes no resume push (an older build). Visibility is
-   *  then the only wake signal available and recovers unconditionally, as it
-   *  did before #1234. Defaults to true. */
-  hasSystemResumeSignal?: boolean;
   recoverNow?: (reason: string) => void;
   documentRef?: Pick<Document, 'addEventListener' | 'removeEventListener'> & {
     visibilityState: DocumentVisibilityState;
@@ -92,35 +103,54 @@ export interface AtlasWakeRecoveryDeps {
 export function initAtlasWakeRecovery(deps: AtlasWakeRecoveryDeps): () => void {
   const {
     onSystemResumed,
-    hasSystemResumeSignal = true,
     recoverNow = (reason) => atlasGuard.recoverNow(reason),
     documentRef = document,
     now = Date.now,
   } = deps;
 
   let lastRecoverAt = -Infinity;
-  let lastResumeAt = -Infinity;
-  const recover = (reason: string): void => {
+  // One-shot latch: a resume delivered while the window was hidden owes us one
+  // visibility recovery. Cleared the moment it is used.
+  let visibilityArmed = false;
+  // Has main's resume push ever actually fired on this machine? Until it has,
+  // visibility stays unconditional (see the header — presence of the API is not
+  // evidence of delivery).
+  let resumeEverDelivered = false;
+
+  const recover = (reason: string, ignoreThrottle = false): void => {
     const t = now();
-    if (t - lastRecoverAt < WAKE_RECOVER_THROTTLE_MS) return;
+    if (!ignoreThrottle && t - lastRecoverAt < WAKE_RECOVER_THROTTLE_MS) return;
     lastRecoverAt = t;
     recoverNow(reason);
   };
 
   const unsubscribeResumed = onSystemResumed(() => {
-    lastResumeAt = now();
+    resumeEverDelivered = true;
+    // Only a resume that lands on a hidden window needs the visibility
+    // backstop; one that lands while visible has already been repaired here.
+    if (documentRef.visibilityState !== 'visible') visibilityArmed = true;
     recover('system-resumed');
   });
   const onVisibilityChange = (): void => {
     if (documentRef.visibilityState !== 'visible') return;
-    // #1234: on Windows this fires on every alt-tab. Only a recent resume makes
-    // the GPU's texture memory suspect; without one, skip the wipe. Logged at
-    // Verbose so the next field report can tell "the guard never ran" from "the
-    // guard ran and did not repair it".
-    if (hasSystemResumeSignal && now() - lastResumeAt >= RESUME_ARM_MS) {
-      console.debug('[wmux:atlas-wake] visibility ignored — no recent system-resumed');
+    if (visibilityArmed) {
+      // Consume the latch first: the rebuild is one-shot per resume, and an
+      // alt-tab storm right after a wake must not re-fire it. Throttle-exempt
+      // so a fast unlock is not swallowed by the resume's own rebuild.
+      visibilityArmed = false;
+      recover('visibility', true);
       return;
     }
+    if (resumeEverDelivered) {
+      // #1234: on Windows this fires on every alt-tab. Nothing invalidated GPU
+      // texture memory, so there is nothing to rebuild and a wipe is pure risk.
+      // Logged at Verbose so the next field report can tell "the guard never
+      // ran" from "the guard ran and did not repair it".
+      console.debug('[wmux:atlas-wake] visibility ignored — unarmed (no pending system-resumed)');
+      return;
+    }
+    // No resume has ever been delivered on this machine; visibility is the only
+    // wake signal we can trust here. Pre-#1234 behaviour.
     recover('visibility');
   };
   documentRef.addEventListener('visibilitychange', onVisibilityChange);


### PR DESCRIPTION
Investigation of #1234 (rendering corruption after alt-tab, Windows 10 / GTX 1660 Ti). Fixes the cause the reporter's 15-minute log points at, rather than adding another repaint trigger.

## What the log proves

633 lines, 08:44:00 – 08:59:20 (15m20s). Every event in it:

| event | count |
| --- | --- |
| `glyph-repaint burst` | 440 |
| `glyph-repaint settle-verify` | 145 |
| `glyph-repaint focus` | 30 |
| `atlas-guard recover (visibility)` | 18 |
| `glyph-repaint visible` | **0** |
| `atlas-guard prevent` / `cure` | **0** |

- 12 of the 18 recoveries follow a `glyph-repaint focus` by 13–26 ms (median 22.5 ms). That is an alt-tab: the textarea refocuses, then Chromium's occlusion tracker flips `visibilityState` a frame later.
- 11 of the 18 landed within ±1 s of a `burst`, i.e. **mid-stream**.
- Inter-recovery gaps range 3.9 s – 264 s; one recovery per ~51 s of ordinary use.

## The mechanism

`atlasWakeRecovery.ts` fires `atlasGuard.recoverNow()` — an unconditional wipe of the *shared* WebGL glyph atlas plus a render-model drop on every owner pane — on two triggers: `system-resumed` and `visibilitychange`. Its own header says window focus is deliberately **not** a trigger, because "wiping the shared atlas while output is flowing re-arms xterm's page-merge race", and it asserts that on Windows the visibility trigger never fires (measured on Electron 41: `visibilityState` stays `visible` behind another window).

That assertion is falsified by this log. On Windows 10.0.19045 with native occlusion active, `visibilitychange` *is* the window-focus event — so the reporter's machine takes the exact path the module refuses to take, 18 times in 15 minutes, 61% of them mid-stream. Each one empties a shared atlas that is then repacked from scratch under a CJK/box-drawing TUI workload, driving the page pool back toward the merge trigger that #741/#798/#902 exist to contain. `[wmux:glyph-repaint] focus` is not the problem; it is the 20 ms warning that the wipe is about to happen.

## The fix

Visibility no longer recovers on its own. Its documented job is narrow — cover the unlock-screen gap where main's `resume` lands while the window is still hidden, i.e. where the rebuild it triggers can be undone by Chromium before first present — and that is a **one-shot latch**, not a time window:

- A resume delivered while the window is **hidden** arms exactly one visibility recovery. It fires on the next transition to visible and clears the latch.
- The latched recovery is **throttle-exempt**, so a fast unlock is not swallowed by the rebuild the resume itself just performed, and it **never expires**, so a slow password entry still recovers.
- A resume delivered while already **visible** does not arm, which keeps `WAKE_RECOVER_THROTTLE_MS`'s original job of collapsing a real wake into one rebuild.
- An unarmed visibility change (every alt-tab) does nothing but log at Verbose.

### Where the latch is required

| platform | behaviour | why |
| --- | --- | --- |
| **win32, darwin** | latch required from the first visibility change | `powerMonitor` resume is dependable on both, and on Windows we now have field evidence that visibility fires on an ordinary alt-tab, so an unarmed visibility change is known to be noise |
| **linux, unknown/absent platform** | **keeps the pre-#1234 unconditional behaviour** until a resume has been delivered once; the latch is required from then on | `powerMonitor` 'resume' exists as an API everywhere but is not reliably emitted on some Linux session setups. Gating on the API's *presence* would silently leave such a machine with no wake recovery at all. The cost is one unjustified wipe per visibility change there until its first sleep — accepted deliberately |

A first draft gated purely on first delivery, on **every** platform. Live dogfood killed it: it left #1234 unfixed on the reporter's own machine until that machine happened to sleep once, and their report is 15 minutes of alt-tabbing with no reason to think it ever did. A fix that waits for a suspend to take effect is not a fix.

The rejected alternative was to stop trusting the event and detect the wake directly — compare wall-clock elapsed against expected elapsed and treat a large unexplained jump as a sleep. More honest in principle, and it would cover Linux too, but its discriminator is unsound in exactly the state it has to work in: a hidden renderer has its timers throttled, and can have them frozen outright, so an ordinary alt-tab away produces the same unexplained jump as a real suspend and would re-arm the wipe on every app switch — the bug being fixed. The monotonic-clock variant only trades that for a different unknown, since whether the monotonic clock advances across suspend differs by platform; if it pauses, the jump never appears and wake recovery dies silently everywhere. The platform gate rests on something actually measured.

Net effect on the reporter's machine: 18 mid-stream atlas wipes per 15 minutes become 0, while real sleep→wake recovery is strictly improved (a slow unlock now recovers where the pre-existing code's rebuild-while-hidden could be undone before first present).

## Instrumentation for the next report

`recover` lines carried only `atlases=1`, which cannot distinguish a wipe that did nothing from a wipe that repacked a full pool. An entry line is now emitted before the rebuild loop (so a throwing rebuild still leaves an attributable record), followed per atlas by `panes=`, pre-wipe `pages(pre)=U/N used`, `clear=` outcome and `gen=before->after` (sampled on both sides, so one line never mixes a pre-wipe reading with a post-wipe one). The suppressed visibility trigger logs at Verbose. If the reporter still sees corruption on a build with this change, the next log will show zero atlas wipes — which exonerates the guard and moves the investigation to the WebGL context/driver path.

## Live dogfood

Module-level A/B inside the real renderer, on `193bda37`:

- **Proved:** `main` recovers on every visibility transition even after a resume; this build recovers exactly once for an armed hidden→visible transition, logs `visibility ignored — unarmed` otherwise, and adds no extra wipes on repeat transitions. The new `recover (...) rebuilt — ...` line matches the intended shape. No rendering regression after app switches: canvases intact, `focus` / `burst` / `settle-verify` all still firing.
- **Also found:** the first-delivery-only gate made this build behave identically to `main` when no resume had ever been delivered (8 recover lines vs main's 4, the extra being the new `rebuilt` lines) — which is what motivated the platform gate above.
- **Could NOT prove:** macOS does not emit `visibilitychange` on app switch, so the transitions had to be simulated by dispatching the event. That is the same listener path the reporter's platform drives natively, but it is a simulation of the trigger, not of their GPU. No real OS sleep or screen lock was performed, so the armed-recovery path was exercised only through a synthetic resume.

## What is proven vs inferred

Tests: `atlasWakeRecovery.test.ts` rewritten around the latch — 10 cases. Resume-then-unlock recovers twice; the latch survives a 120 s unlock and is consumed exactly once; an unarmed alt-tab storm recovers nothing; a resume while visible does not arm; the latch is required immediately on darwin; linux and unknown/absent platforms stay unconditional until a first delivered resume; teardown detaches both triggers. Plus **the reporter's exact condition**: win32, no resume ever delivered, 20 hide/show cycles, zero recoveries. `tsc`, `eslint`, and all 414 tests under `src/renderer/terminal` pass.
