### PR TITLE
fix(toolbar): Ctrl+G owns Rich Input exactly, and stops at the pane

### DIFF
--- a/changelog.d/1286.md
+++ b/changelog.d/1286.md
@@ -9,7 +9,7 @@
   Holding the key toggles once rather than repeating, and it stays out of the
   way while an IME composition is open. In the floating pane (Ctrl+`) and the
   Deck brain terminal, where Rich Input does not apply, Ctrl+G remains a plain
-  `^G`. On macOS the binding is ⌘G, and Ctrl+G stays a plain readline byte.
+  `^G` and no longer opens a popover over whichever pane happens to be active. On macOS the binding is ⌘G, and Ctrl+G stays a plain readline byte.
 
 ### Added
 

--- a/changelog.d/1286.md
+++ b/changelog.d/1286.md
@@ -7,3 +7,10 @@
   combination that included Ctrl and the letter G. It now matches exactly, and
   when it fires the key is consumed instead of being handed to the pane too.
   On macOS the binding is ⌘G, and Ctrl+G stays a plain readline byte.
+
+### Added
+
+- **Rich Input's shortcut can be switched off.** Settings → Shortcuts now
+  lists Ctrl+G with the same toggle the other built-ins have. Turn it off and
+  Ctrl+G goes to the pane instead — the agent's external editor, readline's
+  abort — with no other binding changed.

--- a/changelog.d/1286.md
+++ b/changelog.d/1286.md
@@ -6,7 +6,10 @@
   multiview — opened Rich Input as well, because the binding accepted any
   combination that included Ctrl and the letter G. It now matches exactly, and
   when it fires the key is consumed instead of being handed to the pane too.
-  On macOS the binding is ⌘G, and Ctrl+G stays a plain readline byte.
+  Holding the key toggles once rather than repeating, and it stays out of the
+  way while an IME composition is open. In the floating pane (Ctrl+`) and the
+  Deck brain terminal, where Rich Input does not apply, Ctrl+G remains a plain
+  `^G`. On macOS the binding is ⌘G, and Ctrl+G stays a plain readline byte.
 
 ### Added
 

--- a/changelog.d/1286.md
+++ b/changelog.d/1286.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **Ctrl+G opens Rich Input and nothing else.** Since 3.52.0 it did two things
+  at once: the pane got a `^G` (or the agent CLI opened your external editor)
+  *and* the Rich Input popover appeared. Ctrl+Shift+G — which clears a
+  multiview — opened Rich Input as well, because the binding accepted any
+  combination that included Ctrl and the letter G. It now matches exactly, and
+  when it fires the key is consumed instead of being handed to the pane too.
+  On macOS the binding is ⌘G, and Ctrl+G stays a plain readline byte.

--- a/src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx
+++ b/src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx
@@ -16,6 +16,7 @@ import { createElement, act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { WMUX_KEYMAP } from '../../../../shared/keymap';
 import { useComposeShortcut } from '../useComposeShortcut';
+import { TERMINAL_PTY_ATTR, COMPOSE_OWNER_ATTR } from '../../../terminal/composeChord';
 
 const setToolbarPopover = vi.fn();
 let state: Record<string, unknown>;
@@ -37,10 +38,25 @@ function Probe() {
   return null;
 }
 
-function press(init: KeyboardEventInit): void {
+function press(init: KeyboardEventInit, from?: HTMLElement): void {
   act(() => {
-    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+    const e = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+    (from ?? document).dispatchEvent(e);
   });
+}
+
+/**
+ * A terminal container as useTerminal stamps it: every terminal carries its
+ * ptyId, only the pane-surface one carries the owner marker.
+ */
+function mountTerminal(ptyId: string, owns: boolean): HTMLElement {
+  const host = document.createElement('div');
+  host.setAttribute(TERMINAL_PTY_ATTR, ptyId);
+  if (owns) host.setAttribute(COMPOSE_OWNER_ATTR, '');
+  const textarea = document.createElement('textarea');
+  host.appendChild(textarea);
+  document.body.appendChild(host);
+  return textarea;
 }
 
 /**
@@ -85,6 +101,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => { root.unmount(); });
   container.remove();
+  document.querySelectorAll(`[${TERMINAL_PTY_ATTR}]`).forEach((el) => el.remove());
 });
 
 describe('useComposeShortcut modifier matching (#1280)', () => {
@@ -168,6 +185,42 @@ describe('useComposeShortcut modifier matching (#1280)', () => {
     state.inspectModeActive = true;
     press({ key: 'g', code: 'KeyG', ctrlKey: true });
     expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  describe('ownership — only the active leaf\'s terminal may open the popover', () => {
+    const chord: KeyboardEventInit = { key: 'g', code: 'KeyG', ctrlKey: true };
+
+    it('toggles for a keydown from the owning terminal', () => {
+      press(chord, mountTerminal('pty-1', true));
+      expect(setToolbarPopover).toHaveBeenCalledWith('rich');
+    });
+
+    it('ignores a keydown from the floating pane (no owner marker)', () => {
+      // The live b4135076 failure: Ctrl+` floating pane, Ctrl+G once, popover
+      // opened on the background active leaf while the floating pty got 0
+      // bytes. It is not the active leaf and does not own the chord.
+      press(chord, mountTerminal('daemon-floating', false));
+      expect(setToolbarPopover).not.toHaveBeenCalled();
+    });
+
+    it('ignores a keydown from the Deck brain embed (no owner marker)', () => {
+      press(chord, mountTerminal('deck-brain', false));
+      expect(setToolbarPopover).not.toHaveBeenCalled();
+    });
+
+    it('ignores an owning terminal that is not the active leaf', () => {
+      // A background pane surface: opting in does not make it the pane whose
+      // toolbar renders the popover.
+      press(chord, mountTerminal('pty-other', true));
+      expect(setToolbarPopover).not.toHaveBeenCalled();
+    });
+
+    it('still toggles for a keydown from no terminal at all', () => {
+      // Focus on <body> after a popover closed. The binding never required
+      // terminal focus, so this path is deliberately unchanged.
+      press(chord);
+      expect(setToolbarPopover).toHaveBeenCalledWith('rich');
+    });
   });
 
   describe('macOS', () => {

--- a/src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx
+++ b/src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx
@@ -23,8 +23,9 @@ let state: Record<string, unknown>;
 vi.mock('../../../stores', () => ({
   useStore: { getState: () => state },
 }));
+let focusedPtyId: string | null = 'pty-1';
 vi.mock('../../../utils/focusedSurface', () => ({
-  focusedTerminalPtyId: () => 'pty-1',
+  focusedTerminalPtyId: () => focusedPtyId,
 }));
 
 
@@ -42,22 +43,38 @@ function press(init: KeyboardEventInit): void {
   });
 }
 
-/** Split a stored combo ('Ctrl+Shift+ArrowUp') into a dispatchable event. */
-function eventForCombo(combo: string): KeyboardEventInit {
+/**
+ * Turn a stored combo ('Ctrl+Shift+ArrowUp') into the event that combo
+ * actually produces on `platform` — ⌘ substituted for Ctrl in the cmdOrCtrl
+ * family under macOS, the way useKeyboard dispatches it, with `code` filled in
+ * from the letter so the physical fallback is exercised too. The first version
+ * of this helper set neither `metaKey` nor `code` and had a dead ternary, so it
+ * only ever tested the win32 literal-Ctrl spelling (review on #1286).
+ */
+function eventForCombo(
+  combo: string,
+  platform: 'win32' | 'darwin',
+  literalCtrl: boolean,
+): KeyboardEventInit {
   const parts = combo.split('+');
   // 'Ctrl+Shift++' → the trailing '+' is the key, not a separator.
   const key = parts.pop() || '+';
+  const wantsCtrl = parts.includes('Ctrl');
+  const useMeta = wantsCtrl && platform === 'darwin' && !literalCtrl;
   return {
-    ctrlKey: parts.includes('Ctrl'),
+    key,
+    code: /^[A-Za-z]$/.test(key) ? `Key${key.toUpperCase()}` : key,
+    ctrlKey: wantsCtrl && !useMeta,
+    metaKey: useMeta,
     shiftKey: parts.includes('Shift'),
     altKey: parts.includes('Alt'),
-    key: key.length === 1 ? key : key,
   };
 }
 
 beforeEach(() => {
   setToolbarPopover.mockClear();
-  state = { workspaces: [], activeWorkspaceId: 'w1', toolbarPopover: null, disabledShortcuts: [], setToolbarPopover };
+  focusedPtyId = 'pty-1';
+  state = { workspaces: [], activeWorkspaceId: 'w1', toolbarPopover: null, disabledShortcuts: [], inspectModeActive: false, setToolbarPopover };
   (window as unknown as { electronAPI?: unknown }).electronAPI = { platform: 'win32' };
   container = document.createElement('div');
   document.body.appendChild(container);
@@ -93,6 +110,16 @@ describe('useComposeShortcut modifier matching (#1280)', () => {
     expect(setToolbarPopover).not.toHaveBeenCalled();
   });
 
+  it('does not open Rich Input when no terminal surface is focused', () => {
+    // A browser / editor / remote surface as the active leaf makes
+    // focusedTerminalPtyId null. The pane gate cannot see that, which is why
+    // only the active-leaf terminal opts into swallowing the key
+    // (ownsComposeShortcut) — elsewhere it stays a pane byte.
+    focusedPtyId = null;
+    press({ key: 'g', code: 'KeyG', ctrlKey: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
   it('matches the physical KeyG under an IME (key is "Process")', () => {
     press({ key: 'Process', code: 'KeyG', ctrlKey: true });
     expect(setToolbarPopover).toHaveBeenCalledWith('rich');
@@ -109,17 +136,38 @@ describe('useComposeShortcut modifier matching (#1280)', () => {
     expect(setToolbarPopover).not.toHaveBeenCalled();
   });
 
-  it('no shift-bearing keymap combo reaches Rich Input', () => {
-    // The converse of the Ctrl+Shift+G case, asked of every shifted binding
-    // the renderer owns — the superset bug would have fired on any of them
-    // whose letter happens to be G, and the shape of it on all of them.
+  it('no other keymap combo reaches Rich Input, on either platform', () => {
+    // The converse of the Ctrl+Shift+G case, asked of every binding the
+    // renderer owns — shift-bearing ones first (the superset bug fired on
+    // Ctrl+Shift+G and would have on any shifted G spelling), but the whole
+    // table is cheap and catches the next loose gate too.
     const shifted = WMUX_KEYMAP.filter((k) => k.combo.includes('+Shift+'));
     expect(shifted.length).toBeGreaterThan(10);
-    for (const entry of shifted) {
-      setToolbarPopover.mockClear();
-      press(eventForCombo(entry.combo));
-      expect(setToolbarPopover, `${entry.combo} must not toggle Rich Input`).not.toHaveBeenCalled();
+    for (const platform of ['win32', 'darwin'] as const) {
+      (window as unknown as { electronAPI?: unknown }).electronAPI = { platform };
+      for (const entry of WMUX_KEYMAP) {
+        if (entry.combo === 'Ctrl+G') continue;
+        setToolbarPopover.mockClear();
+        press(eventForCombo(entry.combo, platform, entry.literalCtrl === true));
+        expect(setToolbarPopover, `${entry.combo} on ${platform} must not toggle Rich Input`)
+          .not.toHaveBeenCalled();
+      }
     }
+  });
+
+  it('defers while an IME composition is open', () => {
+    // Hangul preedit: `key` is 'Process' / a jamo and the physical KeyG
+    // fallback would otherwise pop the popover mid-word. Every other
+    // ctrl-letter path defers the same way, and xterm drops the keyCode-229
+    // keydown, so the key is a no-op rather than a byte.
+    press({ key: 'Process', code: 'KeyG', ctrlKey: true, isComposing: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  it('yields while inspect mode owns the keyboard', () => {
+    state.inspectModeActive = true;
+    press({ key: 'g', code: 'KeyG', ctrlKey: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
   });
 
   describe('macOS', () => {

--- a/src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx
+++ b/src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+//
+// #1280 — "Ctrl+G always activates Rich Input". Reported on Windows 11 /
+// PowerShell 5.1 against 3.52.0: Ctrl+G wrote `^G` to the pane AND opened the
+// popover, while Ctrl+Shift+G opened the popover alone.
+//
+// Both halves were one class of defect: this chord gate tested a SUPERSET of
+// the modifier set (`(ctrlKey || metaKey) && (key === 'g' || key === 'G')`).
+// `key` is 'G' exactly when Shift is held, so Ctrl+Shift+G — which
+// WMUX_KEYMAP/useKeyboard own as clearMultiview — toggled Rich Input too.
+// These tests pin an EXACT modifier match, in both directions, plus the same
+// question asked of every other shift-bearing combo the keymap declares.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { WMUX_KEYMAP } from '../../../../shared/keymap';
+import { useComposeShortcut } from '../useComposeShortcut';
+
+const setToolbarPopover = vi.fn();
+let state: Record<string, unknown>;
+
+vi.mock('../../../stores', () => ({
+  useStore: { getState: () => state },
+}));
+vi.mock('../../../utils/focusedSurface', () => ({
+  focusedTerminalPtyId: () => 'pty-1',
+}));
+
+
+let container: HTMLDivElement;
+let root: Root;
+
+function Probe() {
+  useComposeShortcut();
+  return null;
+}
+
+function press(init: KeyboardEventInit): void {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+/** Split a stored combo ('Ctrl+Shift+ArrowUp') into a dispatchable event. */
+function eventForCombo(combo: string): KeyboardEventInit {
+  const parts = combo.split('+');
+  // 'Ctrl+Shift++' → the trailing '+' is the key, not a separator.
+  const key = parts.pop() || '+';
+  return {
+    ctrlKey: parts.includes('Ctrl'),
+    shiftKey: parts.includes('Shift'),
+    altKey: parts.includes('Alt'),
+    key: key.length === 1 ? key : key,
+  };
+}
+
+beforeEach(() => {
+  setToolbarPopover.mockClear();
+  state = { workspaces: [], activeWorkspaceId: 'w1', toolbarPopover: null, disabledShortcuts: [], setToolbarPopover };
+  (window as unknown as { electronAPI?: unknown }).electronAPI = { platform: 'win32' };
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => { root.render(createElement(Probe)); });
+});
+
+afterEach(() => {
+  act(() => { root.unmount(); });
+  container.remove();
+});
+
+describe('useComposeShortcut modifier matching (#1280)', () => {
+  it('Ctrl+G toggles Rich Input and consumes the key', () => {
+    const e = new KeyboardEvent('keydown', { key: 'g', code: 'KeyG', ctrlKey: true, bubbles: true, cancelable: true });
+    act(() => { document.dispatchEvent(e); });
+    expect(setToolbarPopover).toHaveBeenCalledWith('rich');
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it('Ctrl+Shift+G does NOT toggle Rich Input (it is clearMultiview)', () => {
+    press({ key: 'G', code: 'KeyG', ctrlKey: true, shiftKey: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+Alt+G does NOT toggle Rich Input', () => {
+    press({ key: 'g', code: 'KeyG', ctrlKey: true, altKey: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  it('a bare G does NOT toggle Rich Input', () => {
+    press({ key: 'g', code: 'KeyG' });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  it('matches the physical KeyG under an IME (key is "Process")', () => {
+    press({ key: 'Process', code: 'KeyG', ctrlKey: true });
+    expect(setToolbarPopover).toHaveBeenCalledWith('rich');
+  });
+
+  it('yields when the user disabled Ctrl+G in Settings → Shortcuts', () => {
+    state.disabledShortcuts = ['Ctrl+G'];
+    press({ key: 'g', code: 'KeyG', ctrlKey: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  it('key repeat does not flap the popover', () => {
+    press({ key: 'g', code: 'KeyG', ctrlKey: true, repeat: true });
+    expect(setToolbarPopover).not.toHaveBeenCalled();
+  });
+
+  it('no shift-bearing keymap combo reaches Rich Input', () => {
+    // The converse of the Ctrl+Shift+G case, asked of every shifted binding
+    // the renderer owns — the superset bug would have fired on any of them
+    // whose letter happens to be G, and the shape of it on all of them.
+    const shifted = WMUX_KEYMAP.filter((k) => k.combo.includes('+Shift+'));
+    expect(shifted.length).toBeGreaterThan(10);
+    for (const entry of shifted) {
+      setToolbarPopover.mockClear();
+      press(eventForCombo(entry.combo));
+      expect(setToolbarPopover, `${entry.combo} must not toggle Rich Input`).not.toHaveBeenCalled();
+    }
+  });
+
+  describe('macOS', () => {
+    beforeEach(() => {
+      (window as unknown as { electronAPI?: unknown }).electronAPI = { platform: 'darwin' };
+    });
+
+    it('⌘G toggles Rich Input', () => {
+      press({ key: 'g', code: 'KeyG', metaKey: true });
+      expect(setToolbarPopover).toHaveBeenCalledWith('rich');
+    });
+
+    it('Ctrl+G does NOT toggle Rich Input on macOS (it is a readline byte)', () => {
+      press({ key: 'g', code: 'KeyG', ctrlKey: true });
+      expect(setToolbarPopover).not.toHaveBeenCalled();
+    });
+
+    it('⌘+Shift+G does NOT toggle Rich Input on macOS', () => {
+      press({ key: 'G', code: 'KeyG', metaKey: true, shiftKey: true });
+      expect(setToolbarPopover).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/renderer/components/AgentToolbar/useComposeShortcut.ts
+++ b/src/renderer/components/AgentToolbar/useComposeShortcut.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useStore } from '../../stores';
 import { focusedTerminalPtyId } from '../../utils/focusedSurface';
 import { matchesDisabledShortcut } from '../../../shared/keymap';
-import { isComposeChord } from '../../terminal/composeChord';
+import { isComposeChord, composeOwnerHost } from '../../terminal/composeChord';
 
 /**
  * ⌘G / Ctrl+G toggles Rich Input on the focused terminal.
@@ -61,7 +61,19 @@ export function useComposeShortcut(): void {
       }
       const state = useStore.getState();
       const ws = state.workspaces.find((w) => w.id === state.activeWorkspaceId);
-      if (!focusedTerminalPtyId(ws)) return;
+      const activePtyId = focusedTerminalPtyId(ws);
+      if (!activePtyId) return;
+      // Ownership, checked on THIS gate too (#1280 live dogfood). The popover
+      // belongs to the active leaf's toolbar, so only the active leaf's
+      // terminal may open it. A keydown from another xterm — the floating pane
+      // (Ctrl+`), Deck's brain embed, a background surface — used to toggle
+      // Rich Input over the WRONG pane while its own pty got nothing; opting
+      // those surfaces out of the pane-side bubble stopped them swallowing the
+      // key, but this gate still fired. A keydown from no terminal at all
+      // (focus on <body>) is left alone: the binding never required terminal
+      // focus.
+      const origin = composeOwnerHost(e.target);
+      if (origin.ptyId !== null && (!origin.owns || origin.ptyId !== activePtyId)) return;
       e.preventDefault();
       state.setToolbarPopover(state.toolbarPopover === 'rich' ? null : 'rich');
     };

--- a/src/renderer/components/AgentToolbar/useComposeShortcut.ts
+++ b/src/renderer/components/AgentToolbar/useComposeShortcut.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useStore } from '../../stores';
 import { focusedTerminalPtyId } from '../../utils/focusedSurface';
+import { matchesDisabledShortcut } from '../../../shared/keymap';
 
 /**
  * ⌘G / Ctrl+G toggles Rich Input on the focused terminal.
@@ -13,13 +14,34 @@ import { focusedTerminalPtyId } from '../../utils/focusedSurface';
  * It only sets `toolbarPopover`; the bar renders the popover. With the bar
  * hidden the state still flips, and the bar holds itself open for it — that is
  * the keyboard route in.
+ *
+ * #1280 — the modifier set must match EXACTLY, like every other chord gate in
+ * the renderer (useTerminalCopyShortcut, useKeyboard's if-chain). The old test
+ * was `(ctrlKey || metaKey) && (key === 'g' || key === 'G')`, which accepted a
+ * SUPERSET: `key` is 'G' precisely when Shift is held, so Ctrl+Shift+G — the
+ * clearMultiview binding (useKeyboard, WMUX_KEYMAP) — also toggled Rich Input,
+ * and so did Ctrl+Alt+G. Shift/Alt now disqualify the event, and the platform
+ * decides which base modifier owns the chord: ⌘ on macOS (Ctrl+G there is a
+ * readline byte), literal Ctrl elsewhere.
  */
 export function useComposeShortcut(): void {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (!(e.ctrlKey || e.metaKey) || (e.key !== 'g' && e.key !== 'G')) return;
+      if (e.shiftKey || e.altKey) return;
+      const isMac = window.electronAPI?.platform === 'darwin';
+      const baseModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+      if (!baseModifier) return;
+      // Physical `code` as the IME fallback: under a Hangul / non-Latin layout
+      // `e.key` is a composed jamo or 'Process', never 'g' (same class as the
+      // Ctrl+C / Ctrl+J handlers in useTerminal).
+      if (e.key !== 'g' && e.key !== 'G' && e.code !== 'KeyG') return;
       // Key repeat must not flap the popover open and shut.
       if (e.repeat) return;
+      // A combo the user switched off in Settings → Shortcuts belongs to the
+      // pane; useTerminal's disabled gate writes the byte for it.
+      if (matchesDisabledShortcut(
+        useStore.getState().disabledShortcuts, e, isMac ? 'darwin' : 'win32',
+      )) return;
       // Don't hijack the chord while the user is typing in a field that this
       // toolbar owns (Rich Input's textarea, snippet inputs). The focused
       // terminal's own xterm textarea is NOT one of those — it is the primary

--- a/src/renderer/components/AgentToolbar/useComposeShortcut.ts
+++ b/src/renderer/components/AgentToolbar/useComposeShortcut.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useStore } from '../../stores';
 import { focusedTerminalPtyId } from '../../utils/focusedSurface';
 import { matchesDisabledShortcut } from '../../../shared/keymap';
+import { isComposeChord } from '../../terminal/composeChord';
 
 /**
  * ⌘G / Ctrl+G toggles Rich Input on the focused terminal.
@@ -15,32 +16,39 @@ import { matchesDisabledShortcut } from '../../../shared/keymap';
  * hidden the state still flips, and the bar holds itself open for it — that is
  * the keyboard route in.
  *
- * #1280 — the modifier set must match EXACTLY, like every other chord gate in
- * the renderer (useTerminalCopyShortcut, useKeyboard's if-chain). The old test
- * was `(ctrlKey || metaKey) && (key === 'g' || key === 'G')`, which accepted a
+ * #1280 — which keydowns ARE the chord is not decided here. The old inline
+ * test, `(ctrlKey || metaKey) && (key === 'g' || key === 'G')`, accepted a
  * SUPERSET: `key` is 'G' precisely when Shift is held, so Ctrl+Shift+G — the
- * clearMultiview binding (useKeyboard, WMUX_KEYMAP) — also toggled Rich Input,
- * and so did Ctrl+Alt+G. Shift/Alt now disqualify the event, and the platform
- * decides which base modifier owns the chord: ⌘ on macOS (Ctrl+G there is a
- * readline byte), literal Ctrl elsewhere.
+ * clearMultiview binding — also toggled Rich Input, and so did Ctrl+Alt+G.
+ * Worse, useTerminal's pane gate had its own opinion of the same key, and
+ * every condition one gate applied that the other could not see left the key
+ * silently dead. Both gates now call one pure predicate; see
+ * terminal/composeChord.ts.
+ *
+ * Note the one case this gate still loses: a user who bound a CUSTOM
+ * keybinding to Ctrl+G wins via useKeyboard's `stopImmediatePropagation`, so
+ * Rich Input never opens for them. Their explicit rebind beating the built-in
+ * is the right precedence; it is just silent.
  */
 export function useComposeShortcut(): void {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.shiftKey || e.altKey) return;
       const isMac = window.electronAPI?.platform === 'darwin';
-      const baseModifier = isMac ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
-      if (!baseModifier) return;
-      // Physical `code` as the IME fallback: under a Hangul / non-Latin layout
-      // `e.key` is a composed jamo or 'Process', never 'g' (same class as the
-      // Ctrl+C / Ctrl+J handlers in useTerminal).
-      if (e.key !== 'g' && e.key !== 'G' && e.code !== 'KeyG') return;
-      // Key repeat must not flap the popover open and shut.
+      const platform: NodeJS.Platform = isMac ? 'darwin' : 'win32';
+      if (!isComposeChord(e, platform)) return;
+      // Key repeat must not flap the popover open and shut. The pane gate
+      // swallows repeats too (the chord predicate accepts them), so this is a
+      // deliberate NON-REPEATING chord, not a gate disagreement: a held Ctrl+G
+      // toggles once and is then inert.
       if (e.repeat) return;
+      // Inspect mode owns the keyboard while it is armed — useKeyboard applies
+      // the same early-out to every global shortcut. The pane gate checks it
+      // too, so the key is not merely swallowed here.
+      if (useStore.getState().inspectModeActive) return;
       // A combo the user switched off in Settings → Shortcuts belongs to the
       // pane; useTerminal's disabled gate writes the byte for it.
       if (matchesDisabledShortcut(
-        useStore.getState().disabledShortcuts, e, isMac ? 'darwin' : 'win32',
+        useStore.getState().disabledShortcuts, e, platform,
       )) return;
       // Don't hijack the chord while the user is typing in a field that this
       // toolbar owns (Rich Input's textarea, snippet inputs). The focused

--- a/src/renderer/components/Terminal/Terminal.tsx
+++ b/src/renderer/components/Terminal/Terminal.tsx
@@ -240,7 +240,13 @@ export default function TerminalComponent({ ptyId: externalPtyId, shell, cwd, on
   // `isActive` for the stacked/tab case (one tab visible at a time).
   const shown = visible ?? isActive;
   const isVisible = isWorkspaceVisible && shown;
-  const { terminal: terminalRef, terminalInstance, findNext, findPrevious, clearSearch } = useTerminal(containerRef, { ptyId, isVisible, scrollbackFile, onFirstData: scrollbackFile ? handleFirstData : undefined, onContextMenu: handleContextMenu });
+  const { terminal: terminalRef, terminalInstance, findNext, findPrevious, clearSearch } = useTerminal(containerRef, { ptyId, isVisible, scrollbackFile, onFirstData: scrollbackFile ? handleFirstData : undefined, onContextMenu: handleContextMenu,
+    // Only the pane-surface terminal owns ⌘G / Ctrl+G: useComposeShortcut
+    // acts on the active leaf's pty, which is what this component renders.
+    // FloatingPane and Deck's BrainTerminalEmbed deliberately do NOT opt in —
+    // there the key stays a pane byte rather than dying between the two
+    // gates (#1280 review).
+    ownsComposeShortcut: true });
 
   // terminalInstance (state, #1256) — not terminalRef.current (a render-time
   // snapshot): the ref is populated after this render ran, so a snapshot read

--- a/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
@@ -1,96 +1,127 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { isComposeChord } from '../../terminal/composeChord';
+import { resolveCtrlLetterByte } from '../../terminal/ctrlLetterKeys';
 
 /**
- * #1280 — Ctrl+G must LEAVE the pane alone on Windows/Linux.
+ * #1280 — who gets the Ctrl+G keydown, the pane or Rich Input.
  *
  * xterm's own encode path ends in `cancel()`, which calls stopPropagation, so
  * before #1228 a Ctrl+G was swallowed by xterm and the document-level Rich
  * Input listener never saw it. #1228 added a catch-all `resolveCtrlLetterByte`
  * encoder that writes the byte itself with only `preventDefault()` — the event
  * then bubbles, so the pane got BEL (0x07, `^G` / the agent's external editor)
- * AND the popover opened. Fixing only the modifier match in
- * useComposeShortcut would have left the `^G`.
+ * AND the popover opened. The fix bubbles the chord from useTerminal instead
+ * of encoding it, so exactly one of the two happens.
  *
- * The fix bubbles the key, the way Ctrl+D / Ctrl+T already do, so neither
- * xterm nor the catch-all encoder writes anything — but from its OWN branch
- * testing the exact chord, not from those allowlists: their condition is only
- * `ctrlKey && !shiftKey`, so a row there would also swallow Ctrl+Alt+G and
- * Ctrl+Meta+G, which no handler claims (CodeRabbit on #1286).
+ * But only for the surface that OWNS the chord. `useComposeShortcut` acts on
+ * the workspace's active leaf, so a FloatingPane (Ctrl+`) or Deck
+ * BrainTerminalEmbed xterm would have the key swallowed here and declined
+ * there — a dead key, or a popover aimed at a different pty. Those surfaces do
+ * not opt in and keep encoding 0x07.
  *
- * jsdom cannot run xterm's custom key handler faithfully, so — like the
- * macCtrlPassthrough and ctrlLetterEncoding locks next to this file — we pin
- * the source.
+ * The chord predicate itself is unit-tested in
+ * `terminal/__tests__/composeChord.test.ts`; jsdom cannot run xterm's custom
+ * key handler, so the wiring is pinned at the source like the neighbouring
+ * `macCtrlPassthrough` / `ctrlLetterEncoding` locks — kept to the few lines
+ * that matter so reformatting elsewhere cannot break it.
  */
 
-const SRC = readFileSync(
-  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
-  'utf8',
-);
+function read(rel: string): string {
+  return readFileSync(path.resolve(process.cwd(), rel), 'utf8');
+}
 
+const SRC = read('src/renderer/hooks/useTerminal.ts');
 const handlerStart = SRC.indexOf('attachCustomKeyEventHandler');
 const handlerEnd = SRC.indexOf('// Right-click behavior', handlerStart);
 const HANDLER = SRC.slice(handlerStart, handlerEnd);
 
-function bubbleList(name: string): string {
-  const at = HANDLER.indexOf(`const ${name} = isMac`);
-  expect(at).toBeGreaterThan(-1);
-  return HANDLER.slice(at, HANDLER.indexOf(';', at));
-}
+const ctrlG = {
+  key: 'g', code: 'KeyG',
+  ctrlKey: true, metaKey: false, shiftKey: false, altKey: false,
+  isComposing: false,
+};
 
-const COMPOSE_BRANCH = /!isMac && e\.ctrlKey && !e\.shiftKey && !e\.altKey && !e\.metaKey\s*\n?\s*&& \(e\.key === 'g' \|\| e\.code === 'KeyG'\)/;
-
-describe('useTerminal bubbles Ctrl+G to the Rich Input listener (#1280)', () => {
+describe('the pane gate and the popover gate share one chord predicate (#1280)', () => {
   it('locates the custom key event handler', () => {
     expect(handlerStart).toBeGreaterThan(-1);
     expect(handlerEnd).toBeGreaterThan(handlerStart);
   });
 
-  it('bubbles the exact Ctrl+G chord — no Shift, no Alt, no Meta', () => {
-    // Alt/Meta excluded on purpose: those chords are not the binding, and a
-    // bubble would leave them writing no byte and triggering no action.
-    expect(HANDLER).toMatch(COMPOSE_BRANCH);
-  });
-
-  it('matches the physical KeyG too, for a non-Latin layout / IME', () => {
-    expect(COMPOSE_BRANCH.source).toContain("code === 'KeyG'");
-    expect(HANDLER).toMatch(COMPOSE_BRANCH);
-  });
-
-  it('is non-mac only — macOS keeps Ctrl+G as a readline byte (⌘G is the binding)', () => {
-    const at = HANDLER.search(COMPOSE_BRANCH);
-    expect(at).toBeGreaterThan(-1);
-    expect(HANDLER.slice(at, at + 20)).toContain('!isMac');
-    // And 'g' / KeyG stay out of the shared allowlists, whose mac branch would
-    // otherwise hand ⌘-less Ctrl+G to the app on macOS as well.
-    const keys = bubbleList('bubbleKeys');
-    expect(keys).not.toContain("'g'");
-    expect(bubbleList('bubbleCodes')).not.toContain("'KeyG'");
+  it('bubbles on isComposeChord, gated by ownsComposeShortcut', () => {
+    // The one line that wires both halves. Anything more specific than this
+    // is the predicate's own test's job.
+    expect(HANDLER).toMatch(/ownsComposeShortcut && isComposeChord\(e, isMac \? 'darwin' : 'win32'\)/);
+    expect(HANDLER).toMatch(/return false; \/\/ let DOM bubble to useComposeShortcut/);
   });
 
   it('bubbles before the catch-all ctrl encoder, which would write BEL', () => {
     // Order is the whole fix: the catch-all writes 0x07 and returns false.
-    expect(HANDLER.search(COMPOSE_BRANCH))
+    expect(HANDLER.indexOf('ownsComposeShortcut && isComposeChord'))
       .toBeLessThan(HANDLER.indexOf('const ctrlByte = resolveCtrlLetterByte(e)'));
+  });
+
+  it("'g' / KeyG stay out of the shared bubble allowlists", () => {
+    // Those lists test only `ctrlKey && !shiftKey`, so a row there would also
+    // swallow Ctrl+Alt+G and Ctrl+Meta+G, which nobody claims.
+    const list = (name: string) => {
+      const at = HANDLER.indexOf(`const ${name} = isMac`);
+      expect(at).toBeGreaterThan(-1);
+      return HANDLER.slice(at, HANDLER.indexOf(';', at));
+    };
+    expect(list('bubbleKeys')).not.toContain("'g'");
+    expect(list('bubbleCodes')).not.toContain("'KeyG'");
   });
 
   it('the disabled-shortcut branch writes the byte, and runs before the bubble', () => {
     // The escape hatch: Ctrl+G is an advertised keymap row, so a user can
-    // switch it off in Settings → Shortcuts and hand the key back to the pane
-    // (Claude Code's external editor, readline's abort). That needs the
-    // disabled gate to come FIRST and to write the control byte inside its own
-    // branch — returning true would let xterm encode it from the QWERTY
+    // switch it off in Settings → Shortcuts and hand the key back to the pane.
+    // That needs the disabled gate FIRST, writing the control byte inside its
+    // own branch — returning true would let xterm encode it from the QWERTY
     // keyCode instead (#1227). Matched as one contiguous block so the write
-    // cannot drift out of the branch (CodeRabbit on #1286).
-    const disabledBranch = HANDLER.match(
+    // cannot drift out of the branch.
+    const branch = HANDLER.match(
       /if \(matchesDisabledShortcut\([\s\S]{0,300}?\)\) \{[\s\S]{0,900}?\n {6}\}/,
     );
-    expect(disabledBranch).not.toBeNull();
-    expect(disabledBranch?.[0]).toMatch(
+    expect(branch).not.toBeNull();
+    expect(branch?.[0]).toMatch(
       /const disabledCtrl = resolveCtrlLetterByte\(e\);\s*if \(disabledCtrl\) \{\s*e\.preventDefault\(\);\s*window\.electronAPI\.pty\.write\(ptyId, disabledCtrl\);\s*noteUserKeystroke\(disabledCtrl\);\s*return false;/,
     );
-    expect(HANDLER.indexOf(disabledBranch?.[0] ?? ''))
-      .toBeLessThan(HANDLER.search(COMPOSE_BRANCH));
+    expect(HANDLER.indexOf(branch?.[0] ?? ''))
+      .toBeLessThan(HANDLER.indexOf('ownsComposeShortcut && isComposeChord'));
+  });
+});
+
+describe('only the active-leaf terminal owns the chord (#1280 review)', () => {
+  it('Terminal.tsx opts in', () => {
+    expect(read('src/renderer/components/Terminal/Terminal.tsx'))
+      .toMatch(/ownsComposeShortcut: true/);
+  });
+
+  it('FloatingPane and BrainTerminalEmbed do NOT opt in', () => {
+    // Ctrl+` floating pane and Deck's brain embed are never the active leaf
+    // useComposeShortcut resolves, so the popover gate would decline and the
+    // key would die if the pane gate swallowed it.
+    expect(read('src/renderer/components/Terminal/FloatingPane.tsx'))
+      .not.toContain('ownsComposeShortcut');
+    expect(read('src/renderer/components/Deck/BrainTerminalEmbed.tsx'))
+      .not.toContain('ownsComposeShortcut');
+  });
+
+  it('the option defaults to false, so a new embed is dead-key-safe', () => {
+    expect(read('src/renderer/hooks/useTerminal.ts'))
+      .toMatch(/ownsComposeShortcut = false \} = options;/);
+  });
+
+  it('a non-owning terminal still encodes Ctrl+G as BEL', () => {
+    // With the bubble branch skipped, the keydown reaches the catch-all
+    // encoder, which is the byte the floating pane / brain embed shell (or
+    // the agent CLI's external-editor binding) expects — 0x07, exactly what
+    // 3.51.0 sent there.
+    expect(resolveCtrlLetterByte(ctrlG)).toBe('\x07');
+    // And it IS the chord — the predicate is not what excuses the encode;
+    // ownership is. Both gates agree about the key either way.
+    expect(isComposeChord(ctrlG, 'win32')).toBe(true);
   });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
@@ -49,16 +49,17 @@ describe('the pane gate and the popover gate share one chord predicate (#1280)',
     expect(handlerEnd).toBeGreaterThan(handlerStart);
   });
 
-  it('bubbles on isComposeChord, gated by ownsComposeShortcut', () => {
-    // The one line that wires both halves. Anything more specific than this
-    // is the predicate's own test's job.
-    expect(HANDLER).toMatch(/ownsComposeShortcut && isComposeChord\(e, isMac \? 'darwin' : 'win32'\)/);
+  it('bubbles on isComposeChord, gated by the shared ownership marker', () => {
+    // The one line that wires both halves. Both gates read ownership from
+    // composeOwnerHost, so they cannot disagree about it any more than about
+    // the chord. Anything more specific is the predicates' own tests' job.
+    expect(HANDLER).toMatch(/composeOwnerHost\(e\.target\)\.owns && isComposeChord\(e, isMac \? 'darwin' : 'win32'\)/);
     expect(HANDLER).toMatch(/return false; \/\/ let DOM bubble to useComposeShortcut/);
   });
 
   it('bubbles before the catch-all ctrl encoder, which would write BEL', () => {
     // Order is the whole fix: the catch-all writes 0x07 and returns false.
-    expect(HANDLER.indexOf('ownsComposeShortcut && isComposeChord'))
+    expect(HANDLER.indexOf('composeOwnerHost(e.target).owns && isComposeChord'))
       .toBeLessThan(HANDLER.indexOf('const ctrlByte = resolveCtrlLetterByte(e)'));
   });
 
@@ -89,7 +90,7 @@ describe('the pane gate and the popover gate share one chord predicate (#1280)',
       /const disabledCtrl = resolveCtrlLetterByte\(e\);\s*if \(disabledCtrl\) \{\s*e\.preventDefault\(\);\s*window\.electronAPI\.pty\.write\(ptyId, disabledCtrl\);\s*noteUserKeystroke\(disabledCtrl\);\s*return false;/,
     );
     expect(HANDLER.indexOf(branch?.[0] ?? ''))
-      .toBeLessThan(HANDLER.indexOf('ownsComposeShortcut && isComposeChord'));
+      .toBeLessThan(HANDLER.indexOf('composeOwnerHost(e.target).owns && isComposeChord'));
   });
 });
 
@@ -110,8 +111,17 @@ describe('only the active-leaf terminal owns the chord (#1280 review)', () => {
   });
 
   it('the option defaults to false, so a new embed is dead-key-safe', () => {
-    expect(read('src/renderer/hooks/useTerminal.ts'))
-      .toMatch(/ownsComposeShortcut = false \} = options;/);
+    expect(SRC).toMatch(/ownsComposeShortcut = false \} = options;/);
+  });
+
+  it('the option is published as the DOM marker both gates read', () => {
+    // One source of ownership truth: useTerminal stamps every container with
+    // its ptyId and adds the owner attribute only where the option is set, so
+    // the document-level gate can reject a foreign terminal's keydown.
+    expect(SRC).toMatch(/container\.setAttribute\(TERMINAL_PTY_ATTR, ptyId\);/);
+    expect(SRC).toMatch(/if \(ownsComposeShortcut\) container\.setAttribute\(COMPOSE_OWNER_ATTR, ''\);/);
+    // And removed on unmount, or the stale marker would outlive the terminal.
+    expect(SRC).toMatch(/return \(\) => \{\s*container\.removeAttribute\(TERMINAL_PTY_ATTR\);\s*container\.removeAttribute\(COMPOSE_OWNER_ATTR\);/);
   });
 
   it('a non-owning terminal still encodes Ctrl+G as BEL', () => {

--- a/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * #1280 — Ctrl+G must LEAVE the pane alone on Windows/Linux.
+ *
+ * xterm's own encode path ends in `cancel()`, which calls stopPropagation, so
+ * before #1228 a Ctrl+G was swallowed by xterm and the document-level Rich
+ * Input listener never saw it. #1228 added a catch-all `resolveCtrlLetterByte`
+ * encoder that writes the byte itself with only `preventDefault()` — the event
+ * then bubbles, so the pane got BEL (0x07, `^G` / the agent's external editor)
+ * AND the popover opened. Fixing only the modifier match in
+ * useComposeShortcut would have left the `^G`.
+ *
+ * The fix is the allowlist Ctrl+D / Ctrl+T already use: bubble the key so
+ * neither xterm nor the catch-all encoder writes anything. jsdom cannot run
+ * xterm's custom key handler faithfully, so — like the macCtrlPassthrough and
+ * ctrlLetterEncoding locks next to this file — we pin the source.
+ */
+
+const SRC = readFileSync(
+  path.resolve(process.cwd(), 'src/renderer/hooks/useTerminal.ts'),
+  'utf8',
+);
+
+const handlerStart = SRC.indexOf('attachCustomKeyEventHandler');
+const handlerEnd = SRC.indexOf('// Right-click behavior', handlerStart);
+const HANDLER = SRC.slice(handlerStart, handlerEnd);
+
+function bubbleList(name: string): string {
+  const at = HANDLER.indexOf(`const ${name} = isMac`);
+  expect(at).toBeGreaterThan(-1);
+  return HANDLER.slice(at, HANDLER.indexOf(';', at));
+}
+
+describe('useTerminal bubbles Ctrl+G to the Rich Input listener (#1280)', () => {
+  it('locates the custom key event handler', () => {
+    expect(handlerStart).toBeGreaterThan(-1);
+    expect(handlerEnd).toBeGreaterThan(handlerStart);
+  });
+
+  it("non-mac bubbleKeys carries 'g'", () => {
+    const list = bubbleList('bubbleKeys');
+    const nonMac = list.slice(list.indexOf(':'));
+    expect(nonMac).toContain("'g'");
+  });
+
+  it("non-mac bubbleCodes carries 'KeyG' for the IME/non-Latin layout path", () => {
+    const list = bubbleList('bubbleCodes');
+    const nonMac = list.slice(list.indexOf(':'));
+    expect(nonMac).toContain("'KeyG'");
+  });
+
+  it('macOS keeps Ctrl+G as a readline byte (⌘G is the binding there)', () => {
+    const keys = bubbleList('bubbleKeys');
+    const macKeys = keys.slice(0, keys.indexOf(':'));
+    expect(macKeys).not.toContain("'g'");
+    const codes = bubbleList('bubbleCodes');
+    const macCodes = codes.slice(0, codes.indexOf(':'));
+    expect(macCodes).not.toContain("'KeyG'");
+  });
+
+  it('the bubble allowlist is reached before the catch-all ctrl encoder', () => {
+    // Order is the whole fix: the catch-all writes 0x07 and returns false.
+    expect(HANDLER.indexOf('const bubbleKeys = isMac'))
+      .toBeLessThan(HANDLER.indexOf('const ctrlByte = resolveCtrlLetterByte(e)'));
+  });
+
+  it('the disabled-shortcut gate still precedes the bubble allowlist', () => {
+    // A user who switches Ctrl+G off in Settings gets the byte, not the popover.
+    expect(HANDLER.indexOf('matchesDisabledShortcut('))
+      .toBeLessThan(HANDLER.indexOf('const bubbleKeys = isMac'));
+  });
+});

--- a/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
@@ -13,10 +13,15 @@ import path from 'node:path';
  * AND the popover opened. Fixing only the modifier match in
  * useComposeShortcut would have left the `^G`.
  *
- * The fix is the allowlist Ctrl+D / Ctrl+T already use: bubble the key so
- * neither xterm nor the catch-all encoder writes anything. jsdom cannot run
- * xterm's custom key handler faithfully, so — like the macCtrlPassthrough and
- * ctrlLetterEncoding locks next to this file — we pin the source.
+ * The fix bubbles the key, the way Ctrl+D / Ctrl+T already do, so neither
+ * xterm nor the catch-all encoder writes anything — but from its OWN branch
+ * testing the exact chord, not from those allowlists: their condition is only
+ * `ctrlKey && !shiftKey`, so a row there would also swallow Ctrl+Alt+G and
+ * Ctrl+Meta+G, which no handler claims (CodeRabbit on #1286).
+ *
+ * jsdom cannot run xterm's custom key handler faithfully, so — like the
+ * macCtrlPassthrough and ctrlLetterEncoding locks next to this file — we pin
+ * the source.
  */
 
 const SRC = readFileSync(
@@ -34,51 +39,58 @@ function bubbleList(name: string): string {
   return HANDLER.slice(at, HANDLER.indexOf(';', at));
 }
 
+const COMPOSE_BRANCH = /!isMac && e\.ctrlKey && !e\.shiftKey && !e\.altKey && !e\.metaKey\s*\n?\s*&& \(e\.key === 'g' \|\| e\.code === 'KeyG'\)/;
+
 describe('useTerminal bubbles Ctrl+G to the Rich Input listener (#1280)', () => {
   it('locates the custom key event handler', () => {
     expect(handlerStart).toBeGreaterThan(-1);
     expect(handlerEnd).toBeGreaterThan(handlerStart);
   });
 
-  it("non-mac bubbleKeys carries 'g'", () => {
-    const list = bubbleList('bubbleKeys');
-    const nonMac = list.slice(list.indexOf(':'));
-    expect(nonMac).toContain("'g'");
+  it('bubbles the exact Ctrl+G chord — no Shift, no Alt, no Meta', () => {
+    // Alt/Meta excluded on purpose: those chords are not the binding, and a
+    // bubble would leave them writing no byte and triggering no action.
+    expect(HANDLER).toMatch(COMPOSE_BRANCH);
   });
 
-  it("non-mac bubbleCodes carries 'KeyG' for the IME/non-Latin layout path", () => {
-    const list = bubbleList('bubbleCodes');
-    const nonMac = list.slice(list.indexOf(':'));
-    expect(nonMac).toContain("'KeyG'");
+  it('matches the physical KeyG too, for a non-Latin layout / IME', () => {
+    expect(COMPOSE_BRANCH.source).toContain("code === 'KeyG'");
+    expect(HANDLER).toMatch(COMPOSE_BRANCH);
   });
 
-  it('macOS keeps Ctrl+G as a readline byte (⌘G is the binding there)', () => {
+  it('is non-mac only — macOS keeps Ctrl+G as a readline byte (⌘G is the binding)', () => {
+    const at = HANDLER.search(COMPOSE_BRANCH);
+    expect(at).toBeGreaterThan(-1);
+    expect(HANDLER.slice(at, at + 20)).toContain('!isMac');
+    // And 'g' / KeyG stay out of the shared allowlists, whose mac branch would
+    // otherwise hand ⌘-less Ctrl+G to the app on macOS as well.
     const keys = bubbleList('bubbleKeys');
-    const macKeys = keys.slice(0, keys.indexOf(':'));
-    expect(macKeys).not.toContain("'g'");
-    const codes = bubbleList('bubbleCodes');
-    const macCodes = codes.slice(0, codes.indexOf(':'));
-    expect(macCodes).not.toContain("'KeyG'");
+    expect(keys).not.toContain("'g'");
+    expect(bubbleList('bubbleCodes')).not.toContain("'KeyG'");
   });
 
-  it('the bubble allowlist is reached before the catch-all ctrl encoder', () => {
+  it('bubbles before the catch-all ctrl encoder, which would write BEL', () => {
     // Order is the whole fix: the catch-all writes 0x07 and returns false.
-    expect(HANDLER.indexOf('const bubbleKeys = isMac'))
+    expect(HANDLER.search(COMPOSE_BRANCH))
       .toBeLessThan(HANDLER.indexOf('const ctrlByte = resolveCtrlLetterByte(e)'));
   });
 
-  it('the disabled-shortcut gate precedes the bubble allowlist and writes the byte', () => {
+  it('the disabled-shortcut branch writes the byte, and runs before the bubble', () => {
     // The escape hatch: Ctrl+G is an advertised keymap row, so a user can
     // switch it off in Settings → Shortcuts and hand the key back to the pane
-    // (Claude Code's external editor, readline's abort). That only works if
-    // the disabled gate is reached BEFORE the bubble allowlist and writes the
-    // control byte itself — returning true would let xterm encode it from the
-    // QWERTY keyCode instead (#1227).
-    const gate = HANDLER.indexOf('matchesDisabledShortcut(');
-    expect(gate).toBeGreaterThan(-1);
-    expect(gate).toBeLessThan(HANDLER.indexOf('const bubbleKeys = isMac'));
-    expect(HANDLER).toMatch(
-      /const disabledCtrl = resolveCtrlLetterByte\(e\);\s*if \(disabledCtrl\) \{\s*e\.preventDefault\(\);\s*window\.electronAPI\.pty\.write\(ptyId, disabledCtrl\);/,
+    // (Claude Code's external editor, readline's abort). That needs the
+    // disabled gate to come FIRST and to write the control byte inside its own
+    // branch — returning true would let xterm encode it from the QWERTY
+    // keyCode instead (#1227). Matched as one contiguous block so the write
+    // cannot drift out of the branch (CodeRabbit on #1286).
+    const disabledBranch = HANDLER.match(
+      /if \(matchesDisabledShortcut\([\s\S]{0,300}?\)\) \{[\s\S]{0,900}?\n {6}\}/,
     );
+    expect(disabledBranch).not.toBeNull();
+    expect(disabledBranch?.[0]).toMatch(
+      /const disabledCtrl = resolveCtrlLetterByte\(e\);\s*if \(disabledCtrl\) \{\s*e\.preventDefault\(\);\s*window\.electronAPI\.pty\.write\(ptyId, disabledCtrl\);\s*noteUserKeystroke\(disabledCtrl\);\s*return false;/,
+    );
+    expect(HANDLER.indexOf(disabledBranch?.[0] ?? ''))
+      .toBeLessThan(HANDLER.search(COMPOSE_BRANCH));
   });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts
@@ -67,9 +67,18 @@ describe('useTerminal bubbles Ctrl+G to the Rich Input listener (#1280)', () => 
       .toBeLessThan(HANDLER.indexOf('const ctrlByte = resolveCtrlLetterByte(e)'));
   });
 
-  it('the disabled-shortcut gate still precedes the bubble allowlist', () => {
-    // A user who switches Ctrl+G off in Settings gets the byte, not the popover.
-    expect(HANDLER.indexOf('matchesDisabledShortcut('))
-      .toBeLessThan(HANDLER.indexOf('const bubbleKeys = isMac'));
+  it('the disabled-shortcut gate precedes the bubble allowlist and writes the byte', () => {
+    // The escape hatch: Ctrl+G is an advertised keymap row, so a user can
+    // switch it off in Settings → Shortcuts and hand the key back to the pane
+    // (Claude Code's external editor, readline's abort). That only works if
+    // the disabled gate is reached BEFORE the bubble allowlist and writes the
+    // control byte itself — returning true would let xterm encode it from the
+    // QWERTY keyCode instead (#1227).
+    const gate = HANDLER.indexOf('matchesDisabledShortcut(');
+    expect(gate).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(HANDLER.indexOf('const bubbleKeys = isMac'));
+    expect(HANDLER).toMatch(
+      /const disabledCtrl = resolveCtrlLetterByte\(e\);\s*if \(disabledCtrl\) \{\s*e\.preventDefault\(\);\s*window\.electronAPI\.pty\.write\(ptyId, disabledCtrl\);/,
+    );
   });
 });

--- a/src/renderer/hooks/__tests__/useTerminal.macCtrlPassthrough.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.macCtrlPassthrough.test.ts
@@ -42,11 +42,8 @@ describe('useTerminal macOS Ctrl passthrough (source-level lock)', () => {
   });
 
   it('the non-mac bubble list keeps the full original set (no win/linux regression)', () => {
-    // 'g' joined the set in #1280: Ctrl+G is Rich Input (useComposeShortcut),
-    // so it must bubble instead of being encoded as BEL by the catch-all ctrl
-    // writer. Every pre-existing member still has to be here.
     expect(HANDLER).toMatch(
-      /\[',', 'b', 'd', 'g', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'\]/,
+      /\[',', 'b', 'd', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'\]/,
     );
   });
 

--- a/src/renderer/hooks/__tests__/useTerminal.macCtrlPassthrough.test.ts
+++ b/src/renderer/hooks/__tests__/useTerminal.macCtrlPassthrough.test.ts
@@ -42,8 +42,11 @@ describe('useTerminal macOS Ctrl passthrough (source-level lock)', () => {
   });
 
   it('the non-mac bubble list keeps the full original set (no win/linux regression)', () => {
+    // 'g' joined the set in #1280: Ctrl+G is Rich Input (useComposeShortcut),
+    // so it must bubble instead of being encoded as BEL by the catch-all ctrl
+    // writer. Every pre-existing member still has to be here.
     expect(HANDLER).toMatch(
-      /\[',', 'b', 'd', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'\]/,
+      /\[',', 'b', 'd', 'g', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'\]/,
     );
   });
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -30,7 +30,7 @@ import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
 import { resolveCtrlLetterByte } from '../terminal/ctrlLetterKeys';
-import { isComposeChord } from '../terminal/composeChord';
+import { isComposeChord, composeOwnerHost, TERMINAL_PTY_ATTR, COMPOSE_OWNER_ATTR } from '../terminal/composeChord';
 import { foldRemoteKeyboardState, INITIAL_REMOTE_KEYBOARD_STATE, type RemoteKeyboardState } from '../components/Remote/keyboardProtocol';
 import { attachImeAnchor } from '../terminal/imeAnchor';
 import { attachImeResidueGuard } from '../terminal/imeResidueGuard';
@@ -1040,6 +1040,29 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     }
   }, [ptyId, containerRef]);
 
+  // #1280 — publish this terminal's identity and chord ownership on the DOM,
+  // so the document-level Rich Input listener can tell WHICH terminal a
+  // keydown came from. Without it that gate fired for any terminal's keydown
+  // and toggled the popover on the active leaf: pressing Ctrl+G in the
+  // floating pane opened Rich Input over a background pane while the floating
+  // pty got nothing (live dogfood on b4135076).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (!ptyId) {
+      container.removeAttribute(TERMINAL_PTY_ATTR);
+      container.removeAttribute(COMPOSE_OWNER_ATTR);
+      return;
+    }
+    container.setAttribute(TERMINAL_PTY_ATTR, ptyId);
+    if (ownsComposeShortcut) container.setAttribute(COMPOSE_OWNER_ATTR, '');
+    else container.removeAttribute(COMPOSE_OWNER_ATTR);
+    return () => {
+      container.removeAttribute(TERMINAL_PTY_ATTR);
+      container.removeAttribute(COMPOSE_OWNER_ATTR);
+    };
+  }, [ptyId, ownsComposeShortcut, containerRef]);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !ptyId) return;
@@ -1830,7 +1853,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       // `ownsComposeShortcut` is the other half: the popover gate acts on the
       // active leaf's pty, so a floating pane / brain embed would see the key
       // swallowed here and declined there. Those surfaces keep encoding 0x07.
-      if (ownsComposeShortcut && isComposeChord(e, isMac ? 'darwin' : 'win32')
+      if (composeOwnerHost(e.target).owns && isComposeChord(e, isMac ? 'darwin' : 'win32')
           && !useStore.getState().inspectModeActive) {
         return false; // let DOM bubble to useComposeShortcut
       }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1801,21 +1801,34 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         }
         return true;
       }
-      // #1280 — 'g' / KeyG is Rich Input (useComposeShortcut, a document-level
-      // listener). It has to be in this allowlist, not merely preventDefault'd
+      // #1280 — Ctrl+G is Rich Input (useComposeShortcut, a document-level
+      // listener). It has to bubble from HERE, not merely be preventDefault'd
       // downstream: xterm's own encode path calls stopPropagation (its
       // `cancel()`), so before #1228 Ctrl+G never reached the document at all,
       // and after it the catch-all ctrl encoder below wrote BEL (0x07) to the
       // pane and then let the event bubble — `^G` in the shell plus the
-      // popover, which is the reported bug. Bubbling here is the same contract
-      // Ctrl+D / Ctrl+T already use for their app shortcuts. macOS keeps
-      // Ctrl+G as a readline byte; the binding is ⌘G there.
+      // popover, which is the reported bug.
+      //
+      // Its own branch rather than a row in the allowlists below, because the
+      // allowlist condition only tests `ctrlKey && !shiftKey`: adding 'g'
+      // there would also swallow Ctrl+Alt+G and Ctrl+Meta+G, which
+      // useComposeShortcut rejects and no other handler claims, leaving them
+      // dead in both worlds (CodeRabbit on #1286). The binding is the exact
+      // chord, so only the exact chord bubbles. `code` is the IME / non-Latin
+      // layout fallback. macOS keeps Ctrl+G as a readline byte — the binding
+      // is ⌘G there, which xterm does not encode.
+      if (
+        !isMac && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
+        && (e.key === 'g' || e.code === 'KeyG')
+      ) {
+        return false; // let DOM bubble to useComposeShortcut
+      }
       const bubbleKeys = isMac
         ? ['b', 'm', 'ArrowUp', 'ArrowDown']
-        : [',', 'b', 'd', 'g', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'];
+        : [',', 'b', 'd', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'];
       const bubbleCodes = isMac
         ? ['KeyB', 'KeyM', 'ArrowUp', 'ArrowDown']
-        : ['KeyB', 'KeyD', 'KeyG', 'KeyK', 'KeyI', 'KeyN', 'KeyT', 'KeyM', 'Comma', 'ArrowUp', 'ArrowDown'];
+        : ['KeyB', 'KeyD', 'KeyK', 'KeyI', 'KeyN', 'KeyT', 'KeyM', 'Comma', 'ArrowUp', 'ArrowDown'];
       if (e.ctrlKey && !e.shiftKey && bubbleKeys.includes(e.key)) {
         return false; // let DOM bubble to useKeyboard
       }

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -30,6 +30,7 @@ import { terminalFontFamilyCss } from '../utils/terminalFont';
 import { createPathLinkProvider } from '../terminal/pathLinkProvider';
 import { resolveNewlineKeyByte } from '../terminal/newlineKeys';
 import { resolveCtrlLetterByte } from '../terminal/ctrlLetterKeys';
+import { isComposeChord } from '../terminal/composeChord';
 import { foldRemoteKeyboardState, INITIAL_REMOTE_KEYBOARD_STATE, type RemoteKeyboardState } from '../components/Remote/keyboardProtocol';
 import { attachImeAnchor } from '../terminal/imeAnchor';
 import { attachImeResidueGuard } from '../terminal/imeResidueGuard';
@@ -652,6 +653,17 @@ interface UseTerminalOptions {
   onFirstData?: () => void;
   /** Called on right-click to show context menu */
   onContextMenu?: (e: ContextMenuEvent) => void;
+  /**
+   * Does this surface own the Rich Input chord (⌘G / Ctrl+G)?
+   *
+   * `useComposeShortcut` acts on the ACTIVE LEAF's pty, so only the terminal
+   * that is the active surface can honour the key. A non-owning xterm —
+   * FloatingPane (Ctrl+`), Deck's BrainTerminalEmbed — must keep encoding
+   * 0x07, or the chord is swallowed here and declined there: a dead key, or a
+   * popover aimed at a different pane (#1280 review). Defaults to false so a
+   * future embed is dead-key-safe until it opts in.
+   */
+  ownsComposeShortcut?: boolean;
 }
 
 export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>, options: UseTerminalOptions) {
@@ -699,7 +711,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
   // Glyph-corruption repair scheduler (issue #166) — created by the main
   // effect, also poked by the visibility effect on regain.
   const glyphRepaintRef = useRef<GlyphRepaintScheduler | null>(null);
-  const { ptyId, isVisible = true, scrollbackFile, onFirstData, onContextMenu } = options;
+  const { ptyId, isVisible = true, scrollbackFile, onFirstData, onContextMenu, ownsComposeShortcut = false } = options;
   const ptyIdRef = useRef(ptyId);
   ptyIdRef.current = ptyId;
   // Live visibility for long-lived callbacks (the burst repaint below) — the
@@ -1801,26 +1813,25 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         }
         return true;
       }
-      // #1280 — Ctrl+G is Rich Input (useComposeShortcut, a document-level
-      // listener). It has to bubble from HERE, not merely be preventDefault'd
-      // downstream: xterm's own encode path calls stopPropagation (its
-      // `cancel()`), so before #1228 Ctrl+G never reached the document at all,
-      // and after it the catch-all ctrl encoder below wrote BEL (0x07) to the
-      // pane and then let the event bubble — `^G` in the shell plus the
-      // popover, which is the reported bug.
+      // #1280 — the Rich Input chord (⌘G / Ctrl+G) bubbles from HERE, instead
+      // of merely being preventDefault'd downstream: xterm's own encode path
+      // calls stopPropagation (its `cancel()`), so before #1228 Ctrl+G never
+      // reached the document listener at all, and after it the catch-all ctrl
+      // encoder below wrote BEL (0x07) to the pane and then let the event
+      // bubble — `^G` in the shell plus the popover, the reported bug.
       //
-      // Its own branch rather than a row in the allowlists below, because the
-      // allowlist condition only tests `ctrlKey && !shiftKey`: adding 'g'
-      // there would also swallow Ctrl+Alt+G and Ctrl+Meta+G, which
-      // useComposeShortcut rejects and no other handler claims, leaving them
-      // dead in both worlds (CodeRabbit on #1286). The binding is the exact
-      // chord, so only the exact chord bubbles. `code` is the IME / non-Latin
-      // layout fallback. macOS keeps Ctrl+G as a readline byte — the binding
-      // is ⌘G there, which xterm does not encode.
-      if (
-        !isMac && e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey
-        && (e.key === 'g' || e.code === 'KeyG')
-      ) {
+      // Its own branch, not a row in the allowlists below, whose condition is
+      // only `ctrlKey && !shiftKey`: a row there would also swallow
+      // Ctrl+Alt+G and Ctrl+Meta+G, which nobody claims. And the SAME
+      // predicate the popover gate uses, so the two cannot disagree about
+      // which keydown is the chord (composeChord.ts explains why that matters
+      // more than either gate's own correctness).
+      //
+      // `ownsComposeShortcut` is the other half: the popover gate acts on the
+      // active leaf's pty, so a floating pane / brain embed would see the key
+      // swallowed here and declined there. Those surfaces keep encoding 0x07.
+      if (ownsComposeShortcut && isComposeChord(e, isMac ? 'darwin' : 'win32')
+          && !useStore.getState().inspectModeActive) {
         return false; // let DOM bubble to useComposeShortcut
       }
       const bubbleKeys = isMac

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -1801,12 +1801,21 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
         }
         return true;
       }
+      // #1280 — 'g' / KeyG is Rich Input (useComposeShortcut, a document-level
+      // listener). It has to be in this allowlist, not merely preventDefault'd
+      // downstream: xterm's own encode path calls stopPropagation (its
+      // `cancel()`), so before #1228 Ctrl+G never reached the document at all,
+      // and after it the catch-all ctrl encoder below wrote BEL (0x07) to the
+      // pane and then let the event bubble — `^G` in the shell plus the
+      // popover, which is the reported bug. Bubbling here is the same contract
+      // Ctrl+D / Ctrl+T already use for their app shortcuts. macOS keeps
+      // Ctrl+G as a readline byte; the binding is ⌘G there.
       const bubbleKeys = isMac
         ? ['b', 'm', 'ArrowUp', 'ArrowDown']
-        : [',', 'b', 'd', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'];
+        : [',', 'b', 'd', 'g', 'k', 'i', 'n', 't', 'm', 'ArrowUp', 'ArrowDown', '`'];
       const bubbleCodes = isMac
         ? ['KeyB', 'KeyM', 'ArrowUp', 'ArrowDown']
-        : ['KeyB', 'KeyD', 'KeyK', 'KeyI', 'KeyN', 'KeyT', 'KeyM', 'Comma', 'ArrowUp', 'ArrowDown'];
+        : ['KeyB', 'KeyD', 'KeyG', 'KeyK', 'KeyI', 'KeyN', 'KeyT', 'KeyM', 'Comma', 'ArrowUp', 'ArrowDown'];
       if (e.ctrlKey && !e.shiftKey && bubbleKeys.includes(e.key)) {
         return false; // let DOM bubble to useKeyboard
       }

--- a/src/renderer/i18n/__tests__/advertisedShortcutsLocale.test.ts
+++ b/src/renderer/i18n/__tests__/advertisedShortcutsLocale.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { ADVERTISED_SHORTCUTS } from '../../../shared/keymap';
+import { en } from '../locales/en';
+import { ko } from '../locales/ko';
+import { zh } from '../locales/zh';
+
+/**
+ * SettingsPanel renders one row per ADVERTISED_SHORTCUTS entry as
+ * `t(entry.descriptionKey)`. A row whose key has no string falls through t()'s
+ * last fallback and the Settings list shows "settings.sc.richInput" verbatim —
+ * in English too. #1280 added the Ctrl+G row (Rich Input) precisely so the
+ * binding can be switched OFF from that list, so the row has to be legible.
+ *
+ * English is the gate for the whole list: it is the fallback every locale
+ * lands on, so a key missing there is visible in every language. pl has its
+ * own full-coverage lock (plLocaleCoverage.test.ts); ko/zh are maintained but
+ * not complete (#997), and the other 20 locales are the accepted stalled gap —
+ * all of them fall back to English at runtime. The new key is checked in
+ * ko/zh explicitly rather than by sweeping a list they do not fully cover.
+ */
+const enStrings = en as unknown as Record<string, string>;
+
+describe('advertised shortcut labels', () => {
+  it('every advertised row has an English string', () => {
+    for (const entry of ADVERTISED_SHORTCUTS) {
+      // ADVERTISED_SHORTCUTS is filtered to non-null descriptionKeys, but the
+      // declared type keeps the nullable union.
+      const value = enStrings[entry.descriptionKey as string];
+      expect(value, `en missing "${entry.descriptionKey}" for ${entry.combo}`)
+        .toBeTruthy();
+      expect(value).not.toBe(entry.descriptionKey);
+    }
+  });
+
+  it('Ctrl+G (Rich Input) is one of those rows', () => {
+    const row = ADVERTISED_SHORTCUTS.find((e) => e.combo === 'Ctrl+G');
+    expect(row?.descriptionKey).toBe('settings.sc.richInput');
+    expect(enStrings['settings.sc.richInput']).toBe('Toggle Rich Input');
+    // Added to the maintained locales in the same pass.
+    for (const [name, strings] of [
+      ['ko', ko as unknown as Record<string, string>],
+      ['zh', zh as unknown as Record<string, string>],
+    ] as const) {
+      expect(strings['settings.sc.richInput'], `${name} missing the label`).toBeTruthy();
+    }
+  });
+});

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -1039,6 +1039,7 @@ export const en = {
   'settings.sc.searchTerminal': 'Search in terminal',
   'settings.sc.commandPalette': 'Command palette',
   'settings.sc.toggleNotifications': 'Toggle notification panel',
+  'settings.sc.richInput': 'Toggle Rich Input',
   'settings.sc.viCopyMode': 'Vi copy mode',
   'settings.sc.renameWorkspace': 'Rename workspace',
   'settings.sc.highlightPane': 'Highlight active pane',

--- a/src/renderer/i18n/locales/ko.ts
+++ b/src/renderer/i18n/locales/ko.ts
@@ -528,6 +528,7 @@ export const ko = {
   'settings.sc.searchTerminal': '터미널에서 검색',
   'settings.sc.commandPalette': '명령 팔레트',
   'settings.sc.toggleNotifications': '알림 패널 전환',
+  'settings.sc.richInput': '리치 입력 전환',
   'settings.sc.viCopyMode': 'Vi 복사 모드',
   'settings.sc.renameWorkspace': '작업공간 이름 변경',
   'settings.sc.highlightPane': '활성 창 강조',

--- a/src/renderer/i18n/locales/pl.ts
+++ b/src/renderer/i18n/locales/pl.ts
@@ -1022,6 +1022,7 @@ export const pl = {
   'settings.sc.searchTerminal': 'Szukaj w terminalu',
   'settings.sc.commandPalette': 'Paleta poleceń',
   'settings.sc.toggleNotifications': 'Przełącz panel powiadomień',
+  'settings.sc.richInput': 'Przełącz rozbudowane wejście',
   'settings.sc.viCopyMode': 'Tryb kopiowania Vi',
   'settings.sc.renameWorkspace': 'Zmień nazwę obszaru roboczego',
   'settings.sc.highlightPane': 'Wyróżnij aktywny panel',

--- a/src/renderer/i18n/locales/zh.ts
+++ b/src/renderer/i18n/locales/zh.ts
@@ -399,6 +399,7 @@ export const zh = {
   'settings.sc.searchTerminal': '在终端中搜索',
   'settings.sc.commandPalette': '命令面板',
   'settings.sc.toggleNotifications': '切换通知面板',
+  'settings.sc.richInput': '切换富文本输入',
   'settings.sc.viCopyMode': 'Vi 复制模式',
   'settings.sc.renameWorkspace': '重命名工作区',
   'settings.sc.highlightPane': '高亮活动面板',

--- a/src/renderer/terminal/__tests__/composeChord.test.ts
+++ b/src/renderer/terminal/__tests__/composeChord.test.ts
@@ -1,5 +1,12 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { isComposeChord, type ComposeChordEventLike } from '../composeChord';
+import {
+  isComposeChord,
+  composeOwnerHost,
+  TERMINAL_PTY_ATTR,
+  COMPOSE_OWNER_ATTR,
+  type ComposeChordEventLike,
+} from '../composeChord';
 import { WMUX_KEYMAP } from '../../../shared/keymap';
 
 /**
@@ -86,6 +93,39 @@ describe('isComposeChord', () => {
           `${entry.combo} on ${platform} must not read as the compose chord`).toBe(false);
       }
     }
+  });
+});
+
+describe('composeOwnerHost', () => {
+  const mount = (ptyId: string | null, owns: boolean): HTMLElement => {
+    const host = document.createElement('div');
+    if (ptyId !== null) host.setAttribute(TERMINAL_PTY_ATTR, ptyId);
+    if (owns) host.setAttribute(COMPOSE_OWNER_ATTR, '');
+    const inner = document.createElement('textarea');
+    host.appendChild(inner);
+    document.body.appendChild(host);
+    return inner;
+  };
+
+  it('reads the ptyId and the owner marker from the enclosing terminal', () => {
+    expect(composeOwnerHost(mount('pty-1', true))).toEqual({ ptyId: 'pty-1', owns: true });
+  });
+
+  it('reports a non-owning terminal (floating pane, brain embed)', () => {
+    // The live b4135076 failure came from here: the document gate had no way
+    // to tell this keydown apart from the active leaf's.
+    expect(composeOwnerHost(mount('daemon-floating', false)))
+      .toEqual({ ptyId: 'daemon-floating', owns: false });
+  });
+
+  it('reports no terminal for an event from elsewhere, and for a null target', () => {
+    // Distinct from a FOREIGN terminal: the caller keeps acting on the active
+    // leaf here, because the binding never required terminal focus.
+    const loose = document.createElement('button');
+    document.body.appendChild(loose);
+    expect(composeOwnerHost(loose)).toEqual({ ptyId: null, owns: false });
+    expect(composeOwnerHost(null)).toEqual({ ptyId: null, owns: false });
+    loose.remove();
   });
 });
 

--- a/src/renderer/terminal/__tests__/composeChord.test.ts
+++ b/src/renderer/terminal/__tests__/composeChord.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { isComposeChord, type ComposeChordEventLike } from '../composeChord';
+import { WMUX_KEYMAP } from '../../../shared/keymap';
+
+/**
+ * #1280. This predicate exists so the two gates that both handle ⌘G / Ctrl+G —
+ * useTerminal's xterm key handler (does the pane get a byte?) and
+ * useComposeShortcut (does Rich Input open?) — cannot disagree. Testing it
+ * directly is what lets the source-level lock over useTerminal shrink to the
+ * single line that wires it.
+ */
+
+const ev = (over: Partial<ComposeChordEventLike> = {}): ComposeChordEventLike => ({
+  key: 'g', code: 'KeyG',
+  ctrlKey: true, metaKey: false, shiftKey: false, altKey: false,
+  isComposing: false,
+  ...over,
+});
+
+describe('isComposeChord', () => {
+  it('accepts plain Ctrl+G off macOS', () => {
+    expect(isComposeChord(ev(), 'win32')).toBe(true);
+    expect(isComposeChord(ev(), 'linux')).toBe(true);
+  });
+
+  it('rejects Shift — Ctrl+Shift+G is clearMultiview', () => {
+    // The original bug: `key` is 'G' exactly when Shift is held, and the old
+    // inline test accepted both spellings of the letter with no shift check.
+    expect(isComposeChord(ev({ key: 'G', shiftKey: true }), 'win32')).toBe(false);
+  });
+
+  it('accepts an unshifted capital G (Caps Lock)', () => {
+    expect(isComposeChord(ev({ key: 'G' }), 'win32')).toBe(true);
+  });
+
+  it('rejects Alt and Meta — nobody binds Ctrl+Alt+G / Ctrl+Meta+G', () => {
+    // These must keep reaching the pane; swallowing them would leave a key
+    // that writes no byte and triggers no action.
+    expect(isComposeChord(ev({ altKey: true }), 'win32')).toBe(false);
+    expect(isComposeChord(ev({ metaKey: true }), 'win32')).toBe(false);
+  });
+
+  it('rejects the bare letter and every other letter', () => {
+    expect(isComposeChord(ev({ ctrlKey: false }), 'win32')).toBe(false);
+    expect(isComposeChord(ev({ key: 'f', code: 'KeyF' }), 'win32')).toBe(false);
+  });
+
+  it('falls back to the physical KeyG under a non-Latin layout', () => {
+    // Hangul / Pinyin report a composed jamo or 'Process' in `key`.
+    expect(isComposeChord(ev({ key: 'ㅎ' }), 'win32')).toBe(true);
+    expect(isComposeChord(ev({ key: 'Process' }), 'win32')).toBe(true);
+  });
+
+  it('defers while an IME composition is active', () => {
+    // Every other ctrl-letter path defers here (resolveCtrlLetterByte,
+    // resolveNewlineKeyByte, the IME-Escape branch). Without it a Hangul
+    // preedit plus the physical fallback above popped Rich Input mid-word.
+    expect(isComposeChord(ev({ isComposing: true }), 'win32')).toBe(false);
+    expect(isComposeChord(ev({ key: 'Process', isComposing: true }), 'win32')).toBe(false);
+    expect(isComposeChord(ev({ key: 'g', metaKey: true, ctrlKey: false, isComposing: true }), 'darwin')).toBe(false);
+  });
+
+  it('macOS binds ⌘G and leaves literal Ctrl+G to readline', () => {
+    expect(isComposeChord(ev({ ctrlKey: false, metaKey: true }), 'darwin')).toBe(true);
+    expect(isComposeChord(ev(), 'darwin')).toBe(false);
+    // Ctrl+⌘+G is neither: `baseModifier` requires Ctrl to be up on mac.
+    expect(isComposeChord(ev({ ctrlKey: true, metaKey: true }), 'darwin')).toBe(false);
+  });
+
+  it('accepts auto-repeat — a held chord is still the chord', () => {
+    // Repeat is not in the predicate at all, so both gates see the same
+    // answer for a repeat tick. The popover gate then declines to TOGGLE on
+    // one (flapping is not the ask), which makes Ctrl+G a deliberate
+    // non-repeating chord rather than a key that dies between the gates.
+    expect(isComposeChord({ ...ev(), key: 'g' }, 'win32')).toBe(true);
+  });
+
+  it('no other keymap combo is mistaken for the chord', () => {
+    // Swept on BOTH platforms, with ⌘ substituted for Ctrl in the non-literal
+    // family the way useKeyboard dispatches it, and `code` filled in from the
+    // letter so the physical fallback is exercised too.
+    for (const platform of ['win32', 'darwin'] as const) {
+      for (const entry of WMUX_KEYMAP) {
+        if (entry.combo === 'Ctrl+G') continue;
+        expect(isComposeChord(eventForCombo(entry.combo, platform, entry.literalCtrl === true), platform),
+          `${entry.combo} on ${platform} must not read as the compose chord`).toBe(false);
+      }
+    }
+  });
+});
+
+/**
+ * Turn a stored combo ('Ctrl+Shift+ArrowUp') into the event that combo
+ * actually produces on `platform`. The cmdOrCtrl family fires on ⌘ under
+ * macOS; `literalCtrl` rows and rows with no Ctrl at all keep literal Ctrl.
+ */
+function eventForCombo(
+  combo: string,
+  platform: NodeJS.Platform,
+  literalCtrl: boolean,
+): ComposeChordEventLike {
+  const parts = combo.split('+');
+  // 'Ctrl+Shift++' → the trailing '+' is the key, not a separator.
+  const key = parts.pop() || '+';
+  const wantsCtrl = parts.includes('Ctrl');
+  const mac = platform === 'darwin';
+  const useMeta = wantsCtrl && mac && !literalCtrl;
+  return {
+    key,
+    code: /^[A-Za-z]$/.test(key) ? `Key${key.toUpperCase()}` : key,
+    ctrlKey: wantsCtrl && !useMeta,
+    metaKey: useMeta,
+    shiftKey: parts.includes('Shift'),
+    altKey: parts.includes('Alt'),
+    isComposing: false,
+  };
+}

--- a/src/renderer/terminal/composeChord.ts
+++ b/src/renderer/terminal/composeChord.ts
@@ -66,3 +66,50 @@ export function isComposeChord(
   if (!baseModifier) return false;
   return e.key === 'g' || e.key === 'G' || e.code === 'KeyG';
 }
+
+/**
+ * Ownership, the other half of #1280 — and the half the first fix only wired
+ * into ONE of the two gates.
+ *
+ * `useComposeShortcut` toggles Rich Input for the workspace's ACTIVE LEAF pty,
+ * because that is the pane whose toolbar renders the popover. So only that
+ * pane's terminal may fire the chord. Give the key to any other xterm and the
+ * popover opens over the wrong pane: the live dogfood on the floating pane
+ * (Cmd+` / Ctrl+`) hit exactly that — its own pty received 0 bytes while the
+ * popover opened on a background pane, which on Windows is the original
+ * complaint (`^G` in the floating pane AND a popover elsewhere).
+ *
+ * `useTerminal` stamps every terminal container with its ptyId, and adds the
+ * owner marker only where `ownsComposeShortcut` is set (Terminal.tsx, the
+ * pane-surface terminal — not FloatingPane, not Deck's BrainTerminalEmbed).
+ * Both gates then read ownership from the same marker instead of each holding
+ * an opinion.
+ */
+export const TERMINAL_PTY_ATTR = 'data-terminal-pty';
+export const COMPOSE_OWNER_ATTR = 'data-compose-owner';
+
+export interface ComposeOwnerHost {
+  /** ptyId of the terminal the event came from, or null when it came from none. */
+  ptyId: string | null;
+  /** Does that terminal own the chord? Meaningless when `ptyId` is null. */
+  owns: boolean;
+}
+
+/**
+ * Which terminal did this keydown come from, and does it own the chord?
+ *
+ * `{ ptyId: null }` means the event did not originate inside any terminal at
+ * all — focus on <body> after a popover closed, say. That is NOT a foreign
+ * terminal, so the caller keeps its old behaviour there (act on the active
+ * leaf); the point of this helper is to reject a DIFFERENT terminal's keydown,
+ * not to require terminal focus the binding never required.
+ */
+export function composeOwnerHost(target: EventTarget | null): ComposeOwnerHost {
+  const el = target as Element | null;
+  const host = el?.closest?.(`[${TERMINAL_PTY_ATTR}]`) ?? null;
+  if (!host) return { ptyId: null, owns: false };
+  return {
+    ptyId: host.getAttribute(TERMINAL_PTY_ATTR),
+    owns: host.hasAttribute(COMPOSE_OWNER_ATTR),
+  };
+}

--- a/src/renderer/terminal/composeChord.ts
+++ b/src/renderer/terminal/composeChord.ts
@@ -1,0 +1,68 @@
+/**
+ * The ONE definition of the Rich Input chord (⌘G on macOS, Ctrl+G elsewhere).
+ *
+ * Two gates have to agree about this key, and #1280 is what their
+ * disagreement costs:
+ *
+ *   • `useTerminal`'s xterm key handler decides whether the pane gets a byte.
+ *   • `useComposeShortcut` (a document-level listener) decides whether the
+ *     Rich Input popover opens.
+ *
+ * xterm's own encode path calls `stopPropagation` (its `cancel()`), so the
+ * pane gate runs FIRST and the popover gate only ever sees keys the pane gate
+ * let bubble. Any condition one gate applies and the other cannot see produces
+ * a silently dead key: swallowed by the pane, declined by the popover. That is
+ * exactly how the loose matcher shipped — the popover gate accepted
+ * Ctrl+Shift+G (`key` is 'G' precisely when Shift is held) while the pane gate
+ * was still writing BEL for plain Ctrl+G.
+ *
+ * So the chord is a pure predicate, exported, and both gates call it. It can
+ * be wrong, but it cannot be inconsistent.
+ *
+ * What the predicate deliberately excludes:
+ *
+ *   • `isComposing` — every other control-letter path in the renderer defers
+ *     during an IME composition (`resolveCtrlLetterByte`, `resolveNewlineKeyByte`,
+ *     the IME-Escape branch). Without it a Hangul preedit plus the physical
+ *     `KeyG` fallback below popped Rich Input mid-composition. Deferring hands
+ *     the key to xterm, which drops keyCode-229 keydowns — the same no-op every
+ *     other ctrl-letter already has while composing.
+ *   • Shift and Alt — Ctrl+Shift+G is `clearMultiview`, and Ctrl+Alt+G /
+ *     Ctrl+Meta+G are nobody's binding, so they must keep reaching the pane.
+ *
+ * What it deliberately INCLUDES:
+ *
+ *   • `key === 'G'` with Shift up, which happens under Caps Lock.
+ *   • The physical `code` fallback, for a Hangul / non-Latin layout where
+ *     `key` is a composed jamo or 'Process' (mirrors the Ctrl+C / Ctrl+J
+ *     handlers in useTerminal).
+ *   • Auto-repeat. Holding the chord is still the chord: the popover gate
+ *     declines to TOGGLE on a repeat (flapping it open and shut is not what
+ *     the user asked for), but both gates agree the key belongs to the
+ *     binding, so a held Ctrl+G produces one toggle and then nothing —
+ *     a non-repeating chord — instead of a stream of BEL.
+ */
+
+export interface ComposeChordEventLike {
+  key: string;
+  code: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  isComposing: boolean;
+}
+
+export function isComposeChord(
+  e: ComposeChordEventLike,
+  platform: NodeJS.Platform,
+): boolean {
+  if (e.shiftKey || e.altKey || e.isComposing) return false;
+  // macOS binds ⌘G — literal Ctrl+G there is a readline byte, and the toolbar
+  // renders the chip as ⌘G. Windows/Linux bind literal Ctrl+G.
+  const baseModifier = platform === 'darwin'
+    ? e.metaKey && !e.ctrlKey
+    : e.ctrlKey && !e.metaKey;
+  if (!baseModifier) return false;
+  return e.key === 'g' || e.key === 'G' || e.code === 'KeyG';
+}

--- a/src/shared/__tests__/keymap.test.ts
+++ b/src/shared/__tests__/keymap.test.ts
@@ -151,3 +151,45 @@ describe('matchesDisabledShortcut (#1152)', () => {
     expect(matchesDisabledShortcut([], ev({}), 'win32')).toBe(false);
   });
 });
+
+/**
+ * #1280 — Ctrl+G (Rich Input) is an ADVERTISED row, which is what makes the
+ * escape hatch reachable: advertised rows are the ones SettingsPanel renders
+ * with a disable toggle, and a disabled row hands its key back to the pane
+ * (Claude Code's external editor, readline's abort).
+ */
+describe('Ctrl+G Rich Input row (#1280)', () => {
+  it('is advertised, so the Settings shortcut list renders it with a toggle', () => {
+    // ADVERTISED_SHORTCUTS is the exact list SettingsPanel maps over.
+    const row = ADVERTISED_SHORTCUTS.find((e) => e.combo === 'Ctrl+G');
+    expect(row).toBeDefined();
+    expect(row?.descriptionKey).toBe('settings.sc.richInput');
+    // Not literalCtrl: on macOS the binding is ⌘G, and Ctrl+G there stays a
+    // readline byte (useTerminal's mac bubble list excludes 'g').
+    expect(row?.literalCtrl).toBe(false);
+  });
+
+  it('reserves its accelerator so the app menu can never claim Ctrl+G', () => {
+    expect(builtinCombosFor('win32').has('Ctrl+G')).toBe(true);
+  });
+
+  it('disabling it matches a real Ctrl+G keydown — the byte reaches the pane', () => {
+    // Both gates read this one function: useComposeShortcut yields (no
+    // popover) and useTerminal's disabled branch writes the control byte.
+    const g = { key: 'g', code: 'KeyG', ctrlKey: true, metaKey: false, shiftKey: false, altKey: false };
+    expect(matchesDisabledShortcut(['Ctrl+G'], g, 'win32')).toBe(true);
+    // Under a Hangul IME `key` is a jamo / 'Process' — the physical code path.
+    expect(matchesDisabledShortcut(['Ctrl+G'], { ...g, key: 'ㅎ' }, 'win32')).toBe(true);
+    // Enabled (empty list) is the normal case: the binding owns the key.
+    expect(matchesDisabledShortcut([], g, 'win32')).toBe(false);
+    // Ctrl+Shift+G is a DIFFERENT combo (clearMultiview) and must not be
+    // silenced by disabling Ctrl+G.
+    expect(matchesDisabledShortcut(['Ctrl+G'], { ...g, key: 'G', shiftKey: true }, 'win32')).toBe(false);
+  });
+
+  it('macOS: disabling it matches ⌘G, not literal Ctrl+G', () => {
+    const base = { key: 'g', code: 'KeyG', shiftKey: false, altKey: false };
+    expect(matchesDisabledShortcut(['Ctrl+G'], { ...base, ctrlKey: false, metaKey: true }, 'darwin')).toBe(true);
+    expect(matchesDisabledShortcut(['Ctrl+G'], { ...base, ctrlKey: true, metaKey: false }, 'darwin')).toBe(false);
+  });
+});

--- a/src/shared/keymap.ts
+++ b/src/shared/keymap.ts
@@ -79,6 +79,11 @@ export const WMUX_KEYMAP: readonly KeymapEntry[] = [
   { combo: 'Ctrl+Shift+U', descriptionKey: null },
   { combo: 'Ctrl+Shift+L', descriptionKey: null },
   { combo: 'Ctrl+Shift+O', descriptionKey: null },
+  // Rich Input toggle. Not bound in useKeyboard's if-chain — it is
+  // useComposeShortcut (ToolbarHost), a document-level listener — but it is
+  // a real renderer binding, so it reserves its accelerator and feeds
+  // matchesDisabledShortcut like every other row (#1280).
+  { combo: 'Ctrl+G', descriptionKey: null },
   { combo: 'Ctrl+Shift+G', descriptionKey: null },
   { combo: 'Ctrl+Shift+]', descriptionKey: null },
   { combo: 'Ctrl+Shift+[', descriptionKey: null },

--- a/src/shared/keymap.ts
+++ b/src/shared/keymap.ts
@@ -63,6 +63,14 @@ export const WMUX_KEYMAP: readonly KeymapEntry[] = [
   { combo: 'Ctrl+F', descriptionKey: 'settings.sc.searchTerminal' },
   { combo: 'Ctrl+K', descriptionKey: 'settings.sc.commandPalette' },
   { combo: 'Ctrl+I', descriptionKey: 'settings.sc.toggleNotifications' },
+  // Rich Input. Not bound in useKeyboard's if-chain — the owner is
+  // useComposeShortcut (ToolbarHost), a document-level listener — but it is a
+  // real renderer binding, so it reserves its accelerator and feeds
+  // matchesDisabledShortcut like every other row. Advertised so it can be
+  // switched OFF: turning it off hands Ctrl+G back to the pane (Claude Code's
+  // external editor, readline's abort), which is the escape hatch #1280 asked
+  // for.
+  { combo: 'Ctrl+G', descriptionKey: 'settings.sc.richInput' },
   { combo: 'Ctrl+Shift+X', descriptionKey: 'settings.sc.viCopyMode' },
   { combo: 'Ctrl+Shift+R', descriptionKey: 'settings.sc.renameWorkspace' },
   { combo: 'Ctrl+Shift+H', descriptionKey: 'settings.sc.highlightPane' },
@@ -79,11 +87,6 @@ export const WMUX_KEYMAP: readonly KeymapEntry[] = [
   { combo: 'Ctrl+Shift+U', descriptionKey: null },
   { combo: 'Ctrl+Shift+L', descriptionKey: null },
   { combo: 'Ctrl+Shift+O', descriptionKey: null },
-  // Rich Input toggle. Not bound in useKeyboard's if-chain — it is
-  // useComposeShortcut (ToolbarHost), a document-level listener — but it is
-  // a real renderer binding, so it reserves its accelerator and feeds
-  // matchesDisabledShortcut like every other row (#1280).
-  { combo: 'Ctrl+G', descriptionKey: null },
   { combo: 'Ctrl+Shift+G', descriptionKey: null },
   { combo: 'Ctrl+Shift+]', descriptionKey: null },
   { combo: 'Ctrl+Shift+[', descriptionKey: null },


### PR DESCRIPTION
## Summary

Reported by @River-Jang (#1280, 3.52.0, Windows 11 / PowerShell 5.1; 3.51.0 was fine):

- Ctrl+G in a shell pane → `^G` echoed **and** Rich Input opened.
- Ctrl+G in an agent CLI → the configured external editor opened **and** Rich Input opened.
- Ctrl+Shift+G → Rich Input only.

Both observations are the same defect seen from two sides: the Rich Input binding fired when it should not, and when it fired it did not take the key away from the pane. The binding stays on **Ctrl+G**, and this PR also adds a Settings toggle so anyone who wants Ctrl+G to reach the pane can have it.

## Root cause

**1. The chord gate matched a superset of the modifier set.** `useComposeShortcut` tested

```ts
if (!(e.ctrlKey || e.metaKey) || (e.key !== 'g' && e.key !== 'G')) return;
```

`KeyboardEvent.key` is `'G'` precisely when Shift is held, and nothing rejected Shift or Alt. So **Ctrl+Shift+G** — which `WMUX_KEYMAP` and `useKeyboard` own as `clearMultiview` — also toggled Rich Input, and so did Ctrl+Alt+G. That is why the reporter found Ctrl+Shift+G "working": it was riding a different binding.

**2. The leak to the pane is a regression from #1228 (b6225d3c, "fix: Dvorak Ctrl+C, Codex Shift+Enter, and stale agent slug after exit").** xterm's own encode path ends in `cancel()`, which calls `preventDefault()` **and `stopPropagation()`** — so before #1228 a Ctrl+G was consumed by xterm and never reached the document-level listener, and Rich Input's advertised key was quietly dead inside a terminal. #1228 added a catch-all `resolveCtrlLetterByte` encoder that writes the control byte itself with only `preventDefault()`. The event then keeps bubbling: BEL (0x07) to the pane **plus** the popover. Nothing about Ctrl+G changed in #1228; it changed who stops the event.

`resolveCtrlLetterByte` itself is exact (`if (!e.ctrlKey || e.shiftKey || e.altKey || e.metaKey …) return null`), so the same mistake is not in that helper.

### Other bindings audited

- `useKeyboard.ts` — every branch spells `shift` or `!shift` explicitly. The three that deliberately omit it (`Ctrl+=`, `Ctrl+-`, `Ctrl+Tab`) are documented as intentional in `keymap.ts`, and their shifted aliases are listed in `WMUX_KEYMAP` so the conflict checker sees them. No hazard.
- `matchesDisabledShortcut` in `shared/keymap.ts` builds the combo from the actual `shiftKey` value. Exact.
- `useTerminalCopyShortcut` — `if (!e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return;`. Exact.
- `useTerminal`'s custom key handler — every bubble branch is gated on `!e.shiftKey`, with a separate Ctrl+Shift catch-all. Exact.
- Every other `keydown` listener in the renderer is an Escape / outside-dismiss handler with no chord matching.

`useComposeShortcut` was the only loose matcher in the renderer.

## Fix

- `useComposeShortcut` matches **exactly**: no Shift, no Alt, and the platform picks the base modifier — ⌘ on macOS (where Ctrl+G is a readline byte), literal Ctrl elsewhere. Adds a physical `KeyG` fallback so the binding survives a Hangul / non-Latin IME, and yields when the user has switched Ctrl+G off in Settings → Shortcuts.
- `useTerminal` bubbles the chord to that listener instead of encoding it, so **neither xterm nor the catch-all ctrl encoder writes anything** when the binding fires — no more `^G`, no more external editor. It gets its own branch rather than a row in the `bubbleKeys` / `bubbleCodes` allowlists, whose condition is only `ctrlKey && !shiftKey`: a row there would also swallow Ctrl+Alt+G and Ctrl+Meta+G, which no handler claims. macOS is untouched: ⌘G is the binding there and Ctrl+G stays a readline byte.
- **Both gates call one exported pure predicate**, `isComposeChord` (`src/renderer/terminal/composeChord.ts`). The general defect behind #1280 is that each gate had its own opinion of the same key: xterm's encode path calls `stopPropagation`, so the pane gate runs first and the popover gate only sees what it let bubble — every condition one gate applies that the other cannot see is a silently dead key. The predicate can be wrong; it cannot be inconsistent. It also rejects `e.isComposing` (with a Hangul preedit open, `key='Process'` + the physical `KeyG` fallback used to pop Rich Input mid-composition, while every other ctrl-letter path defers) and accepts an unshifted capital `G`, which Caps Lock produces.
- **Only the active-leaf terminal owns the chord, on BOTH gates.** The bubble branch runs in every `useTerminal` consumer, but `useComposeShortcut` acts on the workspace's active leaf, so `FloatingPane` (Ctrl+`) and Deck's `BrainTerminalEmbed` had the key swallowed by the pane gate and declined by the popover gate — a dead key, or Rich Input aimed at a different pty. A new `ownsComposeShortcut` option (true from `Terminal.tsx`, defaulting to false) keeps those surfaces encoding 0x07 exactly as 3.51.0 did. Resolving the popover against the pty that produced the event was the alternative, and was rejected: the popover is rendered by the active leaf's toolbar, so it would open over the wrong pane.

  The first cut of this wired ownership into the pane gate only, and the live dogfood caught what that leaves: from the floating pane, one Ctrl+G still opened Rich Input over the background active leaf while the floating pty received nothing — on Windows, the original complaint reproduced inside the floating pane. Ownership now lives on the DOM and both gates read the same marker: `useTerminal` stamps every container with `data-terminal-pty` and adds `data-compose-owner` only where the option is set, and `composeOwnerHost(target)` resolves a keydown to `{ ptyId, owns }`. The document gate acts only when the keydown came from an owning terminal whose pty **is** the active leaf. A keydown from no terminal at all (focus on `<body>`) keeps the old behaviour — the binding never required terminal focus — and the toolbar-owned-input exemption is unchanged.
- **Auto-repeat is a decision, not an accident.** The predicate accepts repeats, so both gates agree the key belongs to the binding; the popover gate declines only to *toggle* on one. A held Ctrl+G toggles once and is then inert — a deliberate non-repeating chord — rather than producing neither a byte nor an action.
- `useComposeShortcut` picks up the `inspectModeActive` early-out `useKeyboard` applies to every global shortcut, and the pane gate checks the same flag so the key is not merely swallowed.
- `WMUX_KEYMAP` gains the `Ctrl+G` row it never had, **advertised** with a `settings.sc.richInput` label. Advertised rows are exactly the rows `SettingsPanel` renders with a disable toggle, and the disabled gate is wired on both sides (`useComposeShortcut` yields; `useTerminal`'s disabled branch writes the control byte), so switching it off hands Ctrl+G straight back to the pane. The row also reserves its accelerator, so the app-menu drift test now covers it.

## The binding stays Ctrl+G — the reporter's expectation is declined deliberately

The reporter expected "only Ctrl+Shift+G opens Rich Input". That is the *accidental* spelling — the one the superset bug created — not the designed one:

- The toolbar renders a literal `Ctrl G` kbd chip next to the Rich Input button.
- `settings.agentToolbarShowDesc` says "Ctrl+G always works" in all 23 locales.
- The design spec and the implementation plan for the toolbar both specify Ctrl+G, and the hook, `ToolbarHost`, `ComposeHost` and `AgentToolbar` comments all say ⌘G / Ctrl+G.
- **Ctrl+Shift+G is already `clearMultiview`** (`useKeyboard`, `WMUX_KEYMAP`), so Rich Input cannot own it without both actions firing on one keypress.

One case the built-in still loses, worth knowing: a user who has bound a **custom keybinding** to Ctrl+G keeps winning via `useKeyboard`'s `stopImmediatePropagation`, so Rich Input silently never opens for them. Their explicit rebind beating the built-in is the right precedence — it is just silent.

The real cost of keeping Ctrl+G is that it no longer reaches the pane: Claude Code's external-editor key and readline's abort. That is what the new Settings → Shortcuts toggle is for — turn the shortcut off and Ctrl+G behaves exactly as it did in 3.51.0, with no other binding touched.

## Tests

- `src/renderer/components/AgentToolbar/__tests__/useComposeShortcut.test.tsx` — new. Ctrl+G toggles and consumes the key; **Ctrl+Shift+G does not**; Ctrl+Alt+G does not; bare G does not; the IME `key === 'Process'` + `code === 'KeyG'` path does, but **not while composing**; a disabled Ctrl+G yields; inspect mode yields; no focused terminal surface yields; key repeat does not flap. Plus the keymap sweep on both platforms. macOS block: ⌘G toggles, Ctrl+G does not, ⌘+Shift+G does not.
- `src/renderer/terminal/__tests__/composeChord.test.ts` — new. The predicate directly: Shift rejected (Ctrl+Shift+G), Alt and Meta rejected, unshifted capital G accepted (Caps Lock), the physical `KeyG` fallback under a jamo / `Process` key, composing deferred, macOS ⌘G accepted with literal Ctrl+G and Ctrl+⌘+G rejected, repeat accepted — plus a sweep of **every `WMUX_KEYMAP` row on both platforms**, with ⌘ substituted for the cmdOrCtrl family the way `useKeyboard` dispatches it and `code` filled in from the letter.
- `src/renderer/hooks/__tests__/useTerminal.composeBubble.test.ts` — new. jsdom cannot run xterm's custom key handler, so the wiring is pinned at the source like the neighbouring `macCtrlPassthrough` / `ctrlLetterEncoding` locks, but kept to the few lines that matter now that the predicate is tested on its own: the branch is `ownsComposeShortcut && isComposeChord(…)`, it precedes the catch-all encoder, `g` / `KeyG` stay out of the shared allowlists, and the disabled-shortcut branch precedes it **and writes the control byte inside that same branch**. Plus the ownership wiring in all three consumers (`Terminal.tsx` opts in; `FloatingPane.tsx` and `BrainTerminalEmbed.tsx` do not; the option defaults to false) and a behavioural check that a non-owning terminal still resolves Ctrl+G to `0x07` — the floating-pane case.
- `src/shared/__tests__/keymap.test.ts` — Ctrl+G is in `ADVERTISED_SHORTCUTS` (the list SettingsPanel maps over) with the right label key and `literalCtrl: false`; it reserves its accelerator; disabling it matches a real Ctrl+G keydown by `key` and by physical `code`, does **not** match Ctrl+Shift+G, and on macOS matches ⌘G but not literal Ctrl+G.
- `src/renderer/i18n/__tests__/advertisedShortcutsLocale.test.ts` — new. Every advertised row has an English string (a missing one would render the raw key in the Settings list, in every language), and the Rich Input label is present in ko/zh too.

### Locale convention followed

`settings.sc.richInput` was added to **en (authoritative), pl, ko, zh**. Per #997 and the note in `scripts/locale-drift-report.mjs`, those are the maintained locales — pl is gated by `plLocaleCoverage.test.ts`, ko/zh are maintained by hand — while the other 20 are an explicitly accepted stalled gap (ko is at 1159/1607 keys, most locales at 377) that falls back to English at runtime. No translation was invented: each value reuses that locale's existing "Toggle …" phrasing from `settings.sc.toggleNotifications` and its own `toolbar.richInput` term.

Gates: `npx tsc --noEmit` clean; eslint on the changed files clean (the 3 remaining `no-empty-function` errors in `useTerminal.ts` are pre-existing on `main`); full `npx vitest run` → 15580 passed, 1 failed — `generateNotices` only, the known spurious failure under a symlinked `node_modules`.

Fixes #1280

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7XXScnD6iemykDXdtrKN4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the Rich Input shortcut to **Settings → Shortcuts**, with localized labels and an option to disable it.
  - Rich Input now responds to **Ctrl+G on Windows/Linux** and **⌘G on macOS**.
  - The shortcut is handled only by the active pane terminal; floating panes and embedded terminals retain their existing behavior.

- **Bug Fixes**
  - Prevented duplicate toggles from held keys.
  - Suppressed the shortcut during IME composition and inspect mode.
  - Improved handling across keyboard layouts and modifier combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


