### PR TITLE
fix(terminal): normalize OSC 8 destinations and wire the mirror link handler

### DIFF
--- a/changelog.d/1293.md
+++ b/changelog.d/1293.md
@@ -3,15 +3,22 @@
 - **OSC 8 links now open in remote mirror panes.** A mirrored pane built its
   terminal without the link handler local panes use, so clicking a formatted
   hyperlink and confirming the prompt did nothing — the fallback tried to open
-  a blank window, which wmux blocks. Mirror panes now route the link the same
-  way a local pane does. (#1293)
+  a blank window, which wmux blocks. Mirror panes now ask for confirmation and
+  open the link in your system browser. (#1293)
 
 ### Security
 
 - **The OSC 8 confirmation shows the real destination.** The prompt used to
   print the link exactly as the program in the terminal sent it, so hidden
-  right-to-left control characters or a look-alike international domain could
-  make one site read as another. The address is now normalized before it is
-  shown — international domains appear in their `xn--` form and invisible or
-  control characters are removed — and the link opens exactly the address the
-  prompt displayed. Addresses that do not parse are refused. (#1293)
+  right-to-left control characters, a look-alike international domain, or a
+  fake name placed before an `@` (`https://google.com@evil.com/`) could make
+  one site read as another. The address is now normalized before it is shown —
+  international domains appear in their `xn--` form and invisible or control
+  characters are removed — and the link opens exactly the address the prompt
+  displayed. Addresses that do not parse, or that carry a user name or
+  password, are refused. (#1293)
+- **Remote panes cannot aim links at this machine.** A link from a remote
+  mirror pane never opens in a local built-in browser pane, and links to
+  `localhost`, `127.0.0.0/8`, `[::1]` or `0.0.0.0` are refused there: on the
+  remote side those name the remote host, and opening them locally would send
+  requests to services on your own computer. (#1293)

--- a/changelog.d/1293.md
+++ b/changelog.d/1293.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **OSC 8 links now open in remote mirror panes.** A mirrored pane built its
+  terminal without the link handler local panes use, so clicking a formatted
+  hyperlink and confirming the prompt did nothing — the fallback tried to open
+  a blank window, which wmux blocks. Mirror panes now route the link the same
+  way a local pane does. (#1293)
+
+### Security
+
+- **The OSC 8 confirmation shows the real destination.** The prompt used to
+  print the link exactly as the program in the terminal sent it, so hidden
+  right-to-left control characters or a look-alike international domain could
+  make one site read as another. The address is now normalized before it is
+  shown — international domains appear in their `xn--` form and invisible or
+  control characters are removed — and the link opens exactly the address the
+  prompt displayed. Addresses that do not parse are refused. (#1293)

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -13,6 +13,8 @@ import { pastePtyChunked } from '../../utils/clipboardChunk';
 import { copySelectionWithFeedback } from '../../hooks/useTerminal';
 import { XTERM_THEMES, extractXtermColors, type BuiltinThemeId, type ThemeId } from '../../themes';
 import { resolveMinimumContrastRatio } from '../../tailwindPalette';
+import { createOsc8LinkHandler } from '../../terminal/osc8LinkHandler';
+import { openTerminalUrl } from '../../utils/browserPaneActions';
 
 export interface RemoteMirrorTerminalProps {
   /** null while the pane attach is still in flight. */
@@ -361,6 +363,12 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly, onTitl
       // is the one wrapping the whole main area. One attached remote workspace
       // would take the entire local pane grid down with it.
       allowProposedApi: true,
+      // #1271: without this, OSC 8 links fall back to xterm's window.open()
+      // of about:blank, which the window-open policy denies, so a confirmed
+      // click did nothing. Route through the same handler as a local pane.
+      linkHandler: createOsc8LinkHandler((event, uri) => {
+        openTerminalUrl(uri, { modifierHeld: event.ctrlKey || event.metaKey });
+      }),
     });
     // The width model, BEFORE open() — same order as the local pane.
     //

--- a/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
+++ b/src/renderer/components/Remote/RemoteMirrorTerminal.tsx
@@ -13,8 +13,7 @@ import { pastePtyChunked } from '../../utils/clipboardChunk';
 import { copySelectionWithFeedback } from '../../hooks/useTerminal';
 import { XTERM_THEMES, extractXtermColors, type BuiltinThemeId, type ThemeId } from '../../themes';
 import { resolveMinimumContrastRatio } from '../../tailwindPalette';
-import { createOsc8LinkHandler } from '../../terminal/osc8LinkHandler';
-import { openTerminalUrl } from '../../utils/browserPaneActions';
+import { createOsc8LinkHandler, isLoopbackHref } from '../../terminal/osc8LinkHandler';
 
 export interface RemoteMirrorTerminalProps {
   /** null while the pane attach is still in flight. */
@@ -365,10 +364,15 @@ export default function RemoteMirrorTerminal({ attachId, error, readOnly, onTitl
       allowProposedApi: true,
       // #1271: without this, OSC 8 links fall back to xterm's window.open()
       // of about:blank, which the window-open policy denies, so a confirmed
-      // click did nothing. Route through the same handler as a local pane.
-      linkHandler: createOsc8LinkHandler((event, uri) => {
-        openTerminalUrl(uri, { modifierHeld: event.ctrlKey || event.metaKey });
-      }),
+      // click did nothing. Same confirmation handler as a local pane, but the
+      // destination came from a REMOTE PTY: never open it in a local browser
+      // pane, and refuse loopback hosts outright, since `localhost` there
+      // names the remote machine and here would aim requests at local
+      // services.
+      linkHandler: createOsc8LinkHandler(
+        (_event, href) => { void window.electronAPI?.shell?.openExternal(href); },
+        (href) => !isLoopbackHref(href),
+      ),
     });
     // The width model, BEFORE open() — same order as the local pane.
     //

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -14,6 +14,7 @@ import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 import RemoteMirrorTerminal from '../RemoteMirrorTerminal';
 import { useStore } from '../../../stores';
+import { getLeafPanes } from '../../../../shared/paneUtils';
 
 // One shared log so "before open()" is an assertion about the same clock.
 // Two independent counters would compare cleanly and prove nothing.
@@ -203,29 +204,64 @@ describe('RemoteMirrorTerminal', () => {
 
   // #1271: without a linkHandler xterm falls back to window.open(about:blank),
   // which Electron denies, so a confirmed OSC 8 click did nothing.
-  it('constructs the terminal with the OSC 8 link handler that opens the URL', () => {
-    const openExternal = vi.fn(() => Promise.resolve());
-    (window as unknown as { electronAPI: { shell: unknown } }).electronAPI.shell = { openExternal };
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
-    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
-    useStore.setState({ browserBackend: 'external' });
-    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
-    try {
-      const handler = termInstances[0].ctorOptions.linkHandler as {
-        allowNonHttpProtocols?: boolean;
-        activate: (event: MouseEvent, uri: string, range: unknown) => void;
-      };
-      expect(handler).toBeDefined();
+  describe('OSC 8 link handler', () => {
+    type LinkHandler = {
+      allowNonHttpProtocols?: boolean;
+      activate: (event: MouseEvent, uri: string, range: unknown) => void;
+    };
+    const browserSurfaceCount = () => useStore.getState().workspaces.flatMap((ws) =>
+      getLeafPanes(ws.rootPane).flatMap((pane) => pane.surfaces)
+        .filter((surface) => surface.surfaceType === 'browser')).length;
+
+    let openExternal: ReturnType<typeof vi.fn>;
+    let prevBackend: ReturnType<typeof useStore.getState>['browserBackend'];
+    beforeEach(() => {
+      openExternal = vi.fn(() => Promise.resolve());
+      (window as unknown as { electronAPI: { shell: unknown } }).electronAPI.shell = { openExternal };
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      vi.spyOn(window, 'open').mockReturnValue(null);
+      // Builtin is the mode where a local pane WOULD embed localhost, so it is
+      // the one that proves the mirror never does.
+      prevBackend = useStore.getState().browserBackend;
+      useStore.setState({ browserBackend: 'builtin' });
+    });
+    afterEach(() => {
+      useStore.setState({ browserBackend: prevBackend });
+      vi.restoreAllMocks();
+    });
+
+    function mountHandler(): { handler: LinkHandler; unmount: () => void } {
+      const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+      return { handler: termInstances[0].ctorOptions.linkHandler as LinkHandler, unmount };
+    }
+
+    it('opens a confirmed web link in the system browser, never a local pane', () => {
+      const { handler, unmount } = mountHandler();
+      const panesBefore = browserSurfaceCount();
       expect(handler.allowNonHttpProtocols).toBe(false);
       handler.activate(new MouseEvent('click'), 'https://example.com/report', {});
-      expect(confirmSpy).toHaveBeenCalledOnce();
+      expect(window.confirm).toHaveBeenCalledOnce();
       expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com/report');
-      expect(openSpy).not.toHaveBeenCalled();
-    } finally {
+      expect(window.open).not.toHaveBeenCalled();
+      expect(browserSurfaceCount()).toBe(panesBefore);
       unmount();
-      confirmSpy.mockRestore();
-      openSpy.mockRestore();
-    }
+    });
+
+    it.each([
+      'http://localhost:3000/admin',
+      'http://127.0.0.1:8080/',
+      'http://[::1]:5000/',
+      'http://0.0.0.0:9000/',
+    ])('refuses remote loopback destination %s', (url) => {
+      const { handler, unmount } = mountHandler();
+      const panesBefore = browserSurfaceCount();
+      handler.activate(new MouseEvent('click', { ctrlKey: true }), url, {});
+      expect(window.confirm).not.toHaveBeenCalled();
+      expect(openExternal).not.toHaveBeenCalled();
+      expect(window.open).not.toHaveBeenCalled();
+      expect(browserSurfaceCount()).toBe(panesBefore);
+      unmount();
+    });
   });
 
   it('ignores meta/data events for a different attachId', () => {

--- a/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
+++ b/src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx
@@ -201,6 +201,33 @@ describe('RemoteMirrorTerminal', () => {
     unmount();
   });
 
+  // #1271: without a linkHandler xterm falls back to window.open(about:blank),
+  // which Electron denies, so a confirmed OSC 8 click did nothing.
+  it('constructs the terminal with the OSC 8 link handler that opens the URL', () => {
+    const openExternal = vi.fn(() => Promise.resolve());
+    (window as unknown as { electronAPI: { shell: unknown } }).electronAPI.shell = { openExternal };
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+    useStore.setState({ browserBackend: 'external' });
+    const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
+    try {
+      const handler = termInstances[0].ctorOptions.linkHandler as {
+        allowNonHttpProtocols?: boolean;
+        activate: (event: MouseEvent, uri: string, range: unknown) => void;
+      };
+      expect(handler).toBeDefined();
+      expect(handler.allowNonHttpProtocols).toBe(false);
+      handler.activate(new MouseEvent('click'), 'https://example.com/report', {});
+      expect(confirmSpy).toHaveBeenCalledOnce();
+      expect(openExternal).toHaveBeenCalledExactlyOnceWith('https://example.com/report');
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+      confirmSpy.mockRestore();
+      openSpy.mockRestore();
+    }
+  });
+
   it('ignores meta/data events for a different attachId', () => {
     const { unmount } = render(<RemoteMirrorTerminal attachId="a1" />);
     const term = termInstances[0];

--- a/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
+++ b/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Terminal, type ILink, type ILinkProvider } from '@xterm/xterm';
-import { createOsc8LinkHandler } from '../osc8LinkHandler';
+import { createOsc8LinkHandler, normalizeOsc8Uri } from '../osc8LinkHandler';
 import { openTerminalUrl } from '../../utils/browserPaneActions';
 import { useStore } from '../../stores';
 import { getLeafPanes } from '../../../shared/paneUtils';
@@ -72,5 +72,45 @@ describe('formatted terminal hyperlinks', () => {
     expect(await hyperlink(url)).toBeUndefined();
     expect(openExternal).not.toHaveBeenCalled();
     expect(window.confirm).not.toHaveBeenCalled();
+  });
+});
+
+describe('OSC 8 destination normalization (#1272)', () => {
+  it.each([
+    // Bidi override in the path is percent-encoded, not rendered.
+    ['https://example.com/‮gpj.exe', 'https://example.com/%E2%80%AEgpj.exe'],
+    // IDN homograph host (Cyrillic "a") is shown as punycode.
+    ['https://аpple.com/login', 'https://xn--pple-43d.com/login'],
+    // Tab/newline are dropped by the parser; other C0 controls are encoded.
+    ['https://example.com/a\tb\nc\x01d', 'https://example.com/abc%01d'],
+    // Zero-width space and bidi isolate in the fragment.
+    ['https://example.com/#​x⁦y', 'https://example.com/#%E2%80%8Bx%E2%81%A6y'],
+  ])('normalizes %j to an ASCII href', (raw, expected) => {
+    const href = normalizeOsc8Uri(raw);
+    expect(href).toBe(expected);
+    expect(href).toMatch(/^[\x21-\x7E]+$/);
+  });
+
+  it.each(['not a url', 'https://', 'http://[bad', 'javascript:alert(1)', 'file:///etc/passwd'])(
+    'rejects %j', (raw) => {
+      expect(normalizeOsc8Uri(raw)).toBeNull();
+    });
+
+  it('confirms and activates the same normalized href', () => {
+    const activate = vi.fn();
+    const event = new MouseEvent('click');
+    createOsc8LinkHandler(activate).activate(event, 'https://аpple.com/‮evil', undefined as never);
+    const expected = 'https://xn--pple-43d.com/%E2%80%AEevil';
+    const shown = vi.mocked(window.confirm).mock.calls[0][0] as string;
+    expect(shown).toContain(expected);
+    expect(shown).not.toMatch(/[а‮]/);
+    expect(activate).toHaveBeenCalledExactlyOnceWith(event, expected);
+  });
+
+  it('neither confirms nor activates an unparseable destination', () => {
+    const activate = vi.fn();
+    createOsc8LinkHandler(activate).activate(new MouseEvent('click'), 'http://[bad', undefined as never);
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(activate).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
+++ b/src/renderer/terminal/__tests__/osc8LinkHandler.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Terminal, type ILink, type ILinkProvider } from '@xterm/xterm';
-import { createOsc8LinkHandler, normalizeOsc8Uri } from '../osc8LinkHandler';
+import { createOsc8LinkHandler, isLoopbackHref, normalizeOsc8Uri } from '../osc8LinkHandler';
 import { openTerminalUrl } from '../../utils/browserPaneActions';
 import { useStore } from '../../stores';
 import { getLeafPanes } from '../../../shared/paneUtils';
@@ -96,6 +96,31 @@ describe('OSC 8 destination normalization (#1272)', () => {
       expect(normalizeOsc8Uri(raw)).toBeNull();
     });
 
+  it.each([
+    'https://google.com@evil.com/',
+    'https://google.com:443@evil.com/login',
+    'https://user:pass@example.com/',
+    'https://:secret@example.com/',
+  ])('rejects userinfo that can disguise the host: %j', (raw) => {
+    expect(normalizeOsc8Uri(raw)).toBeNull();
+  });
+
+  it('does not prompt for a userinfo-spoofed destination', () => {
+    const activate = vi.fn();
+    createOsc8LinkHandler(activate).activate(new MouseEvent('click'), 'https://google.com@evil.com/', undefined as never);
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  it('skips the prompt and activation when the caller disallows the href', () => {
+    const activate = vi.fn();
+    const isAllowed = vi.fn(() => false);
+    createOsc8LinkHandler(activate, isAllowed).activate(new MouseEvent('click'), 'https://аpple.com/', undefined as never);
+    expect(isAllowed).toHaveBeenCalledExactlyOnceWith('https://xn--pple-43d.com/');
+    expect(window.confirm).not.toHaveBeenCalled();
+    expect(activate).not.toHaveBeenCalled();
+  });
+
   it('confirms and activates the same normalized href', () => {
     const activate = vi.fn();
     const event = new MouseEvent('click');
@@ -112,5 +137,34 @@ describe('OSC 8 destination normalization (#1272)', () => {
     createOsc8LinkHandler(activate).activate(new MouseEvent('click'), 'http://[bad', undefined as never);
     expect(window.confirm).not.toHaveBeenCalled();
     expect(activate).not.toHaveBeenCalled();
+  });
+});
+
+describe('isLoopbackHref', () => {
+  it.each([
+    'http://localhost:3000/',
+    'http://LOCALHOST/',
+    'http://app.localhost/',
+    'http://127.0.0.1/',
+    'http://127.8.9.10:8080/',
+    'http://2130706433/',
+    'http://0.0.0.0:9000/',
+    'http://[::1]:5000/',
+    'http://[::]/',
+    'http://[::ffff:127.0.0.1]/',
+  ])('treats %s as loopback', (raw) => {
+    const href = normalizeOsc8Uri(raw);
+    expect(href).not.toBeNull();
+    expect(isLoopbackHref(href as string)).toBe(true);
+  });
+
+  it.each([
+    'https://example.com/',
+    'http://localhost.example.com/',
+    'http://128.0.0.1/',
+    'http://10.0.0.5/',
+    'http://[::2]/',
+  ])('treats %s as non-loopback', (href) => {
+    expect(isLoopbackHref(href)).toBe(false);
   });
 });

--- a/src/renderer/terminal/osc8LinkHandler.ts
+++ b/src/renderer/terminal/osc8LinkHandler.ts
@@ -21,7 +21,31 @@ export function normalizeOsc8Uri(uri: string): string | null {
     return null;
   }
   if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  // `https://google.com@evil.com/` reads as google.com in the dialog but goes
+  // to evil.com. Terminal links have no legitimate need for credentials.
+  if (url.username !== '' || url.password !== '') return null;
   return url.href.replace(INVISIBLE_OR_CONTROL, '');
+}
+
+/**
+ * True when a normalized href targets this machine's loopback interface.
+ * The WHATWG parser has already canonicalized the host (e.g. `2130706433`
+ * becomes `127.0.0.1`, `::ffff:127.0.0.1` becomes `[::ffff:7f00:1]`).
+ */
+export function isLoopbackHref(href: string): boolean {
+  let host: string;
+  try {
+    host = new URL(href).hostname;
+  } catch {
+    return false;
+  }
+  return host === 'localhost'
+    || host.endsWith('.localhost')
+    || host === '0.0.0.0'
+    || /^127\.\d+\.\d+\.\d+$/.test(host)
+    || host === '[::1]'
+    || host === '[::]'
+    || /^\[::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}\]$/.test(host);
 }
 
 /**
@@ -32,6 +56,7 @@ export function normalizeOsc8Uri(uri: string): string | null {
  */
 export function createOsc8LinkHandler(
   activate: (event: MouseEvent, uri: string) => void,
+  isAllowed: (href: string) => boolean = () => true,
 ): ILinkHandler {
   return {
     allowNonHttpProtocols: false,
@@ -39,7 +64,7 @@ export function createOsc8LinkHandler(
       // The dialog and the activation use the same normalized string, so what
       // the user approves is exactly what opens.
       const href = normalizeOsc8Uri(uri);
-      if (href === null) return;
+      if (href === null || !isAllowed(href)) return;
       if (window.confirm(`Do you want to navigate to ${href}?\n\nWARNING: This link could potentially be dangerous`)) {
         activate(event, href);
       }

--- a/src/renderer/terminal/osc8LinkHandler.ts
+++ b/src/renderer/terminal/osc8LinkHandler.ts
@@ -1,5 +1,29 @@
 import type { ILinkHandler } from '@xterm/xterm';
 
+// C0/C1 controls (Cc) and format characters (Cf), which include the bidi
+// overrides/isolates (U+202A-U+202E, U+2066-U+2069) and zero-width marks.
+const INVISIBLE_OR_CONTROL = /[\p{Cc}\p{Cf}]/gu;
+
+/**
+ * Canonicalize a PTY-supplied OSC 8 URI before it is shown or opened.
+ *
+ * The URI is attacker-controlled: bidi controls can reorder the displayed
+ * text and an IDN homograph host can impersonate another domain. The WHATWG
+ * parser yields an ASCII href (punycode host, percent-encoded non-ASCII), and
+ * any control/format character that survives is stripped. Returns null when
+ * the URI does not parse or is not http(s).
+ */
+export function normalizeOsc8Uri(uri: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  return url.href.replace(INVISIBLE_OR_CONTROL, '');
+}
+
 /**
  * OSC 8 links can hide their destination behind a label, so retain xterm's
  * confirmation. Its default window.open() starts with about:blank, which
@@ -12,8 +36,12 @@ export function createOsc8LinkHandler(
   return {
     allowNonHttpProtocols: false,
     activate(event, uri) {
-      if (window.confirm(`Do you want to navigate to ${uri}?\n\nWARNING: This link could potentially be dangerous`)) {
-        activate(event, uri);
+      // The dialog and the activation use the same normalized string, so what
+      // the user approves is exactly what opens.
+      const href = normalizeOsc8Uri(uri);
+      if (href === null) return;
+      if (window.confirm(`Do you want to navigate to ${href}?\n\nWARNING: This link could potentially be dangerous`)) {
+        activate(event, href);
       }
     },
   };


### PR DESCRIPTION
## Summary

Two follow-ups to #1265's OSC 8 link handler. The remote mirror terminal never got the handler, so a confirmed OSC 8 click did nothing there (#1271). The confirmation dialog also showed the raw PTY-supplied URI, so bidi controls, an IDN homograph host, or userinfo could misrepresent the destination (#1272).

## Changes

- `osc8LinkHandler.ts`:
  - New `normalizeOsc8Uri()` canonicalizes the URI with the WHATWG `URL` parser (punycode host, percent-encoded non-ASCII) and strips any remaining control/format characters (`\p{Cc}`, `\p{Cf}`, which cover bidi overrides/isolates and zero-width marks). It returns `null` for input that doesn't parse, isn't http(s), or carries a `username`/`password`, since `https://google.com@evil.com/` would read as google.com.
  - `createOsc8LinkHandler` shows the normalized href in the dialog and activates that same string. A rejected URI neither prompts nor opens.
  - An optional `isAllowed(href)` lets a caller refuse a destination before the prompt.
  - New `isLoopbackHref()` matches `localhost`, `*.localhost`, `127.0.0.0/8`, `0.0.0.0`, `[::1]`, `[::]` and IPv4-mapped loopback. The check runs on the parser-canonicalized host, so `2130706433` also counts.
- `RemoteMirrorTerminal.tsx`: the mirror's xterm is built with the OSC 8 handler instead of xterm's `defaultActivate`, which calls `window.open` on `about:blank` and gets denied by the window-open policy.

## Decision: remote links never reach local services

A link in a mirror pane comes from a remote PTY. There, `localhost` means the remote host. Opened locally, it would point at the wrong machine and let the remote side send GET requests to local services. So the mirror:

- opens confirmed links only through `shell.openExternal` (the system browser), never `openTerminalUrl`, so never a local built-in browser pane;
- refuses loopback destinations before the confirmation prompt.

Because the mirror no longer goes through `openTerminalUrl`, the missing workspace/pty id can't split a pane in any workspace. Local panes behave as before.

## CHANGELOG entry

Added as `changelog.d/1293.md`.

### Fixed

- OSC 8 hyperlinks in remote mirror panes open in the system browser after confirmation instead of silently doing nothing.

### Security

- The OSC 8 confirmation dialog shows a normalized destination (punycode host, no bidi/control characters, no userinfo), and the link opens exactly that URL.
- Remote mirror panes never open links in a local browser pane and refuse loopback destinations.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- `src/renderer/terminal/__tests__/osc8LinkHandler.test.ts`:
  - Normalization: U+202E in the path, a Cyrillic homograph host that becomes `xn--`, tab/newline/C0 controls, zero-width and bidi isolate in the fragment.
  - Rejection: unparseable, empty host, `javascript:`, `file:`, and four userinfo forms (`host@evil`, `host:443@evil`, `user:pass@`, `:secret@`).
  - The dialog text and the activated URL are the same normalized href. Unparseable, userinfo-spoofed and caller-disallowed hrefs never prompt.
  - `isLoopbackHref` positive and negative cases, including `localhost.example.com`, `128.0.0.1` and `[::2]`.
- `src/renderer/components/Remote/__tests__/RemoteMirrorTerminal.test.tsx` (runs with `browserBackend: 'builtin'`, restored in `afterEach`):
  - A confirmed `https://example.com/report` goes to `shell.openExternal`, never `window.open`, and adds no browser surface.
  - `localhost`, `127.0.0.1`, `[::1]` and `0.0.0.0` links (with Ctrl held) don't prompt, don't open, and add no browser surface.
- Local gates: `tsc --noEmit` clean; vitest on the OSC 8 suite and both RemoteMirrorTerminal suites is 83/83; eslint on the touched files shows 0 errors.
- Not run: live dogfood clicking an OSC 8 link in an attached remote pane.

## Related issues / PRs

Closes #1271
Closes #1272
Follow-up to #1265

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
