### PR TITLE
ci(lint): label repo-wide ESLint step as advisory with measured baseline

### DIFF
--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -117,12 +117,15 @@ jobs:
       - name: Typecheck (cross-platform)
         run: npx tsc --noEmit -p tsconfig.json
 
-      # ESLint runs informationally — the codebase has ~124 pre-existing
-      # baseline errors (mostly require() statements and empty-catch blocks)
-      # that we are intentionally NOT cleaning up as part of the cross-
-      # platform port. Continuing past lint failures lets us see the
-      # downstream Vitest results, which are the actual signal we care about.
-      - name: ESLint (cross-platform, informational)
+      # ADVISORY ONLY — this step is expected to fail and never gates the job.
+      # The repo-wide lint carries a pre-existing baseline of 238 errors /
+      # 1745 warnings across ~100 files (measured 2026-09-13: mostly
+      # no-empty-function, no-var-requires and no-useless-escape, plus
+      # import/no-unresolved on vitest/config and a missing react-hooks
+      # plugin). That is too large to clean up mechanically, so a red result
+      # here carries no signal on its own; read its output only when auditing
+      # lint debt. The strict step below is the real lint gate. See #1287.
+      - name: ESLint (repo-wide, advisory, non-blocking)
         run: npx eslint --ext .ts,.tsx .
         continue-on-error: true
 

--- a/.github/workflows/ci-cross-platform-baseline.yml
+++ b/.github/workflows/ci-cross-platform-baseline.yml
@@ -124,7 +124,9 @@ jobs:
       # import/no-unresolved on vitest/config and a missing react-hooks
       # plugin). That is too large to clean up mechanically, so a red result
       # here carries no signal on its own; read its output only when auditing
-      # lint debt. The strict step below is the real lint gate. See #1287.
+      # lint debt. The strict step below blocks only on its fixed list of 7
+      # files; lint regressions in any other new or changed file are not
+      # blocked anywhere in this workflow. See #1287.
       - name: ESLint (repo-wide, advisory, non-blocking)
         run: npx eslint --ext .ts,.tsx .
         continue-on-error: true


### PR DESCRIPTION
## Summary

The repo-wide ESLint step in the cross-platform Baseline workflow fails on every platform because of pre-existing errors, and the job continues past it, so a red result tells you nothing. There are too many errors to fix mechanically, so this PR keeps the step non-blocking and renames it to say it is advisory. The comment now gives the measured baseline instead of the old count. The strict `--max-warnings=0` step still blocks, but only on its fixed list of 7 files, so this workflow does not block lint regressions in any other new or changed file. This PR does not add a new gate.

**Which option:** the issue allowed two options: fix the errors and make the step blocking, or mark it advisory. I marked it advisory because the fix option was meant for about 40 or fewer mechanically fixable errors, and there are 238.

Error counts (repo-wide `eslint --ext .ts,.tsx .`, measured locally and identical in the latest `main` Baseline run on all three OSes, `1983 problems (238 errors, 1745 warnings)`):

| Rule | Errors |
| --- | --- |
| `@typescript-eslint/no-empty-function` | 127 |
| `@typescript-eslint/no-var-requires` | 41 |
| `no-useless-escape` | 31 |
| `import/no-unresolved` (`vitest/config` x4, `@modelcontextprotocol/sdk/server/*.js` x3) | 7 |
| `@typescript-eslint/ban-types` | 7 |
| `prefer-const` | 7 |
| `react-hooks/exhaustive-deps` (rule definition not found, plugin not configured) | 7 |
| `@typescript-eslint/no-inferrable-types` | 5 |
| `no-control-regex` | 5 |
| `no-fallthrough` | 1 |

The errors are in about 100 files across `src/daemon` (93), `src/main` (46), `src/renderer` (42), `src/mcp` (30), `forge.config.ts`, and the vitest configs. Before and after are the same (238 errors / 1745 warnings) because this PR changes no source files.

## Changes

- `.github/workflows/ci-cross-platform-baseline.yml`: renamed the step `ESLint (cross-platform, informational)` to `ESLint (repo-wide, advisory, non-blocking)`. It keeps `continue-on-error: true`. The comment's stale "~124 errors" is replaced with the measured count and the main causes, and it states that the strict step blocks only on its fixed 7-file list, so lint regressions elsewhere are not blocked.

## CHANGELOG entry

n/a: CI-only change with no user-facing effect, so there is no `changelog.d` fragment.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- Ran the repo-wide lint locally with the repo config only: 238 errors / 1745 warnings, exit 1. This matches the latest `main` Baseline logs on ubuntu, macOS and Windows.
- Ran the strict step's 7-file `--max-warnings=0` lint locally: exit 0.
- `npx tsc --noEmit -p tsconfig.json`: exit 0.
- Parsed the workflow YAML: OK.
- The Baseline CI run on this PR should show the renamed advisory step failing without failing the job, with the strict step and tests unchanged.

## Related issues / PRs

Closes #1287

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
