### PR TITLE
fix(onboarding): sequence the first-boot cheat sheet and clamp the spotlight card

### DIFF
--- a/changelog.d/1295.md
+++ b/changelog.d/1295.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **The keyboard cheat sheet no longer hides behind the first-boot consent
+  prompt.** On a fresh install, closing the setup wizard mounted the shortcuts
+  panel at the same moment as the auto-update question, underneath its
+  backdrop, where its 30-second countdown ran out unseen. It now waits its
+  turn: wizard, then the auto-update question, then the spotlight tour, then
+  the cheat sheet. Opening it yourself with `?` is unaffected. (#1295)
+- **The onboarding tour card stays on screen in small windows.** When the
+  highlighted area left no room beside it, the card was placed below it anyway
+  and could land off-screen (for example at 725×800), leaving Skip and Next
+  unreachable. The card now moves to the side with the most room and is kept
+  inside the window, scrolling if the window is shorter than the card. (#1295)

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -11,7 +11,7 @@ import { EmptyLeafFunnel } from './EmptyLeafFunnel';
 import { selectProjectCwdSignature } from '../../stores/selectors/appLayout';
 import { selectInboxOwnsApprovals } from '../../stores/selectors/approvalInbox';
 import { shouldShowInstallError, shouldReannounceAfterError, truncateReason } from './updateNoticePolicy';
-import { shouldShowAutoUpdatePrompt, shouldStartOnboarding } from './firstBootSequence';
+import { shouldShowAutoUpdatePrompt, shouldShowCheatSheet, shouldStartOnboarding } from './firstBootSequence';
 import { registerSessionSaver, saveSessionNow } from '../../utils/sessionSaveBridge';
 import { resolveReconcileRebind } from '../../hooks/resolveReconcileRebind';
 import { getLeafPanes, getWorkspaceLeafPanes } from '../../../shared/paneUtils';
@@ -1785,8 +1785,8 @@ export default function AppLayout() {
 
   // Wizard close handler (T8a). Mirrors firstRunCompleted into uiSlice (main
   // already wrote the marker via firstRun:complete or :dismiss). The cheat
-  // sheet auto-mounts via the derived condition below as soon as
-  // firstRunCompleted flips true (D11) — no separate reveal flag needed.
+  // sheet auto-mounts via the derived condition below once firstRunCompleted
+  // flips true (D11) and the consent prompt / spotlight have cleared (#1276).
   const handleWizardClose = useCallback(() => {
     setShowFirstRunWizard(null);
     setFirstRunCompleted(true);
@@ -2011,7 +2011,20 @@ export default function AppLayout() {
           the sheet. The component itself is a no-op when dismissed (D11).
           `cheatSheetForceShown` (set by the `?` prefix action) bypasses the
           permanent dismissal so the cheat sheet can always be pulled back up. */}
-      {firstRunCompleted && (!cheatSheetDismissed || cheatSheetForceShown) && <KeyboardCheatSheet />}
+      {/* #1276: waits its turn after the consent prompt and the spotlight tour. */}
+      {shouldShowCheatSheet({
+        firstRunCompleted,
+        dismissed: cheatSheetDismissed,
+        forceShown: cheatSheetForceShown,
+        autoUpdatePromptPending: showAutoUpdatePrompt,
+        onboardingActiveOrStarting: onboardingActive || shouldStartOnboarding({
+          sessionLoaded: sessionLoadedRef.current,
+          autoUpdatePromptPending: showAutoUpdatePrompt,
+          firstRunCompleted,
+          onboardingCompleted,
+          workspaceCount,
+        }),
+      }) && <KeyboardCheatSheet />}
 
       {companyViewVisible && (
         <CompanyView onClose={() => setCompanyViewVisible(false)} />

--- a/src/renderer/components/Layout/AppLayout.tsx
+++ b/src/renderer/components/Layout/AppLayout.tsx
@@ -890,6 +890,12 @@ export default function AppLayout() {
   const [isDragging, setIsDragging] = useState(false);
   const dragCounterRef = useRef(0);
   const sessionLoadedRef = useRef(false);
+  // #1276: render-visible mirror of sessionLoadedRef, so the onboarding-start
+  // effect re-runs when the session lands and the cheat-sheet gate reads the
+  // same input. sessionLoadFailed settles the gate when session.load() throws
+  // (the ref intentionally stays false then — see the save guards below).
+  const [sessionLoaded, setSessionLoaded] = useState(false);
+  const [sessionLoadFailed, setSessionLoadFailed] = useState(false);
   // Fix 0: monotonic startup generation counter. Each mount-effect run
   // bumps it; the startup catch only fires clearAllPtyState if its own
   // gen still matches the current ref. Prevents a stale startup from
@@ -1266,6 +1272,7 @@ export default function AppLayout() {
         const saved = await window.electronAPI.session.load();
         if (!saved) {
           sessionLoadedRef.current = true;
+          setSessionLoaded(true);
           // First ever launch — ask about auto-update
           setShowAutoUpdatePrompt(true);
           return;
@@ -1296,6 +1303,7 @@ export default function AppLayout() {
         }
 
         sessionLoadedRef.current = true;
+        setSessionLoaded(true);
 
         if (isFirstAutoUpdateChoice) {
           setShowAutoUpdatePrompt(true);
@@ -1361,6 +1369,7 @@ export default function AppLayout() {
         // consistent blank slate. Generation check prevents a stale startup
         // from wiping state a fresher startup already reconciled correctly.
         console.warn('[AppLayout] startup reconcile failed:', err);
+        if (!sessionLoadedRef.current) setSessionLoadFailed(true);
         abortCtl?.abort();
         if (gen === startupGenRef.current) {
           clearAllPtyState();
@@ -1452,7 +1461,7 @@ export default function AppLayout() {
   // consent → spotlight.
   useEffect(() => {
     if (shouldStartOnboarding({
-      sessionLoaded: sessionLoadedRef.current,
+      sessionLoaded,
       autoUpdatePromptPending: showAutoUpdatePrompt,
       firstRunCompleted,
       onboardingCompleted,
@@ -1460,7 +1469,7 @@ export default function AppLayout() {
     })) {
       startOnboarding();
     }
-  }, [firstRunCompleted, onboardingCompleted, workspaceCount, showAutoUpdatePrompt, startOnboarding]);
+  }, [sessionLoaded, firstRunCompleted, onboardingCompleted, workspaceCount, showAutoUpdatePrompt, startOnboarding]);
 
   // Re-reconcile when daemon connects late (respawn/reconnect after the
   // startup reconcile already ran). Gating + abort/timeout/preserve logic
@@ -2014,11 +2023,12 @@ export default function AppLayout() {
       {/* #1276: waits its turn after the consent prompt and the spotlight tour. */}
       {shouldShowCheatSheet({
         firstRunCompleted,
+        sessionSettled: sessionLoaded || sessionLoadFailed,
         dismissed: cheatSheetDismissed,
         forceShown: cheatSheetForceShown,
         autoUpdatePromptPending: showAutoUpdatePrompt,
         onboardingActiveOrStarting: onboardingActive || shouldStartOnboarding({
-          sessionLoaded: sessionLoadedRef.current,
+          sessionLoaded,
           autoUpdatePromptPending: showAutoUpdatePrompt,
           firstRunCompleted,
           onboardingCompleted,

--- a/src/renderer/components/Layout/__tests__/firstBootSequence.test.ts
+++ b/src/renderer/components/Layout/__tests__/firstBootSequence.test.ts
@@ -3,7 +3,41 @@
  * onboarding spotlight, never stacked.
  */
 import { describe, it, expect } from 'vitest';
-import { shouldShowAutoUpdatePrompt, shouldStartOnboarding } from '../firstBootSequence';
+import { shouldShowAutoUpdatePrompt, shouldShowCheatSheet, shouldStartOnboarding } from '../firstBootSequence';
+
+describe('shouldShowCheatSheet (#1276)', () => {
+  const base = {
+    firstRunCompleted: true,
+    dismissed: false,
+    forceShown: false,
+    autoUpdatePromptPending: false,
+    onboardingActiveOrStarting: false,
+  };
+
+  it('fresh boot: stays hidden while the consent prompt is pending after the wizard closes', () => {
+    expect(shouldShowCheatSheet({ ...base, autoUpdatePromptPending: true })).toBe(false);
+  });
+
+  it('waits out the spotlight tour (running or about to start), then shows', () => {
+    expect(shouldShowCheatSheet({ ...base, onboardingActiveOrStarting: true })).toBe(false);
+    expect(shouldShowCheatSheet(base)).toBe(true);
+  });
+
+  it('stays behind the wizard and honours the permanent opt-out', () => {
+    expect(shouldShowCheatSheet({ ...base, firstRunCompleted: false })).toBe(false);
+    expect(shouldShowCheatSheet({ ...base, dismissed: true })).toBe(false);
+  });
+
+  it('a user-initiated `?` open is never gated by the first-boot sequence', () => {
+    expect(shouldShowCheatSheet({
+      ...base,
+      dismissed: true,
+      forceShown: true,
+      autoUpdatePromptPending: true,
+      onboardingActiveOrStarting: true,
+    })).toBe(true);
+  });
+});
 
 describe('shouldShowAutoUpdatePrompt', () => {
   it('fresh boot: holds the prompt while the wizard probe is unresolved and while the wizard is open', () => {

--- a/src/renderer/components/Layout/__tests__/firstBootSequence.test.ts
+++ b/src/renderer/components/Layout/__tests__/firstBootSequence.test.ts
@@ -8,6 +8,7 @@ import { shouldShowAutoUpdatePrompt, shouldShowCheatSheet, shouldStartOnboarding
 describe('shouldShowCheatSheet (#1276)', () => {
   const base = {
     firstRunCompleted: true,
+    sessionSettled: true,
     dismissed: false,
     forceShown: false,
     autoUpdatePromptPending: false,
@@ -26,6 +27,51 @@ describe('shouldShowCheatSheet (#1276)', () => {
   it('stays behind the wizard and honours the permanent opt-out', () => {
     expect(shouldShowCheatSheet({ ...base, firstRunCompleted: false })).toBe(false);
     expect(shouldShowCheatSheet({ ...base, dismissed: true })).toBe(false);
+  });
+
+  it('holds until session.load() settles (no mount-then-unmount flicker)', () => {
+    expect(shouldShowCheatSheet({ ...base, sessionSettled: false })).toBe(false);
+  });
+
+  it('returning user (marker present, tour unfinished): firstRun resolves before session load → tour starts, then the sheet shows — never hidden for good', () => {
+    // Mirrors AppLayout: the start effect and the gate read the same inputs,
+    // and the effect re-runs on sessionLoaded.
+    const onboarding = {
+      autoUpdatePromptPending: false,
+      firstRunCompleted: true,
+      onboardingCompleted: false,
+      workspaceCount: 1,
+    };
+    const sheet = (sessionLoaded: boolean, onboardingActive: boolean, onboardingCompleted = false) =>
+      shouldShowCheatSheet({
+        ...base,
+        sessionSettled: sessionLoaded,
+        onboardingActiveOrStarting: onboardingActive
+          || shouldStartOnboarding({ ...onboarding, onboardingCompleted, sessionLoaded }),
+      });
+
+    // 1. firstRun.check resolved, session.load still in flight: nothing yet.
+    expect(shouldStartOnboarding({ ...onboarding, sessionLoaded: false })).toBe(false);
+    expect(sheet(false, false)).toBe(false);
+    // 2. session lands (workspaceCount 1→1): the effect's sessionLoaded dep changed, so it starts the tour.
+    expect(shouldStartOnboarding({ ...onboarding, sessionLoaded: true })).toBe(true);
+    expect(sheet(true, false)).toBe(false);
+    // 3. tour running.
+    expect(sheet(true, true)).toBe(false);
+    // 4. tour skipped/completed → the sheet shows.
+    expect(sheet(true, false, true)).toBe(true);
+  });
+
+  it('a failed session.load() settles the gate — the sheet still shows', () => {
+    // sessionLoaded stays false on failure, so the tour never starts; the sheet must not wait on it.
+    const starting = shouldStartOnboarding({
+      sessionLoaded: false,
+      autoUpdatePromptPending: false,
+      firstRunCompleted: true,
+      onboardingCompleted: false,
+      workspaceCount: 1,
+    });
+    expect(shouldShowCheatSheet({ ...base, sessionSettled: true, onboardingActiveOrStarting: starting })).toBe(true);
   });
 
   it('a user-initiated `?` open is never gated by the first-boot sequence', () => {

--- a/src/renderer/components/Layout/firstBootSequence.ts
+++ b/src/renderer/components/Layout/firstBootSequence.ts
@@ -44,13 +44,23 @@ export function shouldStartOnboarding(gate: OnboardingStartGate): boolean {
 
 export interface CheatSheetGate {
   firstRunCompleted: boolean;
+  /**
+   * session.load() has resolved or failed. Until then the spotlight's
+   * workspaceCount / onboardingCompleted inputs are not final, and mounting
+   * the sheet early would unmount it again (restarting its countdown).
+   */
+  sessionSettled: boolean;
   /** Permanent "Don't show again" opt-out. */
   dismissed: boolean;
   /** User-initiated open (the `?` prefix action) — never held back. */
   forceShown: boolean;
   /** Pending consent — the prompt's modal backdrop would cover the sheet. */
   autoUpdatePromptPending: boolean;
-  /** The spotlight tour is running, or is about to start (shouldStartOnboarding). */
+  /**
+   * The spotlight tour is running, or shouldStartOnboarding() is true — fed
+   * the same inputs as the start effect, so "starting" always becomes
+   * "running" (or false) rather than hiding the sheet indefinitely.
+   */
   onboardingActiveOrStarting: boolean;
 }
 
@@ -64,5 +74,6 @@ export function shouldShowCheatSheet(gate: CheatSheetGate): boolean {
   if (!gate.firstRunCompleted) return false;
   if (gate.forceShown) return true;
   if (gate.dismissed) return false;
+  if (!gate.sessionSettled) return false;
   return !gate.autoUpdatePromptPending && !gate.onboardingActiveOrStarting;
 }

--- a/src/renderer/components/Layout/firstBootSequence.ts
+++ b/src/renderer/components/Layout/firstBootSequence.ts
@@ -2,7 +2,8 @@
  * #1164 — pure gating for the first-boot overlays, extracted from AppLayout
  * (no jsdom fixture there) so the sequencing is unit-testable.
  *
- * One first-boot surface at a time: wizard → auto-update consent → spotlight.
+ * One first-boot surface at a time: wizard → auto-update consent → spotlight
+ * → keyboard cheat sheet (#1276).
  * Stacking them made the lower one pointer-dead under the upper one's
  * full-screen backdrop.
  */
@@ -39,4 +40,29 @@ export function shouldStartOnboarding(gate: OnboardingStartGate): boolean {
   if (!gate.sessionLoaded) return false;
   if (gate.autoUpdatePromptPending) return false;
   return gate.firstRunCompleted && !gate.onboardingCompleted && gate.workspaceCount === 1;
+}
+
+export interface CheatSheetGate {
+  firstRunCompleted: boolean;
+  /** Permanent "Don't show again" opt-out. */
+  dismissed: boolean;
+  /** User-initiated open (the `?` prefix action) — never held back. */
+  forceShown: boolean;
+  /** Pending consent — the prompt's modal backdrop would cover the sheet. */
+  autoUpdatePromptPending: boolean;
+  /** The spotlight tour is running, or is about to start (shouldStartOnboarding). */
+  onboardingActiveOrStarting: boolean;
+}
+
+/**
+ * #1276 — the keyboard cheat sheet is the last first-boot surface:
+ * wizard → consent → spotlight → cheat sheet. Mounting it earlier renders it
+ * behind the consent prompt / spotlight scrim while its 30s countdown runs
+ * out unseen.
+ */
+export function shouldShowCheatSheet(gate: CheatSheetGate): boolean {
+  if (!gate.firstRunCompleted) return false;
+  if (gate.forceShown) return true;
+  if (gate.dismissed) return false;
+  return !gate.autoUpdatePromptPending && !gate.onboardingActiveOrStarting;
 }

--- a/src/renderer/components/Onboarding/OnboardingHighlight.tsx
+++ b/src/renderer/components/Onboarding/OnboardingHighlight.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
 
 export interface TargetRect {
   top: number;
@@ -18,69 +18,86 @@ interface OnboardingHighlightProps {
 const PADDING = 8;
 const TOOLTIP_GAP = 12;
 const TOOLTIP_WIDTH = 320;
+/** Minimum distance between the card and the viewport edge. */
+export const VIEWPORT_MARGIN = 16;
+/** Card height used until the rendered card has been measured. */
+const ESTIMATED_CARD_HEIGHT = 180;
 
-/**
- * Resolves the best placement for the tooltip given available viewport space.
- */
-function resolvePlacement(
-  rect: TargetRect,
-  preferred: 'top' | 'bottom' | 'left' | 'right' | 'auto',
-): TooltipPlacement {
-  if (preferred !== 'auto') return preferred;
-
-  const spaceBelow = window.innerHeight - (rect.top + rect.height);
-  const spaceAbove = rect.top;
-  const spaceRight = window.innerWidth - (rect.left + rect.width);
-  const spaceLeft = rect.left;
-
-  // Prefer below, then above, then right, then left
-  if (spaceBelow >= 160) return 'bottom';
-  if (spaceAbove >= 160) return 'top';
-  if (spaceRight >= TOOLTIP_WIDTH + TOOLTIP_GAP) return 'right';
-  if (spaceLeft >= TOOLTIP_WIDTH + TOOLTIP_GAP) return 'left';
-  return 'bottom';
+export interface ViewportSize {
+  width: number;
+  height: number;
 }
 
+export interface TooltipLayout {
+  placement: TooltipPlacement;
+  style: React.CSSProperties & { top: number; left: number; width: number; maxHeight: number };
+}
+
+const AUTO_ORDER: TooltipPlacement[] = ['bottom', 'top', 'right', 'left'];
+
 /**
- * Computes CSS properties for positioning the tooltip near the target element.
+ * #1275 — resolves the placement and a viewport-clamped position for the
+ * tooltip card. The preferred side (or the auto order) wins when the card
+ * fits there; otherwise the side with the most room is used. Either way the
+ * card is clamped inside the viewport so Skip / Next stay reachable — the old
+ * resolver fell back to 'bottom' unclamped and pushed the card off-screen on
+ * small windows.
  */
-function computeTooltipStyle(
+export function computeTooltipLayout(
   rect: TargetRect,
-  placement: TooltipPlacement,
-): React.CSSProperties {
+  preferred: TooltipPlacement | 'auto',
+  viewport: ViewportSize,
+  cardHeight: number,
+): TooltipLayout {
+  const width = Math.max(0, Math.min(TOOLTIP_WIDTH, viewport.width - VIEWPORT_MARGIN * 2));
+  const maxHeight = Math.max(0, viewport.height - VIEWPORT_MARGIN * 2);
+  const height = Math.min(cardHeight, maxHeight);
+  const rectRight = rect.left + rect.width;
+  const rectBottom = rect.top + rect.height;
+
+  // Room left over on each side once the card (plus gap and margin) is placed there.
+  const slack: Record<TooltipPlacement, number> = {
+    bottom: viewport.height - rectBottom - (PADDING + TOOLTIP_GAP + height + VIEWPORT_MARGIN),
+    top: rect.top - (TOOLTIP_GAP + height + VIEWPORT_MARGIN),
+    right: viewport.width - rectRight - (PADDING + TOOLTIP_GAP + width + VIEWPORT_MARGIN),
+    left: rect.left - (TOOLTIP_GAP + width + VIEWPORT_MARGIN),
+  };
+
+  const order = preferred === 'auto' ? AUTO_ORDER : [preferred, ...AUTO_ORDER.filter((p) => p !== preferred)];
+  const placement = order.find((p) => slack[p] >= 0)
+    ?? order.reduce((best, p) => (slack[p] > slack[best] ? p : best));
+
   const centerX = rect.left + rect.width / 2;
   const centerY = rect.top + rect.height / 2;
-
+  let top: number;
+  let left: number;
   switch (placement) {
     case 'bottom':
-      return {
-        position: 'fixed',
-        top: rect.top + rect.height + PADDING + TOOLTIP_GAP,
-        left: Math.max(16, Math.min(centerX - TOOLTIP_WIDTH / 2, window.innerWidth - TOOLTIP_WIDTH - 16)),
-        width: TOOLTIP_WIDTH,
-      };
+      top = rectBottom + PADDING + TOOLTIP_GAP;
+      left = centerX - width / 2;
+      break;
     case 'top':
-      return {
-        position: 'fixed',
-        bottom: window.innerHeight - rect.top + TOOLTIP_GAP,
-        left: Math.max(16, Math.min(centerX - TOOLTIP_WIDTH / 2, window.innerWidth - TOOLTIP_WIDTH - 16)),
-        width: TOOLTIP_WIDTH,
-      };
+      top = rect.top - TOOLTIP_GAP - height;
+      left = centerX - width / 2;
+      break;
     case 'right':
-      return {
-        position: 'fixed',
-        top: Math.max(16, centerY - 40),
-        left: rect.left + rect.width + PADDING + TOOLTIP_GAP,
-        width: TOOLTIP_WIDTH,
-      };
+      top = centerY - 40;
+      left = rectRight + PADDING + TOOLTIP_GAP;
+      break;
     case 'left':
-      return {
-        position: 'fixed',
-        top: Math.max(16, centerY - 40),
-        right: window.innerWidth - rect.left + TOOLTIP_GAP,
-        width: TOOLTIP_WIDTH,
-      };
+      top = centerY - 40;
+      left = rect.left - TOOLTIP_GAP - width;
+      break;
   }
+
+  const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max));
+  top = clamp(top, VIEWPORT_MARGIN, Math.max(VIEWPORT_MARGIN, viewport.height - VIEWPORT_MARGIN - height));
+  left = clamp(left, VIEWPORT_MARGIN, Math.max(VIEWPORT_MARGIN, viewport.width - VIEWPORT_MARGIN - width));
+
+  return {
+    placement,
+    style: { position: 'fixed', top, left, width, maxHeight, overflowY: 'auto' },
+  };
 }
 
 /**
@@ -98,6 +115,8 @@ export default function OnboardingHighlight({
   const [rect, setRect] = useState<TargetRect | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
   const rafRef = useRef<number>(0);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [cardHeight, setCardHeight] = useState(ESTIMATED_CARD_HEIGHT);
 
   const measure = useCallback(() => {
     const el = document.querySelector(targetSelector);
@@ -141,10 +160,22 @@ export default function OnboardingHighlight({
     };
   }, [targetSelector, measure]);
 
+  // Measure the rendered card so the viewport clamp uses its real height
+  // (scrollHeight stays the content height even when maxHeight caps the box).
+  // Re-runs every render; the equality guard stops the update loop.
+  useLayoutEffect(() => {
+    const measured = tooltipRef.current?.scrollHeight;
+    if (measured && Math.abs(measured - cardHeight) > 1) setCardHeight(measured);
+  });
+
   if (!rect) return null;
 
-  const placement = resolvePlacement(rect, preferredPosition);
-  const tooltipStyle = computeTooltipStyle(rect, placement);
+  const { placement, style: tooltipStyle } = computeTooltipLayout(
+    rect,
+    preferredPosition,
+    { width: window.innerWidth, height: window.innerHeight },
+    cardHeight,
+  );
 
   // Spotlight box-shadow: a huge spread that covers the entire viewport,
   // with an inset "hole" matching the target rect.
@@ -168,7 +199,7 @@ export default function OnboardingHighlight({
         style={spotlightStyle}
         data-testid="onboarding-spotlight"
       />
-      <div style={{ ...tooltipStyle, zIndex: 10001 }} data-testid="onboarding-tooltip">
+      <div ref={tooltipRef} style={{ ...tooltipStyle, zIndex: 10001 }} data-testid="onboarding-tooltip">
         {children(placement, tooltipStyle)}
       </div>
     </>

--- a/src/renderer/components/Onboarding/OnboardingHighlight.tsx
+++ b/src/renderer/components/Onboarding/OnboardingHighlight.tsx
@@ -162,11 +162,13 @@ export default function OnboardingHighlight({
 
   // Measure the rendered card so the viewport clamp uses its real height
   // (scrollHeight stays the content height even when maxHeight caps the box).
-  // Re-runs every render; the equality guard stops the update loop.
+  // Re-measured only when the target / step changes, so a placement flip
+  // near zero slack cannot feed back into another measurement.
   useLayoutEffect(() => {
     const measured = tooltipRef.current?.scrollHeight;
     if (measured && Math.abs(measured - cardHeight) > 1) setCardHeight(measured);
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- cardHeight is the output, not a trigger
+  }, [rect, targetSelector]);
 
   if (!rect) return null;
 

--- a/src/renderer/components/Onboarding/__tests__/OnboardingHighlight.placement.test.ts
+++ b/src/renderer/components/Onboarding/__tests__/OnboardingHighlight.placement.test.ts
@@ -1,0 +1,55 @@
+/**
+ * #1275 — the onboarding card must always land fully inside the viewport so
+ * Skip / Next stay reachable, even when no side of the target has room.
+ */
+import { describe, it, expect } from 'vitest';
+import { computeTooltipLayout, VIEWPORT_MARGIN } from '../OnboardingHighlight';
+import type { TargetRect, ViewportSize } from '../OnboardingHighlight';
+
+const CARD_HEIGHT = 170;
+
+function expectInside(layout: ReturnType<typeof computeTooltipLayout>, viewport: ViewportSize, height: number) {
+  const { top, left, width, maxHeight } = layout.style;
+  const renderedHeight = Math.min(height, maxHeight);
+  expect(top).toBeGreaterThanOrEqual(VIEWPORT_MARGIN);
+  expect(left).toBeGreaterThanOrEqual(VIEWPORT_MARGIN);
+  expect(top + renderedHeight).toBeLessThanOrEqual(viewport.height - VIEWPORT_MARGIN);
+  expect(left + width).toBeLessThanOrEqual(viewport.width - VIEWPORT_MARGIN);
+}
+
+describe('computeTooltipLayout', () => {
+  it('725×800: a pane-area target with no room on any side keeps the card inside the viewport', () => {
+    const viewport = { width: 725, height: 800 };
+    // Step 1 highlights the pane area, which fills nearly the whole window.
+    const paneArea: TargetRect = { top: 28, left: 232, width: 501, height: 760 };
+    const layout = computeTooltipLayout(paneArea, 'bottom', viewport, CARD_HEIGHT);
+    expectInside(layout, viewport, CARD_HEIGHT);
+  });
+
+  it('falls back to the side with the most room when the preferred side does not fit', () => {
+    const viewport = { width: 725, height: 800 };
+    // Target hugs the bottom edge: 'bottom' cannot fit, 'top' has plenty of room.
+    const statusBar: TargetRect = { top: 760, left: 0, width: 725, height: 40 };
+    const layout = computeTooltipLayout(statusBar, 'bottom', viewport, CARD_HEIGHT);
+    expect(layout.placement).toBe('top');
+    expectInside(layout, viewport, CARD_HEIGHT);
+  });
+
+  it('keeps the preferred side when it fits', () => {
+    const viewport = { width: 1440, height: 900 };
+    const button: TargetRect = { top: 100, left: 20, width: 40, height: 40 };
+    const layout = computeTooltipLayout(button, 'right', viewport, CARD_HEIGHT);
+    expect(layout.placement).toBe('right');
+    expect(layout.style.left).toBe(20 + 40 + 8 + 12);
+    expectInside(layout, viewport, CARD_HEIGHT);
+  });
+
+  it('a card taller than the viewport is capped and scrolls instead of overflowing', () => {
+    const viewport = { width: 300, height: 200 };
+    const target: TargetRect = { top: 50, left: 50, width: 100, height: 50 };
+    const layout = computeTooltipLayout(target, 'bottom', viewport, 400);
+    expect(layout.style.maxHeight).toBe(200 - VIEWPORT_MARGIN * 2);
+    expect(layout.style.overflowY).toBe('auto');
+    expectInside(layout, viewport, 400);
+  });
+});


### PR DESCRIPTION
## Summary

Two first-boot overlay fixes. The keyboard cheat sheet now waits its turn in the first-boot sequence instead of rendering behind the auto-update consent prompt (#1276), and the onboarding spotlight card is clamped inside the viewport so Skip / Next stay reachable on small windows (#1275).

## Changes

- `firstBootSequence.ts`: new pure gate `shouldShowCheatSheet`. The cheat sheet is the last surface: wizard → consent → spotlight → cheat sheet. It is held while consent is pending and while the spotlight tour is running or about to start (`onboardingActive || shouldStartOnboarding(...)`, so it does not flash for one frame before the tour mounts). The user-initiated `?` open (`cheatSheetForceShown`) is never gated.
- `AppLayout.tsx`: the cheat sheet mount condition uses the new gate.
- `OnboardingHighlight.tsx`: replaced `resolvePlacement` / `computeTooltipStyle` with a pure `computeTooltipLayout(rect, preferred, viewport, cardHeight)`. It takes the preferred side (then bottom/top/right/left) if the card fits there, otherwise the side with the most room, then clamps `top`/`left` inside the viewport with a 16px margin. It uses the card's measured height (`scrollHeight`, re-measured each render with an equality guard) and caps `maxHeight` with `overflowY: auto` for viewports shorter than the card. Explicit step placements are now fit-checked too; before, they were returned unchecked.

## CHANGELOG entry

Added as `changelog.d/1295.md` (`### Fixed`).

## Stability tier impact

- [x] No external surface touched (internal refactor / docs / tests / CI).

## Substrate contract impact (Substrate 3.0)

n/a

## Test plan

- Unit: `src/renderer/components/Layout/__tests__/firstBootSequence.test.ts` gets `shouldShowCheatSheet` cases: held behind pending consent, held behind the spotlight, held behind the wizard, opt-out honoured, `?` bypasses every gate.
- Unit: new `src/renderer/components/Onboarding/__tests__/OnboardingHighlight.placement.test.ts`. The 725×800 pane-area case asserts the card is fully inside the viewport. Also covers fallback to the roomiest side, keeping a fitting preferred side, and capping a card taller than the viewport.
- `tsc --noEmit` passes. vitest on the touched suites (firstBootSequence, placement, steps.i18n, KeyboardCheatSheet): 54/54 pass.
- Manual repro:
  - #1276: fresh data dir (`WMUX_DATA_SUFFIX=-fresh1276`), dismiss the wizard. Only the consent prompt should show. Answer it and the spotlight starts; skip it and the cheat sheet appears bottom-right.
  - #1275: resize the window to about 725×800 and start onboarding. The step 1 card should sit inside the window with Skip / Next clickable.

## Related issues / PRs

Closes #1275
Closes #1276
Follow-up to #1242.

## Reviewer checklist

- [x] CHANGELOG entry above is filled in or explicitly marked n/a.
- [x] Stability tier impact is correctly classified.
- [x] Substrate contract docs (PROTOCOL.md, inventory.md, stability.md) updated if the surface changed.
- [x] Tests cover the new behavior and the regression case (if a bug fix).
- [x] No accidental commit of secrets, tokens, `.env`, or unrelated large binaries.
