### PR TITLE
test: fix the seven timing-sensitive CI flakes

### DIFF
--- a/scripts/__tests__/opencode-sync-render.runtime.test.mjs
+++ b/scripts/__tests__/opencode-sync-render.runtime.test.mjs
@@ -45,9 +45,15 @@ const pageHtml = `<!doctype html>
   // another 80 ms before reading the screen, so a loaded CI runner whose
   // requestAnimationFrame callback landed later than that read a stale
   // viewport and failed on finalFrameVisible.
-  const nextRender = () => new Promise((resolve) => {
-    const sub = term.onRender(() => { sub.dispose(); resolve(); });
-  });
+  // Returns the promise AND its disposer, so a caller that loses a
+  // Promise.race can drop the listener instead of leaking one per round.
+  const nextRender = () => {
+    let sub;
+    const done = new Promise((resolve) => {
+      sub = term.onRender(() => { sub.dispose(); resolve(); });
+    });
+    return { done, dispose: () => sub.dispose() };
+  };
 
   const visibleText = () => {
     const buffer = term.buffer.active;
@@ -65,7 +71,19 @@ const pageHtml = `<!doctype html>
     const until = Date.now() + deadlineMs;
     while (!visibleText().includes(needle)) {
       if (Date.now() >= until) return false;
-      await Promise.race([nextRender(), new Promise((r) => setTimeout(r, 50))]);
+      const render = nextRender();
+      let timer;
+      try {
+        await Promise.race([
+          render.done,
+          new Promise((r) => { timer = setTimeout(r, 50); }),
+        ]);
+      } finally {
+        // Whichever side won, drop the other: ~200 rounds fit inside the
+        // deadline, and each one used to leave its onRender listener behind.
+        clearTimeout(timer);
+        render.dispose();
+      }
     }
     return true;
   };
@@ -74,7 +92,7 @@ const pageHtml = `<!doctype html>
     const warmedUp = nextRender();
     await write('\\x1b[?2026h' + frameBody(-1));
     await write('\\x1b[?2026l');
-    await warmedUp;
+    await warmedUp.done;
 
     let renders = 0;
     const sub = term.onRender(() => { renders++; });
@@ -114,6 +132,10 @@ it('paints completed synchronized frames while OpenCode-style output remains act
     browser = await chromium.launch({
       channel,
       args: ['--enable-unsafe-swiftshader'],
+      // Bound the one unbounded step. Everything after this — the probe's
+      // waits — is capped at 10 s, so a hung launch should fail here with a
+      // clear Playwright error rather than burn the whole file budget.
+      timeout: 60_000,
     });
     const page = await browser.newPage();
     await page.goto(origin);

--- a/scripts/__tests__/opencode-sync-render.runtime.test.mjs
+++ b/scripts/__tests__/opencode-sync-render.runtime.test.mjs
@@ -40,10 +40,41 @@ const pageHtml = `<!doctype html>
     return '\\x1b[H\\x1b[2J' + rows.join('\\r\\n');
   };
 
+  // #1274: every wait in this probe is driven by an xterm event, not by a
+  // fixed sleep. The old version slept 80 ms after the warm-up frame and
+  // another 80 ms before reading the screen, so a loaded CI runner whose
+  // requestAnimationFrame callback landed later than that read a stale
+  // viewport and failed on finalFrameVisible.
+  const nextRender = () => new Promise((resolve) => {
+    const sub = term.onRender(() => { sub.dispose(); resolve(); });
+  });
+
+  const visibleText = () => {
+    const buffer = term.buffer.active;
+    let text = '';
+    for (let y = 0; y < term.rows; y++) {
+      text += buffer.getLine(buffer.viewportY + y)?.translateToString(true) ?? '';
+    }
+    return text;
+  };
+
+  // Resolve as soon as the wanted frame is on screen. The deadline only
+  // bounds the failure case (the assertion then reports a stale viewport);
+  // a healthy run returns on the very next render event.
+  const waitForVisible = async (needle, deadlineMs) => {
+    const until = Date.now() + deadlineMs;
+    while (!visibleText().includes(needle)) {
+      if (Date.now() >= until) return false;
+      await Promise.race([nextRender(), new Promise((r) => setTimeout(r, 50))]);
+    }
+    return true;
+  };
+
   window.runProbe = async () => {
+    const warmedUp = nextRender();
     await write('\\x1b[?2026h' + frameBody(-1));
     await write('\\x1b[?2026l');
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    await warmedUp;
 
     let renders = 0;
     const sub = term.onRender(() => { renders++; });
@@ -53,19 +84,14 @@ const pageHtml = `<!doctype html>
       await write('\\x1b[?2026l');
     }
     const rendersDuringStream = renders;
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    const finalFrameVisible = await waitForVisible('frame ' + (sent - 1), 10_000);
     sub.dispose();
 
-    const buffer = term.buffer.active;
-    let visibleText = '';
-    for (let y = 0; y < term.rows; y++) {
-      visibleText += buffer.getLine(buffer.viewportY + y)?.translateToString(true) ?? '';
-    }
     return {
       sent,
       rendersDuringStream,
       rendersAfterSettle: renders,
-      finalFrameVisible: visibleText.includes('frame ' + (sent - 1)),
+      finalFrameVisible,
       webglCanvasCount: document.querySelectorAll('.xterm canvas').length,
     };
   };
@@ -102,4 +128,9 @@ it('paints completed synchronized frames while OpenCode-style output remains act
     await browser?.close();
     server.close();
   }
-}, 30_000);
+  // The 30 s budget was hit on ubuntu and windows runners even though the
+  // probe itself finishes in well under a second: the wall clock here is a
+  // cold `chromium.launch()` of the system Chrome/Edge channel plus the
+  // first WebGL context on a shared runner. Sized for the slowest observed
+  // launch with headroom; the probe's own waits are event-driven (above).
+}, 120_000);

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -622,48 +622,35 @@ describe('DaemonSessionManager', () => {
     expect(managed[0].ptyProcess).toBeDefined();
   });
 
-  // v2.8.1 hotfix: actionable error at MAX_SESSIONS (Bug 1)
+  // v2.8.1 hotfix (Bug 1) + substrate 3.0: the cap is configurable and the
+  // error is actionable. One test, because the two are the same branch.
   //
-  // #1274: this used to spawn 200 mock sessions to reach the *default* cap.
-  // Those 200 sessions' garbage was collected during the NEXT test, which is
-  // why "honours a custom session.maxSessions" — a three-session test that
-  // takes 4 ms in isolation — was measured at 5.4-7.3 s against the 5 s
-  // per-test limit on macos-14. The ceiling is read from config (and the
-  // no-config path falls back to createDefaultConfig, asserted below), so a
+  // #1274: this used to be two tests, the first spawning 200 mock sessions to
+  // reach the *default* cap. Those 200 sessions' garbage was collected during
+  // the next one — which is why "honours a custom session.maxSessions", a
+  // three-session test that takes 4 ms in isolation, was measured at 5.4-7.3 s
+  // against the 5 s per-test limit on macos-14. The ceiling is read from
+  // config (and the no-config path falls back to createDefaultConfig), so a
   // small configured cap exercises the identical branch with 1/50th of the
-  // allocation.
-  it('throws an actionable error when the session cap is reached', () => {
+  // allocation, and the default 200 is pinned by an assertion instead of by
+  // 200 PTY spawns.
+  it('honours session.maxSessions and refuses past it with an actionable error', () => {
     const cfg = createDefaultConfig();
-    // The default ceiling is still 200 — pinned here so lowering it for the
-    // spawn loop below does not lose that contract.
     expect(cfg.session.maxSessions).toBe(200);
-    cfg.session.maxSessions = 4;
-    manager.setConfig(cfg);
-    for (let i = 0; i < 4; i++) {
-      manager.createSession({ id: `cap-${i}`, cmd: 'cmd.exe', cwd: '.' });
-    }
-    // The one past the cap must fail with a message the UI can show verbatim.
-    // The pre-v2.8.1 message was "Maximum session limit (50) reached" which
-    // surfaced as a generic "unknown error" toast in the renderer.
-    expect(() =>
-      manager.createSession({ id: 'cap-overflow', cmd: 'cmd.exe', cwd: '.' }),
-    ).toThrow(
-      /Cannot create new terminal: 4 active sessions already running\. Close some panes/,
-    );
-  });
-
-  // substrate 3.0: the session cap is configurable (was a 200 literal)
-  it('honours a custom session.maxSessions from setConfig', () => {
-    const cfg = createDefaultConfig();
     cfg.session.maxSessions = 3;
     manager.setConfig(cfg);
     for (let i = 0; i < 3; i++) {
       manager.createSession({ id: `cm-${i}`, cmd: 'cmd.exe', cwd: '.' });
     }
-    // The cap is now 3, not the default 200 — and the message echoes it.
+    // The cap is now 3, not the default 200 — and the message echoes it. It
+    // must be showable verbatim in the UI: the pre-v2.8.1 text was "Maximum
+    // session limit (50) reached", which surfaced as a generic "unknown error"
+    // toast in the renderer.
     expect(() =>
       manager.createSession({ id: 'cm-overflow', cmd: 'cmd.exe', cwd: '.' }),
-    ).toThrow(/Cannot create new terminal: 3 active sessions already running/);
+    ).toThrow(
+      /Cannot create new terminal: 3 active sessions already running\. Close some panes/,
+    );
   });
 
   // codex P2: DEAD tombstones must not occupy a cap slot

--- a/src/daemon/__tests__/DaemonSessionManager.test.ts
+++ b/src/daemon/__tests__/DaemonSessionManager.test.ts
@@ -623,16 +623,33 @@ describe('DaemonSessionManager', () => {
   });
 
   // v2.8.1 hotfix: actionable error at MAX_SESSIONS (Bug 1)
+  //
+  // #1274: this used to spawn 200 mock sessions to reach the *default* cap.
+  // Those 200 sessions' garbage was collected during the NEXT test, which is
+  // why "honours a custom session.maxSessions" — a three-session test that
+  // takes 4 ms in isolation — was measured at 5.4-7.3 s against the 5 s
+  // per-test limit on macos-14. The ceiling is read from config (and the
+  // no-config path falls back to createDefaultConfig, asserted below), so a
+  // small configured cap exercises the identical branch with 1/50th of the
+  // allocation.
   it('throws an actionable error when the session cap is reached', () => {
-    for (let i = 0; i < 200; i++) {
+    const cfg = createDefaultConfig();
+    // The default ceiling is still 200 — pinned here so lowering it for the
+    // spawn loop below does not lose that contract.
+    expect(cfg.session.maxSessions).toBe(200);
+    cfg.session.maxSessions = 4;
+    manager.setConfig(cfg);
+    for (let i = 0; i < 4; i++) {
       manager.createSession({ id: `cap-${i}`, cmd: 'cmd.exe', cwd: '.' });
     }
-    // The 201st must fail with a message the UI can show verbatim. The
-    // pre-v2.8.1 message was "Maximum session limit (50) reached" which
+    // The one past the cap must fail with a message the UI can show verbatim.
+    // The pre-v2.8.1 message was "Maximum session limit (50) reached" which
     // surfaced as a generic "unknown error" toast in the renderer.
     expect(() =>
-      manager.createSession({ id: 'cap-201', cmd: 'cmd.exe', cwd: '.' }),
-    ).toThrow(/Cannot create new terminal: 200 active sessions already running/);
+      manager.createSession({ id: 'cap-overflow', cmd: 'cmd.exe', cwd: '.' }),
+    ).toThrow(
+      /Cannot create new terminal: 4 active sessions already running\. Close some panes/,
+    );
   });
 
   // substrate 3.0: the session cap is configurable (was a 200 literal)

--- a/src/main/git/__tests__/mergeSession.test.ts
+++ b/src/main/git/__tests__/mergeSession.test.ts
@@ -53,6 +53,13 @@ function addFeat(repo: string, content: string): string {
   return oid;
 }
 
+// #1274: the suites below drive the real `git` binary (init/commit/worktree/merge)
+// against a temp repo, so their runtime tracks process-spawn cost rather than code
+// speed. Locally the whole file is ~6.6 s with the slowest test ~1.2 s; on a loaded
+// windows-latest runner the same work measured 6.0 s against vitest's 5 s default
+// and flaked on PRs that never touch this code. Explicit generous budget instead.
+const GIT_PROCESS_TIMEOUT_MS = 30_000;
+
 describe('parseNulList — NUL(-z)-separated parser', () => {
   it('splits NUL-separated items and drops empty items / trailing NULs', () => {
     expect(parseNulList('a.txt\0b/c.txt\0')).toEqual(['a.txt', 'b/c.txt']);
@@ -69,7 +76,7 @@ describe('isIntegrationPath — prefix recognition', () => {
   });
 });
 
-describe('detectConflicts — conflict detection (not exit code)', () => {
+describe('detectConflicts — conflict detection (not exit code)', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeRepo>;
   beforeEach(() => (scn = makeRepo()));
   afterEach(() => scn.cleanup());
@@ -102,7 +109,7 @@ describe('detectConflicts — conflict detection (not exit code)', () => {
   });
 });
 
-describe('checkTargetPreconditions — target (base) preconditions', () => {
+describe('checkTargetPreconditions — target (base) preconditions', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeRepo>;
   beforeEach(() => (scn = makeRepo()));
   afterEach(() => scn.cleanup());
@@ -142,7 +149,7 @@ describe('checkTargetPreconditions — target (base) preconditions', () => {
   });
 });
 
-describe('resolveBaseFromGit — fallback chain (no gh)', () => {
+describe('resolveBaseFromGit — fallback chain (no gh)', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeRepo>;
   beforeEach(() => (scn = makeRepo()));
   afterEach(() => scn.cleanup());
@@ -225,7 +232,7 @@ describe('linkNodeModules — dep link into the integration worktree', () => {
   });
 });
 
-describe('runVerify — exit-code verdict (injected commands)', () => {
+describe('runVerify — exit-code verdict (injected commands)', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeRepo>;
   beforeEach(() => (scn = makeRepo()));
   afterEach(() => scn.cleanup());
@@ -252,7 +259,7 @@ describe('runVerify — exit-code verdict (injected commands)', () => {
   });
 });
 
-describe('clean merge → Land round-trip', () => {
+describe('clean merge → Land round-trip', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeRepo>;
   beforeEach(() => (scn = makeRepo()));
   afterEach(() => scn.cleanup());

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -1153,12 +1153,15 @@ describe('fan-out task workspaces never run a brain of their own (wave 2 dogfood
     expect(capWrites).toContainEqual({ ws: 'ws-task', patch: { mode: 'off' } });
   });
 
-  // #1274: this failed on windows-latest as `expected +0 to be 1`. The park is
-  // an async ledger append behind the coalescer, and `vi.waitFor`'s DEFAULT
-  // timeout is 1 s — shorter than the coalescer's own 1.5 s debounce, so on a
-  // runner where the flush is not early the poll gave up before the append
-  // could happen. The wait is now sized past the debounce (and the test past
-  // the wait); locally the park lands in ~50 ms, so a healthy run is unaffected.
+  // #1274: this failed on windows-latest as `expected +0 to be 1`. There is no
+  // debounce on this path — deck.handler skips `coalescer.push` for a task
+  // workspace and calls `routeWorkerEventToOwner` inline. The only async step
+  // is `TaskLedger.recordOrphanedEvent` (serialize + jsonl append), whose
+  // rejection is swallowed by a `.catch(console.warn)` in the ledger host, so a
+  // slow or failed append surfaces here only as the poll never seeing the
+  // event. `vi.waitFor`'s DEFAULT timeout is 1 s, which a loaded Windows
+  // runner's fs append can outlast; the wait is now 10 s (and the test past
+  // it). Locally the park lands in ~36 ms, so a healthy run is unaffected.
   it("an owner that is itself a task workspace (nested fan-out) has no brain: the event is parked, not pushed", { timeout: 15_000 }, async () => {
     // ws-1 owns wtask-1 (ws-task); make ws-1 itself a task of ws-root.
     await ledger.register({ id: 'wtask-0', taskWorkspaceId: 'ws-1', ownerWorkspaceId: 'ws-root', title: 'outer' });

--- a/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
+++ b/src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts
@@ -1153,7 +1153,13 @@ describe('fan-out task workspaces never run a brain of their own (wave 2 dogfood
     expect(capWrites).toContainEqual({ ws: 'ws-task', patch: { mode: 'off' } });
   });
 
-  it("an owner that is itself a task workspace (nested fan-out) has no brain: the event is parked, not pushed", async () => {
+  // #1274: this failed on windows-latest as `expected +0 to be 1`. The park is
+  // an async ledger append behind the coalescer, and `vi.waitFor`'s DEFAULT
+  // timeout is 1 s — shorter than the coalescer's own 1.5 s debounce, so on a
+  // runner where the flush is not early the poll gave up before the append
+  // could happen. The wait is now sized past the debounce (and the test past
+  // the wait); locally the park lands in ~50 ms, so a healthy run is unaffected.
+  it("an owner that is itself a task workspace (nested fan-out) has no brain: the event is parked, not pushed", { timeout: 15_000 }, async () => {
     // ws-1 owns wtask-1 (ws-task); make ws-1 itself a task of ws-root.
     await ledger.register({ id: 'wtask-0', taskWorkspaceId: 'ws-1', ownerWorkspaceId: 'ws-root', title: 'outer' });
     eventBus.emit({
@@ -1166,7 +1172,10 @@ describe('fan-out task workspaces never run a brain of their own (wave 2 dogfood
       decision: 'emit',
     });
     // The park is an async ledger append; poll instead of a fixed delay.
-    await vi.waitFor(() => expect(ledger.peekOrphanedEvents('ws-1').length).toBe(1));
+    await vi.waitFor(
+      () => expect(ledger.peekOrphanedEvents('ws-1').length).toBe(1),
+      { timeout: 10_000, interval: 25 },
+    );
     expect(adapters).toHaveLength(0);
   });
 });

--- a/src/main/ipc/handlers/__tests__/diff.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/diff.handler.test.ts
@@ -113,7 +113,15 @@ function makeScenario(): {
   };
 }
 
-describe('diff:read — 워킹트리 대조·untracked 합성·스냅샷', () => {
+// #1274: every suite in this file builds temp git repos and shells out to the real
+// `git` binary (init/commit/worktree/diff/apply) per test, so runtime tracks
+// process-spawn cost rather than code speed. Locally the file is ~35 s with the
+// slowest test ~2.4 s; on a loaded windows-latest validate run it measured 10.2 s
+// and blew vitest's 5 s default on PRs that never touch this code. Explicit
+// generous per-test budget instead of raising the global timeout.
+const GIT_PROCESS_TIMEOUT_MS = 30_000;
+
+describe('diff:read — 워킹트리 대조·untracked 합성·스냅샷', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -143,7 +151,7 @@ describe('diff:read — 워킹트리 대조·untracked 합성·스냅샷', () =>
   });
 });
 
-describe('diff:applyHunks — 채택 all-or-nothing', () => {
+describe('diff:applyHunks — 채택 all-or-nothing', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -281,7 +289,7 @@ describe('diff:applyHunks — 채택 all-or-nothing', () => {
 // file with +/- and no hunks, or hunks that cannot be applied. Note neither
 // configured command is ever spawned once the flags are in place — these tests
 // assert the flags took effect, not the tools' behaviour.
-describe('diff:read — external diff drivers cannot replace the patch', () => {
+describe('diff:read — external diff drivers cannot replace the patch', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -338,7 +346,7 @@ describe('diff:read — external diff drivers cannot replace the patch', () => {
 // the worktree in between used to be adopted silently — the wrong hunk, or only
 // the part of the selection that still resolved. Every case below must reject
 // the whole request and leave the target byte-identical.
-describe('diff:applyHunks — source integrity gate', () => {
+describe('diff:applyHunks — source integrity gate', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   const BASE_A = 'a1\na2\na3\na4\na5\n';
   const BASE_B = 'b1\nb2\nb3\n';
@@ -549,7 +557,7 @@ describe('diff:applyHunks — source integrity gate', () => {
 });
 
 // ── F1: quotepath 경로 파싱(공백·한글·따옴표·rename) ─────────────────────────
-describe('diff:read/applyHunks — F1 특수문자 파일명(-z quotepath=false)', () => {
+describe('diff:read/applyHunks — F1 특수문자 파일명(-z quotepath=false)', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -598,7 +606,7 @@ describe('diff:read/applyHunks — F1 특수문자 파일명(-z quotepath=false)
 });
 
 // ── F2: 프로브 의미론 — 의존 hunk 결합 성공·alreadyApplied 명시 거부 ──────────
-describe('diff:applyHunks — F2 결합 게이트·alreadyApplied 거부', () => {
+describe('diff:applyHunks — F2 결합 게이트·alreadyApplied 거부', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -672,7 +680,7 @@ describe('diff:applyHunks — F2 결합 게이트·alreadyApplied 거부', () =>
 });
 
 // ── F3: untracked symlink 차단 ───────────────────────────────────────────────
-describe('diff:read — F3 symlink untracked는 unsupported(repo 밖 노출 차단)', () => {
+describe('diff:read — F3 symlink untracked는 unsupported(repo 밖 노출 차단)', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -711,7 +719,7 @@ describe('diff:read — F3 symlink untracked는 unsupported(repo 밖 노출 차�
 });
 
 // ── F4: delete diff의 dirty 게이트 경로 ──────────────────────────────────────
-describe('diff:applyHunks — F4 delete 파일이 타겟에서 dirty면 거부', () => {
+describe('diff:applyHunks — F4 delete 파일이 타겟에서 dirty면 거부', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -748,7 +756,7 @@ describe('diff:applyHunks — F4 delete 파일이 타겟에서 dirty면 거부',
 });
 
 // ── F7: truncated(캡 초과) 파일 채택 차단 ────────────────────────────────────
-describe('diff:read/applyHunks — F7 캡 초과 파일 채택 불가', () => {
+describe('diff:read/applyHunks — F7 캡 초과 파일 채택 불가', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -785,7 +793,7 @@ describe('diff:read/applyHunks — F7 캡 초과 파일 채택 불가', () => {
 });
 
 // ── F8: targetHeadOid 인자 가드 ──────────────────────────────────────────────
-describe('diff:read — F8 targetHeadOid 형식 가드', () => {
+describe('diff:read — F8 targetHeadOid 형식 가드', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let scn: ReturnType<typeof makeScenario>;
   beforeEach(() => {
     captured.clear();
@@ -808,7 +816,7 @@ describe('diff:read — F8 targetHeadOid 형식 가드', () => {
 // ── 워크스페이스 diff 모드 — 일반 repo를 targetHeadOid 미지정으로 읽기 ─────────
 // resolveTargetRepo→repo 자신, merge-base HEAD HEAD=HEAD → `git diff HEAD`
 // (staged+unstaged) + untracked 합성. 백엔드 무변경으로 성립하는 계약을 고정한다.
-describe('diff:read — 워크스페이스 모드(일반 repo, oid 미지정)', () => {
+describe('diff:read — 워크스페이스 모드(일반 repo, oid 미지정)', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let base: string;
   let repo: string;
 
@@ -918,7 +926,7 @@ describe('diff:read — 워크스페이스 모드(일반 repo, oid 미지정)', 
 });
 
 // ── diff:resolveRepo — 팔레트 진입점의 cwd → worktree toplevel 정규화 ─────────
-describe('diff:resolveRepo — cwd 정규화', () => {
+describe('diff:resolveRepo — cwd 정규화', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   let base: string;
   let repo: string;
 
@@ -978,7 +986,7 @@ describe('diff:resolveRepo — cwd 정규화', () => {
 
 // ── Guards for the README's adoption claim: hunks are picked individually, and
 //    the all-or-nothing part is the apply of that selection (not the whole diff).
-describe('diff:applyHunks — per-hunk selection granularity and selection-wide atomicity', () => {
+describe('diff:applyHunks — per-hunk selection granularity and selection-wide atomicity', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {
   // Local fixture: two files long enough that two distant edits each land in two
   // hunks. The shared makeScenario files are too short to split. `diff.context`
   // and `diff.interHunkContext` are pinned because the hunk split — and so the

--- a/src/main/ipc/handlers/__tests__/diff.handler.test.ts
+++ b/src/main/ipc/handlers/__tests__/diff.handler.test.ts
@@ -115,10 +115,14 @@ function makeScenario(): {
 
 // #1274: every suite in this file builds temp git repos and shells out to the real
 // `git` binary (init/commit/worktree/diff/apply) per test, so runtime tracks
-// process-spawn cost rather than code speed. Locally the file is ~35 s with the
-// slowest test ~2.4 s; on a loaded windows-latest validate run it measured 10.2 s
-// and blew vitest's 5 s default on PRs that never touch this code. Explicit
-// generous per-test budget instead of raising the global timeout.
+// process-spawn cost rather than code speed — and the numbers below are not
+// comparable to each other, so state the conditions. Run alone and serially on
+// macOS the whole file is ~35 s (cold) / ~11 s (warm) and the slowest single
+// test is ~2.4 s cold. On windows-latest `validate`, where the file shares the
+// runner with parallel vitest workers and Git-for-Windows process spawn costs
+// an order of magnitude more, ONE test measured 10.2 s and blew vitest's 5 s
+// per-test default — on a PR that never touched this code. The budget is sized
+// for that CI-parallel worst case, not for the local serial figure.
 const GIT_PROCESS_TIMEOUT_MS = 30_000;
 
 describe('diff:read — 워킹트리 대조·untracked 합성·스냅샷', { timeout: GIT_PROCESS_TIMEOUT_MS }, () => {

--- a/src/main/worktask/__tests__/FanOutService.test.ts
+++ b/src/main/worktask/__tests__/FanOutService.test.ts
@@ -149,7 +149,15 @@ function baseReq(overrides?: Partial<Parameters<FanOutService['start']>[0]>) {
   };
 }
 
-describe('buildInitialCommand (§4 D4)', () => {
+// #1274: the two suites below are the only ones here that exec a real shell
+// (`bash -c` / `sh -c`) to prove the launch string survives an alias-expanding
+// shell. Locally those tests are 8-25 ms, but the work is real-process, so it
+// scales with runner load: "uses a same-shell form" took 7.4 s on windows-latest
+// and blew vitest's 5 s default on a PR that never touched this code. Explicit
+// generous budget for the shell-spawning suites only.
+const SHELL_SPAWN_TIMEOUT_MS = 30_000;
+
+describe('buildInitialCommand (§4 D4)', { timeout: SHELL_SPAWN_TIMEOUT_MS }, () => {
   it('§7: promptPath 없으면 agentCmd만 그대로(빈 인자로 발사하지 않는다)', () => {
     expect(buildInitialCommand('claude', undefined)).toBe('claude');
     expect(buildInitialCommand('claude')).toBe('claude');
@@ -199,7 +207,7 @@ describe('buildInitialCommand (§4 D4)', () => {
 
 // ── F15: the worker's model is wmux's decision, not the login shell's ─────────
 
-describe('workerLaunchCommand (F15)', () => {
+describe('workerLaunchCommand (F15)', { timeout: SHELL_SPAWN_TIMEOUT_MS }, () => {
   const POSIX = { platform: 'darwin' as NodeJS.Platform };
 
   it('neutralises a shell-exported ANTHROPIC_MODEL for a plain claude worker', () => {

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -43,7 +43,7 @@
 // mock global via `setChannelsRpc` to drive the success/failure
 // paths without a real `useRpcBridge` mount.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import {
@@ -650,13 +650,19 @@ describe('channelsSlice — wiring (composed store)', () => {
   // asserts — the sidebar (U7) and composer (U8) will read these
   // through `useStore((s) => s.channels)` etc.
   //
-  // #1274: the assertions here are instant, but the `await import` below pulls
-  // in — and Vite-transforms — the entire composed renderer store graph. In
-  // isolation that costs ~350 ms; inside a full parallel suite run it was
-  // measured at 5022 ms and tripped the 5 s default limit locally. The
-  // explicit timeout covers the one-off module-graph cost on a loaded runner.
-  it('is reachable through the composed store via channels selector', { timeout: 30_000 }, async () => {
-    const { useStore } = await import('../../index');
+  // #1274: the assertions here are instant, but importing the composed store
+  // pulls in — and Vite-transforms — the entire renderer store module graph.
+  // In isolation that costs ~350 ms; inside a full parallel suite run it was
+  // measured at 5022 ms and failed against the 5 s per-test default. Hoisting
+  // the import into a hook moves that one-off cost out of the test body (hooks
+  // get their own budget), so the test is measured on its assertions again
+  // instead of on a module-graph transform.
+  let useStore: Awaited<typeof import('../../index')>['useStore'];
+  beforeAll(async () => {
+    ({ useStore } = await import('../../index'));
+  }, 60_000);
+
+  it('is reachable through the composed store via channels selector', () => {
     // Initial state: every field defaults to its empty value.
     const s = useStore.getState();
     expect(s.channels).toEqual({});

--- a/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
+++ b/src/renderer/stores/slices/__tests__/channelsSlice.test.ts
@@ -649,7 +649,13 @@ describe('channelsSlice — wiring (composed store)', () => {
   // selector. This is the property the plan's U6 verification
   // asserts — the sidebar (U7) and composer (U8) will read these
   // through `useStore((s) => s.channels)` etc.
-  it('is reachable through the composed store via channels selector', async () => {
+  //
+  // #1274: the assertions here are instant, but the `await import` below pulls
+  // in — and Vite-transforms — the entire composed renderer store graph. In
+  // isolation that costs ~350 ms; inside a full parallel suite run it was
+  // measured at 5022 ms and tripped the 5 s default limit locally. The
+  // explicit timeout covers the one-off module-graph cost on a loaded runner.
+  it('is reachable through the composed store via channels selector', { timeout: 30_000 }, async () => {
     const { useStore } = await import('../../index');
     // Initial state: every field defaults to its empty value.
     const s = useStore.getState();

--- a/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
+++ b/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
@@ -203,34 +203,75 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
     try { process.kill(pid, 0); return true; } catch { return false; }
   }
 
-  // #1274: this case is asserted under `definitiveOnly: true` on purpose.
-  // On win32 the argv probe shells out to PowerShell + Get-CimInstance with a
-  // 5 s timeout and returns null on any failure; a loaded CI runner blows past
-  // that budget. With `definitiveOnly: false` a null cmdline plus a matching
-  // image (both plain node) is DOCUMENTED to proceed to SIGKILL, so the old
-  // `toBe(false)` here was a race against WMI latency, not a statement about
-  // the matcher. `definitiveOnly: true` must refuse on an indeterminate
-  // cmdline, which makes the refusal deterministic at any probe latency while
-  // still exercising the argv gate whenever the probe does resolve. The
-  // `definitiveOnly: false` "proceed when indeterminate" behaviour is covered
-  // by its own test below, with the probe stubbed.
+  /**
+   * Re-import the module with ONLY the win32 argv probe stubbed, so a refusal
+   * case can stay in the `definitiveOnly: false` mode that `killDaemonByPidFile`
+   * actually uses and still be deterministic.
+   *
+   * #1274: on win32 `getProcessArgv` shells out to PowerShell + Get-CimInstance
+   * with a 5 s timeout and returns null on failure, and a null cmdline under
+   * `definitiveOnly: false` is DOCUMENTED to proceed to SIGKILL — so on a loaded
+   * runner these tests killed their own sleeper. Asserting them under
+   * `definitiveOnly: true` instead would make them tautologies on exactly the
+   * platform that flaked: production returns false on ANY indeterminate probe
+   * before `argvIdentifiesDaemonScript` is ever called, so the #1025
+   * entry-position guard would no longer be exercised there. Replacing just the
+   * CIM call with the sleeper's real command line keeps the matcher in the loop
+   * on every platform. Every other `execFileSync` call — the tasklist / `ps`
+   * image lookup included — passes through to the real implementation, and on
+   * macOS/Linux the argv probe is untouched (it is fast and never flaked).
+   */
+  async function importWithStubbedWin32Cmdline(argv: string[]) {
+    vi.resetModules();
+    vi.doMock('child_process', async () => {
+      const actual = await vi.importActual<typeof import('child_process')>('child_process');
+      const execFileSync = ((file: unknown, args?: unknown, opts?: unknown) => {
+        const isCimProbe = Array.isArray(args)
+          && args.some((a) => typeof a === 'string' && a.includes('Get-CimInstance Win32_Process'));
+        // The CIM string quotes arguments carrying spaces; production
+        // re-tokenizes it quote-aware, so quote every part.
+        if (isCimProbe) return argv.map((part) => `"${part}"`).join(' ');
+        return (actual.execFileSync as (...rest: unknown[]) => unknown)(file, args, opts);
+      }) as typeof actual.execFileSync;
+      return { ...actual, default: { ...actual, execFileSync }, execFileSync };
+    });
+    return import('../daemonLauncherCore');
+  }
+
+  function undoModuleStubs(): void {
+    vi.doUnmock('child_process');
+    vi.doUnmock('fs');
+    vi.resetModules();
+  }
+
+  // #1274: stays in `definitiveOnly: false` — the mode `killDaemonByPidFile`
+  // uses — with the win32 CIM probe stubbed to the sleeper's real command line
+  // (see importWithStubbedWin32Cmdline). The argv gate is therefore the only
+  // thing refusing the kill on every platform, instead of the probe's latency
+  // deciding the outcome.
   it('refuses an unrelated process whose argv merely ends in daemon/index.js (the #1025 repro)', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-innocent-'));
     // Somebody else's program, using the same everyday layout. The image
     // matches too (both plain node), so the argv gate is the ONLY thing
     // standing between this process and a SIGKILL.
-    const pid = await spawnSleeper(path.join(tmpDir, 'someone-elses-app', 'daemon', 'index.js'));
+    const scriptPath = path.join(tmpDir, 'someone-elses-app', 'daemon', 'index.js');
+    const pid = await spawnSleeper(scriptPath);
 
-    expect(killVerifiedDaemonPid(pid, { definitiveOnly: true })).toBe(false);
-    expect(killVerifiedDaemonPid(pid, {
-      definitiveOnly: true,
-      scriptCandidates: [path.join(tmpDir, 'unrelated', 'daemon-bundle', 'index.js')],
-    })).toBe(false);
-    expect(isAlive(pid)).toBe(true);
-    // Explicit 30 s budget (#1274): two kill attempts, each of which may pay
-    // the win32 tasklist (3 s) + WMI cmdline (5 s) worst case, so the real
-    // ceiling is ~16 s and the previous 15 s was under it.
-  }, 30_000);
+    try {
+      const stubbed = await importWithStubbedWin32Cmdline([process.execPath, scriptPath]);
+      expect(stubbed.killVerifiedDaemonPid(pid, { definitiveOnly: false })).toBe(false);
+      expect(stubbed.killVerifiedDaemonPid(pid, {
+        definitiveOnly: false,
+        scriptCandidates: [path.join(tmpDir, 'unrelated', 'daemon-bundle', 'index.js')],
+      })).toBe(false);
+      expect(isAlive(pid)).toBe(true);
+    } finally {
+      undoModuleStubs();
+    }
+    // 15 s: two kill attempts, each paying the real win32 tasklist image
+    // lookup (3 s worst case). The 5 s cmdline probe is stubbed out, so the
+    // old 5 s default was only ever missed by the image lookup plus spawn.
+  }, 15_000);
 
   // #1274: the other half of the split — the documented indeterminate branch.
   // When the argv probe cannot resolve and the caller is in the before-quit
@@ -263,17 +304,21 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
       return { ...actual, default: { ...actual, readFileSync }, readFileSync };
     });
 
+    let survivorPid = 0;
     try {
       const stubbed = await import('../daemonLauncherCore');
       expect(stubbed.killVerifiedDaemonPid(pid, { definitiveOnly: false })).toBe(true);
       // ...and the same indeterminate reading REFUSES under definitiveOnly.
-      const survivorPid = await spawnSleeper(path.join(tmpDir, 'second', 'daemon', 'index.js'));
+      survivorPid = await spawnSleeper(path.join(tmpDir, 'second', 'daemon', 'index.js'));
       expect(stubbed.killVerifiedDaemonPid(survivorPid, { definitiveOnly: true })).toBe(false);
       expect(isAlive(survivorPid)).toBe(true);
     } finally {
-      vi.doUnmock('child_process');
-      vi.doUnmock('fs');
-      vi.resetModules();
+      // afterEach only tracks the LAST spawned child, and a failed expect
+      // above would skip the survivor spawn entirely — reap both by hand so a
+      // red run cannot orphan 30 s sleepers on the runner.
+      try { process.kill(pid, 'SIGKILL'); } catch { /* already gone */ }
+      if (survivorPid) { try { process.kill(survivorPid, 'SIGKILL'); } catch { /* already gone */ } }
+      undoModuleStubs();
     }
   }, 15_000);
 
@@ -284,16 +329,24 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
     // along as a plain argument (an editor, a build tool, a log grepper).
     const pid = await spawnSleeper(path.join(tmpDir, 'unrelated-entry.js'), [bundlePath]);
 
-    // #1274: a refusal assertion, so it runs under `definitiveOnly: true`
-    // for the same reason as the #1025 repro above — a 5 s-timed-out win32
-    // WMI probe would otherwise legitimately proceed to SIGKILL.
-    expect(killVerifiedDaemonPid(pid, {
-      definitiveOnly: true,
-      scriptCandidates: [bundlePath],
-    })).toBe(false);
-    expect(isAlive(pid)).toBe(true);
-    // 20 s: one kill attempt at the win32 tasklist + WMI worst case (~8 s).
-  }, 20_000);
+    // #1274: a refusal assertion, so the win32 cmdline probe is stubbed to
+    // this sleeper's real argv (entry script first, bundlePath as a trailing
+    // argument) and the mode stays `definitiveOnly: false` — the
+    // entry-position guard is what must refuse here, not probe latency.
+    try {
+      const stubbed = await importWithStubbedWin32Cmdline([
+        process.execPath, path.join(tmpDir, 'unrelated-entry.js'), bundlePath,
+      ]);
+      expect(stubbed.killVerifiedDaemonPid(pid, {
+        definitiveOnly: false,
+        scriptCandidates: [bundlePath],
+      })).toBe(false);
+      expect(isAlive(pid)).toBe(true);
+    } finally {
+      undoModuleStubs();
+    }
+    // 15 s: one kill attempt at the real win32 tasklist worst case (3 s).
+  }, 15_000);
 
   it('kills a process running exactly one of the supplied candidate scripts', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-ours-'));
@@ -310,17 +363,27 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
 
   it('requirement 3, executed: daemon-bundler/index.js is refused, daemon-bundle/index.js is killed', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-shape-'));
-    const bundlerPid = await spawnSleeper(path.join(tmpDir, 'daemon-bundler', 'index.js'));
-    // #1274: refusal half under `definitiveOnly: true` (indeterminate cmdline
-    // must refuse); the kill half below stays in the before-quit mode.
-    expect(killVerifiedDaemonPid(bundlerPid, { definitiveOnly: true })).toBe(false);
-    expect(isAlive(bundlerPid)).toBe(true);
+    const bundlerScript = path.join(tmpDir, 'daemon-bundler', 'index.js');
+    const bundlerPid = await spawnSleeper(bundlerScript);
+    // #1274: the refusal half runs with the win32 cmdline probe stubbed to
+    // this sleeper's real argv, so the near-miss path shape ("daemon-bundler"
+    // vs "daemon-bundle") is what refuses — in the same
+    // `definitiveOnly: false` mode the kill half below uses.
+    try {
+      const stubbed = await importWithStubbedWin32Cmdline([process.execPath, bundlerScript]);
+      expect(stubbed.killVerifiedDaemonPid(bundlerPid, { definitiveOnly: false })).toBe(false);
+      expect(isAlive(bundlerPid)).toBe(true);
+    } finally {
+      undoModuleStubs();
+    }
     try { process.kill(bundlerPid, 'SIGKILL'); } catch { /* cleanup */ }
 
+    // The kill half keeps the real probe: it must pass the matcher on a real
+    // cmdline read, which is the other half of the #1028 guarantee.
     const exactPid = await spawnSleeper(path.join(tmpDir, 'daemon-bundle', 'index.js'));
     expect(killVerifiedDaemonPid(exactPid, { definitiveOnly: false })).toBe(true);
-    // 30 s: two spawns and two kill attempts, each kill paying up to ~8 s of
-    // win32 probes (#1274).
+    // 30 s: two spawns plus the kill half's real win32 tasklist (3 s) + WMI
+    // cmdline (5 s) worst case (#1274).
   }, 30_000);
 });
 

--- a/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
+++ b/src/shared/daemon/__tests__/daemonScriptIdentity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -203,6 +203,17 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
     try { process.kill(pid, 0); return true; } catch { return false; }
   }
 
+  // #1274: this case is asserted under `definitiveOnly: true` on purpose.
+  // On win32 the argv probe shells out to PowerShell + Get-CimInstance with a
+  // 5 s timeout and returns null on any failure; a loaded CI runner blows past
+  // that budget. With `definitiveOnly: false` a null cmdline plus a matching
+  // image (both plain node) is DOCUMENTED to proceed to SIGKILL, so the old
+  // `toBe(false)` here was a race against WMI latency, not a statement about
+  // the matcher. `definitiveOnly: true` must refuse on an indeterminate
+  // cmdline, which makes the refusal deterministic at any probe latency while
+  // still exercising the argv gate whenever the probe does resolve. The
+  // `definitiveOnly: false` "proceed when indeterminate" behaviour is covered
+  // by its own test below, with the probe stubbed.
   it('refuses an unrelated process whose argv merely ends in daemon/index.js (the #1025 repro)', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-innocent-'));
     // Somebody else's program, using the same everyday layout. The image
@@ -210,12 +221,60 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
     // standing between this process and a SIGKILL.
     const pid = await spawnSleeper(path.join(tmpDir, 'someone-elses-app', 'daemon', 'index.js'));
 
-    expect(killVerifiedDaemonPid(pid, { definitiveOnly: false })).toBe(false);
+    expect(killVerifiedDaemonPid(pid, { definitiveOnly: true })).toBe(false);
     expect(killVerifiedDaemonPid(pid, {
-      definitiveOnly: false,
+      definitiveOnly: true,
       scriptCandidates: [path.join(tmpDir, 'unrelated', 'daemon-bundle', 'index.js')],
     })).toBe(false);
     expect(isAlive(pid)).toBe(true);
+    // Explicit 30 s budget (#1274): two kill attempts, each of which may pay
+    // the win32 tasklist (3 s) + WMI cmdline (5 s) worst case, so the real
+    // ceiling is ~16 s and the previous 15 s was under it.
+  }, 30_000);
+
+  // #1274: the other half of the split — the documented indeterminate branch.
+  // When the argv probe cannot resolve and the caller is in the before-quit
+  // mode (`definitiveOnly: false`, what `killDaemonByPidFile` uses), a null
+  // cmdline next to a non-mismatching image is INTENDED to proceed to
+  // SIGKILL. The probe is stubbed (execFileSync throws, /proc reads throw) so
+  // the assertion never waits on the real 5 s WMI timeout.
+  it('proceeds to SIGKILL when the argv probe cannot resolve and definitiveOnly is false', async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-indeterminate-'));
+    const pid = await spawnSleeper(path.join(tmpDir, 'someone-elses-app', 'daemon', 'index.js'));
+
+    vi.resetModules();
+    // Kill every OS probe the module can use to read an image or a cmdline:
+    // `execFileSync` covers win32 (tasklist / PowerShell) and macOS (`ps`),
+    // and the /proc guard covers Linux. Everything else passes through, so
+    // the real `process.kill` still does the killing.
+    vi.doMock('child_process', async () => {
+      const actual = await vi.importActual<typeof import('child_process')>('child_process');
+      const execFileSync = () => { throw new Error('stubbed probe failure (#1274)'); };
+      return { ...actual, default: { ...actual, execFileSync }, execFileSync };
+    });
+    vi.doMock('fs', async () => {
+      const actual = await vi.importActual<typeof import('fs')>('fs');
+      const readFileSync = ((file: unknown, ...rest: unknown[]) => {
+        if (typeof file === 'string' && file.startsWith('/proc/')) {
+          throw new Error('stubbed /proc failure (#1274)');
+        }
+        return (actual.readFileSync as (...args: unknown[]) => unknown)(file, ...rest);
+      }) as typeof actual.readFileSync;
+      return { ...actual, default: { ...actual, readFileSync }, readFileSync };
+    });
+
+    try {
+      const stubbed = await import('../daemonLauncherCore');
+      expect(stubbed.killVerifiedDaemonPid(pid, { definitiveOnly: false })).toBe(true);
+      // ...and the same indeterminate reading REFUSES under definitiveOnly.
+      const survivorPid = await spawnSleeper(path.join(tmpDir, 'second', 'daemon', 'index.js'));
+      expect(stubbed.killVerifiedDaemonPid(survivorPid, { definitiveOnly: true })).toBe(false);
+      expect(isAlive(survivorPid)).toBe(true);
+    } finally {
+      vi.doUnmock('child_process');
+      vi.doUnmock('fs');
+      vi.resetModules();
+    }
   }, 15_000);
 
   it('requirement 1, executed: our script path as a trailing ARGUMENT does not verify the process', async () => {
@@ -225,12 +284,16 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
     // along as a plain argument (an editor, a build tool, a log grepper).
     const pid = await spawnSleeper(path.join(tmpDir, 'unrelated-entry.js'), [bundlePath]);
 
+    // #1274: a refusal assertion, so it runs under `definitiveOnly: true`
+    // for the same reason as the #1025 repro above — a 5 s-timed-out win32
+    // WMI probe would otherwise legitimately proceed to SIGKILL.
     expect(killVerifiedDaemonPid(pid, {
-      definitiveOnly: false,
+      definitiveOnly: true,
       scriptCandidates: [bundlePath],
     })).toBe(false);
     expect(isAlive(pid)).toBe(true);
-  }, 15_000);
+    // 20 s: one kill attempt at the win32 tasklist + WMI worst case (~8 s).
+  }, 20_000);
 
   it('kills a process running exactly one of the supplied candidate scripts', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-ours-'));
@@ -248,13 +311,17 @@ describe('killVerifiedDaemonPid — execution (#1025/#1028)', () => {
   it('requirement 3, executed: daemon-bundler/index.js is refused, daemon-bundle/index.js is killed', async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-identity-shape-'));
     const bundlerPid = await spawnSleeper(path.join(tmpDir, 'daemon-bundler', 'index.js'));
-    expect(killVerifiedDaemonPid(bundlerPid, { definitiveOnly: false })).toBe(false);
+    // #1274: refusal half under `definitiveOnly: true` (indeterminate cmdline
+    // must refuse); the kill half below stays in the before-quit mode.
+    expect(killVerifiedDaemonPid(bundlerPid, { definitiveOnly: true })).toBe(false);
     expect(isAlive(bundlerPid)).toBe(true);
     try { process.kill(bundlerPid, 'SIGKILL'); } catch { /* cleanup */ }
 
     const exactPid = await spawnSleeper(path.join(tmpDir, 'daemon-bundle', 'index.js'));
     expect(killVerifiedDaemonPid(exactPid, { definitiveOnly: false })).toBe(true);
-  }, 20_000);
+    // 30 s: two spawns and two kill attempts, each kill paying up to ~8 s of
+    // win32 probes (#1274).
+  }, 30_000);
 });
 
 describe('ensureDaemon — cmdline-mismatch branch refuses instead of cleaning (#1028 requirement 4)', () => {


### PR DESCRIPTION
Fixes the seven timing-sensitive test failures tracked in #1274. All of them failed on loaded GitHub runners, on PRs that never touch the code under test, and all of them passed on rerun — today they cost a ~15-minute rerun on almost every PR.

Test-only change. No production file is modified, no assertion is weakened, and the global vitest timeout in `vitest.config.ts` is untouched.

## Per-test cause and fix

**1. `src/daemon/__tests__/DaemonSessionManager.test.ts` › honours a custom session.maxSessions from setConfig** (5 s limit, measured 5.4–7.3 s on macos-14)

The three-session test itself takes **4 ms in isolation**. The cost belonged to its neighbour: `throws an actionable error when the session cap is reached` spawned 200 mock sessions to reach the *default* ceiling, and that garbage was collected during the next test — measured as 283 ms locally, which is exactly the 5.4–7.3 s seen on a loaded macos-14 runner. The ceiling is read from config (the no-config path falls back to `createDefaultConfig`), so the cap test now configures a cap of 4 and asserts the full user-facing message; the default-200 contract is pinned by an explicit assertion on `createDefaultConfig()` rather than by spawning 200 PTYs. Work shrunk 50×, no coverage lost. The two near-duplicate cap tests (the rewritten one and the adjacent configurable-cap one) are folded into a single test, since they are the same branch.

**2. `scripts/__tests__/opencode-sync-render.runtime.test.mjs` › paints completed synchronized frames…** (30 s wall clock, ubuntu + windows)

Three problems. The probe slept a fixed 80 ms after the warm-up frame and another 80 ms before reading the viewport, so a runner whose `requestAnimationFrame` callback landed later than that read a stale screen and failed `finalFrameVisible` — every wait is now driven by xterm's `onRender` event, resolving on the first render that shows the frame (the deadline only bounds the failure case). Separately, the wall clock here is a cold `chromium.launch()` of the system Chrome/Edge channel plus the first WebGL context: measured at **31.5 s** in a full parallel suite run locally. File budget raised to 120 s with that measurement in the comment, and `chromium.launch` now carries an explicit 60 s timeout so the one unbounded step fails with a clear Playwright error instead of eating the whole budget. Third, `waitForVisible` leaked an `onRender` listener every round the 50 ms timer won the race (~200 over the 10 s deadline); the disposable is held and the losing side disposed.

**3. `src/main/ipc/handlers/__tests__/deck.handler.loop.test.ts:1169` nested fan-out brain parking** (`expected +0 to be 1`)

There is no debounce on this path: `deck.handler.ts:1753` skips `coalescer.push` for a task workspace and calls `routeWorkerEventToOwner` inline. The only async step is `TaskLedger.recordOrphanedEvent` (serialize + jsonl append, `taskLedger.ts:534`), whose rejection is swallowed by a `.catch(console.warn)` in `taskLedgerHost.ts:80` — so a slow or failed append surfaces here only as the poll never seeing the event. `vi.waitFor`'s *default* timeout is 1000 ms, which a loaded Windows runner's fs append can outlast. The wait is now 10 s at a 25 ms interval and the test past it; locally the park lands in ~36 ms, so a healthy run is unaffected.

**4. Real-process files — explicit, named, justified budgets**

These exec real `git` and real shells, so their runtime is process-spawn cost and scales with runner load rather than with code speed. Per-suite timeouts are applied to the spawning suites only; pure-parser suites in the same files keep the 5 s default.

- `src/main/git/__tests__/mergeSession.test.ts` — real `git init/commit/worktree add/merge` against a per-test temp repo (each test mutates its repo, so sharing a fixture would break isolation). `GIT_PROCESS_TIMEOUT_MS = 30_000` on the 5 git-driven suites.
- `src/main/ipc/handlers/__tests__/diff.handler.test.ts` — every test builds two temp repos and shells out to `git diff/apply/apply --check`. 30 s on all 13 suites.
- `src/main/worktask/__tests__/FanOutService.test.ts` — the assertion *is* a real `bash -c` / `sh -c` round-trip proving the launch string survives an alias-expanding shell; irreducible. 30 s on the two shell-spawning suites (`workerLaunchCommand (F15)` and its sibling `buildInitialCommand (§4 D4)`, the same latent flake).

**5. `src/shared/daemon/__tests__/daemonScriptIdentity.test.ts` › refuses an unrelated process whose argv merely ends in daemon/index.js**

On win32 `getProcessArgv` shells out to `powershell … Get-CimInstance Win32_Process` with `timeout: 5000` and returns `null` on any failure. Under `definitiveOnly: false` a null cmdline next to a non-mismatching image is documented and intended to proceed to SIGKILL — so on a loaded runner the test killed its own sleeper, and the old `toBe(false)` was racing WMI latency rather than stating anything about the matcher. `killVerifiedDaemonPid` is unchanged.

The first revision of this PR asserted the refusals under `definitiveOnly: true`; review correctly flagged that as a tautology on exactly the platform that flaked — production returns false on *any* indeterminate probe (`daemonLauncherCore.ts:1477/1488`) before `argvIdentifiesDaemonScript` is ever called, so the #1025 entry-position guard would no longer be exercised there, and the repro would no longer be asserted in the mode `killDaemonByPidFile` actually uses. So the three refusal assertions keep `definitiveOnly: false`, and only the win32 CIM call is stubbed — to the sleeper's real command line — via the same `vi.doMock` technique as the new indeterminate test. The matcher therefore decides the outcome on every platform and probe latency decides nothing; every other `execFileSync` call, the tasklist / `ps` image lookup included, passes through to the real implementation, and on macOS/Linux the argv probe is untouched (it is fast and never flaked).

The indeterminate branch keeps its own test with the probe fully stubbed (`definitiveOnly: false` → proceeds, `definitiveOnly: true` → refuses), and now SIGKILLs both sleepers in its `finally` so a failed first expect cannot orphan 30 s sleepers on the runner.

## Triage sweep

Applied the issue's rule once across the whole suite (`vitest run --reporter=verbose`, 15,607 tests): any test whose runtime under a full parallel run is within ~2× of its per-test timeout.

It found an eighth flake that **actually failed locally**: `src/renderer/stores/slices/__tests__/channelsSlice.test.ts` › `is reachable through the composed store via channels selector` — 348 ms in isolation, **5022 ms** in the parallel run, i.e. over the 5 s default. The assertions are instant; the cost is the one-off Vite transform of the entire composed renderer store graph pulled in by `await import('../../index')`. Fixed properly rather than budgeted: the import is hoisted into a `beforeAll`, so that one-off cost is no longer charged to the test body. The test now measures 0 ms and keeps the 5 s default.

Remaining candidates, reported not fixed (runtime under a full parallel suite run vs the 5 s default, no explicit timeout on the test):

| Test file | Slowest test | Runtime | Margin |
|---|---|---|---|
| `src/renderer/__tests__/typeScaleLint.test.ts` | fires on a string className | 4566 ms | 1.1× |
| `src/main/worktask/__tests__/fanoutEnvironment.test.ts` | kills the whole process tree on timeout | 4221 ms | 1.2× |
| `src/renderer/stores/slices/__tests__/notificationSlice.test.ts` | decrements the evicted surface's index | 4188 ms | 1.2× |
| `src/main/pipe/__tests__/RpcDispatchProvenance.sourceInvariant.test.ts` | keeps externalWire writes inside the envelope | 4023 ms | 1.2× |
| `src/shared/__tests__/humanRhythm.test.ts` | stays inside the clamp on every draw | 3211 ms | 1.6× |
| `src/daemon/web/__tests__/WebTerminalServer.test.ts` | collapses a resize storm | 3188 ms | 1.6× |
| `src/main/ipc/handlers/__tests__/worktree.handler.merge.test.ts` | status — conflict path | 2635 ms | 1.9× |
| `src/mcp/playwright/__tests__/PlaywrightEngine.test.ts` | getPage auto-opens with the session | 2516 ms | 2.0× |
| `src/mcp/playwright/__tests__/lazyPlaywright.test.ts` | loads playwright-core on first call | 2103 ms | 2.4× |

Also noted inside a file this PR touches: `FanOutService.test.ts` › `fan-out worker first run (A-1)` › "reports a worker still stuck on a first-run screen instead of calling it working" — 1507 ms against the 5 s default. Not fixed, because shrinking it would mean changing the watcher's real poll interval (production) or faking timers (which changes what the test proves).

## Runtime table (macOS, local)

| File | Slowest test | Before | After | Per-test timeout in effect |
|---|---|---|---|---|
| `DaemonSessionManager.test.ts` | maxSessions + cap (now one test) | 283 ms + 43 ms / 200 spawns | 6 ms / 3 spawns | 5 s (default) |
| `opencode-sync-render.runtime.test.mjs` | the probe | 31.5 s (parallel suite) | 1.6–1.9 s standalone | 120 s, launch 60 s |
| `deck.handler.loop.test.ts` | nested fan-out parking | 53 ms (waitFor capped at 1 s) | 36 ms | 15 s (wait 10 s) |
| `deck.handler.loop.test.ts` | fast reject-and-requeue | 3244 ms | 3244 ms | 10 s (pre-existing) |
| `mergeSession.test.ts` | clean merge → Land round-trip | 1125 ms | 340 ms warm | 30 s |
| `diff.handler.test.ts` | alreadyApplied hunk rejection | 2406 ms | 660 ms warm | 30 s |
| `FanOutService.test.ts` | same-shell form, aliased claude | 8 ms local / 7.4 s windows | 8 ms | 30 s |
| `daemonScriptIdentity.test.ts` | #1025 repro | 6.3 s windows (failing) | 335 ms | 15 s |
| `daemonScriptIdentity.test.ts` | requirement 1, executed | 350 ms | 317 ms | 15 s |
| `daemonScriptIdentity.test.ts` | requirement 3, executed | 647 ms | 628 ms | 30 s |
| `daemonScriptIdentity.test.ts` | indeterminate branch (new) | — | 612 ms | 15 s |
| `channelsSlice.test.ts` | composed store selector | 5022 ms (failing) | 0 ms (import in `beforeAll`) | 5 s (default) |

File totals after the change, measured over 3 consecutive local runs each: `DaemonSessionManager` 0.35–0.41 s; `deck.handler.loop` 5.86–5.92 s; `daemonScriptIdentity` 4.36–4.40 s; `channelsSlice` 0.48–0.54 s; `mergeSession` 1.69–1.74 s; `diff.handler` 8.88–9.18 s; `FanOutService` 1.87–1.90 s; `opencode-sync-render` 1.75–2.19 s. All green on every run.

Note on comparing numbers: local figures are a single file run serially on macOS; CI figures are a file sharing a runner with parallel vitest workers, on Windows where process spawn costs an order of magnitude more. The budgets are sized for the latter.

## Gates

- `npx tsc --noEmit` — clean.
- `npx eslint` on all changed files — 0 new problems. The one error (`FanOutService.test.ts:540 no-empty-function`) and all warnings are byte-identical at HEAD.
- Every touched test file run 3× and green every time; the daemon and git ones included. Full suite (before the fixes): 15,531 passed / 2 failed — `generateNotices` drift, which needs a real `npm ci` rather than a symlinked `node_modules`, and the `channelsSlice` timeout this PR fixes.

No changelog fragment: CI-only, no user-facing change.

Refs #1274 — deliberately does not close it, since the `frameBudget.N8` perf-gate half (#1288) is separate and unaddressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7XXScnD6iemykDXdtrKN4
