### PR TITLE
fix(sidebar): collapsed rail + opens the new-workspace picker

### DIFF
--- a/changelog.d/1294.md
+++ b/changelog.d/1294.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **"Attach remote workspace…" has one clear way in.** The sidebar still held
+  a leftover copy of the new-workspace picker that nothing could open, so the
+  remote-attach flow looked unreachable. The dead copy is gone. Attach a remote
+  workspace from the **+** button beside the WMUX wordmark in the titlebar: it
+  is the last row of the menu. That path is now covered by a test. (#1294)

--- a/changelog.d/1294.md
+++ b/changelog.d/1294.md
@@ -1,7 +1,10 @@
 ### Fixed
 
-- **"Attach remote workspace…" has one clear way in.** The sidebar still held
-  a leftover copy of the new-workspace picker that nothing could open, so the
-  remote-attach flow looked unreachable. The dead copy is gone. Attach a remote
-  workspace from the **+** button beside the WMUX wordmark in the titlebar: it
-  is the last row of the menu. That path is now covered by a test. (#1294)
+- **"Attach remote workspace…" is reachable with the sidebar collapsed.** When
+  the sidebar was hidden (Ctrl+B), the **+** at the top of the 48px rail made a
+  blank workspace straight away, and the titlebar **+** that opens the
+  new-workspace menu was clipped out of sight. With no way to open that menu,
+  there was no way to attach a remote workspace either. The rail's **+** now
+  opens the same menu beside the rail, with browse folder, empty workspace,
+  layout presets and "Attach remote workspace…". Ctrl+N still creates a
+  workspace directly. (#1294)

--- a/src/renderer/components/Sidebar/MiniSidebar.tsx
+++ b/src/renderer/components/Sidebar/MiniSidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { useStore } from '../../stores';
 import { selectWorkspaceRailSummary } from '../../stores/selectors/workspaceProjections';
@@ -11,6 +11,10 @@ import { expandDirection } from './sidebarGlyphs';
 import { IconPlus, IconChevronDir } from '../icons';
 import { FOCUS_RING } from '../focusRing';
 import { workspaceColorHex } from '../../../shared/workspaceColors';
+import PresetPicker from './PresetPicker';
+
+/** PresetPicker width (w-52), used to keep the flyout on-screen. */
+const PICKER_MENU_WIDTH = 208;
 
 export default function MiniSidebar() {
   const t = useT();
@@ -53,7 +57,30 @@ export default function MiniSidebar() {
     0,
   );
 
-  const addWorkspace = useStore((s) => s.addWorkspace);
+  // #1284 — the rail's + opens the same PresetPicker as the titlebar +. With
+  // the sidebar collapsed the titlebar + is clipped by its 48px segment, so
+  // this is the only way to reach "Attach remote workspace…" (the picker's
+  // last row). The picker flies out beside the 48px rail — measured at open
+  // time, on the side facing the content area, clamped to the window.
+  const plusBtnRef = useRef<HTMLButtonElement | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerAnchor, setPickerAnchor] = useState({ left: 8, top: 8 });
+  const togglePicker = useCallback(() => {
+    setPickerOpen((v) => {
+      if (!v) {
+        const r = plusBtnRef.current?.getBoundingClientRect();
+        if (r) {
+          const desired = sidebarPosition === 'right' ? r.left - PICKER_MENU_WIDTH - 4 : r.right + 4;
+          setPickerAnchor({
+            left: Math.max(8, Math.min(desired, window.innerWidth - PICKER_MENU_WIDTH - 8)),
+            top: Math.max(8, r.top),
+          });
+        }
+      }
+      return !v;
+    });
+  }, [sidebarPosition]);
+  const closePicker = useCallback(() => setPickerOpen(false), []);
 
   // Drag state per render — refs avoid re-render on every dragover tick.
   const dragStartTimeRef = useRef<number>(0);
@@ -64,9 +91,11 @@ export default function MiniSidebar() {
     <div className={`flex flex-col h-full bg-[var(--bg-mantle)] ${sidebarPosition === 'right' ? 'border-l' : 'border-r'} border-[var(--bg-surface)]`} style={{ width: 48, borderColor: 'var(--border-soft)' }} {...tokenAttrs('bgMantle', 'bg')} {...tokenAttrs('bgSurface', 'border')}>
       {/* Header — new workspace button */}
       <button
+        ref={plusBtnRef}
         className={`flex items-center justify-center h-10 text-[var(--text-subtle)] hover:text-[var(--accent-green)] transition-colors duration-150 border-b border-[var(--bg-surface)] font-mono text-lg leading-none ${FOCUS_RING}`}
         style={{ borderColor: 'var(--border-soft)' }}
-        onClick={() => addWorkspace()}
+        onClick={togglePicker}
+        data-mini-add-workspace
         title={t('sidebar.newWorkspaceTooltip')}
         aria-label={t('sidebar.newWorkspaceTooltip')}
         data-onboarding-target="add-workspace"
@@ -76,6 +105,7 @@ export default function MiniSidebar() {
       >
         <IconPlus size={14} />
       </button>
+      {pickerOpen && <PresetPicker onClose={closePicker} anchorStyle={pickerAnchor} />}
 
       {/* Workspace dots */}
       <div className="flex-1 overflow-y-auto py-2 flex flex-col items-center gap-1">

--- a/src/renderer/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/components/Sidebar/Sidebar.tsx
@@ -9,7 +9,6 @@ import RemoteWorkspaceItem from './RemoteWorkspaceItem';
 import OrphanSessions from './OrphanSessions';
 import ArchivedWorkspaces from './ArchivedWorkspaces';
 import MissionsSection from './MissionsSection';
-import PresetPicker from './PresetPicker';
 import type { AgentStatus, Workspace } from '../../../shared/types';
 import { getWorkspacePtyIds } from '../../../shared/paneUtils';
 import { destroyWorkspaceRemoteSessions } from '../../utils/remoteSessionTeardown';
@@ -98,10 +97,6 @@ export default function Sidebar() {
   const setSidebarMode = useStore((s) => s.setSidebarMode);
   const pushToast = useStore((s) => s.pushToast);
 
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const togglePicker = useCallback(() => setPickerOpen((v) => !v), []);
-  const closePicker = useCallback(() => setPickerOpen(false), []);
-
   // Ctrl+F → focus workspace search, but only while focus is already inside
   // the sidebar. A document-level listener would collide with the global
   // Ctrl+F terminal-search shortcut (useKeyboard), so this is scoped to the
@@ -165,8 +160,6 @@ export default function Sidebar() {
       {...tokenAttrs('bgMantle', 'bg')} {...tokenAttrs('bgSurface', 'border')}
       onKeyDown={handleSidebarKeyDown}
     >
-      {pickerOpen && <PresetPicker onClose={closePicker} />}
-
       {/* Workspace search input — only visible when 3+ workspaces */}
       {workspaces.length >= 3 && (
         <div className="px-2 pt-2">

--- a/src/renderer/components/Sidebar/__tests__/MiniSidebar.attachRemote.test.tsx
+++ b/src/renderer/components/Sidebar/__tests__/MiniSidebar.attachRemote.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+//
+// #1284 — with the sidebar collapsed, the titlebar + is clipped by its 48px
+// segment, so the rail's own + is the only UI path to PresetPicker and its
+// "Attach remote workspace…" row. It used to call addWorkspace() directly.
+// Pin: the rail + opens the picker (not a new workspace), the picker flies
+// out beside the rail instead of inside it, and the attach row mounts
+// AttachRemoteModal.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import MiniSidebar from '../MiniSidebar';
+import { useStore } from '../../../stores';
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) fn();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+let hostsList: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  hostsList = vi.fn().mockResolvedValue([]);
+  const noopSub = vi.fn(() => () => { /* noop unsubscribe */ });
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    platform: 'linux',
+    remote: {
+      hostsList,
+      hostsAdd: vi.fn(),
+      hostsPair: vi.fn(),
+      hostsRemove: vi.fn(),
+      workspacesList: vi.fn().mockResolvedValue({ ok: true, workspaces: [] }),
+      workspaceCreate: vi.fn(),
+      paneAttach: vi.fn(),
+      paneDetach: vi.fn(),
+      paneWrite: vi.fn(),
+      onPaneMeta: noopSub,
+      onPaneData: noopSub,
+      onPaneExit: noopSub,
+      onPaneError: noopSub,
+    },
+  };
+  act(() => useStore.setState({ sidebarPosition: 'left', sidebarVisible: false }));
+});
+
+function render(): HTMLDivElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<MiniSidebar />));
+  cleanups.push(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+  return container;
+}
+
+function railPlus(container: HTMLElement): HTMLButtonElement {
+  return container.querySelector('[data-mini-add-workspace]') as HTMLButtonElement;
+}
+
+function findAttachRow(container: HTMLElement): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('Attach remote workspace'),
+  );
+}
+
+describe('collapsed rail + reaches Attach remote workspace (#1284)', () => {
+  it('opens the preset picker beside the rail instead of adding a workspace', () => {
+    const container = render();
+    const before = useStore.getState().workspaces.length;
+    const plus = railPlus(container);
+    expect(plus).not.toBeNull();
+    plus.getBoundingClientRect = () =>
+      ({ left: 0, right: 48, top: 36, bottom: 76, width: 48, height: 40, x: 0, y: 36, toJSON: () => ({}) }) as DOMRect;
+
+    act(() => plus.click());
+
+    expect(useStore.getState().workspaces.length).toBe(before);
+    const attachRow = findAttachRow(container);
+    expect(attachRow).toBeDefined();
+    const menu = attachRow?.parentElement as HTMLElement;
+    expect(menu.className).toContain('fixed');
+    expect(menu.style.left).toBe('52px');
+    expect(menu.style.top).toBe('36px');
+  });
+
+  it('swaps the picker for AttachRemoteModal when the attach row is chosen', async () => {
+    const container = render();
+    act(() => railPlus(container).click());
+
+    const attachRow = findAttachRow(container);
+    expect(attachRow).toBeDefined();
+    act(() => attachRow?.click());
+    await act(async () => {
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    });
+
+    expect(hostsList).toHaveBeenCalled();
+    expect(findAttachRow(container)).toBeUndefined();
+  });
+});

--- a/src/renderer/components/Titlebar/__tests__/Titlebar.attachRemote.test.tsx
+++ b/src/renderer/components/Titlebar/__tests__/Titlebar.attachRemote.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// #1284 — the only UI path to "Attach remote workspace…" is the titlebar +
+// button: it opens PresetPicker, whose last row swaps the dropdown for
+// AttachRemoteModal. The sidebar header that used to own this button was
+// removed in #418, which left a second, never-opened picker behind in
+// Sidebar.tsx and made the flow look unreachable. Pin the live path so the
+// control cannot silently lose its call site again.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import Titlebar from '../Titlebar';
+import { useStore } from '../../../stores';
+
+vi.mock('../../StatusBar/StatusBar', () => ({ default: () => null }));
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) fn();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+let hostsList: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  hostsList = vi.fn().mockResolvedValue([]);
+  const noopSub = vi.fn(() => () => { /* noop unsubscribe */ });
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    platform: 'linux',
+    window: {},
+    remote: {
+      hostsList,
+      hostsAdd: vi.fn(),
+      hostsPair: vi.fn(),
+      hostsRemove: vi.fn(),
+      workspacesList: vi.fn().mockResolvedValue({ ok: true, workspaces: [] }),
+      workspaceCreate: vi.fn(),
+      paneAttach: vi.fn(),
+      paneDetach: vi.fn(),
+      paneWrite: vi.fn(),
+      onPaneMeta: noopSub,
+      onPaneData: noopSub,
+      onPaneExit: noopSub,
+      onPaneError: noopSub,
+    },
+  };
+  act(() => useStore.setState({ sidebarPosition: 'left', sidebarVisible: true }));
+});
+
+function render(): HTMLDivElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(<Titlebar />));
+  cleanups.push(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+  return container;
+}
+
+function findAttachRow(container: HTMLElement): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('Attach remote workspace'),
+  );
+}
+
+describe('Titlebar + button reaches Attach remote workspace (#1284)', () => {
+  it('opens the preset picker, which offers the attach-remote row', () => {
+    const container = render();
+    expect(findAttachRow(container)).toBeUndefined();
+
+    const plus = container.querySelector('[data-onboarding-target="add-workspace"]') as HTMLButtonElement;
+    expect(plus).not.toBeNull();
+    act(() => plus.click());
+
+    expect(findAttachRow(container)).toBeDefined();
+  });
+
+  it('swaps the picker for AttachRemoteModal when the row is chosen', async () => {
+    const container = render();
+    const plus = container.querySelector('[data-onboarding-target="add-workspace"]') as HTMLButtonElement;
+    act(() => plus.click());
+
+    const attachRow = findAttachRow(container);
+    expect(attachRow).toBeDefined();
+    act(() => attachRow?.click());
+    await act(async () => {
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    });
+
+    // The modal mounted (it loads the registered hosts on open) and the
+    // dropdown it replaced is gone.
+    expect(hostsList).toHaveBeenCalled();
+    expect(findAttachRow(container)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

With the sidebar collapsed there was no UI path to the new-workspace picker, so none to "Attach remote workspace…". The rail's **+** called `addWorkspace()` directly, and the titlebar **+** that does open the picker is clipped out of view. The rail **+** now opens the same `PresetPicker` as the titlebar **+**, as a flyout beside the rail.

## Root cause

- #418 (418e5f07) deleted the expanded sidebar's header, which held the `onClick={togglePicker}` **+**, and moved that button into `Titlebar.tsx`. `Sidebar.tsx` kept its `pickerOpen` / `togglePicker` / `PresetPicker` render with no caller. That orphan is what #1284 spotted.
- With the sidebar expanded, the titlebar **+** works: it sits inside a 240px left segment.
- With the sidebar collapsed, that segment is 48px wide and `overflow-hidden` (`flex items-center gap-2 px-3 overflow-hidden`). Live CDP probe on this branch: the button's box starts at x≈139 while the segment ends at x=128, and `elementFromPoint` at the button's center hits the WMUX wordmark. The only visible **+** is the rail's (`MiniSidebar.tsx`), which has always called `addWorkspace()` with no picker.
- `AttachRemoteModal` has one gate: the last row of `PresetPicker`. So the collapsed state had no way to attach a remote workspace.

## Changes

- `MiniSidebar.tsx`: the rail **+** toggles `PresetPicker`, the same way the titlebar **+** does.
  - The picker gets a viewport-fixed anchor measured at open time: just outside the rail on the side facing the content (right of it when docked left, left of it when docked right), top-aligned with the button, clamped to the window. The 48px rail never clips it.
  - Adds `data-mini-add-workspace` to the button for tests and dogfood.
- `Sidebar.tsx`: removes the orphaned picker state and render left behind by #418.
  - `Sidebar` is unmounted while the rail is shown (`sidebarVisible ? <Sidebar /> : <MiniSidebar />`), so that state could never serve the rail button.
  - The expanded sidebar has no header to hang a button on; its path is the titlebar **+**.
- Tests:
  - `MiniSidebar.attachRemote.test.tsx`: the rail **+** opens the picker without creating a workspace, anchored beside the rail, and the attach row mounts `AttachRemoteModal`.
  - `Titlebar.attachRemote.test.tsx`: the same path from the titlebar **+** (expanded sidebar).
- Ctrl+N is unchanged and still creates a workspace directly. "Empty workspace" is the picker's second row.

Not changed here, observed only: the titlebar **+** is clipped when the sidebar is collapsed (see root cause). It is left alone because the rail **+** now covers that state.

## CHANGELOG entry

See `changelog.d/1294.md`.

### Fixed

- "Attach remote workspace…" is reachable with the sidebar collapsed: the rail's **+** opens the new-workspace menu instead of creating a blank workspace immediately.

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- `tsc --noEmit -p tsconfig.json`: passes.
- `vitest run` on `src/renderer/components/{Titlebar,Sidebar,Inspect}`, `components/__tests__/chromeAccessibleNames.test.ts`, `renderer/__tests__/badgeGeometry.test.ts` and `stores/selectors`: 34 files, 349 tests pass.
- eslint on the changed files: clean.
- Live check (collapsed):
  1. Press Ctrl+B to hide the sidebar.
  2. Click the rail **+** (`[data-mini-add-workspace]`).
  3. The picker should open to the right of the rail, fully on-screen.
  4. Click "Attach remote workspace…" and check that the attach modal opens.

## Related issues / PRs

Closes #1284

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
